### PR TITLE
Fix Error When Submitting Crop Tool Without Making a Selection

### DIFF
--- a/src/main/resources/templates/crop.html
+++ b/src/main/resources/templates/crop.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}" th:dir="#{language.direction}" th:data-language="${#locale.toString()}" xmlns:th="https://www.thymeleaf.org">
   <head>
-  <th:block th:insert="~{fragments/common :: head(title=#{crop.title}, header=#{crop.header})}"></th:block>
+    <th:block th:insert="~{fragments/common :: head(title=#{crop.title}, header=#{crop.header})}"></th:block>
   </head>
 
   <body>
@@ -72,6 +72,16 @@
                   });
                 };
                 reader.readAsArrayBuffer(file);
+              }
+            });
+
+            cropForm.addEventListener('submit', function(e) {
+              if (xInput.value == "" && yInput.value == "" && widthInput.value == "" && heightInput.value == "") {
+                // Ορίστε συντεταγμένες για ολόκληρη την επιφάνεια του PDF
+                xInput.value = 0;
+                yInput.value = 0;
+                widthInput.value = pdfCanvas.width;
+                heightInput.value = pdfCanvas.height;
               }
             });
 


### PR DESCRIPTION
# Description

This pull request addresses the issue where an error occurs if the crop tool form is submitted without making a selection. 

### Changes Made
Added logic to set default values for x, y, width, and height inputs if no selection is made. This ensures the entire PDF is selected by default when the form is submitted without any user selection.

Closes #1342

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
