### PR TITLE
Optimize DockerfileBase for Improved Efficiency and Reduced Size

### DIFF
--- a/DockerfileBase
+++ b/DockerfileBase
@@ -33,6 +33,7 @@ apt-get update && \
         ocrmypdf \
         unpaper && \
     rm -rf /var/lib/apt/lists/* && \
+    mv /usr/share/tesseract-ocr /usr/share/tesseract-ocr-original && \
     pip install --upgrade pip && \
     pip install --no-cache-dir --upgrade ocrmypdf && \
     pip install --no-cache-dir --upgrade pillow==10.0.1 reportlab==3.6.13 wheel==0.38.1 setuptools==65.5.1 pyjwt==2.4.0 cryptography==39.0.1
@@ -40,13 +41,3 @@ apt-get update && \
     
 #CV and HTML   
 RUN pip install --no-cache-dir opencv-python-headless WeasyPrint 
-
-
-# cleanup and etc
-RUN mkdir /usr/share/tesseract-ocr-original && \
-    cp -r /usr/share/tesseract-ocr/* /usr/share/tesseract-ocr-original && \
-    rm -rf /usr/share/tesseract-ocr
-
-
-
-    

--- a/DockerfileBase
+++ b/DockerfileBase
@@ -34,7 +34,7 @@ apt-get update && \
         unpaper && \
     rm -rf /var/lib/apt/lists/* && \
     mv /usr/share/tesseract-ocr /usr/share/tesseract-ocr-original && \
-    pip install --upgrade pip && \
+    pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir --upgrade ocrmypdf && \
     pip install --no-cache-dir --upgrade pillow==10.0.1 reportlab==3.6.13 wheel==0.38.1 setuptools==65.5.1 pyjwt==2.4.0 cryptography==39.0.1
     

--- a/DockerfileBase
+++ b/DockerfileBase
@@ -6,7 +6,8 @@ FROM ubuntu:latest AS base
 # JDK for app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    	openjdk-17-jre
+    	openjdk-17-jre && \
+    rm -rf /var/lib/apt/lists/*
     	
 # Doc conversion
 RUN apt-get update && \
@@ -18,7 +19,8 @@ RUN apt-get update && \
         libreoffice-impress \
 		python3-uno \
 		curl \
-		unoconv
+		unoconv && \
+    rm -rf /var/lib/apt/lists/*
 		
 		
 # OCR MY PDF (unpaper for descew and other advanced featues)
@@ -30,6 +32,7 @@ apt-get update && \
         python3-pip \
         ocrmypdf \
         unpaper && \
+    rm -rf /var/lib/apt/lists/* && \
     pip install --upgrade pip && \
     pip install --no-cache-dir --upgrade ocrmypdf && \
     pip install --no-cache-dir --upgrade pillow==10.0.1 reportlab==3.6.13 wheel==0.38.1 setuptools==65.5.1 pyjwt==2.4.0 cryptography==39.0.1
@@ -40,8 +43,7 @@ RUN pip install --no-cache-dir opencv-python-headless WeasyPrint
 
 
 # cleanup and etc
-RUN rm -rf /var/lib/apt/lists/* && \
-    mkdir /usr/share/tesseract-ocr-original && \
+RUN mkdir /usr/share/tesseract-ocr-original && \
     cp -r /usr/share/tesseract-ocr/* /usr/share/tesseract-ocr-original && \
     rm -rf /usr/share/tesseract-ocr
 


### PR DESCRIPTION
This pull request includes three commits that collectively optimize the DockerfileBase. The changes are focused on improving the build process, reducing the Docker image size, and maintaining consistency across the Dockerfile commands.
Optimize DockerfileBase for Image Efficiency

- Add the `--no-cache-dir` flag to `pip install --upgrade pip` to align with other pip installation commands, prevent caching, and reduce Docker image layer size.
- Move Tesseract-OCR files to '/usr/share/tesseract-ocr-original' to prevent redundant operations and improve the efficiency of the backup process.
- Clean the apt cache within the same RUN statement after package installations by including `rm -rf /var/lib/apt/lists/*`, ensuring a reduced Docker image size by avoiding the retention of transient package data.

These changes contribute to a more efficient build process and a minimized Docker image, aligning with best practices for Dockerfile maintenance and deployment.

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
