### PR TITLE
fix: switch to pdftohtml for pdf to html conversions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /et
         shadow \
 # Doc conversion
         libreoffice@testing \
+# pdftohtml
+        poppler-utils \
 # OCR MY PDF (unpaper for descew and other advanced featues)
         ocrmypdf \
         tesseract-ocr-data-eng \

--- a/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
+++ b/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
@@ -244,6 +244,6 @@ public class EndpointConfiguration {
             }
         }
     }
-    
+
     private static final String REMOVE_BLANKS = "remove-blanks";
 }

--- a/src/main/java/stirling/software/SPDF/controller/api/UserController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/UserController.java
@@ -291,6 +291,6 @@ public class UserController {
         }
         return ResponseEntity.ok(apiKey);
     }
-    
+
     private static final String LOGIN_MESSAGETYPE_CREDSUPDATED = "/login?messageType=credsUpdated";
 }

--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToOffice.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToOffice.java
@@ -29,18 +29,6 @@ import stirling.software.SPDF.utils.WebResponseUtils;
 @Tag(name = "Convert", description = "Convert APIs")
 public class ConvertPDFToOffice {
 
-    @PostMapping(consumes = "multipart/form-data", value = "/pdf/html")
-    @Operation(
-            summary = "Convert PDF to HTML",
-            description =
-                    "This endpoint converts a PDF file to HTML format. Input:PDF Output:HTML Type:SISO")
-    public ResponseEntity<byte[]> processPdfToHTML(@ModelAttribute PDFFile request)
-            throws Exception {
-        MultipartFile inputFile = request.getFileInput();
-        PDFToFile pdfToFile = new PDFToFile();
-        return pdfToFile.processPdfToOfficeFormat(inputFile, "html", "writer_pdf_import");
-    }
-
     @PostMapping(consumes = "multipart/form-data", value = "/pdf/presentation")
     @Operation(
             summary = "Convert PDF to Presentation format",

--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPDF.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPDF.java
@@ -6,8 +6,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImageScansController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImageScansController.java
@@ -219,6 +219,6 @@ public class ExtractImageScansController {
                     });
         }
     }
-    
+
     private static final String REPLACEFIRST = "[.][^.]+$";
 }

--- a/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineDirectoryProcessor.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineDirectoryProcessor.java
@@ -26,7 +26,6 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import stirling.software.SPDF.model.ApplicationProperties;
 import stirling.software.SPDF.model.PipelineConfig;
 import stirling.software.SPDF.model.PipelineOperation;
 

--- a/src/main/java/stirling/software/SPDF/repository/UserRepository.java
+++ b/src/main/java/stirling/software/SPDF/repository/UserRepository.java
@@ -3,8 +3,6 @@ package stirling.software.SPDF.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import stirling.software.SPDF.model.User;
 

--- a/src/main/java/stirling/software/SPDF/utils/ProcessExecutor.java
+++ b/src/main/java/stirling/software/SPDF/utils/ProcessExecutor.java
@@ -24,6 +24,7 @@ public class ProcessExecutor {
 
     public enum Processes {
         LIBRE_OFFICE,
+        PDFTOHTML,
         OCR_MY_PDF,
         PYTHON_OPENCV,
         GHOSTSCRIPT,
@@ -45,6 +46,7 @@ public class ProcessExecutor {
                     int semaphoreLimit =
                             switch (key) {
                                 case LIBRE_OFFICE -> 1;
+                                case PDFTOHTML -> 1;
                                 case OCR_MY_PDF -> 2;
                                 case PYTHON_OPENCV -> 8;
                                 case GHOSTSCRIPT -> 16;
@@ -56,6 +58,7 @@ public class ProcessExecutor {
                     long timeoutMinutes =
                             switch (key) {
                                 case LIBRE_OFFICE -> 30;
+                                case PDFTOHTML -> 5;
                                 case OCR_MY_PDF -> 30;
                                 case PYTHON_OPENCV -> 30;
                                 case GHOSTSCRIPT -> 5;

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -957,7 +957,7 @@ PDFToText.submit=تحويل
 #PDFToHTML
 PDFToHTML.title=PDF إلى HTML
 PDFToHTML.header=PDF إلى HTML
-PDFToHTML.credit=تستخدم هذه الخدمة LibreOffice لتحويل الملفات.
+PDFToHTML.credit=تستخدم هذه الخدمة pdftohtml لتحويل الملفات.
 PDFToHTML.submit=تحويل
 
 

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Преобразуване
 #PDFToHTML
 PDFToHTML.title=PDF към HTML
 PDFToHTML.header=PDF към HTML
-PDFToHTML.credit=Тази услуга използва LibreOffice за преобразуване на файлове.
+PDFToHTML.credit=Тази услуга използва pdftohtml за преобразуване на файлове.
 PDFToHTML.submit=Преобразуване
 
 

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Converteix
 #PDFToHTML
 PDFToHTML.title=PDF a HTML
 PDFToHTML.header=PDF a HTML
-PDFToHTML.credit=Utilitza LibreOffice per a la conversió d'Arxius.
+PDFToHTML.credit=Utilitza pdftohtml per a la conversió d'Arxius.
 PDFToHTML.submit=Converteix
 
 

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Konvertieren
 #PDFToHTML
 PDFToHTML.title=PDF zu HTML
 PDFToHTML.header=PDF zu HTML
-PDFToHTML.credit=Dieser Dienst verwendet LibreOffice für die Dateikonvertierung.
+PDFToHTML.credit=Dieser Dienst verwendet pdftohtml für die Dateikonvertierung.
 PDFToHTML.submit=Konvertieren
 
 

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Μετατροπή
 #PDFToHTML
 PDFToHTML.title=PDF σε HTML
 PDFToHTML.header=PDF σε HTML
-PDFToHTML.credit=Αυτή η υπηρεσία χρησιμοποιεί LibreOffice για τη μετατροπή των αρχείων.
+PDFToHTML.credit=Αυτή η υπηρεσία χρησιμοποιεί pdftohtml για τη μετατροπή των αρχείων.
 PDFToHTML.submit=Μετατροπή
 
 

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Convert
 #PDFToHTML
 PDFToHTML.title=PDF to HTML
 PDFToHTML.header=PDF to HTML
-PDFToHTML.credit=This service uses LibreOffice for file conversion.
+PDFToHTML.credit=This service uses pdftohtml for file conversion.
 PDFToHTML.submit=Convert
 
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Convert
 #PDFToHTML
 PDFToHTML.title=PDF to HTML
 PDFToHTML.header=PDF to HTML
-PDFToHTML.credit=This service uses LibreOffice for file conversion.
+PDFToHTML.credit=This service uses pdftohtml for file conversion.
 PDFToHTML.submit=Convert
 
 

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Convertir
 #PDFToHTML
 PDFToHTML.title=PDF a HTML
 PDFToHTML.header=PDF a HTML
-PDFToHTML.credit=Este servicio utiliza LibreOffice para la conversión de archivos
+PDFToHTML.credit=Este servicio utiliza pdftohtml para la conversión de archivos
 PDFToHTML.submit=Convertir
 
 

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Bihurtu
 #PDFToHTML
 PDFToHTML.title=PDFa HTML bihurtu
 PDFToHTML.header=PDFa HTML bihurtu
-PDFToHTML.credit=Zerbitzu honek LibreOffice erabiltzen du fitxategiak bihurtzeko
+PDFToHTML.credit=Zerbitzu honek pdftohtml erabiltzen du fitxategiak bihurtzeko
 PDFToHTML.submit=Bihurtu
 
 

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Convertir
 #PDFToHTML
 PDFToHTML.title=PDF en HTML
 PDFToHTML.header=PDF en HTML
-PDFToHTML.credit=Ce service utilise LibreOffice pour la conversion de fichiers.
+PDFToHTML.credit=Ce service utilise pdftohtml pour la conversion de fichiers.
 PDFToHTML.submit=Convertir
 
 

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -957,7 +957,7 @@ PDFToText.submit=परिवर्तित करें
 #PDFToHTML
 PDFToHTML.title=PDF से HTML
 PDFToHTML.header=PDF से HTML
-PDFToHTML.credit=यह सेवा फ़ाइल परिवर्तन के लिए LibreOffice का उपयोग करती है।
+PDFToHTML.credit=यह सेवा फ़ाइल परिवर्तन के लिए pdftohtml का उपयोग करती है।
 PDFToHTML.submit=परिवर्तित करें
 
 

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Konvertálás
 #PDFToHTML
 PDFToHTML.title=PDF >> HTML
 PDFToHTML.header=PDF >> HTML
-PDFToHTML.credit=Ez a szolgáltatás a LibreOffice-t használja a fájlkonverzióhoz.
+PDFToHTML.credit=Ez a szolgáltatás a pdftohtml-t használja a fájlkonverzióhoz.
 PDFToHTML.submit=Konvertálás
 
 

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Konversi
 #PDFToHTML
 PDFToHTML.title=PDF Ke HTML
 PDFToHTML.header=PDF ke HTML
-PDFToHTML.credit=Layanan ini menggunakan LibreOffice untuk konversi berkas.
+PDFToHTML.credit=Layanan ini menggunakan pdftohtml untuk konversi berkas.
 PDFToHTML.submit=Konversi
 
 

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Converti
 #PDFToHTML
 PDFToHTML.title=Da PDF a HTML
 PDFToHTML.header=Da PDF a HTML
-PDFToHTML.credit=Questo servizio utilizza LibreOffice per la conversione.
+PDFToHTML.credit=Questo servizio utilizza pdftohtml per la conversione.
 PDFToHTML.submit=Converti
 
 

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -957,7 +957,7 @@ PDFToText.submit=変換
 #PDFToHTML
 PDFToHTML.title=PDFをHTMLに変換
 PDFToHTML.header=PDFをHTMLに変換
-PDFToHTML.credit=本サービスはファイル変換にLibreOfficeを使用しています。
+PDFToHTML.credit=本サービスはファイル変換にpdftohtmlを使用しています。
 PDFToHTML.submit=変換
 
 

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -957,7 +957,7 @@ PDFToText.submit=변환
 #PDFToHTML
 PDFToHTML.title=PDF를 HTML로
 PDFToHTML.header=PDF 문서를 HTML로 변환
-PDFToHTML.credit=이 서비스는 파일 변환을 위해 LibreOffice를 사용합니다.
+PDFToHTML.credit=이 서비스는 파일 변환을 위해 pdftohtml를 사용합니다.
 PDFToHTML.submit=변환
 
 

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Converteren
 #PDFToHTML
 PDFToHTML.title=PDF naar HTML
 PDFToHTML.header=PDF naar HTML
-PDFToHTML.credit=Deze service gebruikt LibreOffice voor bestandsconversie.
+PDFToHTML.credit=Deze service gebruikt pdftohtml voor bestandsconversie.
 PDFToHTML.submit=Converteren
 
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Konwertuj
 #PDFToHTML
 PDFToHTML.title=PDF na HTML
 PDFToHTML.header=PDF na HTML
-PDFToHTML.credit=Ta usługa używa LibreOffice do konwersji plików.
+PDFToHTML.credit=Ta usługa używa pdftohtml do konwersji plików.
 PDFToHTML.submit=Konwertuj
 
 

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Converter
 #PDFToHTML
 PDFToHTML.title=PDF para HTML
 PDFToHTML.header=PDF para HTML
-PDFToHTML.credit=Este serviço usa o LibreOffice para Conversão de Arquivos.
+PDFToHTML.credit=Este serviço usa o pdftohtml para Conversão de Arquivos.
 PDFToHTML.submit=Converter
 
 

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Converter
 #PDFToHTML
 PDFToHTML.title=PDF para HTML
 PDFToHTML.header=PDF para HTML
-PDFToHTML.credit=Este serviço usa o LibreOffice para Conversão de ficheiros.
+PDFToHTML.credit=Este serviço usa o pdftohtml para Conversão de ficheiros.
 PDFToHTML.submit=Converter
 
 

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Convert
 #PDFToHTML
 PDFToHTML.title=PDF către HTML
 PDFToHTML.header=PDF către HTML
-PDFToHTML.credit=Acest serviciu utilizează LibreOffice pentru conversia fișierului.
+PDFToHTML.credit=Acest serviciu utilizează pdftohtml pentru conversia fișierului.
 PDFToHTML.submit=Convert
 
 

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Конвертировать
 #PDFToHTML
 PDFToHTML.title=PDF в HTML
 PDFToHTML.header=PDF в HTML
-PDFToHTML.credit=Этот сервис использует LibreOffice для преобразования файлов.
+PDFToHTML.credit=Этот сервис использует pdftohtml для преобразования файлов.
 PDFToHTML.submit=Конвертировать
 
 

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Konvertuj
 #PDFToHTML
 PDFToHTML.title=PDF u HTML
 PDFToHTML.header=PDF u HTML
-PDFToHTML.credit=Ova usluga koristi LibreOffice za konverziju fajlova.
+PDFToHTML.credit=Ova usluga koristi pdftohtml za konverziju fajlova.
 PDFToHTML.submit=Konvertuj
 
 

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Konvertera
 #PDFToHTML
 PDFToHTML.title=PDF till HTML
 PDFToHTML.header=PDF till HTML
-PDFToHTML.credit=Denna tjänst använder LibreOffice för filkonvertering.
+PDFToHTML.credit=Denna tjänst använder pdftohtml för filkonvertering.
 PDFToHTML.submit=Konvertera
 
 

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -957,7 +957,7 @@ PDFToText.submit=Dönüştür
 #PDFToHTML
 PDFToHTML.title=PDF'den HTML'e
 PDFToHTML.header=PDF'den HTML'e
-PDFToHTML.credit=Bu hizmet dosya dönüşümü için LibreOffice kullanır.
+PDFToHTML.credit=Bu hizmet dosya dönüşümü için pdftohtml kullanır.
 PDFToHTML.submit=Dönüştür
 
 

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -957,7 +957,7 @@ PDFToText.submit=转换
 #PDFToHTML
 PDFToHTML.title=PDF To HTML
 PDFToHTML.header=将PDF转换成HTML
-PDFToHTML.credit=此服务使用LibreOffice进行文件转换。
+PDFToHTML.credit=此服务使用pdftohtml进行文件转换。
 PDFToHTML.submit=转换
 
 

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -957,7 +957,7 @@ PDFToText.submit=轉換
 #PDFToHTML
 PDFToHTML.title=PDF 轉 HTML
 PDFToHTML.header=PDF 轉 HTML
-PDFToHTML.credit=此服務使用 LibreOffice 進行檔案轉換。
+PDFToHTML.credit=此服務使用 pdftohtml 進行檔案轉換。
 PDFToHTML.submit=轉換
 
 


### PR DESCRIPTION
# Description

Switch from LibreOffice to pdftohtml for PDF to HTML conversions.

Closes #567 

## Checklist:

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
