### PR TITLE
fix: use fork of joi with full features on browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 android/
 ios/
 releases/
+.vscode/

--- a/client-tauri/src/pages/Dynamic.tsx
+++ b/client-tauri/src/pages/Dynamic.tsx
@@ -17,9 +17,9 @@ function Dynamic() {
             const LoadingModule = import(`@stirling-pdf/shared-operations/src/functions/${selectedValue}`) as Promise<{ [key: string]: typeof Operator }>;
             LoadingModule.then((Module) => {
                 const Operator = Module[capitalizeFirstLetter(selectedValue)];
-                const description = Operator.schema.describe(); // TODO: The browser build of joi does not include describe. 
-                
-                console.log(description);
+                const description = Operator.schema.describe();
+
+                console.log("abc", description);
                 // TODO: use description to generate fields
             }); 
         });

--- a/client-tauri/src/pages/Dynamic.tsx
+++ b/client-tauri/src/pages/Dynamic.tsx
@@ -6,12 +6,12 @@ import i18next from "i18next";
 
 function Dynamic() {
     const operators = ["impose"]; // TODO: Make this dynamic
-    
+
     function selectionChanged(s: BaseSyntheticEvent) {
         const selectedValue = s.target.value;
         if(selectedValue == "none") return;
 
-        i18next.loadNamespaces("impose", (err, t) => { 
+        i18next.loadNamespaces("impose", (err, t) => {
             if (err) throw err;
 
             const LoadingModule = import(`@stirling-pdf/shared-operations/src/functions/${selectedValue}`) as Promise<{ [key: string]: typeof Operator }>;
@@ -19,9 +19,9 @@ function Dynamic() {
                 const Operator = Module[capitalizeFirstLetter(selectedValue)];
                 const description = Operator.schema.describe();
 
-                console.log("abc", description);
+                console.log(description);
                 // TODO: use description to generate fields
-            }); 
+            });
         });
     }
 
@@ -35,19 +35,19 @@ function Dynamic() {
 
             <input type="file" id="pdfFile" accept=".pdf" multiple />
             <br />
-            
+
             <br />
             <textarea name="workflow" id="workflow"></textarea>
             <br />
             <select id="pdfOptions" onChange={selectionChanged}>
                 <option value="none">none</option>
-                { operators.map((operator, i) => { 
-                    return (<option value={operator}>{operator}</option>) 
+                { operators.map((operator, i) => {
+                    return (<option value={operator}>{operator}</option>)
                 }) }
             </select>
             <button id="loadButton">Load</button>
             <br />
-            
+
             <br />
             <button id="doneButton">Done</button>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
         "server-node",
         "shared-operations"
       ],
+      "dependencies": {
+        "@stirling-tools/joi": "github:Stirling-Tools/joi"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.17.0",
         "@typescript-eslint/parser": "^6.17.0",
@@ -1923,6 +1926,32 @@
     "node_modules/@stirling-pdf/shared-operations": {
       "resolved": "shared-operations",
       "link": true
+    },
+    "node_modules/@stirling-tools/joi": {
+      "version": "17.12.0",
+      "resolved": "git+ssh://git@github.com/Stirling-Tools/joi.git#f2994904b4716082ac74449cfa1f1574616c5883",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.0.2",
+        "@hapi/topo": "^6.0.2"
+      }
+    },
+    "node_modules/@stirling-tools/joi/node_modules/@hapi/hoek": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
+      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
+    },
+    "node_modules/@stirling-tools/joi/node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
     },
     "node_modules/@swc/core": {
       "version": "1.3.102",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1926,7 +1926,7 @@
     },
     "node_modules/@stirling-tools/joi": {
       "version": "17.12.0",
-      "resolved": "git+ssh://git@github.com/Stirling-Tools/joi.git#f2994904b4716082ac74449cfa1f1574616c5883",
+      "resolved": "git+ssh://git@github.com/Stirling-Tools/joi.git#fc6eddf22e5535155080934ab21dba45c610f199",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
         "server-node",
         "shared-operations"
       ],
-      "dependencies": {
-        "@stirling-tools/joi": "github:Stirling-Tools/joi"
-      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.17.0",
         "@typescript-eslint/parser": "^6.17.0",
@@ -2879,32 +2876,6 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@vizzly/joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/@vizzly/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-VpLziKclrc0ul9euaxhD0C+31CXwkmrKBxg7RKNEKnZi/iy4mQPERkxBHCaYksjoZKQEOAnB/IXY7PPbF/OiUw==",
-      "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.0.2",
-        "@hapi/topo": "^6.0.2"
-      }
-    },
-    "node_modules/@vizzly/joi/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
-    "node_modules/@vizzly/joi/node_modules/@hapi/topo": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@wasmer/wasmfs": {
@@ -9409,7 +9380,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@vizzly/joi": "^17.11.0",
+        "@stirling-tools/joi": "github:Stirling-Tools/joi",
         "i18next-resources-to-backend": "^1.2.0",
         "image-js": "^0.35.5",
         "next-i18next": "^15.1.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
   "engines": {
     "npm": ">=7.24.2"
   },
-  "engineStrict": true,
-  "dependencies": {
-    "@stirling-tools/joi": "github:Stirling-Tools/joi"
-  }
+  "engineStrict": true
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "dev-all": "concurrently --names \"node,tauri\" -c \"red.bold,cyan.bold\" --kill-others \"npm run -w server-node dev\" \"npm run -w client-tauri dev\"",
-    "update-all-dependencies": "npm i --workspace=server-node --workspace=client-tauri --workspace=shared-operation",
+    "update-all-dependencies": "npm i --workspace=stirling-pdf --workspace=server-node --workspace=client-tauri --workspace=shared-operation",
     "update-backend-dependencies": "npm i --workspace=server-node --workspace=shared-operation",
     "update-frontend-dependencies": "npm i --workspace=client-tauri --workspace=shared-operation"
   },

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "engines": {
     "npm": ">=7.24.2"
   },
-  "engineStrict": true
+  "engineStrict": true,
+  "dependencies": {
+    "@stirling-tools/joi": "github:Stirling-Tools/joi"
+  }
 }

--- a/server-node/src/index.ts
+++ b/server-node/src/index.ts
@@ -1,5 +1,4 @@
-import { init } from "@stirling-pdf/shared-operations/src/i18next.config";
-init("./public/locales/");
+import "@stirling-pdf/shared-operations/src/i18next.config";
 
 import express from "express";
 const app = express();

--- a/shared-operations/package.json
+++ b/shared-operations/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@vizzly/joi": "^17.11.0",
+    "@stirling-tools/joi": "github:Stirling-Tools/joi",
     "i18next-resources-to-backend": "^1.2.0",
     "image-js": "^0.35.5",
     "next-i18next": "^15.1.1",

--- a/shared-operations/src/functions/impose.ts
+++ b/shared-operations/src/functions/impose.ts
@@ -4,7 +4,7 @@ import { Operator, Progress, oneToOne } from ".";
 
 import * as pdfcpuWrapper from "#pdfcpu"; // This is updated by tsconfig.json/paths for the context (browser, node, etc.) this module is used in.
 
-import Joi from "joi";
+import Joi from "@stirling-tools/joi";
 import { JoiPDFFileSchema } from "../wrappers/PdfFileJoi";
 
 import i18next from "i18next";

--- a/shared-operations/src/functions/index.ts
+++ b/shared-operations/src/functions/index.ts
@@ -1,5 +1,5 @@
 import { Action } from "../../declarations/Action";
-import Joi from "joi";
+import Joi from "@stirling-tools/joi";
 
 export interface ValidationResult { 
     valid: boolean, 

--- a/shared-operations/src/functions/scalePage.ts
+++ b/shared-operations/src/functions/scalePage.ts
@@ -1,5 +1,5 @@
 
-import Joi from "joi";
+import Joi from "@stirling-tools/joi";
 import { PDFPage } from "pdf-lib";
 import { PdfFile, RepresentationType, JoiPDFFileSchema } from "../wrappers/PdfFileJoi";
 

--- a/shared-operations/src/wrappers/PdfFile.ts
+++ b/shared-operations/src/wrappers/PdfFile.ts
@@ -1,7 +1,7 @@
 import * as PDFJS from "pdfjs-dist";
 import type { PDFDocumentProxy as PDFJSDocument } from "pdfjs-dist/types/src/display/api";
 import { PDFDocument as PDFLibDocument } from "pdf-lib";
-import Joi from "joi";
+import Joi from "@stirling-tools/joi";
 
 export enum RepresentationType {
     Uint8Array,

--- a/shared-operations/src/wrappers/PdfFileJoi.ts
+++ b/shared-operations/src/wrappers/PdfFileJoi.ts
@@ -1,4 +1,4 @@
-import Joi from "joi";
+import Joi from "@stirling-tools/joi";
 import { PdfFile } from "./PdfFile";
 
 export const JoiPDFFileSchema = Joi.custom((value: Express.Multer.File[] /* <- also handles single files */ | PdfFile[] | PdfFile, helpers) => {


### PR DESCRIPTION
# Description

Switch to our joi [fork](https://github.com/Stirling-Tools/joi) for full features on browsers.

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
