### PR TITLE
Drag&drop bug

### DIFF
--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -104,4 +104,9 @@ function setupFileInput(chooser) {
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(pdfPrompt);
     }
   }
+  //Listen for event of file being removed and the filter it out of the allFiles array
+  document.addEventListener("fileRemoved", function (e) {
+    const fileName = e.detail;
+    allFiles = allFiles.filter(file => file.name !== fileName);
+  });
 }

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -76,7 +76,6 @@ function attachMoveButtons() {
       //Dispatch a custom event with the name of the removed file
       var event = new CustomEvent("fileRemoved", { detail: fileName });
       document.dispatchEvent(event);
-      //end new code
     });
   }
 }

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -69,8 +69,14 @@ function attachMoveButtons() {
     removeButtons[i].addEventListener("click", function (event) {
       event.preventDefault();
       var parent = this.closest(".list-group-item");
+      //Get name of removed file
+      var fileName = parent.querySelector(".filename").innerText;
       parent.remove();
       updateFiles();
+      //Dispatch a custom event with the name of the removed file
+      var event = new CustomEvent("fileRemoved", { detail: fileName });
+      document.dispatchEvent(event);
+      //end new code
     });
   }
 }


### PR DESCRIPTION
# Description
Added a event and a listener to listen for removed files. Now also files that are added via drag and drop, are actually deleted when pressing the delete button and do not reappear again after a new file has been added.

Closes #738 

## Checklist:

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
