### PR TITLE
Add missing of Ukrainian translation to the resource file

### DIFF
--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -62,17 +62,17 @@ downgradeCurrentUserMessage=Неможливо понизити роль пот�
 downgradeCurrentUserLongMessage=Неможливо понизити роль поточного користувача. Отже, поточний користувач не відображатиметься.
 userAlreadyExistsOAuthMessage=The user already exists as an OAuth2 user.
 userAlreadyExistsWebMessage=The user already exists as an web user.
-error=Error
-oops=Oops!
-help=Help
-goHomepage=Go to Homepage
-joinDiscord=Join our Discord server
-seeDockerHub=See Docker Hub
-visitGithub=Visit Github Repository
-donate=Donate
-color=Color
-sponsor=Sponsor
-info=Info
+error=Помилка
+oops=Упс!
+help=Допомога
+goHomepage=До головної сторінки
+joinDiscord=Приєднуйтесь до нашого Discord серверу
+seeDockerHub=Переглянути Docker Hub
+visitGithub=Переглянути Github репозиторій
+donate=Задонатити
+color=Колір
+sponsor=Спонсор
+info=Інформація
 
 
 
@@ -107,25 +107,25 @@ pipelineOptions.validateButton=Перевірити
 #############
 #  NAVBAR   #
 #############
-navbar.favorite=Favorites
+navbar.favorite=Обране
 navbar.darkmode=Темний режим
-navbar.language=Languages
+navbar.language=Мови
 navbar.settings=Налаштування
-navbar.allTools=Tools
-navbar.multiTool=Multi Tools
-navbar.sections.organize=Organize
-navbar.sections.convertTo=Convert to PDF
-navbar.sections.convertFrom=Convert from PDF
-navbar.sections.security=Sign & Security
-navbar.sections.advance=Advanced
-navbar.sections.edit=View & Edit
+navbar.allTools=Інструменти
+navbar.multiTool=Мультіінструмент
+navbar.sections.organize=Організувати
+navbar.sections.convertTo=Конвертувати в PDF
+navbar.sections.convertFrom=Конвертувати з PDF
+navbar.sections.security=Підпис та Безпека
+navbar.sections.advance=Додаткове
+navbar.sections.edit=Перегляд та Редагування
 
 #############
 #  SETTINGS #
 #############
 settings.title=Налаштування
 settings.update=Доступне оновлення
-settings.updateAvailable={0} is the current installed version. A new version ({1}) is available.
+settings.updateAvailable=Зараз встановлена версія {0}. Нова версія ({1}) доступна.
 settings.appVersion=Версія додатку:
 settings.downloadOption.title=Виберіть варіант завантаження (для завантаження одного файлу без zip):
 settings.downloadOption.1=Відкрити в тому ж вікні
@@ -175,8 +175,8 @@ adminUserSettings.header=Налаштування контролю корист�
 adminUserSettings.admin=Адміністратор
 adminUserSettings.user=Користувач
 adminUserSettings.addUser=Додати нового користувача
-adminUserSettings.deleteUser=Delete User
-adminUserSettings.confirmDeleteUser=Should the user be deleted?
+adminUserSettings.deleteUser=Видалити користувача
+adminUserSettings.confirmDeleteUser=Видалити цього користувача?
 adminUserSettings.usernameInfo=Ім’я користувача може містити лише літери, цифри та наступні спеціальні символи @._+- або має бути дійсною електронною адресою.
 adminUserSettings.roles=Ролі
 adminUserSettings.role=Роль
@@ -189,7 +189,7 @@ adminUserSettings.internalApiUser=Внутрішній користувач API
 adminUserSettings.forceChange=Примусити користувача змінити пароль при вході в систему
 adminUserSettings.submit=Зберегти користувача
 adminUserSettings.changeUserRole=Змінити роль користувача
-adminUserSettings.authenticated=Authenticated
+adminUserSettings.authenticated=Автентифіковано
 
 #############
 # HOME-PAGE #
@@ -336,8 +336,8 @@ home.certSign.title=Підписати сертифікатом
 home.certSign.desc=Підписати PDF сертифікатом/ключем (PEM/P12)
 certSign.tags=authenticate,PEM,P12,official,encrypt
 
-home.removeCertSign.title=Remove Certificate Sign
-home.removeCertSign.desc=Remove certificate signature from PDF
+home.removeCertSign.title=Видалити підпис сертифікатом
+home.removeCertSign.desc=Видалити підпис сертифікатом з PDF-документу
 removeCertSign.tags=authenticate,PEM,P12,official,decrypt
 
 home.pageLayout.title=Об'єднати сторінки
@@ -405,7 +405,7 @@ home.PdfToSinglePage.desc=Об'єднує всі сторінки PDF в одн�
 PdfToSinglePage.tags=single page
 
 
-home.showJS.title=Показати Javascript
+home.showJS.title=Показати JavaScript
 home.showJS.desc=Шукає та відображає будь-який JS, вбудований у PDF-файл.
 showJS.tags=JS
 
@@ -460,12 +460,12 @@ login.locked=Ваш обліковий запис заблоковано.
 login.signinTitle=Будь ласка, увійдіть
 login.ssoSignIn=Увійти через єдиний вхід
 login.oauth2AutoCreateDisabled=Автоматичне створення користувача OAUTH2 ВИМКНЕНО
-login.oauth2RequestNotFound=Authorization request not found
-login.oauth2InvalidUserInfoResponse=Invalid User Info Response
-login.oauth2invalidRequest=Invalid Request
-login.oauth2AccessDenied=Access Denied
-login.oauth2InvalidTokenResponse=Invalid Token Response
-login.oauth2InvalidIdToken=Invalid Id Token
+login.oauth2RequestNotFound=Запит на авторизація не знайдено
+login.oauth2InvalidUserInfoResponse=Недійсна відповідь з інформацією користувача
+login.oauth2invalidRequest=Недійсний запит
+login.oauth2AccessDenied=Доступ заблоковано
+login.oauth2InvalidTokenResponse=Недійсна відповідь з токеном
+login.oauth2InvalidIdToken=Недійсний Id токен
 
 
 #auto-redact
@@ -482,9 +482,9 @@ autoRedact.submitButton=Надіслати
 
 
 #showJS
-showJS.title=Показати Javascript
-showJS.header=Показати Javascript
-showJS.downloadJS=Завантажити Javascript
+showJS.title=Показати JavaScript
+showJS.header=Показати JavaScript
+showJS.downloadJS=Завантажити JavaScript
 showJS.submit=Показати
 
 
@@ -664,10 +664,10 @@ certSign.submit=Підписати PDF
 
 
 #removeCertSign
-removeCertSign.title=Remove Certificate Signature
-removeCertSign.header=Remove the digital certificate from the PDF
-removeCertSign.selectPDF=Select a PDF file:
-removeCertSign.submit=Remove Signature
+removeCertSign.title=Видалення підпису сертифікатом
+removeCertSign.header=Видалення підпису сертифікатом з PDF документу
+removeCertSign.selectPDF=Оберіть PDF-файл:
+removeCertSign.submit=Видалити підпис
 
 
 #removeBlanks
@@ -725,7 +725,7 @@ repair.submit=Ремонтувати
 #flatten
 flatten.title=Згладжування
 flatten.header=Згладжування PDF
-flatten.flattenOnlyForms=Flatten only forms
+flatten.flattenOnlyForms=Згладити тільки форми
 flatten.submit=Згладити
 
 
@@ -827,7 +827,7 @@ pdfOrganiser.placeholder=(наприклад, 1,3,2 або 4-8,2,10-12 або 2n
 #multiTool
 multiTool.title=Мультіінструмент PDF
 multiTool.header=Мультіінструмент PDF
-multiTool.uploadPrompts=File Name
+multiTool.uploadPrompts=Ім'я файлу
 
 #view pdf
 viewPdf.title=Переглянути PDF
@@ -980,8 +980,8 @@ pdfToPDFA.header=PDF в PDF/A
 pdfToPDFA.credit=Цей сервіс використовує OCRmyPDF для перетворення у формат PDF/A
 pdfToPDFA.submit=Конвертувати
 pdfToPDFA.tip=Наразі не працює для кількох вхідних файлів одночасно
-pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
+pdfToPDFA.outputFormat=Вихідний формат
+pdfToPDFA.pdfWithDigitalSignature=Цей PDF документ має цифровий підпис. Цей підпис буде видалений у наступному кроці.
 
 
 #PDFToWord
@@ -1067,11 +1067,11 @@ split-by-sections.merge=Об'єднати в один PDF
 
 
 #printFile
-printFile.title=Print File
-printFile.header=Print File to Printer
-printFile.selectText.1=Select File to Print
-printFile.selectText.2=Enter Printer Name
-printFile.submit=Print
+printFile.title=Роздрукувати файл
+printFile.header=Роздрукувати файл прінтером
+printFile.selectText.1=Обрати файл для роздрукування
+printFile.selectText.2=Обрати назву прінтера
+printFile.submit=Роздрукувати
 
 
 #licenses
@@ -1083,13 +1083,13 @@ licenses.version=Версія
 licenses.license=Ліцензія
 
 #survey
-survey.nav=Survey
-survey.title=Stirling-PDF Survey
-survey.description=Stirling-PDF has no tracking so we want to hear from our users to improve Stirling-PDF!
-survey.please=Please consider taking our survey!
-survey.disabled=(Survey popup will be disabled in following updates but available at foot of page)
-survey.button=Take Survey
-survey.dontShowAgain=Don't show again
+survey.nav=Опитування
+survey.title=Опитування Stirling-PDF
+survey.description=Stirling-PDF не має аналітичних засобів для відслідковування, тому ми хочемо почути думку від користувачів, як покращити Stirling-PDF!
+survey.please=Будь-ласка, пройдіть опитування!
+survey.disabled=(Вікно з опитування буде відключено у наступних оновленнях, але буде доступне внизу сторінки)
+survey.button=Пройти опитування
+survey.dontShowAgain=Не показувати це вікно
 
 
 #error


### PR DESCRIPTION
# Description

Hello! I've added the missing Ukrainian translation to the resource file (I believe it happened because of active development). Also, as a native Ukrainian speaker I would like to suggest to revise the Ukrainian translation to consistent wording as there are a lot of definitions which mean the same: 

For example:

- "файл PDF"
- "PDF-документ"
- "документ PDF"
- etc  


## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
