### PR TITLE
 Adding Stamp to PDF Pages with Opacity Control

### DIFF
--- a/scripts/add_stamp.py
+++ b/scripts/add_stamp.py
@@ -1,0 +1,74 @@
+from PyPDF2 import PdfReader, PdfWriter
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+from io import BytesIO
+from PIL import Image
+from reportlab.lib.utils import ImageReader  # Import ImageReader from reportlab
+
+def add_stamp_to_pdf(input_pdf_path, stamp_image_path, output_pdf_path, opacity=0.5):
+    input_pdf = PdfReader(open(input_pdf_path, "rb"))
+    output = PdfWriter()
+
+    stamp = Image.open(stamp_image_path)
+    stamp = stamp.convert("RGBA")
+
+    # Create a new image with adjusted opacity
+    stamp_with_opacity = Image.new("RGBA", stamp.size)
+    for x in range(stamp.width):
+        for y in range(stamp.height):
+            r, g, b, a = stamp.getpixel((x, y))
+            stamp_with_opacity.putpixel((x, y), (r, g, b, int(a * opacity) if opacity < 1.0 else a))
+
+    for page_num in range(len(input_pdf.pages)):
+        page = input_pdf.pages[page_num]
+
+        # Get page dimensions using mediabox
+        page_mediabox = page['/MediaBox']
+        page_width = float(page_mediabox[2])
+        page_height = float(page_mediabox[3])
+
+        stamp_width, stamp_height = stamp.size
+
+        # Calculate scaling factors to maintain original stamp size
+        scale_x = page_width / stamp_width
+        scale_y = page_height / stamp_height
+
+        # Choose the smaller scale to maintain original stamp size within the page
+        scale_factor = min(scale_x, scale_y)
+
+        # Resize stamp image with adjusted opacity to match the scaled dimensions
+        stamp_with_opacity_resized = stamp_with_opacity.resize((int(stamp_width * scale_factor), int(stamp_height * scale_factor)))
+
+        # Create a PDF buffer for the stamped page
+        stamped_page_buffer = BytesIO()
+        c = canvas.Canvas(stamped_page_buffer, pagesize=(page_width, page_height))
+
+        # Draw the stamp centered on the PDF page
+        x_offset = (page_width - stamp_with_opacity_resized.width) / 2
+        y_offset = (page_height - stamp_with_opacity_resized.height) / 2
+
+        # Convert Image object to ReportLab's ImageReader
+        stamp_buffer = BytesIO()
+        stamp_with_opacity_resized.save(stamp_buffer, format="PNG")
+        stamp_buffer.seek(0)
+        stamp_reader = ImageReader(stamp_buffer)
+
+        c.drawImage(stamp_reader, x_offset, y_offset, width=stamp_with_opacity_resized.width, height=stamp_with_opacity_resized.height, mask='auto', preserveAspectRatio=True)
+
+        c.save()
+
+        # Merge the stamped page with the original PDF content
+        stamped_page = PdfReader(BytesIO(stamped_page_buffer.getvalue())).pages[0]
+        stamped_page.merge_page(page)
+        output.add_page(stamped_page)
+
+    # Save the modified PDF
+    with open(output_pdf_path, "wb") as output_pdf:
+        output.write(output_pdf)
+
+# Paths
+input_pdf_path = "D:\Projects\Add_PDF_Stamp/input.pdf"
+stamp_image_path = "D:\Projects\Add_PDF_Stamp/stamp.png"
+output_pdf_path = "D:\Projects\Add_PDF_Stamp/output.pdf"
+
+add_stamp_to_pdf(input_pdf_path, stamp_image_path, output_pdf_path, opacity=0.7)


### PR DESCRIPTION
This Python script modifies a PDF file by adding a stamp image to each page. The stamp image, provided as a PNG file, is placed at the center of every page in the input PDF. The opacity of the stamp can be adjusted using the 'opacity' parameter (0.0 to 1.0). The modified PDF is then saved as an output file specified by the user. The script utilizes PyPDF2 for PDF handling and ReportLab for generating the stamp image within the PDF.
and Fix for the issue #519 

![Screenshot (38)](https://github.com/Stirling-Tools/Stirling-PDF/assets/47359760/ae8c46b1-a2ef-4d26-b1fd-0cd153881ddc)
![Screenshot (39)](https://github.com/Stirling-Tools/Stirling-PDF/assets/47359760/3c6f7fb6-6aea-4baa-bc04-0e0d2f2bea7f)


# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
