### PR TITLE
User Friendly Merge File Selection

### DIFF
--- a/src/main/resources/static/css/fileSelect.css
+++ b/src/main/resources/static/css/fileSelect.css
@@ -8,3 +8,7 @@
   overflow-y: auto;
   white-space: pre-wrap;
 }
+.duplicate-warning {
+    color: red;
+    font-weight: bold;
+}

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -47,12 +47,11 @@ function setupFileInput(chooser) {
     const dt = e.dataTransfer;
     const files = dt.files;
 
-    for (let i = 0; i < files.length; i++) {
-      allFiles.push(files[i]);
-    }
-
+    //Do not Update allFiles array here to prevent duplication, the change event listener will take care of that
     const dataTransfer = new DataTransfer();
-    allFiles.forEach((file) => dataTransfer.items.add(file));
+    for (let i = 0; i < files.length; i++) {
+      dataTransfer.items.add(files[i]);
+    }
 
     const fileInput = document.getElementById(elementId);
     fileInput.files = dataTransfer.files;
@@ -81,8 +80,21 @@ function setupFileInput(chooser) {
   document.body.addEventListener("drop", dropListener);
 
   $("#" + elementId).on("change", function (e) {
-    allFiles = Array.from(e.target.files);
+    //Get newly Added Files
+    const newFiles = Array.from(e.target.files);
+
+    //Add Files to existing Files
+    allFiles = allFiles.concat(newFiles);
+
+    //Update the file inout`s files property
+    const dataTransfer = new DataTransfer();
+    allFiles.forEach((file) => dataTransfer.items.add(file));
+    e.target.files = dataTransfer.files;
+
     handleFileInputChange(this);
+
+    //Call the displayFiles function with the allFiles array
+    displayFiles(allFiles)
   });
 
   function handleFileInputChange(inputElement) {

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -109,10 +109,7 @@ function setupFileInput(chooser) {
 // Listen for event of file being removed and then filter it out of the allFiles array
   document.addEventListener("fileRemoved", function (e) {
     const fileId = e.detail;
-    console.log('File to be removed:', fileId); // Log the uniqueId of the file to be removed
-    console.log('All files before removal:', allFiles); // Log all files before removal
     allFiles = allFiles.filter(fileObj => fileObj.uniqueId !== fileId); // Remove the file from the allFiles array using the unique identifier
-    console.log('All files after removal:', allFiles); // Log all files after removal
     // Dispatch a custom event with the allFiles array
     var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
     document.dispatchEvent(filesUpdated);

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -9,7 +9,7 @@ document.getElementById("fileInput-input").addEventListener("change", function (
 });
 
 /**
- * @param {FileList} files
+ * @param {File[]} files
  */
 function displayFiles(files) {
   const list = document.getElementById("selectedFiles");

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -132,15 +132,15 @@ document.getElementById("sortByDateBtn").addEventListener("click", function () {
 });
 
 function sortFiles(comparator) {
-  // Convert FileList to array and sort
-  const sortedFilesArray = Array.from(document.getElementById("fileInput-input").files).sort(comparator);
+  // Sort the filesWithUniqueId array
+  const sortedFilesArray = filesWithUniqueId.sort((a, b) => comparator(a.file, b.file));
 
   // Refresh displayed list
   displayFiles(sortedFilesArray);
 
   // Update the files property
   const dataTransfer = new DataTransfer();
-  sortedFilesArray.forEach((file) => dataTransfer.items.add(file));
+  sortedFilesArray.forEach((fileObj) => dataTransfer.items.add(fileObj.file));
   document.getElementById("fileInput-input").files = dataTransfer.files;
 }
 

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -13,6 +13,7 @@ document.getElementById("fileInput-input").addEventListener("change", function (
  */
 function displayFiles(files) {
   const list = document.getElementById("selectedFiles");
+  const processedFiles = [];
 
   while (list.firstChild) {
     list.removeChild(list.firstChild);
@@ -21,9 +22,23 @@ function displayFiles(files) {
   for (let i = 0; i < files.length; i++) {
     const item = document.createElement("li");
     item.className = "list-group-item";
+    const fileNameDiv = document.createElement("div");
+    fileNameDiv.className = "filename";
+    fileNameDiv.textContent = files[i].name;
+
+    // Check for duplicates
+    if (processedFiles.includes(files[i].name)) {
+      const warning = document.createElement("span");
+      warning.className = "duplicate-warning";
+      warning.textContent = "(Duplicate)";
+      fileNameDiv.appendChild(warning);
+    } else {
+      processedFiles.push(files[i].name);
+    }
+
     item.innerHTML = `
             <div class="d-flex justify-content-between align-items-center w-100">
-                <div class="filename">${files[i].name}</div>
+                ${fileNameDiv.outerHTML}
                 <div class="arrows d-flex">
                     <button class="btn btn-secondary move-up"><span>&uarr;</span></button>
                     <button class="btn btn-secondary move-down"><span>&darr;</span></button>
@@ -33,7 +48,6 @@ function displayFiles(files) {
         `;
     list.appendChild(item);
   }
-
   attachMoveButtons();
 }
 

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -2,6 +2,7 @@ let currentSort = {
   field: null,
   descending: false,
 };
+//New Array to keep track of unique id
 let filesWithUniqueId = [];
 let processedFiles = [];
 
@@ -15,6 +16,7 @@ document.getElementById("fileInput-input").addEventListener("change", function (
   filesWithUniqueId = files;
   displayFiles(files);
 });
+//Get Files Updated Event from FileInput
 document.addEventListener("filesUpdated", function (e) {
   filesWithUniqueId = e.detail;
   displayFiles(filesWithUniqueId);
@@ -39,7 +41,7 @@ function displayFiles(files) {
     fileNameDiv.className = "filename";
     fileNameDiv.textContent = files[i].file.name;
 
-    // Check for duplicates
+    // Check for duplicates and add a warning if necessary
     const duplicateFiles = files.filter(file => file.file.name === files[i].file.name);
     if (duplicateFiles.length > 1) {
       const warning = document.createElement("span");
@@ -151,7 +153,6 @@ function updateFiles() {
 
   for (var i = 0; i < liElements.length; i++) {
     var fileIdFromList = liElements[i].dataset.id; // Get the unique identifier from the list item
-    var fileFromFiles;
     for (var j = 0; j < filesWithUniqueId.length; j++) {
       var fileObj = filesWithUniqueId[j];
       if (fileObj.uniqueId === fileIdFromList) {

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -2,39 +2,52 @@ let currentSort = {
   field: null,
   descending: false,
 };
+let filesWithUniqueId = [];
+let processedFiles = [];
 
 document.getElementById("fileInput-input").addEventListener("change", function () {
-  var files = this.files;
+  var files = Array.from(this.files).map(file => {
+    return {
+      file: file,
+      uniqueId: file.name + Date.now()
+    };
+  });
+  filesWithUniqueId = files;
   displayFiles(files);
 });
+document.addEventListener("filesUpdated", function (e) {
+  filesWithUniqueId = e.detail;
+  displayFiles(filesWithUniqueId);
+});
 
-/**
- * @param {File[]} files
- */
+
 function displayFiles(files) {
   const list = document.getElementById("selectedFiles");
-  const processedFiles = [];
 
   while (list.firstChild) {
     list.removeChild(list.firstChild);
   }
 
+  // Clear the processedFiles array
+  processedFiles = [];
+
   for (let i = 0; i < files.length; i++) {
     const item = document.createElement("li");
     item.className = "list-group-item";
+    item.dataset.id = files[i].uniqueId; // Assign the uniqueId to the list item
     const fileNameDiv = document.createElement("div");
     fileNameDiv.className = "filename";
-    fileNameDiv.textContent = files[i].name;
+    fileNameDiv.textContent = files[i].file.name;
 
     // Check for duplicates
-    if (processedFiles.includes(files[i].name)) {
+    const duplicateFiles = files.filter(file => file.file.name === files[i].file.name);
+    if (duplicateFiles.length > 1) {
       const warning = document.createElement("span");
       warning.className = "duplicate-warning";
       warning.textContent = "(Duplicate)";
       fileNameDiv.appendChild(warning);
-    } else {
-      processedFiles.push(files[i].name);
     }
+
 
     item.innerHTML = `
             <div class="d-flex justify-content-between align-items-center w-100">
@@ -80,16 +93,18 @@ function attachMoveButtons() {
 
   var removeButtons = document.querySelectorAll(".remove-file");
   for (var i = 0; i < removeButtons.length; i++) {
+    // When the delete button is clicked
     removeButtons[i].addEventListener("click", function (event) {
       event.preventDefault();
       var parent = this.closest(".list-group-item");
-      //Get name of removed file
-      var fileName = parent.querySelector(".filename").innerText;
+      var fileId = parent.dataset.id; // Get the unique identifier of the file to be deleted
       parent.remove();
+      // Remove the file from the filesWithUniqueId array
+      filesWithUniqueId = filesWithUniqueId.filter(fileObj => fileObj.uniqueId !== fileId);
       updateFiles();
-      //Dispatch a custom event with the name of the removed file
-      var event = new CustomEvent("fileRemoved", { detail: fileName });
-      document.dispatchEvent(event);
+      // Dispatch a custom event with the unique identifier of the file to be deleted
+      var fileRemoved = new CustomEvent("fileRemoved", { detail: fileId });
+      document.dispatchEvent(fileRemoved);
     });
   }
 }
@@ -129,18 +144,18 @@ function sortFiles(comparator) {
   document.getElementById("fileInput-input").files = dataTransfer.files;
 }
 
+
 function updateFiles() {
   var dataTransfer = new DataTransfer();
   var liElements = document.querySelectorAll("#selectedFiles li");
-  const files = document.getElementById("fileInput-input").files;
 
   for (var i = 0; i < liElements.length; i++) {
-    var fileNameFromList = liElements[i].querySelector(".filename").innerText;
+    var fileIdFromList = liElements[i].dataset.id; // Get the unique identifier from the list item
     var fileFromFiles;
-    for (var j = 0; j < files.length; j++) {
-      var file = files[j];
-      if (file.name === fileNameFromList) {
-        dataTransfer.items.add(file);
+    for (var j = 0; j < filesWithUniqueId.length; j++) {
+      var fileObj = filesWithUniqueId[j];
+      if (fileObj.uniqueId === fileIdFromList) {
+        dataTransfer.items.add(fileObj.file);
         break;
       }
     }


### PR DESCRIPTION
# User Friendly Merge File Selction

If you had already added files to Merge them, but forgot one or more files and you went ahead and pressed the "Select Files" button, all previously selected Files were deleted.
I fixed that and made it possible to add Files "File by File". Additionally if someone should add the same File twice, a duplicate warning is now displayed, which is removed, if the duplicates are removed. Merging duplicates is possibel though if someone should want to do that. To work with duplicates I added a unique id for each added FIle in the merging process. This makes it possible to differ between files that have the same Name.

Closes #1174 

## Checklist:

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
