### PR TITLE
Fix typo in example yaml file

### DIFF
--- a/exampleYmlFiles/docker-compose-latest-security.yml
+++ b/exampleYmlFiles/docker-compose-latest-security.yml
@@ -22,7 +22,7 @@ services:
       DOCKER_ENABLE_SECURITY: "true"
       SECURITY_ENABLELOGIN: "true"
       PUID: 1002
-      GGID: 1002
+      PGID: 1002
       UMASK: "022"
       SYSTEM_DEFAULTLOCALE: en-US
       UI_APPNAME: Stirling-PDF


### PR DESCRIPTION
# Description

Fixed a typo in example yaml file (GGID -> PGID)

https://github.com/Stirling-Tools/Stirling-PDF/blob/3066b3e50017639a63ae5420238965549ce2416a/exampleYmlFiles/docker-compose-latest-security.yml#L25

https://github.com/Stirling-Tools/Stirling-PDF/blob/3066b3e50017639a63ae5420238965549ce2416a/scripts/init.sh#L22

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
