### PR TITLE
Formating of language string in example

### DIFF
--- a/exampleYmlFiles/docker-compose-latest-lite-security.yml
+++ b/exampleYmlFiles/docker-compose-latest-lite-security.yml
@@ -21,7 +21,7 @@ services:
     environment:
       DOCKER_ENABLE_SECURITY: "true"
       SECURITY_ENABLELOGIN: "true"
-      SYSTEM_DEFAULTLOCALE: en_US
+      SYSTEM_DEFAULTLOCALE: en-US
       UI_APPNAME: Stirling-PDF-Lite
       UI_HOMEDESCRIPTION: Demo site for Stirling-PDF-Lite Latest with Security
       UI_APPNAMENAVBAR: Stirling-PDF-Lite Latest

--- a/exampleYmlFiles/docker-compose-latest-lite.yml
+++ b/exampleYmlFiles/docker-compose-latest-lite.yml
@@ -20,7 +20,7 @@ services:
     environment:
       DOCKER_ENABLE_SECURITY: "false"
       SECURITY_ENABLELOGIN: "false"
-      SYSTEM_DEFAULTLOCALE: en_US
+      SYSTEM_DEFAULTLOCALE: en-US
       UI_APPNAME: Stirling-PDF-Lite
       UI_HOMEDESCRIPTION: Demo site for Stirling-PDF-Lite Latest
       UI_APPNAMENAVBAR: Stirling-PDF-Lite Latest

--- a/exampleYmlFiles/docker-compose-latest-security.yml
+++ b/exampleYmlFiles/docker-compose-latest-security.yml
@@ -21,7 +21,7 @@ services:
     environment:
       DOCKER_ENABLE_SECURITY: "true"
       SECURITY_ENABLELOGIN: "true"
-      SYSTEM_DEFAULTLOCALE: en_US
+      SYSTEM_DEFAULTLOCALE: en-US
       UI_APPNAME: Stirling-PDF
       UI_HOMEDESCRIPTION: Demo site for Stirling-PDF Latest with Security
       UI_APPNAMENAVBAR: Stirling-PDF Latest

--- a/exampleYmlFiles/docker-compose-latest-ultra-lite-security.yml
+++ b/exampleYmlFiles/docker-compose-latest-ultra-lite-security.yml
@@ -21,7 +21,7 @@ services:
     environment:
       DOCKER_ENABLE_SECURITY: "true"
       SECURITY_ENABLELOGIN: "true"
-      SYSTEM_DEFAULTLOCALE: en_US
+      SYSTEM_DEFAULTLOCALE: en-US
       UI_APPNAME: Stirling-PDF-Lite
       UI_HOMEDESCRIPTION: Demo site for Stirling-PDF-Lite Latest with Security
       UI_APPNAMENAVBAR: Stirling-PDF-Lite Latest

--- a/exampleYmlFiles/docker-compose-latest-ultra-lite.yml
+++ b/exampleYmlFiles/docker-compose-latest-ultra-lite.yml
@@ -20,7 +20,7 @@ services:
     environment:
       DOCKER_ENABLE_SECURITY: "false"
       SECURITY_ENABLELOGIN: "false"
-      SYSTEM_DEFAULTLOCALE: en_US
+      SYSTEM_DEFAULTLOCALE: en-US
       UI_APPNAME: Stirling-PDF-Ultra-lite
       UI_HOMEDESCRIPTION: Demo site for Stirling-PDF-Ultra-lite Latest
       UI_APPNAMENAVBAR: Stirling-PDF-Ultra-lite Latest

--- a/exampleYmlFiles/docker-compose-latest.yml
+++ b/exampleYmlFiles/docker-compose-latest.yml
@@ -21,7 +21,7 @@ services:
     environment:
       DOCKER_ENABLE_SECURITY: "false"
       SECURITY_ENABLELOGIN: "false"
-      SYSTEM_DEFAULTLOCALE: en_US
+      SYSTEM_DEFAULTLOCALE: en-US
       UI_APPNAME: Stirling-PDF
       UI_HOMEDESCRIPTION: Demo site for Stirling-PDF Latest
       UI_APPNAMENAVBAR: Stirling-PDF Latest


### PR DESCRIPTION
As descibed in #702 formating of language string in examples for compose is not working properly. Just adjusted the examples.

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
