### PR TITLE
update alpine to v3.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /et
         ca-certificates \
         tzdata \
         tini \
-        openssl \
-        openssl-dev \
         bash \
         curl \
-        openjdk21-jre \
-        su-exec \
         shadow \
+        su-exec \
+        openssl \
+        openssl-dev \
+        openjdk21-jre \
 # Doc conversion
         libreoffice \
 # pdftohtml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Main stage
-FROM alpine:20240329
+FROM alpine:3.20.0
 
 # Copy necessary files
 COPY scripts /scripts
@@ -10,35 +10,33 @@ COPY build/libs/*.jar app.jar
 
 ARG VERSION_TAG
 
-
 # Set Environment Variables
 ENV DOCKER_ENABLE_SECURITY=false \
     VERSION_TAG=$VERSION_TAG \
     JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMPercentage=75" \
-	HOME=/home/stirlingpdfuser \
-	PUID=1000 \
+    HOME=/home/stirlingpdfuser \
+    PUID=1000 \
     PGID=1000 \
     UMASK=022
-
 
 # JDK for app
 RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories && \
     echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories && \
     echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" | tee -a /etc/apk/repositories && \
-    apk update && \
+    apk upgrade --no-cache -a && \
     apk add --no-cache \
         ca-certificates \
         tzdata \
         tini \
         openssl \
-openssl-dev \
+        openssl-dev \
         bash \
         curl \
         openjdk21-jre \
         su-exec \
         shadow \
 # Doc conversion
-        libreoffice@testing \
+        libreoffice \
 # pdftohtml
         poppler-utils \
 # OCR MY PDF (unpaper for descew and other advanced featues)
@@ -60,10 +58,9 @@ openssl-dev \
     addgroup -S stirlingpdfgroup && adduser -S stirlingpdfuser -G stirlingpdfgroup && \
     chown -R stirlingpdfuser:stirlingpdfgroup $HOME /scripts /usr/share/fonts/opentype/noto /configs /customFiles /pipeline && \
     chown stirlingpdfuser:stirlingpdfgroup /app.jar && \
-    tesseract --list-langs && \
-    rm -rf /var/cache/apk/*
+    tesseract --list-langs
 
-EXPOSE 8080
+EXPOSE 8080/tcp
 
 # Set user and run command
 ENTRYPOINT ["tini", "--", "/scripts/init.sh"]

--- a/Dockerfile-ultra-lite
+++ b/Dockerfile-ultra-lite
@@ -1,5 +1,5 @@
 # use alpine
-FROM alpine:3.19.1
+FROM alpine:3.20.0
 
 ARG VERSION_TAG
 
@@ -8,7 +8,7 @@ ENV DOCKER_ENABLE_SECURITY=false \
     HOME=/home/stirlingpdfuser \
     VERSION_TAG=$VERSION_TAG \
     JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMPercentage=75" \
-	PUID=1000 \
+    PUID=1000 \
     PGID=1000 \
     UMASK=022
 
@@ -18,24 +18,23 @@ COPY scripts/init-without-ocr.sh /scripts/init-without-ocr.sh
 COPY pipeline /pipeline
 COPY build/libs/*.jar app.jar
 
-
 # Set up necessary directories and permissions
-
-RUN mkdir /configs /logs /customFiles && \
-    chmod +x /scripts/*.sh && \
+RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories && \
+    echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories && \
+    echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" | tee -a /etc/apk/repositories && \
+    apk upgrade --no-cache -a && \
     apk add --no-cache \
         ca-certificates \
         tzdata \
         tini \
         bash \
         curl \
-        su-exec \
         shadow \
+        su-exec \
         openjdk21-jre && \
-    echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /etc/apk/repositories && \
-    echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories && \
-    echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" | tee -a /etc/apk/repositories && \
     # User permissions
+    mkdir /configs /logs /customFiles && \
+    chmod +x /scripts/*.sh && \
     addgroup -S stirlingpdfgroup && adduser -S stirlingpdfuser -G stirlingpdfgroup && \
     chown -R stirlingpdfuser:stirlingpdfgroup $HOME /scripts  /configs /customFiles /pipeline && \
     chown stirlingpdfuser:stirlingpdfgroup /app.jar    
@@ -43,9 +42,8 @@ RUN mkdir /configs /logs /customFiles && \
 # Set environment variables
 ENV ENDPOINTS_GROUPS_TO_REMOVE=CLI
 
-EXPOSE 8080
-
-ENTRYPOINT ["tini", "--", "/scripts/init-without-ocr.sh"]
+EXPOSE 8080/tcp
 
 # Run the application
+ENTRYPOINT ["tini", "--", "/scripts/init-without-ocr.sh"]
 CMD ["java", "-Dfile.encoding=UTF-8", "-jar", "/app.jar"]


### PR DESCRIPTION
# Description

I've updated alpine to v3.20.0 (I didn't create an Issue)
libreoffice should now work without edge

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
