### PR TITLE
Add selection for PDF/A output format

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
@@ -16,7 +16,7 @@ import io.github.pixee.security.Filenames;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import stirling.software.SPDF.model.api.PDFFile;
+import stirling.software.SPDF.model.api.converters.PdfToPdfARequest;
 import stirling.software.SPDF.utils.ProcessExecutor;
 import stirling.software.SPDF.utils.ProcessExecutor.ProcessExecutorResult;
 import stirling.software.SPDF.utils.WebResponseUtils;
@@ -31,8 +31,9 @@ public class ConvertPDFToPDFA {
             summary = "Convert a PDF to a PDF/A",
             description =
                     "This endpoint converts a PDF file to a PDF/A file. PDF/A is a format designed for long-term archiving of digital documents. Input:PDF Output:PDF Type:SISO")
-    public ResponseEntity<byte[]> pdfToPdfA(@ModelAttribute PDFFile request) throws Exception {
+    public ResponseEntity<byte[]> pdfToPdfA(@ModelAttribute PdfToPdfARequest request) throws Exception {
         MultipartFile inputFile = request.getFileInput();
+        String outputFormat = request.getOutputFormat();
 
         // Save the uploaded file to a temporary location
         Path tempInputFile = Files.createTempFile("input_", ".pdf");
@@ -47,7 +48,7 @@ public class ConvertPDFToPDFA {
         command.add("--skip-text");
         command.add("--tesseract-timeout=0");
         command.add("--output-type");
-        command.add("pdfa");
+        command.add(outputFormat.toString());
         command.add(tempInputFile.toString());
         command.add(tempOutputFile.toString());
 

--- a/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPdfARequest.java
+++ b/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPdfARequest.java
@@ -1,0 +1,17 @@
+package stirling.software.SPDF.model.api.converters;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import stirling.software.SPDF.model.api.PDFFile;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PdfToPdfARequest extends PDFFile {
+
+    @Schema(
+            description = "The output PDF/A type",
+            allowableValues = {"pdfa", "pdfa-1"})
+    private String outputFormat;
+}

--- a/src/main/resources/templates/convert/pdf-to-pdfa.html
+++ b/src/main/resources/templates/convert/pdf-to-pdfa.html
@@ -20,8 +20,8 @@
 					<div class="mb-3">
 						<label th:text="#{pdfToPDFA.outputFormat}"></label>
 						<select class="form-control" name="outputFormat">
-							<option value="pdfa">PDF/A-2b</option>
 							<option value="pdfa-1">PDF/A-1b</option>
+							<option value="pdfa">PDF/A-2b</option>
 						</select>
 					</div>
                 <br>

--- a/src/main/resources/templates/convert/pdf-to-pdfa.html
+++ b/src/main/resources/templates/convert/pdf-to-pdfa.html
@@ -17,6 +17,13 @@
               <p th:text="#{pdfToPDFA.tip}"></p>
               <form method="post" enctype="multipart/form-data" th:action="@{api/v1/convert/pdf/pdfa}">
                 <div th:replace="~{fragments/common :: fileSelector(name='fileInput', multiple=false, accept='application/pdf')}"></div>
+					<div class="mb-3">
+						<label th:text="#{pdfToPDFA.outputFormat}"></label>
+						<select class="form-control" name="outputFormat">
+							<option value="pdfa">PDF/A-2b</option>
+							<option value="pdfa-1">PDF/A-1b</option>
+						</select>
+					</div>
                 <br>
                 <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{pdfToPDFA.submit}"></button>
               </form>


### PR DESCRIPTION
# Description

Add selection for PDF/A output format in PDF to PDF/A conversion. You can choose between PDF/A-1b and PDF/A-2b.

## Checklist:

- [ x ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
