### PR TITLE
 When converting PDF to word, add parameters to speed up soffice startup

### DIFF
--- a/src/main/java/stirling/software/SPDF/utils/PDFToFile.java
+++ b/src/main/java/stirling/software/SPDF/utils/PDFToFile.java
@@ -140,6 +140,8 @@ public class PDFToFile {
                     new ArrayList<>(
                             Arrays.asList(
                                     "soffice",
+                                    "--headless",
+                                    "--nologo",
                                     "--infilter=" + libreOfficeFilter,
                                     "--convert-to",
                                     outputFormat,


### PR DESCRIPTION
# Description

 When converting PDF to word, add parameters to speed up soffice startup

Closes #(issue_number)

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
