### PR TITLE
PDF Stamper: Adding Images to PDF Pages with Opacity Control

### DIFF
--- a/src/main/resources/static/3rdPartyLicenses.json
+++ b/src/main/resources/static/3rdPartyLicenses.json
@@ -356,22 +356,22 @@
         },
         {
             "moduleName": "org.apache.pdfbox:fontbox",
-            "moduleUrl": "http://pdfbox.apache.org/",
-            "moduleVersion": "2.0.29",
+            "moduleUrl": "https://pdfbox.apache.org",
+            "moduleVersion": "2.0.30",
             "moduleLicense": "Apache License, Version 2.0",
             "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
         },
         {
             "moduleName": "org.apache.pdfbox:pdfbox",
-            "moduleUrl": "http://pdfbox.apache.org",
-            "moduleVersion": "2.0.29",
+            "moduleUrl": "https://pdfbox.apache.org",
+            "moduleVersion": "2.0.30",
             "moduleLicense": "Apache License, Version 2.0",
             "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
         },
         {
             "moduleName": "org.apache.pdfbox:xmpbox",
-            "moduleUrl": "http://pdfbox.apache.org",
-            "moduleVersion": "2.0.29",
+            "moduleUrl": "https://pdfbox.apache.org",
+            "moduleVersion": "2.0.30",
             "moduleLicense": "Apache License, Version 2.0",
             "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
         },


### PR DESCRIPTION
This Python script modifies a PDF file by adding a stamp image to each page. The stamp image, provided as a PNG file, is placed at the center of every page in the input PDF. The opacity of the stamp can be adjusted using the 'opacity' parameter (0.0 to 1.0). The modified PDF is then saved as an output file specified by the user. The script utilizes PyPDF2 for PDF handling and ReportLab for generating the stamp image within the PDF.  And fix for the issue #519 