### PR TITLE
Fix TypeError by rotation

### DIFF
--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -179,7 +179,9 @@ class PdfContainer {
 
   rotateAll(deg) {
     for (var i = 0; i < this.pagesContainer.childNodes.length; i++) {
-      const img = this.pagesContainer.childNodes[i].querySelector("img");
+      const child = this.pagesContainer.children[i];
+      if (!child) continue;
+      const img = child.querySelector("img");
       if (!img) continue;
       this.rotateElement(img, deg);
     }


### PR DESCRIPTION
# Description

Fixes the error in the PDF multitool when rotating all pages at the same time.

```javascript
PdfContainer.js:182
Uncaught TypeError: this.pagesContainer.childNodes[i].querySelector is not a function
    at PdfContainer.rotateAll (PdfContainer.js:182:53)
    at HTMLButtonElement.onclick (multi-tool:679:100)
```

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
