### PR TITLE
Fixed a spelling mistake in French

### DIFF
--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -271,7 +271,7 @@ home.fileToPDF.desc=Convertissez presque n’importe quel fichiers en PDF (DOCX,
 fileToPDF.tags=convertion,transformation,format,document,image,slide,texte,conversion,office,docs,word,excel,powerpoint
 
 home.ocr.title=OCR / Nettoyage des numérisations
-home.ocr.desc=Utilisez l’OCR pour analyser et détecter le texte des images d’un PDF et le rajouter en temps que tel.
+home.ocr.desc=Utilisez l’OCR pour analyser et détecter le texte des images d’un PDF et le rajouter en tant que tel.
 ocr.tags=ocr,reconnaissance,texte,image,numérisation,scan,read,identify,detection,editable
 
 


### PR DESCRIPTION
# Description

I started to use stirling PDF and I found this mistake in French translation : "en temps que" is not correct, it should be written "en tant que"

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
