### PR TITLE
fix: Fix package name of openjdk for debian

### DIFF
--- a/LocalRunGuide.md
+++ b/LocalRunGuide.md
@@ -42,7 +42,7 @@ For Debian-based systems, you can use the following command:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y git  automake  autoconf  libtool  libleptonica-dev  pkg-config zlib1g-dev make g++ java-17-openjdk python3 python3-pip
+sudo apt-get install -y git  automake  autoconf  libtool  libleptonica-dev  pkg-config zlib1g-dev make g++ openjdk-17-jdk python3 python3-pip
 ```
 
 For Fedora-based systems use this command:


### PR DESCRIPTION
# Description

Fix package name of openjdk for debian

Closes #983 

## Checklist:

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
