### PR TITLE
Amended typo: trailing space

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ security:
   enableLogin: false # set to 'true' to enable login
   csrfDisabled: true # Set to 'true' to disable CSRF protection (not recommended for production)
   loginAttemptCount: 5 # lock user account after 5 tries
-  loginResetTimeMinutes : 120 # lock account for 2 hours after x attempts
+  loginResetTimeMinutes: 120 # lock account for 2 hours after x attempts
 #  initialLogin:
 #    username: "admin" # Initial username for the first login (these are defaulted)
 #    password: "stirling" # Initial password for the first login

--- a/src/main/resources/settings.yml.template
+++ b/src/main/resources/settings.yml.template
@@ -6,7 +6,7 @@ security:
   enableLogin: false # set to 'true' to enable login
   csrfDisabled: true # Set to 'true' to disable CSRF protection (not recommended for production)
   loginAttemptCount: 5 # lock user account after 5 tries
-  loginResetTimeMinutes : 120 # lock account for 2 hours after x attempts
+  loginResetTimeMinutes: 120 # lock account for 2 hours after x attempts
 #  initialLogin:
 #    username: "admin" # Initial username for the first login
 #    password: "stirling" # Initial password for the first login


### PR DESCRIPTION
# Description

Trailing space before colon in the `settings.yml` has been fixed, and changes are reflected in the README.md file too.

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
