### PR TITLE
Closes #359

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/SplitPDFController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/SplitPDFController.java
@@ -27,7 +27,9 @@ import io.github.pixee.security.Filenames;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import stirling.software.SPDF.model.PdfMetadata;
 import stirling.software.SPDF.model.api.PDFWithPageNums;
+import stirling.software.SPDF.utils.PdfUtils;
 import stirling.software.SPDF.utils.WebResponseUtils;
 
 @RestController
@@ -49,6 +51,7 @@ public class SplitPDFController {
         // open the pdf document
 
         PDDocument document = Loader.loadPDF(file.getBytes());
+        PdfMetadata metadata = PdfUtils.extractMetadataFromPdf(document);
         int totalPages = document.getNumberOfPages();
         List<Integer> pageNumbers = request.getPageNumbersList(document, false);
         System.out.println(
@@ -74,6 +77,9 @@ public class SplitPDFController {
                     logger.info("Adding page {} to split document", i);
                 }
                 previousPageNumber = splitPoint + 1;
+
+                // Transfer metadata to split pdf
+                PdfUtils.setMetadataToPdf(splitDocument, metadata);
 
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 splitDocument.save(baos);

--- a/src/main/java/stirling/software/SPDF/model/PdfMetadata.java
+++ b/src/main/java/stirling/software/SPDF/model/PdfMetadata.java
@@ -1,0 +1,19 @@
+package stirling.software.SPDF.model;
+
+import java.util.Calendar;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PdfMetadata {
+    private String author;
+    private String producer;
+    private String title;
+    private String creator;
+    private String subject;
+    private String keywords;
+    private Calendar creationDate;
+    private Calendar modificationDate;
+}

--- a/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
+++ b/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
@@ -19,11 +19,8 @@ import javax.imageio.stream.ImageOutputStream;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSName;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.*;
 import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode;
-import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
@@ -38,6 +35,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.github.pixee.security.Filenames;
+
+import stirling.software.SPDF.model.PdfMetadata;
 
 public class PdfUtils {
 
@@ -420,5 +419,31 @@ public class PdfUtils {
         document.save(baos);
         logger.info("PDF successfully saved to byte array");
         return baos.toByteArray();
+    }
+
+    public static PdfMetadata extractMetadataFromPdf(PDDocument pdf) {
+        return PdfMetadata.builder()
+                .author(pdf.getDocumentInformation().getAuthor())
+                .producer(pdf.getDocumentInformation().getProducer())
+                .title(pdf.getDocumentInformation().getTitle())
+                .creator(pdf.getDocumentInformation().getCreator())
+                .subject(pdf.getDocumentInformation().getSubject())
+                .keywords(pdf.getDocumentInformation().getKeywords())
+                .creationDate(pdf.getDocumentInformation().getCreationDate())
+                .modificationDate(pdf.getDocumentInformation().getModificationDate())
+                .build();
+    }
+
+    public static PDDocument setMetadataToPdf(PDDocument pdf, PdfMetadata pdfMetadata) {
+        pdf.getDocumentInformation().setAuthor(pdfMetadata.getAuthor());
+        pdf.getDocumentInformation().setProducer(pdfMetadata.getProducer());
+        pdf.getDocumentInformation().setTitle(pdfMetadata.getTitle());
+        pdf.getDocumentInformation().setCreator(pdfMetadata.getCreator());
+        pdf.getDocumentInformation().setSubject(pdfMetadata.getSubject());
+        pdf.getDocumentInformation().setKeywords(pdfMetadata.getKeywords());
+        pdf.getDocumentInformation().setCreationDate(pdfMetadata.getCreationDate());
+        pdf.getDocumentInformation().setModificationDate(pdfMetadata.getModificationDate());
+
+        return pdf;
     }
 }


### PR DESCRIPTION
# Description

Fixes the bug of not transferring the pdf metadata to the newly created split pdf files.

Closes #(issue_number)

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
