### PR TITLE
Install locally on a machine with no-root, docker, apt, yum, and apk via nix package manager.

### DIFF
--- a/LocalRunGuide.md
+++ b/LocalRunGuide.md
@@ -214,9 +214,11 @@ or
 java -jar /opt/Stirling-PDF/Stirling-PDF-*.jar
 ```
 
-Non-root users can run from the Stirling-PDF directory using the following commands:
+Non-root users can run from the Stirling-PDF directory using the following commands (can use any temp directory you want):
 
 ```bash
+mkdir temp
+export DBUS_SESSION_BUS_ADDRESS="unix:path=./temp"
 ./gradlew bootRun
 or
 java -jar ./Stirling-PDF-*.jar

--- a/LocalRunGuide.md
+++ b/LocalRunGuide.md
@@ -41,7 +41,7 @@ Install the following software, if not already installed:
 For Debian-based systems, you can use the following command:
 
 ```bash
-sudo apt-get upda te
+sudo apt-get update
 sudo apt-get install -y git  automake  autoconf  libtool  libleptonica-dev  pkg-config zlib1g-dev make g++ openjdk-17-jdk python3 python3-pip
 ```
 

--- a/LocalRunGuide.md
+++ b/LocalRunGuide.md
@@ -161,8 +161,6 @@ If you plan to use the OCR (Optical Character Recognition) functionality, you mi
 ##### Installing Language Packs
 Easiest is to use the langpacks provided by your repositories. Skip the other steps.
 
-**Note:** Nix Package Manager pre-installs almost all the packages by default.
-
 Manual:
 
 1. Download the desired language pack(s) by selecting the `.traineddata` file(s) for the language(s) you need.
@@ -204,6 +202,8 @@ Nix:
 nix-env -iA nixpkgs.tesseract
 ```
 
+**Note:** Nix Package Manager pre-installs almost all the language packs when tesseract is installed.
+
 ### Step 7: Run Stirling-PDF
 
 Those who have pushed to the root directory, run the following commands:
@@ -214,7 +214,11 @@ or
 java -jar /opt/Stirling-PDF/Stirling-PDF-*.jar
 ```
 
-Non-root users can run from the Stirling-PDF directory using the following commands (can use any temp directory you want):
+Since libreoffice, soffice, and conversion tools have their dbus_tmp_dir set as `dbus_tmp_dir="/run/user/$(id -u)/libreoffice-dbus"`, you might get the following error when using their endpoints:
+```
+[Thread-7] INFO  s.s.SPDF.utils.ProcessExecutor - mkdir: cannot create directory ‘/run/user/1501’: Permission denied
+```
+To resolve this, before starting the Stirling-PDF, you have to set the environment variable to a directory you have write access to by using the following commands:
 
 ```bash
 mkdir temp

--- a/LocalRunGuide.md
+++ b/LocalRunGuide.md
@@ -41,7 +41,7 @@ Install the following software, if not already installed:
 For Debian-based systems, you can use the following command:
 
 ```bash
-sudo apt-get update
+sudo apt-get upda te
 sudo apt-get install -y git  automake  autoconf  libtool  libleptonica-dev  pkg-config zlib1g-dev make g++ openjdk-17-jdk python3 python3-pip
 ```
 
@@ -51,7 +51,15 @@ For Fedora-based systems use this command:
 sudo dnf install -y git automake autoconf libtool leptonica-devel pkg-config zlib-devel make gcc-c++ java-17-openjdk python3 python3-pip
 ```
 
+For non-root users with Nix Package Manager, use the following command:
+```bash
+nix-channel --update
+nix-env -iA nixpkgs.jdk17 nixpkgs.git nixpkgs.python38 nixpkgs.gnumake nixpkgs.libgcc nixpkgs.automake nixpkgs.autoconf nixpkgs.libtool nixpkgs.pkg-config nixpkgs.zlib nixpkgs.leptonica
+```
+
 ### Step 2: Clone and Build jbig2enc (Only required for certain OCR functionality)
+
+For Debian and Fedora, you can build it from source using the following commands:
 
 ```bash
 mkdir ~/.git
@@ -62,6 +70,11 @@ cd jbig2enc &&\
 ./configure &&\
 make &&\
 sudo make install
+```
+
+For Nix, you will face `Leptonica not detected`. Bypass this by installing it directly using the following command:
+```bash
+nix-env -iA nixpkgs.jbig2enc
 ```
 
 ### Step 3: Install Additional Software
@@ -105,6 +118,13 @@ sudo dnf install -y libreoffice-writer libreoffice-calc libreoffice-impress unpa
 pip3 install uno opencv-python-headless unoconv pngquant WeasyPrint
 ```
 
+For Nix:
+
+```bash
+nix-env -iA nixpkgs.unpaper nixpkgs.libreoffice nixpkgs.ocrmypdf nixpkgs.poppler_utils
+pip3 install uno opencv-python-headless unoconv pngquant WeasyPrint
+```
+
 ### Step 4: Clone and Build Stirling-PDF
 
 ```bash
@@ -115,13 +135,12 @@ chmod +x ./gradlew &&\
 ./gradlew build
 ```
 
-
 ### Step 5: Move jar to desired location
 
 After the build process, a `.jar` file will be generated in the `build/libs` directory.
 You can move this file to a desired location, for example, `/opt/Stirling-PDF/`.
 You must also move the Script folder within the Stirling-PDF repo that you have downloaded to this directory.
-This folder is required for the python scripts using OpenCV
+This folder is required for the python scripts using OpenCV.
 
 ```bash
 sudo mkdir /opt/Stirling-PDF &&\
@@ -129,19 +148,27 @@ sudo mv ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/ &&\
 sudo mv scripts /opt/Stirling-PDF/ &&\
 echo "Scripts installed."
 ```
+
+For non-root users, you can just keep the jar in the main directory of Stirling-PDF using the following command:
+```bash
+mv ./build/libs/Stirling-PDF-*.jar ./Stirling-PDF-*.jar
+```
+
 ### Step 6: Other files
 #### OCR
 If you plan to use the OCR (Optical Character Recognition) functionality, you might need to install language packs for Tesseract if running non-english scanning.
 
 ##### Installing Language Packs
-Easiest is to use the langpacks provided by your repositories. Skip the other steps
+Easiest is to use the langpacks provided by your repositories. Skip the other steps.
+
+**Note:** Nix Package Manager pre-installs almost all the packages by default.
 
 Manual:
 
 1. Download the desired language pack(s) by selecting the `.traineddata` file(s) for the language(s) you need.
 2. Place the `.traineddata` files in the Tesseract tessdata directory: `/usr/share/tessdata`
-3.
-Please view  [OCRmyPDF install guide](https://ocrmypdf.readthedocs.io/en/latest/installation.html) for more info.
+3. Please view  [OCRmyPDF install guide](https://ocrmypdf.readthedocs.io/en/latest/installation.html) for more info.
+
 **IMPORTANT:** DO NOT REMOVE EXISTING `eng.traineddata`, IT'S REQUIRED.
 
 Debian based systems, install languages with this command:
@@ -171,12 +198,28 @@ dnf search -C tesseract-langpack-
 rpm -qa | grep tesseract-langpack | sed 's/tesseract-langpack-//g'
 ```
 
+Nix:
+
+```bash
+nix-env -iA nixpkgs.tesseract
+```
+
 ### Step 7: Run Stirling-PDF
+
+Those who have pushed to the root directory, run the following commands:
 
 ```bash
 ./gradlew bootRun
 or
 java -jar /opt/Stirling-PDF/Stirling-PDF-*.jar
+```
+
+Non-root users can run from the Stirling-PDF directory using the following commands:
+
+```bash
+./gradlew bootRun
+or
+java -jar ./Stirling-PDF-*.jar
 ```
 
 ### Step 8: Adding a Desktop icon
@@ -202,7 +245,19 @@ EOF
 
 Note: Currently the app will run in the background until manually closed.
 
-### Optional: Run Stirling-PDF as a service
+### Optional: Changing the host and port of the application:
+
+To override the default configuration, you can add the following to `/.git/Stirling-PDF/configs/custom_settings.yml` file:
+
+```bash
+server:
+  host: 0.0.0.0
+  port: 3000
+```
+
+**Note:** This file is created after the first application launch. To have it before that, you can create the directory and add the file yourself.
+
+### Optional: Run Stirling-PDF as a service (requires root).
 
 First create a .env file, where you can store environment variables:
 ```
@@ -239,6 +294,7 @@ WantedBy=multi-user.target
 ```
 
 Notify systemd that it has to rebuild its internal service database (you have to run this command every time you make a change in the service file):
+
 ```
 sudo systemctl daemon-reload
 ```


### PR DESCRIPTION
# Description

So, I worked on a template to contribute to Codesphere which involved installing Stirling-PDF and its dependencies locally.
The catch was that there was no root access and packages should be installed via Nix package manager (nix-env).
So it took me many many hours to research and find a way to make it work using no-root and Nix.
So this PR contains my edit in the `LocalRunGuide.md` file where I added instructions for the no-root and Nix method.

Also, I caught a small line break issue and fixed it along the way:
![Line break image](https://i.ibb.co/cXdTnG3/Bad-line-break.png?raw=true)

Closes #1175 

## Checklist:

✅ I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md).
✅ I have performed a self-review of my own code.
✅ I have commented my code, particularly in hard-to-understand areas.
✅ My changes generate no new warnings.

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
