### PR TITLE
Specify code block language in Markdown for syntax highlighting

### DIFF
--- a/FolderScanning.md
+++ b/FolderScanning.md
@@ -2,7 +2,7 @@
 
 ### Whilst Pipelines are in alpha...
 You must enable this alpha functionality by setting
-```
+```yaml
 system:
   enableAlphaFunctionality: true
 ```

--- a/HowToAddNewLanguage.md
+++ b/HowToAddNewLanguage.md
@@ -16,7 +16,7 @@ If your language isnt represented by a flag just find whichever closely matches 
 
 
 For example to add Polish you would add 
-```
+```html
 <a class="dropdown-item lang_dropdown-item" href="" data-language-code="pl_PL">
     <img src="images/flags/pl.svg" alt="icon" width="20" height="15"> Polski
 </a>

--- a/PipelineFeature.md
+++ b/PipelineFeature.md
@@ -2,7 +2,7 @@
 
 ## Whilst Pipelines are in alpha...
 You must enable this alpha functionality by setting
-```
+```yaml
 system:
   enableAlphaFunctionality: true
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For people that don't mind about space optimization just use the latest tag.
 ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/frooodle/s-pdf/latest-ultra-lite?label=Stirling-PDF%20Ultra-Lite)
 
 Docker Run
-```
+```bash
 docker run -d \
   -p 8080:8080 \
   -v /location/of/trainingData:/usr/share/tesseract-ocr/5/tessdata \
@@ -125,7 +125,7 @@ docker run -d \
   -v /location/of/customFiles:/customFiles \
 ```
 Docker Compose
-```
+```yaml
 version: '3.3'
 services:
   stirling-pdf:
@@ -197,7 +197,7 @@ This file is located in the ``/configs`` directory and follows standard YAML for
 
 Environment variables are also supported and would override the settings file
 For example in the settings.yml you have
-```
+```yaml
 system:
   defaultLocale: 'en-US'
 ```
@@ -205,7 +205,7 @@ system:
 To have this via an environment variable you would have ``SYSTEM_DEFAULTLOCALE``
 
 The Current list of settings is
-```
+```yaml
 security:
   enableLogin: false # set to 'true' to enable login
   csrfDisabled: true


### PR DESCRIPTION
This will help improve the readability of rendered Markdown docs.

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
