### PR TITLE
Update view-pdf.html

### DIFF
--- a/src/main/resources/templates/view-pdf.html
+++ b/src/main/resources/templates/view-pdf.html
@@ -30,7 +30,6 @@ See https://github.com/adobe-type-tools/cmap-resources
     <!-- Bootstrap -->
     <script src="js/thirdParty/popper.min.js"></script>
     <script src="js/thirdParty/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="css/bootstrap.min.css">
 
     <link rel="stylesheet" href="css/theme/componentes.css">
     <link rel="stylesheet" href="css/navbar.css">
@@ -321,7 +320,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <button id="download" class="toolbarButton hiddenMediumView" title="Save" role="radio" aria-checked="false" tabindex="35" data-l10n-id="pdfjs-save-button">
                     <span data-l10n-id="pdfjs-save-button-label">Save</span>
                   </button>
-                  <button id="editorStamp" class="toolbarButton hidden" hidden="true" disabled="disabled" title="Add or edit images" role="radio" aria-checked="false" aria-controls="editorStampParamsToolbar" tabindex="36" data-l10n-id="pdfjs-editor-stamp-button">
+                  <button id="editorStamp" class="toolbarButton hiddenMediumView" title="Add or edit images" role="radio" aria-checked="false" aria-controls="editorStampParamsToolbar" tabindex="36" data-l10n-id="pdfjs-editor-stamp-button">
                     <span data-l10n-id="pdfjs-editor-stamp-button-label">Add or edit images</span>
                   </button>
                 </div>


### PR DESCRIPTION
# Description

Remove bootstrap.css which regresses a previous issue that caused imported images to incorrectly resize.
Reintroduce "Import image" option.

Closes #(issue_number)

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
