### PR TITLE
Add OAUTH2 OIDC login support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-security:3.2.4'
         implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5:3.1.2.RELEASE'
         implementation "org.springframework.boot:spring-boot-starter-data-jpa:3.2.4"
+        implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.2.4'
 
         //2.2.x requires rebuild of DB file.. need migration path
         implementation "com.h2database:h2:2.1.214"

--- a/exampleYmlFiles/docker-compose-latest-security-with-sso.yml
+++ b/exampleYmlFiles/docker-compose-latest-security-with-sso.yml
@@ -1,0 +1,39 @@
+version: '3.3'
+services:
+  stirling-pdf:
+    container_name: Stirling-PDF-Security
+    image: frooodle/s-pdf:latest
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/api/v1/info/status | grep -q 'UP' && curl -fL http://localhost:8080/ | grep -q 'Please sign in'"]
+      interval: 5s
+      timeout: 10s
+      retries: 16
+    ports:
+      - 8080:8080
+    volumes:
+      - /stirling/latest/data:/usr/share/tessdata:rw
+      - /stirling/latest/config:/configs:rw
+      - /stirling/latest/logs:/logs:rw
+    environment:
+      DOCKER_ENABLE_SECURITY: "true"
+      SECURITY_ENABLELOGIN: "true"
+      SECURITY_OAUTH2_ENABLED: "true"
+      SECURITY_OAUTH2_AUTOCREATEUSER: "true" # This is set to true to allow auto-creation of non-existing users in Striling-PDF
+      SECURITY_OAUTH2_ISSUER: "https://accounts.google.com"  # Change with any other provider that supports OpenID Connect Discovery (/.well-known/openid-configuration) end-point
+      SECURITY_OAUTH2_CLIENTID: "<YOUR CLIENT ID>.apps.googleusercontent.com" # Client ID from your provider
+      SECURITY_OAUTH2_CLIENTSECRET: "<YOUR CLIENT SECRET>"  # Client Secret from your provider
+      PUID: 1002
+      PGID: 1002
+      UMASK: "022"
+      SYSTEM_DEFAULTLOCALE: en-US
+      UI_APPNAME: Stirling-PDF
+      UI_HOMEDESCRIPTION: Demo site for Stirling-PDF Latest with Security
+      UI_APPNAMENAVBAR: Stirling-PDF Latest
+      SYSTEM_MAXFILESIZE: "100"
+      METRICS_ENABLED: "true"
+      SYSTEM_GOOGLEVISIBILITY: "true"
+    restart: on-failure:5

--- a/src/main/java/stirling/software/SPDF/config/AppConfig.java
+++ b/src/main/java/stirling/software/SPDF/config/AppConfig.java
@@ -24,6 +24,31 @@ public class AppConfig {
         return applicationProperties.getSecurity().getEnableLogin();
     }
 
+    @Bean(name = "OAUTH2Enabled")
+    public boolean OAUTH2Enabled() {
+        return applicationProperties.getSecurity().getOAUTH2().getEnabled();
+    }
+
+    @Bean(name = "OAUTH2Issuer")
+    public String OAUTH2Issuer() {
+        return applicationProperties.getSecurity().getOAUTH2().getIssuer();
+    }
+
+    @Bean(name = "OAUTH2ClientId")
+    public String OAUTH2ClientId() {
+        return applicationProperties.getSecurity().getOAUTH2().getClientId();
+    }
+
+    @Bean(name = "OAUTH2Secret")
+    public String OAUTH2Secret() {
+        return applicationProperties.getSecurity().getOAUTH2().getClientSecret();
+    }
+
+    @Bean(name = "OAUTH2AutoCreateUser")
+    public boolean OAUTH2AutoCreateUser() {
+        return applicationProperties.getSecurity().getOAUTH2().getAutoCreateUser();
+    }
+
     @Bean(name = "appName")
     public String appName() {
         String homeTitle = applicationProperties.getUi().getAppName();

--- a/src/main/java/stirling/software/SPDF/config/security/CustomLogoutSuccessHandler.java
+++ b/src/main/java/stirling/software/SPDF/config/security/CustomLogoutSuccessHandler.java
@@ -1,0 +1,43 @@
+package stirling.software.SPDF.config.security;
+
+import java.io.IOException;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.ServletException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+
+public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler
+{
+    @Bean
+    public SessionRegistry sessionRegistry() {
+        return new SessionRegistryImpl();
+    }
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException
+    {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            String sessionId = session.getId();
+            sessionRegistry()
+                    .removeSessionInformation(
+                            sessionId);
+        }
+
+        if(request.getParameter("oauth2AutoCreateDisabled") != null)
+        {
+            response.sendRedirect(request.getContextPath()+"/login?error=oauth2AutoCreateDisabled");
+        }
+        else
+        {
+            response.sendRedirect(request.getContextPath() + "/login?logout=true");
+        }
+    }
+}

--- a/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
+++ b/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.config.security;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -10,19 +13,28 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 import jakarta.servlet.http.HttpSession;
 import stirling.software.SPDF.repository.JPATokenRepositoryImpl;
+
+import java.io.IOException;
 
 @Configuration
 @EnableWebSecurity()
@@ -41,6 +53,26 @@ public class SecurityConfiguration {
     @Autowired
     @Qualifier("loginEnabled")
     public boolean loginEnabledValue;
+
+    @Autowired
+    @Qualifier("OAUTH2Enabled")
+    public boolean OAUTH2EnabledValue;
+
+    @Autowired
+    @Qualifier("OAUTH2Issuer")
+    public String OAUTH2IssuerValue;
+
+    @Autowired
+    @Qualifier("OAUTH2ClientId")
+    public String OAUTH2ClientIdValue;
+
+    @Autowired
+    @Qualifier("OAUTH2Secret")
+    public String OAUTH2SecretValue;
+
+    @Autowired
+    @Qualifier("OAUTH2AutoCreateUser")
+    public boolean OAUTH2AutoCreateUserValue;
 
     @Autowired private UserAuthenticationFilter userAuthenticationFilter;
 
@@ -124,6 +156,7 @@ public class SecurityConfiguration {
                                                                         : uri;
 
                                                         return trimmedUri.startsWith("/login")
+                                                                || trimmedUri.startsWith("/oauth")
                                                                 || trimmedUri.endsWith(".svg")
                                                                 || trimmedUri.startsWith(
                                                                         "/register")
@@ -140,13 +173,60 @@ public class SecurityConfiguration {
                                             .authenticated())
                     .userDetailsService(userDetailsService)
                     .authenticationProvider(authenticationProvider());
+
+             if (OAUTH2EnabledValue) {
+
+                 http.oauth2Login( oauth2 -> oauth2
+                         .loginPage("/oauth2")
+//                         .userInfoEndpoint(userInfo -> userInfo
+//                                 .userService(oauthUserService)
+//                         )
+                         .successHandler(new AuthenticationSuccessHandler() {
+                                @Override
+                                public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws ServletException , IOException{
+//                                    CustomOAuth2User oauthUser = (CustomOAuth2User) authentication.getPrincipal();
+//                                    userService.processOAuthPostLogin(oauthUser.getEmail());
+                                    OAuth2User oauthUser =  (OAuth2User) authentication.getPrincipal();
+                                    if (userService.processOAuthPostLogin(oauthUser.getAttribute("email"), OAUTH2AutoCreateUserValue)) {
+                                        response.sendRedirect("/");
+                                    }
+                                    else{
+                                        response.sendRedirect("/logout?error=true");
+                                    }
+                                }
+                            }
+                          )
+                 );
+
+             }
+
         } else {
             http.csrf(csrf -> csrf.disable())
                     .authorizeHttpRequests(authz -> authz.anyRequest().permitAll());
         }
 
+
+
         return http.build();
     }
+
+
+    @Bean
+	public ClientRegistrationRepository clientRegistrationRepository() {
+		return new InMemoryClientRegistrationRepository(this.oidcClientRegistration());
+	}
+
+	private ClientRegistration oidcClientRegistration() {
+		return ClientRegistrations.fromOidcIssuerLocation(OAUTH2IssuerValue)
+			.registrationId("oidc")
+            .clientId(OAUTH2ClientIdValue)
+			.clientSecret(OAUTH2SecretValue)
+			.scope("openid", "profile", "email")
+			.userNameAttributeName("email")
+			.clientName("OIDC")
+			.build();
+	}
 
     @Bean
     public IPRateLimitingFilter rateLimitingFilter() {

--- a/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
+++ b/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
@@ -119,7 +119,7 @@ public class SecurityConfiguration {
                             logout ->
                                     logout.logoutRequestMatcher(
                                                     new AntPathRequestMatcher("/logout"))
-                                            .logoutSuccessUrl("/login?logout=true")
+                                            .logoutSuccessHandler(new CustomLogoutSuccessHandler())
                                             .invalidateHttpSession(true) // Invalidate session
                                             .deleteCookies("JSESSIONID", "remember-me")
                                             .addLogoutHandler(
@@ -192,7 +192,7 @@ public class SecurityConfiguration {
                                         response.sendRedirect("/");
                                     }
                                     else{
-                                        response.sendRedirect("/logout?error=true");
+                                        response.sendRedirect("/logout?oauth2AutoCreateDisabled=true");
                                     }
                                 }
                             }

--- a/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
+++ b/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
@@ -178,15 +178,10 @@ public class SecurityConfiguration {
 
                  http.oauth2Login( oauth2 -> oauth2
                          .loginPage("/oauth2")
-//                         .userInfoEndpoint(userInfo -> userInfo
-//                                 .userService(oauthUserService)
-//                         )
                          .successHandler(new AuthenticationSuccessHandler() {
                                 @Override
                                 public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws ServletException , IOException{
-//                                    CustomOAuth2User oauthUser = (CustomOAuth2User) authentication.getPrincipal();
-//                                    userService.processOAuthPostLogin(oauthUser.getEmail());
                                     OAuth2User oauthUser =  (OAuth2User) authentication.getPrincipal();
                                     if (userService.processOAuthPostLogin(oauthUser.getAttribute("email"), OAUTH2AutoCreateUserValue)) {
                                         response.sendRedirect("/");
@@ -196,21 +191,16 @@ public class SecurityConfiguration {
                                     }
                                 }
                             }
-                          )
+                         )
                  );
-
              }
-
         } else {
             http.csrf(csrf -> csrf.disable())
                     .authorizeHttpRequests(authz -> authz.anyRequest().permitAll());
         }
 
-
-
         return http.build();
     }
-
 
     @Bean
 	public ClientRegistrationRepository clientRegistrationRepository() {

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -38,7 +38,6 @@ public class UserService implements UserServiceInterface {
         if (autoCreateUser) {
             User user = new User();
             user.setUsername(username);
-            //newUser.setProvider(Provider.GOOGLE);
             user.setEnabled(true);
             user.setFirstLogin(false);
             user.addAuthority(new Authority( Role.USER.getRoleId(), user));

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -30,7 +30,8 @@ public class UserService implements UserServiceInterface {
 
     @Autowired private PasswordEncoder passwordEncoder;
 
-     public boolean processOAuthPostLogin(String username, boolean autoCreateUser) {
+    // Handle OAUTH2 login and user auto creation.
+    public boolean processOAuth2PostLogin(String username, boolean autoCreateUser) {
         Optional<User> existUser = userRepository.findByUsernameIgnoreCase(username);
         if (existUser.isPresent()) {
             return true;

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -30,6 +30,21 @@ public class UserService implements UserServiceInterface {
 
     @Autowired private PasswordEncoder passwordEncoder;
 
+     public boolean processOAuthPostLogin(String username, boolean autoCreateUser) {
+        Optional<User> existUser = userRepository.findByUsernameIgnoreCase(username);
+        if (existUser.isEmpty() && autoCreateUser) {
+            User user = new User();
+            user.setUsername(username);
+            //newUser.setProvider(Provider.GOOGLE);
+            user.setEnabled(true);
+            user.setFirstLogin(false);
+            user.addAuthority(new Authority( Role.USER.getRoleId(), user));
+            userRepository.save(user);
+            return true;
+        }
+        return false;
+    }
+
     public Authentication getAuthentication(String apiKey) {
         User user = getUserByApiKey(apiKey);
         if (user == null) {

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -32,7 +32,10 @@ public class UserService implements UserServiceInterface {
 
      public boolean processOAuthPostLogin(String username, boolean autoCreateUser) {
         Optional<User> existUser = userRepository.findByUsernameIgnoreCase(username);
-        if (existUser.isEmpty() && autoCreateUser) {
+        if (existUser.isPresent()) {
+            return true;
+        }
+        if (autoCreateUser) {
             User user = new User();
             user.setUsername(username);
             //newUser.setProvider(Provider.GOOGLE);

--- a/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -29,11 +30,17 @@ import stirling.software.SPDF.repository.UserRepository;
 @Tag(name = "Account Security", description = "Account Security APIs")
 public class AccountWebController {
 
+    @Autowired
+    @Qualifier("OAUTH2Enabled")
+    public boolean OAUTH2EnabledValue;
+
     @GetMapping("/login")
     public String login(HttpServletRequest request, Model model, Authentication authentication) {
         if (authentication != null && authentication.isAuthenticated()) {
             return "redirect:/";
         }
+
+        model.addAttribute("oAuth2Enabled", OAUTH2EnabledValue);
 
         model.addAttribute("currentPage", "login");
 

--- a/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -85,14 +86,23 @@ public class AccountWebController {
         }
         if (authentication != null && authentication.isAuthenticated()) {
             Object principal = authentication.getPrincipal();
+            String username = null;
 
             if (principal instanceof UserDetails) {
                 // Cast the principal object to UserDetails
                 UserDetails userDetails = (UserDetails) principal;
 
                 // Retrieve username and other attributes
-                String username = userDetails.getUsername();
+                username = userDetails.getUsername();
+            }
+            if (principal instanceof OAuth2User) {
+                // Cast the principal object to UserDetails
+                OAuth2User userDetails = (OAuth2User) principal;
 
+                // Retrieve username and other attributes
+                username = userDetails.getAttribute("email");
+            }
+            if (username != null) {
                 // Fetch user details from the database
                 Optional<User> user =
                         userRepository.findByUsernameIgnoreCase(

--- a/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
@@ -94,13 +94,19 @@ public class AccountWebController {
 
                 // Retrieve username and other attributes
                 username = userDetails.getUsername();
+
+                // Add oAuth2 Login attributes to the model
+                model.addAttribute("oAuth2Login", false);
             }
             if (principal instanceof OAuth2User) {
-                // Cast the principal object to UserDetails
+                // Cast the principal object to OAuth2User
                 OAuth2User userDetails = (OAuth2User) principal;
 
                 // Retrieve username and other attributes
                 username = userDetails.getAttribute("email");
+
+                // Add oAuth2 Login attributes to the model
+                model.addAttribute("oAuth2Login", true);
             }
             if (username != null) {
                 // Fetch user details from the database

--- a/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
+++ b/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
@@ -118,6 +118,7 @@ public class ApplicationProperties {
         private Boolean enableLogin;
         private Boolean csrfDisabled;
         private InitialLogin initialLogin;
+        private OAUTH2 oauth2;
         private int loginAttemptCount;
         private long loginResetTimeMinutes;
 
@@ -145,6 +146,14 @@ public class ApplicationProperties {
             this.initialLogin = initialLogin;
         }
 
+        public OAUTH2 getOAUTH2() {
+            return oauth2 != null ? oauth2 : new OAUTH2();
+        }
+
+        public void setOAUTH2(OAUTH2 oauth2) {
+            this.oauth2 = oauth2;
+        }
+
         public Boolean getEnableLogin() {
             return enableLogin;
         }
@@ -165,6 +174,8 @@ public class ApplicationProperties {
         public String toString() {
             return "Security [enableLogin="
                     + enableLogin
+                    + ", oauth2="
+                    + oauth2
                     + ", initialLogin="
                     + initialLogin
                     + ",  csrfDisabled="
@@ -199,6 +210,70 @@ public class ApplicationProperties {
                         + username
                         + ", password="
                         + (password != null && !password.isEmpty() ? "MASKED" : "NULL")
+                        + "]";
+            }
+        }
+
+        public static class OAUTH2 {
+
+            private boolean enabled;
+            private String issuer;
+            private String clientId;
+            private String clientSecret;
+            private boolean autoCreateUser;
+
+            public boolean getEnabled() {
+                return enabled;
+            }
+
+            public void setEnabled(boolean enabled) {
+                this.enabled = enabled;
+            }
+
+            public String getIssuer() {
+                return issuer;
+            }
+
+            public void setIssuer(String issuer) {
+                this.issuer = issuer;
+            }
+
+            public String getClientId() {
+                return clientId;
+            }
+
+            public void setClientId(String clientId) {
+                this.clientId = clientId;
+            }
+
+            public String getClientSecret() {
+                return clientSecret;
+            }
+
+            public void setClientSecret(String clientSecret) {
+                this.clientSecret = clientSecret;
+            }
+
+            public boolean getAutoCreateUser() {
+                return autoCreateUser;
+            }
+
+            public void setAutoCreateUser(boolean autoCreateUser) {
+                this.autoCreateUser = autoCreateUser;
+            }
+
+            @Override
+            public String toString() {
+                return "OAUTH2 [enabled="
+                        + enabled
+                        + ", issuer="
+                        + issuer
+                        + ", clientId="
+                        + clientId
+                        + ", clientSecret="
+                        + clientSecret
+                        + ", autoCreateUser="
+                        + autoCreateUser
                         + "]";
             }
         }

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -437,6 +437,8 @@ login.rememberme=Remember me
 login.invalid=Invalid username or password.
 login.locked=Your account has been locked.
 login.signinTitle=Please sign in
+login.ssoSignIn=Login via Single Sign-on
+login.oauth2AutoCreateDisabled=OAUTH2 Auto-Create User Disabled
 
 
 #auto-redact

--- a/src/main/resources/templates/account.html
+++ b/src/main/resources/templates/account.html
@@ -42,7 +42,7 @@
               </div>
               </th:block>
               <!-- Change Username Form -->
-              <form action="api/v1/user/change-username" method="post">
+              <form th:if="${!oAuth2Login}" action="api/v1/user/change-username" method="post">
                 <div class="mb-3">
                   <label for="newUsername" th:text="#{account.changeUsername}">Change Username</label>
                   <input type="text" class="form-control" name="newUsername" id="newUsername" th:placeholder="#{account.newUsername}">
@@ -59,8 +59,8 @@
               <hr> <!-- Separator Line -->
 
               <!-- Change Password Form -->
-              <h4 th:text="#{account.changePassword}">Change Password?</h4>
-              <form action="api/v1/user/change-password" method="post">
+              <h4 th:if="${!oAuth2Login}" th:text="#{account.changePassword}">Change Password?</h4>
+              <form th:if="${!oAuth2Login}" action="api/v1/user/change-password" method="post">
                 <div class="mb-3">
                   <label for="currentPassword" th:text="#{account.oldPassword}">Old Password</label>
                   <input type="password" class="form-control" name="currentPassword" id="currentPasswordPassword" th:placeholder="#{account.oldPassword}">

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -139,6 +139,11 @@
         <form th:action="@{login}" method="post">
           <img class="mb-4" src="favicon.svg?v=2" alt="" width="144" height="144">
           <h1 class="h1 mb-3 fw-normal" th:text="${@appName}">Stirling-PDF</h1>
+          <a href="oauth2/authorization/oidc" class="w-100 btn btn-lg btn-primary" th:text="#{login.ssoSignIn}">Login Via SSO</a>
+          <div class="text-danger text-center">
+            <div th:if="${error == 'oauth2AutoCreateDisabled'}" th:text="#{login.oauth2AutoCreateDisabled}">OAUTH2 Auto-Create User Disabled.</div>
+          </div>
+          <hr />
           <h2 class="h5 mb-3 fw-normal" th:text="#{login.signinTitle}">Please sign in</h2>
 
           <div class="form-floating">

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -139,11 +139,13 @@
         <form th:action="@{login}" method="post">
           <img class="mb-4" src="favicon.svg?v=2" alt="" width="144" height="144">
           <h1 class="h1 mb-3 fw-normal" th:text="${@appName}">Stirling-PDF</h1>
-          <a href="oauth2/authorization/oidc" class="w-100 btn btn-lg btn-primary" th:text="#{login.ssoSignIn}">Login Via SSO</a>
-          <div class="text-danger text-center">
-            <div th:if="${error == 'oauth2AutoCreateDisabled'}" th:text="#{login.oauth2AutoCreateDisabled}">OAUTH2 Auto-Create User Disabled.</div>
+          <div th:if="${oAuth2Enabled}">
+            <a href="oauth2/authorization/oidc" class="w-100 btn btn-lg btn-primary" th:text="#{login.ssoSignIn}">Login Via SSO</a>
+            <div class="text-danger text-center">
+              <div th:if="${error == 'oauth2AutoCreateDisabled'}" th:text="#{login.oauth2AutoCreateDisabled}">OAUTH2 Auto-Create User Disabled.</div>
+            </div>
+            <hr />
           </div>
-          <hr />
           <h2 class="h5 mb-3 fw-normal" th:text="#{login.signinTitle}">Please sign in</h2>
 
           <div class="form-floating">


### PR DESCRIPTION
# Description

This PR adds support for Single Sign-On (SSO) using  OAUTH2 OpenID Connect (OIDC). This also supports auto-creation of the users if they do not exist in the database. This functionality can also be disabled. An error message will be given in that case.

An example docker-compose file has also been added.

Closes #994 
Related Discussions #781, #467

If the OAUTH2 login is enabled a new button shows up on the login page as per the screenshot below:

![image](https://github.com/Stirling-Tools/Stirling-PDF/assets/812110/6ec3b233-2eb7-4838-bcc9-f93ca0c21cec)


## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
