### PR TITLE
fix: missing pdf to html endpoint

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToHtml.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToHtml.java
@@ -1,0 +1,38 @@
+package stirling.software.SPDF.controller.api.converters;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import stirling.software.SPDF.model.api.PDFFile;
+import stirling.software.SPDF.utils.PDFToFile;
+
+@RestController
+@Tag(name = "Convert", description = "Convert APIs")
+@RequestMapping("/api/v1/convert")
+public class ConvertPDFToHtml {
+
+    @Autowired
+    @Qualifier("bookAndHtmlFormatsInstalled")
+    private boolean bookAndHtmlFormatsInstalled;
+
+    @PostMapping(consumes = "multipart/form-data", value = "/pdf/html")
+    @Operation(
+            summary = "Convert PDF to HTML",
+            description =
+                    "This endpoint converts a PDF file to HTML format. Input:PDF Output:HTML Type:SISO")
+    public ResponseEntity<byte[]> processPdfToHTML(@ModelAttribute PDFFile request)
+            throws Exception {
+        MultipartFile inputFile = request.getFileInput();
+        PDFToFile pdfToFile = new PDFToFile();
+        return pdfToFile.processPdfToHtml(inputFile);
+    }
+}

--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToHtml.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToHtml.java
@@ -1,7 +1,5 @@
 package stirling.software.SPDF.controller.api.converters;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,10 +17,6 @@ import stirling.software.SPDF.utils.PDFToFile;
 @Tag(name = "Convert", description = "Convert APIs")
 @RequestMapping("/api/v1/convert")
 public class ConvertPDFToHtml {
-
-    @Autowired
-    @Qualifier("bookAndHtmlFormatsInstalled")
-    private boolean bookAndHtmlFormatsInstalled;
 
     @PostMapping(consumes = "multipart/form-data", value = "/pdf/html")
     @Operation(


### PR DESCRIPTION
# Description

Forgot to add `ConvertPDFToHtml.java` in 4655eae.

Closes #1037 

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
