### PR TITLE
Check `DOCKER_ENABLE_SECURITY` for UI

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/AppConfig.java
+++ b/src/main/java/stirling/software/SPDF/config/AppConfig.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
@@ -84,5 +85,11 @@ public class AppConfig {
             installOps = System.getenv("INSTALL_BOOK_AND_ADVANCED_HTML_OPS");
         }
         return "true".equalsIgnoreCase(installOps);
+    }
+
+    @ConditionalOnMissingClass("stirling.software.SPDF.config.security.SecurityConfiguration")
+    @Bean(name = "activSecurity")
+    public boolean missingActivSecurity() {
+        return false;
     }
 }

--- a/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
+++ b/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
@@ -166,4 +166,9 @@ public class SecurityConfiguration {
     public PersistentTokenRepository persistentTokenRepository() {
         return new JPATokenRepositoryImpl();
     }
+
+    @Bean
+    public boolean activSecurity() {
+        return true;
+    }
 }

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -218,10 +218,10 @@
                     <input type="checkbox" class="form-check-input" id="cacheInputs" th:title="#{settings.cacheInputs.help}">
                     <label class="form-check-label" for="cacheInputs" th:text="#{settings.cacheInputs.name}"></label>
                   </div>
-                  <a th:if="${@loginEnabled}" href="account" class="btn btn-sm btn-outline-primary" role="button" th:text="#{settings.accountSettings}" target="_blank">Account Settings</a>
+                  <a th:if="${@loginEnabled and @activSecurity}" href="account" class="btn btn-sm btn-outline-primary" role="button" th:text="#{settings.accountSettings}" target="_blank">Account Settings</a>
                 </div>
                 <div class="modal-footer">
-                  <a th:if="${@loginEnabled}" class="btn btn-danger" role="button" th:text="#{settings.signOut}" href="logout">Sign Out</a>
+                  <a th:if="${@loginEnabled and @activSecurity}" class="btn btn-danger" role="button" th:text="#{settings.signOut}" href="logout">Sign Out</a>
                   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" th:text="#{close}"></button>
                 </div>
               </div>


### PR DESCRIPTION
# Description

When using `DOCKER_ENABLE_SECURITY=false`, the logout button and Account Settings button are no longer displayed.

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
