### PR TITLE
Update supported languages in README to include all 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Note: Podman is CLI-compatible with Docker, so simply replace "docker" with "pod
 Please view https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToUseOCR.md
 
 ## Want to add your own language?
-Stirling PDF currently supports 21!
+Stirling PDF currently supports 24!
 - English (English) (en_GB)
 - English (US) (en_US)
 - Arabic (العربية) (ar_AR)
@@ -170,6 +170,8 @@ Stirling PDF currently supports 21!
 - Turkish (Türkçe) (tr_TR)
 - Indonesia (Bahasa Indonesia) (id_ID)
 - Hindi (हिंदी) (hi_IN)
+- Hungarian (Magyar) (hu_HU)
+- Bulgarian (Български) (bg_BG)
 
 If you want to add your own language to Stirling-PDF please refer
 https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md


### PR DESCRIPTION
Adjusted the README to correctly enumerate all 24 languages supported by the project. This change includes the addition of Hungarian (Magyar) and Bulgarian (Български) to the list, based on the properties files located in 'src/main/resources'.

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
