### PR TITLE
Enhance OAuth2 Client Registration with Dynamic Provider Details

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
+++ b/src/main/java/stirling/software/SPDF/config/security/SecurityConfiguration.java
@@ -238,7 +238,7 @@ public class SecurityConfiguration {
         GoogleProvider google = client.getGoogle();
         return google != null && google.isSettingsValid()
                 ? Optional.of(
-                        ClientRegistration.withRegistrationId("google")
+                        ClientRegistration.withRegistrationId(google.getName())
                                 .clientId(google.getClientId())
                                 .clientSecret(google.getClientSecret())
                                 .scope(google.getScopes())
@@ -246,8 +246,8 @@ public class SecurityConfiguration {
                                 .tokenUri(google.getTokenuri())
                                 .userInfoUri(google.getUserinfouri())
                                 .userNameAttributeName(google.getUseAsUsername())
-                                .clientName("Google")
-                                .redirectUri("{baseUrl}/login/oauth2/code/google")
+                                .clientName(google.getClientName())
+                                .redirectUri("{baseUrl}/login/oauth2/code/" + google.getName())
                                 .authorizationGrantType(
                                         org.springframework.security.oauth2.core
                                                 .AuthorizationGrantType.AUTHORIZATION_CODE)
@@ -269,12 +269,12 @@ public class SecurityConfiguration {
         return keycloak != null && keycloak.isSettingsValid()
                 ? Optional.of(
                         ClientRegistrations.fromIssuerLocation(keycloak.getIssuer())
-                                .registrationId("keycloak")
+                                .registrationId(keycloak.getName())
                                 .clientId(keycloak.getClientId())
                                 .clientSecret(keycloak.getClientSecret())
                                 .scope(keycloak.getScopes())
                                 .userNameAttributeName(keycloak.getUseAsUsername())
-                                .clientName("Keycloak")
+                                .clientName(keycloak.getClientName())
                                 .build())
                 : Optional.empty();
     }
@@ -291,7 +291,7 @@ public class SecurityConfiguration {
         GithubProvider github = client.getGithub();
         return github != null && github.isSettingsValid()
                 ? Optional.of(
-                        ClientRegistration.withRegistrationId("github")
+                        ClientRegistration.withRegistrationId(github.getName())
                                 .clientId(github.getClientId())
                                 .clientSecret(github.getClientSecret())
                                 .scope(github.getScopes())
@@ -299,8 +299,8 @@ public class SecurityConfiguration {
                                 .tokenUri(github.getTokenuri())
                                 .userInfoUri(github.getUserinfouri())
                                 .userNameAttributeName(github.getUseAsUsername())
-                                .clientName("GitHub")
-                                .redirectUri("{baseUrl}/login/oauth2/code/github")
+                                .clientName(github.getClientName())
+                                .redirectUri("{baseUrl}/login/oauth2/code/" + github.getName())
                                 .authorizationGrantType(
                                         org.springframework.security.oauth2.core
                                                 .AuthorizationGrantType.AUTHORIZATION_CODE)

--- a/src/main/java/stirling/software/SPDF/config/security/oauth2/CustomOAuth2LogoutSuccessHandler.java
+++ b/src/main/java/stirling/software/SPDF/config/security/oauth2/CustomOAuth2LogoutSuccessHandler.java
@@ -81,7 +81,7 @@ public class CustomOAuth2LogoutSuccessHandler extends SimpleUrlLogoutSuccessHand
             logger.info("Session invalidated: " + sessionId);
         }
 
-        switch (registrationId) {
+        switch (registrationId.toLowerCase()) {
             case "keycloak":
                 // Add Keycloak specific logout URL if needed
                 String logoutUrl =

--- a/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
@@ -52,23 +52,23 @@ public class AccountWebController {
         OAUTH2 oauth = applicationProperties.getSecurity().getOAUTH2();
         if (oauth != null) {
             if (oauth.isSettingsValid()) {
-                providerList.put("oidc", "OpenID Connect");
+                providerList.put("oidc", oauth.getProvider());
             }
             Client client = oauth.getClient();
             if (client != null) {
                 GoogleProvider google = client.getGoogle();
                 if (google.isSettingsValid()) {
-                    providerList.put("google", "Google");
+                    providerList.put(google.getName(), google.getClientName());
                 }
 
                 GithubProvider github = client.getGithub();
                 if (github.isSettingsValid()) {
-                    providerList.put("github", "Github");
+                    providerList.put(github.getName(), github.getClientName());
                 }
 
                 KeycloakProvider keycloak = client.getKeycloak();
                 if (keycloak.isSettingsValid()) {
-                    providerList.put("keycloak", "Keycloak");
+                    providerList.put(keycloak.getName(), keycloak.getClientName());
                 }
             }
         }

--- a/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
+++ b/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
@@ -455,6 +455,7 @@ public class ApplicationProperties {
         @Override
         public Collection<String> getScopes() {
             if (scopes == null || scopes.isEmpty()) {
+                scopes = new ArrayList<>();
                 scopes.add("https://www.googleapis.com/auth/userinfo.email");
                 scopes.add("https://www.googleapis.com/auth/userinfo.profile");
             }
@@ -560,6 +561,7 @@ public class ApplicationProperties {
 
         public Collection<String> getScopes() {
             if (scopes == null || scopes.isEmpty()) {
+                scopes = new ArrayList<>();
                 scopes.add("read:user");
             }
             return scopes;
@@ -652,6 +654,7 @@ public class ApplicationProperties {
         @Override
         public Collection<String> getScopes() {
             if (scopes == null || scopes.isEmpty()) {
+                scopes = new ArrayList<>();
                 scopes.add("profile");
                 scopes.add("email");
             }

--- a/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
+++ b/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
@@ -356,7 +356,7 @@ public class ApplicationProperties {
                 private KeycloakProvider keycloak = new KeycloakProvider();
 
                 public Provider get(String registrationId) throws Exception {
-                    switch (registrationId) {
+                    switch (registrationId.toLowerCase()) {
                         case "google":
                             return getGoogle();
                         case "github":
@@ -495,6 +495,11 @@ public class ApplicationProperties {
             return "google";
         }
 
+        @Override
+        public String getClientName() {
+            return "Google";
+        }
+
         public boolean isSettingsValid() {
             return super.isValid(this.getClientId(), "clientId")
                     && super.isValid(this.getClientSecret(), "clientSecret")
@@ -594,6 +599,11 @@ public class ApplicationProperties {
             return "github";
         }
 
+        @Override
+        public String getClientName() {
+            return "GitHub";
+        }
+
         public boolean isSettingsValid() {
             return super.isValid(this.getClientId(), "clientId")
                     && super.isValid(this.getClientSecret(), "clientSecret")
@@ -642,7 +652,6 @@ public class ApplicationProperties {
         @Override
         public Collection<String> getScopes() {
             if (scopes == null || scopes.isEmpty()) {
-                scopes.add("openid");
                 scopes.add("profile");
                 scopes.add("email");
             }
@@ -682,6 +691,11 @@ public class ApplicationProperties {
         @Override
         public String getName() {
             return "keycloak";
+        }
+
+        @Override
+        public String getClientName() {
+            return "Keycloak";
         }
 
         public boolean isSettingsValid() {

--- a/src/main/java/stirling/software/SPDF/model/Provider.java
+++ b/src/main/java/stirling/software/SPDF/model/Provider.java
@@ -4,9 +4,14 @@ import java.util.Collection;
 
 public class Provider implements ProviderInterface {
     private String name;
+    private String clientName;
 
     public String getName() {
         return name;
+    }
+
+    public String getClientName() {
+        return clientName;
     }
 
     protected boolean isValid(String value, String name) {


### PR DESCRIPTION
# Description

This pull request updates the OAuth2 client registration process to dynamically use provider-specific details instead of hardcoded values. The changes improve the flexibility and maintainability of the code by fetching registration IDs, client names, and redirect URIs from provider configuration objects.

## Changes:

- Updated Google OAuth2 client registration to use google.getName() for registration ID and client name.
- Updated Keycloak OAuth2 client registration to use keycloak.getName() for registration ID and client name.
- Updated GitHub OAuth2 client registration to use github.getName() for registration ID and client name.
- Modified redirect URIs to dynamically include the provider name.
- Ensured client names are dynamically set using the getClientName() method of each provider object.

## Benefits:

- Flexibility: The client registration process now adapts to different providers without requiring hardcoded values.
- Maintainability: Simplifies future updates and maintenance by centralizing provider-specific details in their respective configuration objects.
- Scalability: Easily accommodates additional OAuth2 providers with minimal changes to the existing code structure.

## Testing:

- Verified that OAuth2 login works correctly for Google, Keycloak, and GitHub providers.
- Ensured that the dynamically generated redirect URIs are correctly formed and functional.
- Tested the application to confirm that all OAuth2 flows are operational without hardcoded values.

## Notes:

- Ensure that the provider configuration objects (GoogleProvider, KeycloakProvider, GithubProvider) are correctly populated with valid settings before deployment.

Closes #1367

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
