### PR TITLE
fix: show only selected files for merge tool

### DIFF
--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -8,11 +8,18 @@ document.getElementById("fileInput-input").addEventListener("change", function()
     displayFiles(files);
 });
 
+/**
+ * @param {FileList} files 
+ */
 function displayFiles(files) {
-    var list = document.getElementById("selectedFiles");
+    const list = document.getElementById("selectedFiles");
 
-    for (var i = 0; i < files.length; i++) {
-        var item = document.createElement("li");
+    while (list.firstChild) {
+        list.removeChild(list.firstChild);
+    }
+
+    for (let i = 0; i < files.length; i++) {
+        const item = document.createElement("li");
         item.className = "list-group-item";
         item.innerHTML = `
             <div class="d-flex justify-content-between align-items-center w-100">


### PR DESCRIPTION
The merge PDF tool incorrectly displays the list of selected files when files are selected one after one. To reproduce:
1. Go to `/merge-pdfs`
2. Select one file using either the file input or drag & drop
3. Select a second file using either the file input or drag & drop

There are two possible problems that can occur, depending if file input or drag & drop was used:
- File input: both files are listed, however the first file is no longer selected
- Drag & drop: the second file is listed twice

The issue is fixed by clearing the list of selected files, before appending the selected files to the `#selectedFiles` element. Also fixes #660 and fixes #671, these have the same underlying issue.

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
