### PR TITLE
Add: Bypass for too many requests to the github api

### DIFF
--- a/src/main/resources/static/js/githubVersion.js
+++ b/src/main/resources/static/js/githubVersion.js
@@ -40,7 +40,8 @@ async function getCurrentVersionFromBypass() {
     const response = await fetch(url);
     if (response.status === 200) {
       const text = await response.text();
-      const match = text.match(/version\s*=\s*['"](\d+\.\d+\.\d+)['"]/);
+      const versionRegex = /version\s*=\s*['"](\d+\.\d+\.\d+)['"]/;
+      const match = versionRegex.exec(text);
       if (match) {
         return match[1];
       }

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -5,7 +5,7 @@
     const noFavourites = /*[[#{noFavourites}]]*/ '';
     const updateAvailable =  /*[[#{settings.updateAvailable}]]*/ '';
   </script>
-  <script th:if="${@shouldShow}" src="js/githubVersion.js"></script>
+  <script src="js/githubVersion.js"></script>
   <nav class="navbar navbar-expand-lg">
     <div class="container ">
       <a class="navbar-brand" th:href="@{/}" style="display: flex;">
@@ -403,7 +403,7 @@
 
             <a href="swagger-ui/index.html" class="btn btn-sm btn-outline-primary mx-1" role="button"
               target="_blank">API</a>
-            <a th:if="${@shouldShow}" href="https://github.com/Stirling-Tools/Stirling-PDF/releases"
+            <a href="https://github.com/Stirling-Tools/Stirling-PDF/releases"
               class="btn btn-sm btn-outline-primary mx-1" id="update-btn" th:utext="#{settings.update}" role="button"
               target="_blank"></a>
           </div>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -5,7 +5,7 @@
     const noFavourites = /*[[#{noFavourites}]]*/ '';
     const updateAvailable =  /*[[#{settings.updateAvailable}]]*/ '';
   </script>
-  <script src="js/githubVersion.js"></script>
+  <script th:if="${@shouldShow}" src="js/githubVersion.js"></script>
   <nav class="navbar navbar-expand-lg">
     <div class="container ">
       <a class="navbar-brand" th:href="@{/}" style="display: flex;">


### PR DESCRIPTION
# Description

Bypass for too many requests to the github api

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
