### PR TITLE
fix fr translation of "Sign"

### DIFF
--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -114,7 +114,7 @@ navbar.multiTool=Multi Outils
 navbar.sections.organize=Oragnisation
 navbar.sections.convertTo=Convertir en PDF
 navbar.sections.convertFrom=Convertir depuis PDF
-navbar.sections.security=Signalisation et sécurité
+navbar.sections.security=Signature et sécurité
 navbar.sections.advance=Mode avancé
 navbar.sections.edit=Voir la modification
 


### PR DESCRIPTION
# Description

In french To Sign is "Signer" not "Signaliser"

We speak of "digital signature" which translate to "signature numerique"
"Signalisation" is "Signage" 

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
