### PR TITLE
Fix: Error after logging out and selecting another language

### DIFF
--- a/src/main/resources/static/js/languageSelection.js
+++ b/src/main/resources/static/js/languageSelection.js
@@ -47,8 +47,10 @@ function handleDropdownItemClick(event) {
     localStorage.setItem("languageCode", languageCode);
 
     const currentUrl = window.location.href;
-    if (currentUrl.indexOf("?lang=") === -1) {
+    if (currentUrl.indexOf("?lang=") === -1 && currentUrl.indexOf("&lang=") === -1) {
       window.location.href = currentUrl + "?lang=" + languageCode;
+    } else if (currentUrl.indexOf("&lang=") !== -1 && currentUrl.indexOf("?lang=") === -1) {
+      window.location.href = currentUrl.replace(/&lang=\w{2,}/, "&lang=" + languageCode);
     } else {
       window.location.href = currentUrl.replace(/\?lang=\w{2,}/, "?lang=" + languageCode);
     }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -118,10 +118,12 @@
                 console.log("currentLang", currentLang)
                 console.log("languageCode", languageCode)
                 const currentUrl = window.location.href;
-                if (currentUrl.indexOf('?lang=') === -1) {
-                  window.location.href = currentUrl + '?lang=' + languageCode;
+                if (currentUrl.indexOf("?lang=") === -1 && currentUrl.indexOf("&lang=") === -1) {
+                  window.location.href = currentUrl + "?lang=" + languageCode;
+                } else if (currentUrl.indexOf("&lang=") !== -1 && currentUrl.indexOf("?lang=") === -1) {
+                  window.location.href = currentUrl.replace(/&lang=\w{2,}/, "&lang=" + languageCode);
                 } else {
-                  window.location.href = currentUrl.replace(/\?lang=\w{2,}/, '?lang=' + languageCode);
+                  window.location.href = currentUrl.replace(/\?lang=\w{2,}/, "?lang=" + languageCode);
                 }
               }
               dropdown.innerHTML = event.currentTarget.innerHTML;  // Update the dropdown button's content


### PR DESCRIPTION
# Description

When logging out, the language is passed as a parameter in the URL. When changing the language, the parameter is supplemented with `?lang=` and should be replaced.

after logout: `http://127.0.0.1:8080/login?logout=true&lang=de_DE`
after logout and language change: `http://127.0.0.1:8080/login?logout=true&lang=de_DE?lang=ca_CA`

Should: `http://127.0.0.1:8080/login?logout=true&lang=ca_CA`

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
