### PR TITLE
fix: type correction around google OAUTH2 provider

### DIFF
--- a/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
+++ b/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
@@ -357,7 +357,7 @@ public class ApplicationProperties {
 
                 public Provider get(String registrationId) throws Exception {
                     switch (registrationId) {
-                        case "gogole":
+                        case "google":
                             return getGoogle();
                         case "github":
                             return getGithub();


### PR DESCRIPTION
# Description

Typo correction within google oauth2 code, spotted this while trying to update the docker-compose example for using SSO

## Checklist:

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
