### PR TITLE
new workaround for remove digital signature

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
@@ -1,10 +1,22 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
+import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.apache.pdfbox.pdmodel.interactive.form.PDField;
+import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,6 +38,8 @@ import stirling.software.SPDF.utils.WebResponseUtils;
 @Tag(name = "Convert", description = "Convert APIs")
 public class ConvertPDFToPDFA {
 
+    private static final Logger logger = LoggerFactory.getLogger(ConvertPDFToPDFA.class);
+
     @PostMapping(consumes = "multipart/form-data", value = "/pdf/pdfa")
     @Operation(
             summary = "Convert a PDF to a PDF/A",
@@ -36,9 +50,39 @@ public class ConvertPDFToPDFA {
         MultipartFile inputFile = request.getFileInput();
         String outputFormat = request.getOutputFormat();
 
-        // Save the uploaded file to a temporary location
+        // Convert MultipartFile to byte[]
+        byte[] pdfBytes = inputFile.getBytes();
+
+        // Load the PDF document
+        PDDocument document = Loader.loadPDF(pdfBytes);
+
+        // Get the document catalog
+        PDDocumentCatalog catalog = document.getDocumentCatalog();
+
+        // Get the AcroForm
+        PDAcroForm acroForm = catalog.getAcroForm();
+        if (acroForm != null) {
+            // Remove signature fields safely
+            List<PDField> fieldsToRemove =
+                    acroForm.getFields().stream()
+                            .filter(field -> field instanceof PDSignatureField)
+                            .collect(Collectors.toList());
+
+            if (!fieldsToRemove.isEmpty()) {
+                acroForm.flatten(fieldsToRemove, false);
+
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                document.save(baos);
+                pdfBytes = baos.toByteArray();
+            }
+        }
+        document.close();
+
+        // Save the uploaded (and possibly modified) file to a temporary location
         Path tempInputFile = Files.createTempFile("input_", ".pdf");
-        inputFile.transferTo(tempInputFile.toFile());
+        try (OutputStream outputStream = new FileOutputStream(tempInputFile.toFile())) {
+            outputStream.write(pdfBytes);
+        }
 
         // Prepare the output file path
         Path tempOutputFile = Files.createTempFile("output_", ".pdf");
@@ -58,7 +102,7 @@ public class ConvertPDFToPDFA {
                         .runCommandWithOutputHandling(command);
 
         // Read the optimized PDF file
-        byte[] pdfBytes = Files.readAllBytes(tempOutputFile);
+        byte[] optimizedPdfBytes = Files.readAllBytes(tempOutputFile);
 
         // Clean up the temporary files
         Files.deleteIfExists(tempInputFile);
@@ -69,6 +113,6 @@ public class ConvertPDFToPDFA {
                 Filenames.toSimpleFileName(inputFile.getOriginalFilename())
                                 .replaceFirst("[.][^.]+$", "")
                         + "_PDFA.pdf";
-        return WebResponseUtils.bytesToWebResponse(pdfBytes, outputFilename);
+        return WebResponseUtils.bytesToWebResponse(optimizedPdfBytes, outputFilename);
     }
 }

--- a/src/main/java/stirling/software/SPDF/controller/api/security/RemoveCertSignController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/security/RemoveCertSignController.java
@@ -1,11 +1,14 @@
 package stirling.software.SPDF.controller.api.security;
 
 import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.apache.pdfbox.pdmodel.interactive.form.PDField;
 import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,8 +57,15 @@ public class RemoveCertSignController {
         // Get the AcroForm
         PDAcroForm acroForm = catalog.getAcroForm();
         if (acroForm != null) {
-            // Remove signature fields
-            acroForm.getFields().removeIf(field -> field instanceof PDSignatureField);
+            // Remove signature fields safely
+            List<PDField> fieldsToRemove =
+                    acroForm.getFields().stream()
+                            .filter(field -> field instanceof PDSignatureField)
+                            .collect(Collectors.toList());
+
+            if (!fieldsToRemove.isEmpty()) {
+                acroForm.flatten(fieldsToRemove, false);
+            }
         }
 
         // Save the modified document to the ByteArrayOutputStream

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=تستخدم هذه الخدمة OCRmyPDF لتحويل PDF / A.
 pdfToPDFA.submit=تحويل
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=تستخدم هذه الخدمة OCRmyPDF لتحويل PDF / A.
 pdfToPDFA.submit=تحويل
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Тази услуга използва OCRmyPDF за PDF/A пр
 pdfToPDFA.submit=Преобразуване
 pdfToPDFA.tip=В момента не работи за няколко входа наведнъж
 pdfToPDFA.outputFormat=Изходен формат
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Тази услуга използва OCRmyPDF за PDF/A пр
 pdfToPDFA.submit=Преобразуване
 pdfToPDFA.tip=В момента не работи за няколко входа наведнъж
 pdfToPDFA.outputFormat=Изходен формат
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Utilitza OCRmyPDF per la conversió a PDF/A
 pdfToPDFA.submit=Converteix
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Utilitza OCRmyPDF per la conversió a PDF/A
 pdfToPDFA.submit=Converteix
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Tato služba používá OCRmyPDF pro konverzi do formátu PDF/A
 pdfToPDFA.submit=Převést
 pdfToPDFA.tip=V současné době nepracuje pro více vstupů najednou
 pdfToPDFA.outputFormat=Výstupní formát
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Tato služba používá OCRmyPDF pro konverzi do formátu PDF/A
 pdfToPDFA.submit=Převést
 pdfToPDFA.tip=V současné době nepracuje pro více vstupů najednou
 pdfToPDFA.outputFormat=Výstupní formát
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Dieser Dienst verwendet OCRmyPDF für die PDF/A-Konvertierung
 pdfToPDFA.submit=Konvertieren
 pdfToPDFA.tip=Dieser Dienst kann nur einzelne Eingangsdateien verarbeiten.
 pdfToPDFA.outputFormat=Ausgabeformat
-pdfToPDFA.pdfWithDigitalSignature=Das PDF enthält eine digitale Signatur.
+pdfToPDFA.pdfWithDigitalSignature=Das PDF enthält eine digitale Signatur. Sie wird im nächsten Schritt entfernt.
 
 
 #PDFToWord

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Dieser Dienst verwendet OCRmyPDF für die PDF/A-Konvertierung
 pdfToPDFA.submit=Konvertieren
 pdfToPDFA.tip=Dieser Dienst kann nur einzelne Eingangsdateien verarbeiten.
 pdfToPDFA.outputFormat=Ausgabeformat
+pdfToPDFA.pdfWithDigitalSignature=Das PDF enthält eine digitale Signatur.
 
 
 #PDFToWord

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Αυτή η υπηρεσία χρησιμοποιεί OCRmyPDF 
 pdfToPDFA.submit=Μετατροπή
 pdfToPDFA.tip=Προς το παρόν δεν λειτουργεί για πολλαπλές εισόδους ταυτόχρονα
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Αυτή η υπηρεσία χρησιμοποιεί OCRmyPDF 
 pdfToPDFA.submit=Μετατροπή
 pdfToPDFA.tip=Προς το παρόν δεν λειτουργεί για πολλαπλές εισόδους ταυτόχρονα
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=This service uses OCRmyPDF for PDF/A conversion
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=This service uses OCRmyPDF for PDF/A conversion
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=This service uses OCRmyPDF for PDF/A conversion
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=This service uses OCRmyPDF for PDF/A conversion
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Este servicio usa OCRmyPDF para la conversión a PDF/A
 pdfToPDFA.submit=Convertir
 pdfToPDFA.tip=Actualmente no funciona para múltiples entrada a la vez
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Este servicio usa OCRmyPDF para la conversión a PDF/A
 pdfToPDFA.submit=Convertir
 pdfToPDFA.tip=Actualmente no funciona para múltiples entrada a la vez
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Zerbitzu honek OCRmyPDF erabiltzen du PDFak PDF/A bihurtzeko
 pdfToPDFA.submit=Bihurtu
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Zerbitzu honek OCRmyPDF erabiltzen du PDFak PDF/A bihurtzeko
 pdfToPDFA.submit=Bihurtu
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Ce service utilise OCRmyPDF pour la conversion en PDF/A.
 pdfToPDFA.submit=Convertir
 pdfToPDFA.tip=Ne fonctionne actuellement pas pour plusieurs entrées à la fois
 pdfToPDFA.outputFormat=Format de sortie
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Ce service utilise OCRmyPDF pour la conversion en PDF/A.
 pdfToPDFA.submit=Convertir
 pdfToPDFA.tip=Ne fonctionne actuellement pas pour plusieurs entrées à la fois
 pdfToPDFA.outputFormat=Format de sortie
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=इस सेवा में PDF/A परिवर्तन �
 pdfToPDFA.submit=परिवर्तित करें
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=इस सेवा में PDF/A परिवर्तन �
 pdfToPDFA.submit=परिवर्तित करें
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -972,7 +972,7 @@ pdfToPDFA.credit=Ova usluga koristi OCRmyPDF za PDF/A pretvorbu
 pdfToPDFA.submit=Pretvoriti
 pdfToPDFA.tip=Trenutno ne radi za više unosa odjednom
 pdfToPDFA.outputFormat=Izlazni format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -331,6 +331,9 @@ compare.tags=razlikovati,kontrast,izmjene,analiza
 home.certSign.title=Potpišite s certifikatom
 home.certSign.desc=Potpisuje PDF s certifikatom/ključem (PEM/P12)
 certSign.tags=autentifikacija,PEM,P12,zvanično,šifriranje
+# home.removeCertSign.title=Remove Certificate Sign
+# home.removeCertSign.desc=Remove certificate signature from PDF
+# removeCertSign.tags=authenticate,PEM,P12,official,decrypt
 
 home.pageLayout.title=Izgled s više stranica
 home.pageLayout.desc=Spojite više stranica PDF dokumenta u jednu stranicu
@@ -653,6 +656,10 @@ certSign.reason=Razlog
 certSign.location=Mjesto
 certSign.name=Ime
 certSign.submit=Potpiši PDF
+# removeCertSign.title=Remove Certificate Signature
+# removeCertSign.header=Remove the digital certificate from the PDF
+# removeCertSign.selectPDF=Select a PDF file:
+# removeCertSign.submit=Remove Signature
 
 
 #removeBlanks
@@ -965,6 +972,7 @@ pdfToPDFA.credit=Ova usluga koristi OCRmyPDF za PDF/A pretvorbu
 pdfToPDFA.submit=Pretvoriti
 pdfToPDFA.tip=Trenutno ne radi za više unosa odjednom
 pdfToPDFA.outputFormat=Izlazni format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Ez a szolgáltatás az OCRmyPDF-t használja a PDF/A konverzió
 pdfToPDFA.submit=Konvertálás
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Ez a szolgáltatás az OCRmyPDF-t használja a PDF/A konverzió
 pdfToPDFA.submit=Konvertálás
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Layanan ini menggunakan OCRmyPDF untuk konversi PDF/A.
 pdfToPDFA.submit=Konversi
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Layanan ini menggunakan OCRmyPDF untuk konversi PDF/A.
 pdfToPDFA.submit=Konversi
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Questo servizio utilizza OCRmyPDF per la conversione in PDF/A.
 pdfToPDFA.submit=Converti
 pdfToPDFA.tip=Attualmente non funziona per più input contemporaneamente
 pdfToPDFA.outputFormat=Formato di output
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Questo servizio utilizza OCRmyPDF per la conversione in PDF/A.
 pdfToPDFA.submit=Converti
 pdfToPDFA.tip=Attualmente non funziona per più input contemporaneamente
 pdfToPDFA.outputFormat=Formato di output
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=本サービスはPDF/Aの変換にOCRmyPDFを使用してい�
 pdfToPDFA.submit=変換
 pdfToPDFA.tip=現在、一度に複数の入力に対して機能しません
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=本サービスはPDF/Aの変換にOCRmyPDFを使用してい�
 pdfToPDFA.submit=変換
 pdfToPDFA.tip=現在、一度に複数の入力に対して機能しません
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=이 서비스는 PDF/A 변환을 위해 OCRmyPDF 문서를 사�
 pdfToPDFA.submit=변환
 pdfToPDFA.tip=현재 한 번에 여러 입력에 대해 작동하지 않습니다.
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=이 서비스는 PDF/A 변환을 위해 OCRmyPDF 문서를 사�
 pdfToPDFA.submit=변환
 pdfToPDFA.tip=현재 한 번에 여러 입력에 대해 작동하지 않습니다.
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Deze service gebruikt OCRmyPDF voor PDF/A-conversie
 pdfToPDFA.submit=Converteren
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Deze service gebruikt OCRmyPDF voor PDF/A-conversie
 pdfToPDFA.submit=Converteren
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Ta usługa używa OCRmyPDF do konwersji PDF/A
 pdfToPDFA.submit=Konwertuj
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Ta usługa używa OCRmyPDF do konwersji PDF/A
 pdfToPDFA.submit=Konwertuj
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Este serviço usa OCRmyPDF para Conversão de PDF/A
 pdfToPDFA.submit=Converter
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Este serviço usa OCRmyPDF para Conversão de PDF/A
 pdfToPDFA.submit=Converter
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Este serviço usa OCRmyPDF para Conversão de PDF/A
 pdfToPDFA.submit=Converter
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Este serviço usa OCRmyPDF para Conversão de PDF/A
 pdfToPDFA.submit=Converter
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Acest serviciu utilizează OCRmyPDF pentru conversia în PDF/A
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Acest serviciu utilizează OCRmyPDF pentru conversia în PDF/A
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Этот сервис использует OCRmyPDF для пр
 pdfToPDFA.submit=Конвертировать
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Этот сервис использует OCRmyPDF для пр
 pdfToPDFA.submit=Конвертировать
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Táto služba používa OCRmyPDF na konverziu PDF/A
 pdfToPDFA.submit=Konvertovať
 pdfToPDFA.tip=Momentálne nefunguje pre viacero vstupov naraz
 pdfToPDFA.outputFormat=Výstupný formát
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Táto služba používa OCRmyPDF na konverziu PDF/A
 pdfToPDFA.submit=Konvertovať
 pdfToPDFA.tip=Momentálne nefunguje pre viacero vstupov naraz
 pdfToPDFA.outputFormat=Výstupný formát
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Ova usluga koristi OCRmyPDF za konverziju u PDF/A format
 pdfToPDFA.submit=Konvertuj
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Ova usluga koristi OCRmyPDF za konverziju u PDF/A format
 pdfToPDFA.submit=Konvertuj
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Denna tjänst använder OCRmyPDF för PDF/A-konvertering
 pdfToPDFA.submit=Konvertera
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Denna tjänst använder OCRmyPDF för PDF/A-konvertering
 pdfToPDFA.submit=Konvertera
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Bu hizmet PDF/A dönüşümü için OCRmyPDF kullanır
 pdfToPDFA.submit=Dönüştür
 pdfToPDFA.tip=Şu anda aynı anda birden fazla giriş için çalışmıyor
 pdfToPDFA.outputFormat=Çıkış formatı
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Bu hizmet PDF/A dönüşümü için OCRmyPDF kullanır
 pdfToPDFA.submit=Dönüştür
 pdfToPDFA.tip=Şu anda aynı anda birden fazla giriş için çalışmıyor
 pdfToPDFA.outputFormat=Çıkış formatı
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=Цей сервіс використовує OCRmyPDF для п
 pdfToPDFA.submit=Конвертувати
 pdfToPDFA.tip=Наразі не працює для кількох вхідних файлів одночасно
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=Цей сервіс використовує OCRmyPDF для п
 pdfToPDFA.submit=Конвертувати
 pdfToPDFA.tip=Наразі не працює для кількох вхідних файлів одночасно
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=此服务使用OCRmyPDF进行PDF/A转换
 pdfToPDFA.submit=转换
 pdfToPDFA.tip=目前不支持上传多个
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=此服务使用OCRmyPDF进行PDF/A转换
 pdfToPDFA.submit=转换
 pdfToPDFA.tip=目前不支持上传多个
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -976,7 +976,7 @@ pdfToPDFA.credit=此服務使用 OCRmyPDF 進行 PDF/A 轉換
 pdfToPDFA.submit=轉換
 pdfToPDFA.tip=目前不支援上傳多個
 pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
 
 
 #PDFToWord

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -976,6 +976,7 @@ pdfToPDFA.credit=此服務使用 OCRmyPDF 進行 PDF/A 轉換
 pdfToPDFA.submit=轉換
 pdfToPDFA.tip=目前不支援上傳多個
 pdfToPDFA.outputFormat=Output format
+pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature.
 
 
 #PDFToWord

--- a/src/main/resources/templates/convert/pdf-to-pdfa.html
+++ b/src/main/resources/templates/convert/pdf-to-pdfa.html
@@ -58,7 +58,7 @@
 
                     if (hasSignature) {
                       /*<![CDATA[*/
-                      resultDiv.textContent = /*[[#{pdfToPDFA.pdfWithDigitalSignature}]]*/ "The PDF contains a digital signature.";
+                      resultDiv.textContent = /*[[#{pdfToPDFA.pdfWithDigitalSignature}]]*/ "The PDF contains a digital signature. This will be removed in the next step.";
                       /*]]>*/
                     }
                   } catch (error) {

--- a/src/main/resources/templates/convert/pdf-to-pdfa.html
+++ b/src/main/resources/templates/convert/pdf-to-pdfa.html
@@ -21,15 +21,51 @@
               <form method="post" enctype="multipart/form-data" th:action="@{api/v1/convert/pdf/pdfa}">
                 <div th:replace="~{fragments/common :: fileSelector(name='fileInput', multiple=false, accept='application/pdf')}"></div>
                 <div class="mb-3">
-                  <label th:text="#{pdfToPDFA.outputFormat}"></label>
-                  <select class="form-control" name="outputFormat">
+                  <label for="outputFormat" th:text="#{pdfToPDFA.outputFormat}"></label>
+                  <select class="form-control" name="outputFormat" id="outputFormat">
                     <option value="pdfa-1">PDF/A-1b</option>
                     <option value="pdfa">PDF/A-2b</option>
                   </select>
                 </div>
-                <br>
+                <div id="result" class="alert-warning"></div>
                 <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{pdfToPDFA.submit}"></button>
               </form>
+              <script th:inline="javascript">
+                document.getElementById('fileInput-input').addEventListener('change', async () => {
+                  pdfjsLib.GlobalWorkerOptions.workerSrc = './pdfjs/pdf.worker.mjs';
+                  const fileInput = document.getElementById('fileInput-input');
+                  const resultDiv = document.getElementById('result');
+
+                  const file = fileInput.files[0];
+                  const arrayBuffer = await file.arrayBuffer();
+
+                  try {
+                    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+                    
+                    let hasSignature = false;
+
+                    for (let i = 1; i <= pdf.numPages; i++) {
+                      const page = await pdf.getPage(i);
+                      const annotations = await page.getAnnotations({ intent: 'display' });
+
+                      annotations.forEach(annotation => {
+                        console.log(annotation)
+                        if (annotation.subtype === 'Widget' && annotation.fieldType === 'Sig') {
+                          hasSignature = true;
+                        }
+                      });
+                    }
+
+                    if (hasSignature) {
+                      /*<![CDATA[*/
+                      resultDiv.textContent = /*[[#{pdfToPDFA.pdfWithDigitalSignature}]]*/ "The PDF contains a digital signature.";
+                      /*]]>*/
+                    }
+                  } catch (error) {
+                    resultDiv.textContent = 'Error reading the PDF: ' + error.message;
+                  }
+              });
+              </script>
               <p class="mt-3" th:text="#{pdfToPDFA.credit}"></p>
             </div>
           </div>


### PR DESCRIPTION
# Description

A notification will now appear if the PDF has a digital signature.

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
