### PR TITLE
Enable support for tables in the conversion from Markdown to HTML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ dependencies {
     implementation group: 'com.google.zxing', name: 'core', version: '3.5.2'
     // https://mvnrepository.com/artifact/org.commonmark/commonmark
     implementation 'org.commonmark:commonmark:0.21.0'
+    implementation 'org.commonmark:commonmark-ext-gfm-tables:0.17.2'
     // https://mvnrepository.com/artifact/com.github.vladimir-bukhtoyarov/bucket4j-core
     implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.6.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ dependencies {
     implementation group: 'com.google.zxing', name: 'core', version: '3.5.2'
     // https://mvnrepository.com/artifact/org.commonmark/commonmark
     implementation 'org.commonmark:commonmark:0.21.0'
-    implementation 'org.commonmark:commonmark-ext-gfm-tables:0.17.2'
+    implementation 'org.commonmark:commonmark-ext-gfm-tables:0.21.0'
     // https://mvnrepository.com/artifact/com.github.vladimir-bukhtoyarov/bucket4j-core
     implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.6.0'
 

--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertMarkdownToPdf.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertMarkdownToPdf.java
@@ -65,7 +65,6 @@ public class ConvertMarkdownToPdf {
                         .build();
 
         String htmlContent = renderer.render(document);
-        System.out.println(htmlContent);
 
         byte[] pdfBytes =
                 FileToPdf.convertHtmlToPdf(

--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertMarkdownToPdf.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertMarkdownToPdf.java
@@ -1,5 +1,9 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import java.util.List;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -47,9 +51,10 @@ public class ConvertMarkdownToPdf {
         }
 
         // Convert Markdown to HTML using CommonMark
-        Parser parser = Parser.builder().build();
+        List<Extension> extensions = List.of(TablesExtension.create());
+        Parser parser = Parser.builder().extensions(extensions).build();
         Node document = parser.parse(new String(fileInput.getBytes()));
-        HtmlRenderer renderer = HtmlRenderer.builder().build();
+        HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
         String htmlContent = renderer.render(document);
 
         byte[] pdfBytes =

--- a/src/main/resources/static/3rdPartyLicenses.json
+++ b/src/main/resources/static/3rdPartyLicenses.json
@@ -356,22 +356,22 @@
         },
         {
             "moduleName": "org.apache.pdfbox:fontbox",
-            "moduleUrl": "http://pdfbox.apache.org/",
-            "moduleVersion": "2.0.29",
+            "moduleUrl": "https://pdfbox.apache.org",
+            "moduleVersion": "2.0.30",
             "moduleLicense": "Apache License, Version 2.0",
             "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
         },
         {
             "moduleName": "org.apache.pdfbox:pdfbox",
-            "moduleUrl": "http://pdfbox.apache.org",
-            "moduleVersion": "2.0.29",
+            "moduleUrl": "https://pdfbox.apache.org",
+            "moduleVersion": "2.0.30",
             "moduleLicense": "Apache License, Version 2.0",
             "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
         },
         {
             "moduleName": "org.apache.pdfbox:xmpbox",
-            "moduleUrl": "http://pdfbox.apache.org",
-            "moduleVersion": "2.0.29",
+            "moduleUrl": "https://pdfbox.apache.org",
+            "moduleVersion": "2.0.30",
             "moduleLicense": "Apache License, Version 2.0",
             "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
         },


### PR DESCRIPTION
# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
 
# What does this PR do?

for issue #507 
Add the `commonmark-ext-gfm-tables` dependency to enable support for tables in the conversion from Markdown to HTML.

before：
<img width="908" alt="image" src="https://github.com/Stirling-Tools/Stirling-PDF/assets/43905872/40e555f8-b00d-46e8-9fb8-94e70ca3a9c0">

after：
<img width="526" alt="image" src="https://github.com/Stirling-Tools/Stirling-PDF/assets/43905872/fb48e41a-d000-49b0-baf8-64679f7a294f">
