### PR TITLE
fix Remove Redundant Back to Main Page Button

### DIFF
--- a/src/main/resources/templates/view-pdf.html
+++ b/src/main/resources/templates/view-pdf.html
@@ -185,11 +185,6 @@ See https://github.com/adobe-type-tools/cmap-resources
         <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
             <div id="secondaryToolbarButtonContainer">
 
-                <a id="secondaryBackToHome" class="secondaryToolbarButton visibleLargeView" title="Back to Main Page"
-                   tabindex="50"
-                   data-l10n-id="back_to_home" th:href="@{/}">
-                    <span data-l10n-id="back_to_home_label">Back to Main Page</span>
-                </a>
                 <button id="secondaryOpenFile" class="secondaryToolbarButton visibleLargeView" title="Open File"
                         tabindex="51"
                         data-l10n-id="open_file">


### PR DESCRIPTION
# Description

Remove Redundant Back to Main Page Button in View-pdf page.

Closes #489

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
