### PR TITLE
Added option to split PDF into multiple parts and merge into one PDF

### DIFF
--- a/pipeline/defaultWebUIConfigs/split-rotate-auto-rename.json
+++ b/pipeline/defaultWebUIConfigs/split-rotate-auto-rename.json
@@ -6,7 +6,8 @@
       "parameters": {
         "horizontalDivisions": 2,
         "verticalDivisions": 2,
-        "fileInput": "automated"
+        "fileInput": "automated",
+        "merge": false
       }
     },
     {

--- a/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
@@ -38,7 +38,7 @@ public class MergeController {
 
     private static final Logger logger = LoggerFactory.getLogger(MergeController.class);
 
-    private PDDocument mergeDocuments(List<PDDocument> documents) throws IOException {
+    public PDDocument mergeDocuments(List<PDDocument> documents) throws IOException {
         PDDocument mergedDoc = new PDDocument();
         for (PDDocument doc : documents) {
             for (PDPage page : doc.getPages()) {

--- a/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
@@ -1,19 +1,16 @@
 package stirling.software.SPDF.controller.api;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.multipdf.LayerUtility;
-import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -63,9 +60,11 @@ public class SplitPdfBySectionsController {
                 Filenames.toSimpleFileName(file.getOriginalFilename())
                         .replaceFirst("[.][^.]+$", "");
         if (merge) {
-            ByteArrayOutputStream mergedPdf = mergeSplitPdfs(splitDocuments);
+            MergeController mergeController = new MergeController();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            mergeController.mergeDocuments(splitDocuments).save(baos);
             return WebResponseUtils.bytesToWebResponse(
-                    mergedPdf.toByteArray(),
+                    baos.toByteArray(),
                     filename + "_split.pdf",
                     MediaType.APPLICATION_OCTET_STREAM);
         }
@@ -157,22 +156,4 @@ public class SplitPdfBySectionsController {
         return splitDocuments;
     }
 
-    public ByteArrayOutputStream mergeSplitPdfs(List<PDDocument> splitDocuments)
-            throws IOException {
-        PDFMergerUtility pdfMerger = new PDFMergerUtility();
-        ByteArrayOutputStream mergedPdfOutputStream = new ByteArrayOutputStream();
-
-        for (PDDocument doc : splitDocuments) {
-            String tempFileName = UUID.randomUUID().toString();
-            File tempFile = File.createTempFile(tempFileName, ".pdf");
-            doc.save(tempFile);
-            pdfMerger.addSource(tempFile);
-            tempFile.deleteOnExit();
-        }
-
-        pdfMerger.setDestinationStream(mergedPdfOutputStream);
-        pdfMerger.mergeDocuments(null);
-
-        return mergedPdfOutputStream;
-    }
 }

--- a/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
+++ b/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
@@ -15,4 +15,7 @@ public class SplitPdfBySectionsRequest extends PDFFile {
 
     @Schema(description = "Number of vertical divisions for each PDF page", example = "2")
     private int verticalDivisions;
+
+    @Schema(description = "Merge the split documents into a single PDF", example = "true")
+    private boolean merge;
 }

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertikale Teiler
 split-by-sections.horizontal.placeholder=Anzahl horizontaler Teiler eingeben
 split-by-sections.vertical.placeholder=Anzahl vertikaler Teiler eingeben
 split-by-sections.submit=PDF teilen
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Lizenzen

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Divisiones Verticales
 split-by-sections.horizontal.placeholder=Introduzca el número de divisiones horizontales
 split-by-sections.vertical.placeholder=Introduzca el número de divisiones verticales
 split-by-sections.submit=Dividir PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licencias

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Divisions verticales
 split-by-sections.horizontal.placeholder=Saisir le nombre de divisions horizontales
 split-by-sections.vertical.placeholder=Entrer le nombre de divisions verticales
 split-by-sections.submit=Diviser le PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licences

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=लंबवत विभाजन
 split-by-sections.horizontal.placeholder=क्षैतिज विभाजन की संख्या दर्ज करें
 split-by-sections.vertical.placeholder=लंबवत विभाजन की संख्या दर्ज करें
 split-by-sections.submit=PDF को विभाजित करें
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vízszintes szakaszok
 split-by-sections.horizontal.placeholder=Adja meg a vízszintes szakaszok számát
 split-by-sections.vertical.placeholder=Adja meg a függőleges szakaszok számát
 split-by-sections.submit=Felosztás
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Pembagian Vertikal
 split-by-sections.horizontal.placeholder=Input angka untuk pembagian horizontal
 split-by-sections.vertical.placeholder=Input angka untuk pembagian vertikal
 split-by-sections.submit=Pisahkan PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Divisioni verticali
 split-by-sections.horizontal.placeholder=Inserire il numero di divisioni orizzontali
 split-by-sections.vertical.placeholder=Inserire il numero di divisioni verticali
 split-by-sections.submit=Dividi PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenze

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=垂直方向
 split-by-sections.horizontal.placeholder=水平方向の分割数を選択
 split-by-sections.vertical.placeholder=垂直方向の分割数を選択
 split-by-sections.submit=分割
-
+split-by-sections.merge=1 つの PDF に結合するかどうか
 
 #licenses
 licenses.nav=ライセンス

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Verticale secties
 split-by-sections.horizontal.placeholder=Voer het aantal horizontale secties in
 split-by-sections.vertical.placeholder=Voer het aantal verticale secties in
 split-by-sections.submit=PDF splitsen
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenties

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -958,7 +958,7 @@ split-by-sections.vertical.label=Divisões Verticais
 split-by-sections.horizontal.placeholder=Introduza o número de divisões horizontais
 split-by-sections.vertical.placeholder=Introduza o número de divisões verticais
 split-by-sections.submit=Dividir PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenças

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertikalne podele
 split-by-sections.horizontal.placeholder=Unesite broj horizontalnih podele
 split-by-sections.vertical.placeholder=Unesite broj vertikalnih podele
 split-by-sections.submit=Razdvoji PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=Vertical Divisions
 split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
 split-by-sections.vertical.placeholder=Enter number of vertical divisions
 split-by-sections.submit=Split PDF
-
+split-by-sections.merge=Merge Into One PDF
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=垂直分割
 split-by-sections.horizontal.placeholder=输入水平分割数
 split-by-sections.vertical.placeholder=输入垂直分割数
 split-by-sections.submit=分割PDF
-
+split-by-sections.merge=是否合并为一个pdf
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -960,7 +960,7 @@ split-by-sections.vertical.label=垂直劃分
 split-by-sections.horizontal.placeholder=輸入水平劃分的數量
 split-by-sections.vertical.placeholder=輸入垂直劃分的數量
 split-by-sections.submit=分割 PDF
-
+split-by-sections.merge=是否合併為一個pdf
 
 #licenses
 licenses.nav=Licenses

--- a/src/main/resources/templates/split-pdf-by-sections.html
+++ b/src/main/resources/templates/split-pdf-by-sections.html
@@ -23,6 +23,9 @@
                   <label for="verticalDivisions" th:text="#{split-by-sections.vertical.label}">Vertical Divisions</label>
                   <input type="number" id="verticalDivisions" name="verticalDivisions" class="form-control" min="0" max="300" required value="1" th:placeholder="#{split-by-sections.vertical.placeholder}">
                   <br>
+                  <label for="verticalDivisions" th:text="#{split-by-sections.merge}">merge PDFs into one</label>
+                  <input type="checkbox" id="merge" name="merge" th:placeholder="#{split-by-sections.merge}">
+                  <br>
                   <div id="pdfVisualAid" class="pdf-visual-aid"></div>
                   <script>
                     function updateVisualAid() {


### PR DESCRIPTION
# Description

Added the option to merge into one PDF in the function of splitting a PDF into multiple parts to facilitate the work of splitting a single-page PDF in the middle and then merging it.

Closes #(issue_number)

## Checklist:

- [*] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
