### PR TITLE
🐛 Fix: `index out of bounds` #861 #842

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
@@ -51,7 +51,7 @@ public class RearrangePagesPDFController {
         String[] pageOrderArr = pagesToDelete.split(",");
 
         List<Integer> pagesToRemove =
-                GeneralUtils.parsePageList(pageOrderArr, document.getNumberOfPages());
+                GeneralUtils.parsePageList(pageOrderArr, document.getNumberOfPages(), true);
 
         Collections.sort(pagesToRemove);
 
@@ -195,7 +195,7 @@ public class RearrangePagesPDFController {
             if (sortType != null && sortType.length() > 0) {
                 newPageOrder = processSortTypes(sortType, totalPages);
             } else {
-                newPageOrder = GeneralUtils.parsePageList(pageOrderArr, totalPages);
+                newPageOrder = GeneralUtils.parsePageList(pageOrderArr, totalPages, true);
             }
             logger.info("newPageOrder = " + newPageOrder);
             logger.info("totalPages = " + totalPages);

--- a/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
@@ -2,6 +2,7 @@ package stirling.software.SPDF.controller.api;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.pdfbox.Loader;
@@ -52,8 +53,10 @@ public class RearrangePagesPDFController {
         List<Integer> pagesToRemove =
                 GeneralUtils.parsePageList(pageOrderArr, document.getNumberOfPages());
 
+        Collections.sort(pagesToRemove);
+
         for (int i = pagesToRemove.size() - 1; i >= 0; i--) {
-            int pageIndex = pagesToRemove.get(i);
+            int pageIndex = pagesToRemove.get(i) - 1;
             document.removePage(pageIndex);
         }
         return WebResponseUtils.pdfDocToWebResponse(
@@ -199,7 +202,7 @@ public class RearrangePagesPDFController {
             // Create a new list to hold the pages in the new order
             List<PDPage> newPages = new ArrayList<>();
             for (int i = 0; i < newPageOrder.size(); i++) {
-                newPages.add(document.getPage(newPageOrder.get(i)));
+                newPages.add(document.getPage(newPageOrder.get(i) - 1));
             }
 
             // Remove all the pages from the original document

--- a/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
@@ -56,7 +56,7 @@ public class RearrangePagesPDFController {
         Collections.sort(pagesToRemove);
 
         for (int i = pagesToRemove.size() - 1; i >= 0; i--) {
-            int pageIndex = pagesToRemove.get(i) - 1;
+            int pageIndex = pagesToRemove.get(i);
             document.removePage(pageIndex);
         }
         return WebResponseUtils.pdfDocToWebResponse(
@@ -202,7 +202,7 @@ public class RearrangePagesPDFController {
             // Create a new list to hold the pages in the new order
             List<PDPage> newPages = new ArrayList<>();
             for (int i = 0; i < newPageOrder.size(); i++) {
-                newPages.add(document.getPage(newPageOrder.get(i) - 1));
+                newPages.add(document.getPage(newPageOrder.get(i)));
             }
 
             // Remove all the pages from the original document


### PR DESCRIPTION
# Description

1. Addition of Collections Import:
- Added import java.util.Collections;
- This allows the use of the Collections.sort() method, which is applied in the following modifications.
2. Sorting of Pages:
- By adding Collections.sort(pagesToRemove);, the page numbers to be removed are sorted in ascending order.
- Sorting is crucial to ensure pages are removed in the correct sequence, especially when iterating backwards through the list, to avoid issues caused by page re-indexing after removals.
3. Adjustment of Page Indexes:
- In lines where pages are removed from the document (document.removePage(pageIndex);) or reordered (newPages.add(document.getPage(newPageOrder.get(i) - 1));), the index is adjusted by subtracting 1: pageIndex = pagesToRemove.get(i) - 1; and newPageOrder.get(i) - 1.
- PDFBox uses 0-based indices for pages, but user inputs are typically 1-based (i.e., the first page is page 1, not page 0). Subtracting 1 from each index reconciles this difference, ensuring the correct page in the PDF document is referenced.

### Why Were These Changes Made?

- **Sorting:** Sorting the pages to be removed ensures that pages are removed in the correct order, avoiding shifts in indices that could lead to errors such as removing the wrong page or generating an IndexOutOfBoundsException.

- **Index Adjustment:** Modifying the page index by 1 was done to ensure correct indexing, as user inputs are usually 1-based, while PDFBox (and most Java-based systems) use 0-based indexing. This adjustment prevents IndexOutOfBoundsException and ensures that the intended pages are correctly handled.

Closes #861 #842

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
