### PR TITLE
fix: change "crop image" to "crop pdf"

### DIFF
--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Crop
-crop.header=Crop Image
+crop.header=Crop PDF
 crop.submit=Submit
 
 

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Изтегли
 
 #crop
 crop.title=Изрязване
-crop.header=Изрязване на изображение
+crop.header=Изрязване на PDF
 crop.submit=Подайте
 
 

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Talla
-crop.header=Talla Imatge
+crop.header=Talla PDF
 crop.submit=Submit
 
 

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Stáhnout
 
 #crop
 crop.title=Oříznout
-crop.header=Oříznout obrázek
+crop.header=Oříznout PDF
 crop.submit=Odeslat
 
 

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Herunterladen
 
 #crop
 crop.title=Zuschneiden
-crop.header=Bild zuschneiden
+crop.header=PDF zuschneiden
 crop.submit=Abschicken
 
 

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Λήψη
 
 #crop
 crop.title=Κοπή
-crop.header=Κοπή Εικόνας
+crop.header=Περικοπή PDF
 crop.submit=Υποβολή
 
 

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Crop
-crop.header=Crop Image
+crop.header=Crop PDF
 crop.submit=Submit
 
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Crop
-crop.header=Crop Image
+crop.header=Crop PDF
 crop.submit=Submit
 
 

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Descargar
 
 #crop
 crop.title=Recortar
-crop.header=Recortar Imagen
+crop.header=Recortar PDF
 crop.submit=Entregar
 
 

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Distira
 
 #crop
 crop.title=Moztu
-crop.header=Irudia Moztu
+crop.header=Moztu PDF
 crop.submit=Bidali
 
 

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -597,7 +597,7 @@ adjustContrast.download=डाउनलोड
 
 #crop
 crop.title=कटौती
-crop.header=छवि काटो
+crop.header=क्रॉप पीडीएफ़
 crop.submit=प्रस्तुत करें
 
 

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Letöltés
 
 #crop
 crop.title=Körülvágás
-crop.header=Kép körülvégésa
+crop.header=Crop PDF
 crop.submit=Elküldés
 
 

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Unduh
 
 #crop
 crop.title=Pangkas
-crop.header=Pangkas Gambar
+crop.header=Pangkas PDF
 crop.submit=Kirim
 
 

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Ritaglia
-crop.header=Ritaglia l'immagine
+crop.header=Ritaglia PDF
 crop.submit=Invia
 
 

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -597,7 +597,7 @@ adjustContrast.download=ダウンロード
 
 #crop
 crop.title=切り抜き
-crop.header=画像の切り抜き
+crop.header=PDFのトリミング
 crop.submit=送信
 
 

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -597,7 +597,7 @@ adjustContrast.download=다운로드
 
 #crop
 crop.title=잘라내기
-crop.header=잘라내기
+crop.header=PDF 잘라내기
 crop.submit=확인
 
 

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Downloaden
 
 #crop
 crop.title=Bijwerken
-crop.header=Afbeelding bijwerken
+crop.header=PDF bijsnijden
 crop.submit=Indienen
 
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Crop
-crop.header=Crop Image
+crop.header=Crop PDF
 crop.submit=Submit
 
 

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Cortar
-crop.header=Cortar Imagem
+crop.header=Cortar PDF
 crop.submit=Enviar
 
 

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Cortar
-crop.header=Cortar Imagem
+crop.header=Cortar PDF
 crop.submit=Enviar
 
 

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Crop
-crop.header=Crop Image
+crop.header=Crop PDF
 crop.submit=Submit
 
 

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Скачать
 
 #crop
 crop.title=Обрезать
-crop.header=Обрезать изображение
+crop.header=Обрезать PDF-файл
 crop.submit=Отправить
 
 

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Stiahnuť
 
 #crop
 crop.title=Orezať
-crop.header=Orezať obrázok
+crop.header=Orezať PDF
 crop.submit=Odoslať
 
 

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Preuzmi
 
 #crop
 crop.title=Iseci
-crop.header=Iseci Sliku
+crop.header=Skraćivanje PDF-a
 crop.submit=Potvrdi
 
 

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Download
 
 #crop
 crop.title=Crop
-crop.header=Crop Image
+crop.header=Crop PDF
 crop.submit=Submit
 
 

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -597,7 +597,7 @@ adjustContrast.download=İndir
 
 #crop
 crop.title=Kırp
-crop.header=Resmi Kırp
+crop.header=PDF'i Kırp
 crop.submit=Gönder
 
 

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -597,7 +597,7 @@ adjustContrast.download=Завантажити
 
 #crop
 crop.title=Обрізати
-crop.header=Обрізати зображення
+crop.header=Обрізати PDF-файл
 crop.submit=Надіслати
 
 

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -597,7 +597,7 @@ adjustContrast.download=下载
 
 #crop
 crop.title=裁剪
-crop.header=裁剪图像
+crop.header=裁剪PDF
 crop.submit=提交
 
 

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -597,7 +597,7 @@ adjustContrast.download=下載
 
 #crop
 crop.title=裁剪
-crop.header=裁剪影像
+crop.header=裁剪 PDF
 crop.submit=送出
 
 


### PR DESCRIPTION
# Description

Change "crop image" to "crop pdf".

Closes #1298 

## Checklist:

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
