### PR TITLE
Add translations for OAUTH2 Related Text

### DIFF
--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -437,6 +437,8 @@ login.rememberme=Remember me
 login.invalid=Invalid username or password.
 login.locked=Your account has been locked.
 login.signinTitle=Please sign in
+login.ssoSignIn=تسجيل الدخول عبر تسجيل الدخول الأحادي
+login.oauth2AutoCreateDisabled=تم تعطيل مستخدم الإنشاء التلقائي لـ OAuth2
 
 
 #auto-redact

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -437,6 +437,8 @@ login.rememberme=Запомни ме
 login.invalid=Невалидно потребителско име или парола.
 login.locked=Вашият акаунт е заключен.
 login.signinTitle=Моля впишете се
+login.ssoSignIn=Влизане чрез еднократно влизане
+login.oauth2AutoCreateDisabled=OAUTH2 Автоматично създаване на потребител е деактивирано
 
 
 #auto-redact

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -437,6 +437,8 @@ login.rememberme=Recordar
 login.invalid=Nom usuari / password no vàlid
 login.locked=Compte bloquejat
 login.signinTitle=Autenticat
+login.ssoSignIn=Inicia sessió mitjançant l'inici de sessió ún
+login.oauth2AutoCreateDisabled=L'usuari de creació automàtica OAUTH2 està desactivat
 
 
 #auto-redact

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -437,6 +437,8 @@ login.rememberme=Angemeldet bleiben
 login.invalid=Benutzername oder Passwort ungültig.
 login.locked=Ihr Konto wurde gesperrt.
 login.signinTitle=Bitte melden Sie sich an.
+login.ssoSignIn=Anmeldung per Single Sign-On
+login.oauth2AutoCreateDisabled=OAUTH2 Benutzer automatisch erstellen deaktiviert
 
 
 #auto-redact

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -437,6 +437,8 @@ login.rememberme=Να Με Θυμάσαι
 login.invalid=Λάθος όνομα χρήστη ή κωδικού πρόσβασης.
 login.locked=Ο λογαριασμός σας έχει κλειδωθεί.
 login.signinTitle=Παρακαλώ, συνδεθείτε
+login.ssoSignIn=Σύνδεση μέσω μοναδικής σύνδεσης
+login.oauth2AutoCreateDisabled=Απενεργοποιήθηκε ο χρήστης αυτόματης δημιουργίας OAUTH2
 
 
 #auto-redact

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -437,6 +437,8 @@ login.rememberme=Recordarme
 login.invalid=Nombre de usuario o contraseña erróneos.
 login.locked=Su cuenta se ha bloqueado.
 login.signinTitle=Por favor, inicie sesión
+login.ssoSignIn=Iniciar sesión a través del inicio de sesión único
+login.oauth2AutoCreateDisabled=Usuario DE creación automática de OAUTH2 DESACTIVADO
 
 
 #auto-redact

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -437,6 +437,8 @@ login.rememberme=Oroitu nazazu
 login.invalid=Okerreko erabiltzaile izena edo pasahitza.
 login.locked=Zure kontua blokeatu egin da.
 login.signinTitle=Mesedez, hasi saioa
+login.ssoSignIn=Hasi saioa Saioa hasteko modu bakarraren bidez
+login.oauth2AutoCreateDisabled=OAUTH2 Sortu automatikoki erabiltzailea desgaituta dago
 
 
 #auto-redact

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -437,6 +437,8 @@ login.rememberme=Se souvenir de moi
 login.invalid=Nom d’utilisateur ou mot de passe invalide.
 login.locked=Votre compte a été verrouillé.
 login.signinTitle=Veuillez vous connecter
+login.ssoSignIn=Se connecter via l'authentification unique
+login.oauth2AutoCreateDisabled=OAUTH2 Création automatique d'utilisateur désactivée
 
 
 #auto-redact

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -437,6 +437,8 @@ login.rememberme=मुझे याद रखें
 login.invalid=अमान्य उपयोगकर्ता नाम या पासवर्ड।
 login.locked=आपका खाता लॉक कर दिया गया है।
 login.signinTitle=कृपया साइन इन करें
+login.ssoSignIn=सिंगल साइन - ऑन के ज़रिए लॉग इन करें
+login.oauth2AutoCreateDisabled=OAUTH2 ऑटो - क्रिएट यूज़र अक्षम किया गया
 
 
 #auto-redact

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -437,6 +437,8 @@ login.rememberme=Emlékezz rám
 login.invalid=Érvénytelen felhasználónév vagy jelszó!
 login.locked=A fiókja zárolva lett!
 login.signinTitle=Kérjük, jelentkezzen be!
+login.ssoSignIn=Bejelentkezés egyszeri bejelentkezéssel
+login.oauth2AutoCreateDisabled=OAUTH2 Felhasználó automatikus létrehozása letiltva
 
 
 #auto-redact

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -437,6 +437,8 @@ login.rememberme=Ingat saya
 login.invalid=Nama pengguna atau kata sandi tidak valid.
 login.locked=Akun Anda telah dikunci.
 login.signinTitle=Silakan masuk
+login.ssoSignIn=Masuk melalui Single Sign - on
+login.oauth2AutoCreateDisabled=OAUTH2 Buat Otomatis Pengguna Dinonaktifkan
 
 
 #auto-redact

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -437,6 +437,8 @@ login.rememberme=Ricordami
 login.invalid=Nome utente o password errati.
 login.locked=Il tuo account è stato bloccato.
 login.signinTitle=Per favore accedi
+login.ssoSignIn=Accedi tramite Single Sign-on
+login.oauth2AutoCreateDisabled=Creazione automatica utente OAUTH2 DISABILITATA
 
 
 #auto-redact

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -437,6 +437,8 @@ login.rememberme=サインイン状態を記憶する
 login.invalid=ユーザー名かパスワードが無効です。
 login.locked=あなたのアカウントはロックされています。
 login.signinTitle=サインインしてください
+login.ssoSignIn=シングルサインオンでログイン
+login.oauth2AutoCreateDisabled=OAuth 2自動作成ユーザーが無効
 
 
 #auto-redact

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -437,6 +437,8 @@ login.rememberme=로그인 유지
 login.invalid=사용자 이름이나 비밀번호가 틀립니다.
 login.locked=계정이 잠겼습니다.
 login.signinTitle=로그인해 주세요.
+login.ssoSignIn=싱글사인온을 통한 로그인
+login.oauth2AutoCreateDisabled=OAUTH2 사용자 자동 생성 비활성화됨
 
 
 #auto-redact

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -437,6 +437,8 @@ login.rememberme=Onthoud mij
 login.invalid=Ongeldige gebruikersnaam of wachtwoord.
 login.locked=Je account is geblokkeerd.
 login.signinTitle=Gelieve in te loggen
+login.ssoSignIn=Inloggen via Single Sign-on
+login.oauth2AutoCreateDisabled=OAUTH2 Automatisch aanmaken gebruiker uitgeschakeld
 
 
 #auto-redact

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -437,6 +437,8 @@ login.rememberme=Remember me
 login.invalid=Invalid username or password.
 login.locked=Your account has been locked.
 login.signinTitle=Please sign in
+login.ssoSignIn=Zaloguj się za pomocą logowania jednokrotnego
+login.oauth2AutoCreateDisabled=Wyłączono automatyczne tworzenie użytkownika OAUTH2
 
 
 #auto-redact

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -437,6 +437,8 @@ login.rememberme=Remember me
 login.invalid=Invalid username or password.
 login.locked=Your account has been locked.
 login.signinTitle=Please sign in
+login.ssoSignIn=Iniciar sessão através de início de sessão único
+login.oauth2AutoCreateDisabled=OAUTH2 Auto-Criar Usuário Desativado
 
 
 #auto-redact

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -437,6 +437,8 @@ login.rememberme=Lembrar dados
 login.invalid=Utilizador ou senha inválidos.
 login.locked=A sua conta foi bloqueada.
 login.signinTitle=Introduza os seus dados de acesso
+login.ssoSignIn=Iniciar sessão através de início de sessão único
+login.oauth2AutoCreateDisabled=OAUTH2 Criação Automática de Utilizador Desativada
 
 
 #auto-redact

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -437,6 +437,8 @@ login.rememberme=Remember me
 login.invalid=Invalid username or password.
 login.locked=Your account has been locked.
 login.signinTitle=Please sign in
+login.ssoSignIn=Conectare prin conectare unică
+login.oauth2AutoCreateDisabled=OAUTH2 Creare automată utilizator dezactivată
 
 
 #auto-redact

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -437,6 +437,8 @@ login.rememberme=Запомнить меня
 login.invalid=Недействительное имя пользователя или пароль.
 login.locked=Ваша учетная запись заблокирована.
 login.signinTitle=Пожалуйста, войдите
+login.ssoSignIn=Вход через единый вход
+login.oauth2AutoCreateDisabled=OAUTH2 Автоматическое создание пользователя отключено
 
 
 #auto-redact

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -437,6 +437,8 @@ login.rememberme=Zapamti me
 login.invalid=Neispravno korisničko ime ili lozinka.
 login.locked=Vaš nalog je zaključan.
 login.signinTitle=Molimo vas da se prijavite
+login.ssoSignIn=Prijavite se putem jedinstvene prijave
+login.oauth2AutoCreateDisabled=OAUTH2 automatsko kreiranje korisnika je onemogućeno
 
 
 #auto-redact

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -437,6 +437,8 @@ login.rememberme=Remember me
 login.invalid=Invalid username or password.
 login.locked=Your account has been locked.
 login.signinTitle=Please sign in
+login.ssoSignIn=Logga in via enkel inloggning
+login.oauth2AutoCreateDisabled=OAUTH2 Auto-Create User inaktiverad
 
 
 #auto-redact

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -437,6 +437,8 @@ login.rememberme=Beni hatırla
 login.invalid=Geçersiz kullanıcı adı veya şifre.
 login.locked=Hesabınız kilitlendi.
 login.signinTitle=Lütfen giriş yapınız.
+login.ssoSignIn=Tek Oturum Açma ile Giriş Yap
+login.oauth2AutoCreateDisabled=OAUTH2 Otomatik Oluşturma Kullanıcı Devre Dışı Bırakıldı
 
 
 #auto-redact

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -437,6 +437,8 @@ login.rememberme=Запам'ятати мене
 login.invalid=Недійсне ім'я користувача або пароль.
 login.locked=Ваш обліковий запис заблоковано.
 login.signinTitle=Будь ласка, увійдіть
+login.ssoSignIn=Увійти через єдиний вхід
+login.oauth2AutoCreateDisabled=Автоматичне створення користувача OAUTH2 ВИМКНЕНО
 
 
 #auto-redact

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -437,6 +437,8 @@ login.rememberme=记住我
 login.invalid=用户名或密码无效。
 login.locked=您的账户已被锁定。
 login.signinTitle=请登录
+login.ssoSignIn=通过单点登录登录
+login.oauth2AutoCreateDisabled=OAUTH2自动创建用户已禁用
 
 
 #auto-redact

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -437,6 +437,8 @@ login.rememberme=記住我
 login.invalid=使用者名稱或密碼無效。
 login.locked=您的帳戶已被鎖定。
 login.signinTitle=請登入
+login.ssoSignIn=透過織網單一簽入
+login.oauth2AutoCreateDisabled=OAUTH2自動建立使用者已停用
 
 
 #auto-redact


### PR DESCRIPTION
# Description

This PR Adds translations for OAUTH2 Related Text for all remaining languages. Earlier in #1140 only English was added.


## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
