### PR TITLE
[DRAFT] [Help wanted] Sign zoom handles

### DIFF
--- a/src/main/resources/static/css/sign.css
+++ b/src/main/resources/static/css/sign.css
@@ -37,6 +37,7 @@ select#font-select option {
 .button-group {
   display: flex;
   justify-content: center;
+  align-items: center;
   gap: 10px;
   padding: 10px;
 }
@@ -44,6 +45,7 @@ select#font-select option {
 .button-group > button {
   background-color: rgba(13, 110, 253, 0.1);
   z-index: 10;
+  align-items: center;
 }
 #page-container {
   position: relative;

--- a/src/main/resources/static/css/sign.css
+++ b/src/main/resources/static/css/sign.css
@@ -1,7 +1,7 @@
 select#font-select,
 select#font-select option {
-  height: 60px; /* Adjust as needed */
-  font-size: 30px; /* Adjust as needed */
+  height: 60px;
+  font-size: 30px;
 }
 
 .drawing-pad-container {
@@ -17,18 +17,7 @@ select#font-select option {
   position: relative;
   margin: 20px 0;
 }
-.draggable-buttons-box {
-  position: absolute;
-  top: 0;
-  padding: 10px;
-  width: 100%;
-  display: flex;
-  gap: 5px;
-}
-.draggable-buttons-box > button {
-  z-index: 10;
-  background-color: rgba(13, 110, 253, 0.1);
-}
+
 .draggable-canvas {
   border: 1px solid red;
   position: absolute;
@@ -36,4 +25,31 @@ select#font-select option {
   user-select: none;
   top: 0px;
   left: 0;
+}
+.draggable-buttons-box {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+
+.button-group {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px;
+}
+
+.button-group > button {
+  background-color: rgba(13, 110, 253, 0.1);
+  z-index: 10;
+}
+#page-container {
+  position: relative;
+  height: 100vh;
+}
+#pdf-viewer {
+  height: calc(100% - 100px); /* Adjust according to the size of your banners */
+  overflow: auto;
 }

--- a/src/main/resources/static/js/draggable-utils.js
+++ b/src/main/resources/static/js/draggable-utils.js
@@ -340,8 +340,8 @@ const DraggableUtils = {
 
         // Draw the image at the position relative to the PDF document
         page.drawImage(pdfImageObject, {
-          x: (dragLeft + viewportLeft / scale) / widthDiff ,
-          y: pdfDoc.offsetHeight - (dragTop  + viewportTop / scale) - draggableData.offsetHeight / scale,
+          x: ((dragLeft + viewportLeft / scale) / widthDiff),
+          y: (pdfDoc.offsetHeight - (dragTop  + viewportTop / scale) - draggableData.offsetHeight / scale) / heightDiff,
           width: draggableData.offsetWidth / scale,
           height: draggableData.offsetHeight / scale,
         });

--- a/src/main/resources/static/js/draggable-utils.js
+++ b/src/main/resources/static/js/draggable-utils.js
@@ -332,10 +332,15 @@ const DraggableUtils = {
         console.log("scale:", scale);
         console.log("viewportLeft:", viewportLeft);
         console.log("viewportTop:", viewportTop);
+        const firstPage = pdfDocModified.getPage(0);
+
+        // Calculate the difference in size between pdfDoc and pdfDocModified
+        const widthDiff = pdfDoc.offsetWidth / firstPage.getWidth();
+        const heightDiff = pdfDoc.offsetHeight / firstPage.getHeight();
 
         // Draw the image at the position relative to the PDF document
         page.drawImage(pdfImageObject, {
-          x: (dragLeft + viewportLeft / scale),
+          x: (dragLeft + viewportLeft / scale) / widthDiff ,
           y: pdfDoc.offsetHeight - (dragTop  + viewportTop / scale) - draggableData.offsetHeight / scale,
           width: draggableData.offsetWidth / scale,
           height: draggableData.offsetHeight / scale,
@@ -348,8 +353,14 @@ const DraggableUtils = {
     }
 
     this.loadPageContents();
-    console.log("new width", pdfDocModified.offsetWidth);
-    console.log("new height", pdfDocModified.offsetHeight);
+    const firstPage = pdfDocModified.getPage(0);
+
+// Get the width and height of the page
+    const width = firstPage.getWidth();
+    const height = firstPage.getHeight();
+
+    console.log("Width of the first page:", width);
+    console.log("Height of the first page:", height);
     return pdfDocModified;
 
 

--- a/src/main/resources/templates/sign.html
+++ b/src/main/resources/templates/sign.html
@@ -267,7 +267,9 @@
 
               <script>
                 document.getElementById("download-pdf").addEventListener('click', async() => {
-                  const modifiedPdf = await DraggableUtils.getOverlayedPdfDocument();
+                  const pdfWidth = DraggableUtils.pdfCanvas.width;
+                  const pdfHeight = DraggableUtils.pdfCanvas.height;
+                  const modifiedPdf = await DraggableUtils.getOverlayedPdfDocument(scale, pdfWidth, pdfHeight);
                   const modifiedPdfBytes = await modifiedPdf.save();
                   const blob = new Blob([modifiedPdfBytes], { type: 'application/pdf' });
                   const link = document.createElement('a');
@@ -281,7 +283,6 @@
 
                 // Initial scale
                 var scale = 1;
-
 
                 // Set transform origin
                 pdfContainer.style.transformOrigin = '0 0';
@@ -308,7 +309,7 @@
                 // Event listener for zoom out button
                 document.getElementById('zoomOut').addEventListener('mousedown', function() {
                   zoomInterval = setInterval(function() {
-                    if (scale > 1) { //Don't allow to zoom out more than original size
+                    if (scale > 1) { // Don't allow to zoom out more than original size
                       scale -= 0.1;
                       pdfContainer.style.transform = 'scale(' + scale + ')';
                       adjustScrollPosition();
@@ -333,6 +334,7 @@
                   viewer.scrollLeft = viewer.scrollWidth / 2 - viewer.clientWidth / 2;
                   viewer.scrollTop = viewer.scrollHeight / 2 - viewer.clientHeight / 2;
                 }
+
 
               </script>
 

--- a/src/main/resources/templates/sign.html
+++ b/src/main/resources/templates/sign.html
@@ -284,13 +284,14 @@
 
 
                 // Set transform origin
-                pdfContainer.style.transformOrigin = '50% 50%';
+                pdfContainer.style.transformOrigin = '0 0';
 
                 // Event listener for zoom in button
                 document.getElementById('zoomIn').addEventListener('mousedown', function() {
                   zoomInterval = setInterval(function() {
                     scale += 0.1;
                     pdfContainer.style.transform = 'scale(' + scale + ')';
+                    adjustScrollPosition();
                   }, 100); // Zoom in every 100ms
                 });
 
@@ -301,6 +302,7 @@
                 document.getElementById('zoomIn').addEventListener('click', function() {
                   scale += 0.1;
                   pdfContainer.style.transform = 'scale(' + scale + ')';
+                  adjustScrollPosition();
                 });
 
                 // Event listener for zoom out button
@@ -309,6 +311,7 @@
                     if (scale > 1) { //Don't allow to zoom out more than original size
                       scale -= 0.1;
                       pdfContainer.style.transform = 'scale(' + scale + ')';
+                      adjustScrollPosition();
                     }
                   }, 100); // Zoom out every 100ms
                 });
@@ -321,8 +324,15 @@
                   if (scale > 1) {
                     scale -= 0.1;
                     pdfContainer.style.transform = 'scale(' + scale + ')';
+                    adjustScrollPosition();
                   }
                 });
+
+                function adjustScrollPosition() {
+                  const viewer = document.getElementById('pdf-viewer');
+                  viewer.scrollLeft = viewer.scrollWidth / 2 - viewer.clientWidth / 2;
+                  viewer.scrollTop = viewer.scrollHeight / 2 - viewer.clientHeight / 2;
+                }
 
               </script>
 

--- a/src/main/resources/templates/sign.html
+++ b/src/main/resources/templates/sign.html
@@ -228,25 +228,35 @@
 
               <!-- draggables box -->
               <div id="box-drag-container" class="show-on-file-selected">
-                <canvas id="pdf-canvas"></canvas>
+                <div id="pdf-viewer" style="margin-top: 50px; margin-bottom: 50px;">
+                  <canvas id="pdf-canvas"></canvas>
+                </div>
                 <script src="js/draggable-utils.js"></script>
                 <div class="draggable-buttons-box ignore-rtl">
-                  <button class="btn btn-outline-secondary" onclick="DraggableUtils.deleteDraggableCanvas(DraggableUtils.getLastInteracted())">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
-                      <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6Z"/>
-                      <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1ZM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118ZM2.5 3h11V2h-11v1Z"/>
-                    </svg>
-                  </button>
-                  <button class="btn btn-outline-secondary" onclick="document.documentElement.getAttribute('dir')==='rtl' ? DraggableUtils.incrementPage() : DraggableUtils.decrementPage()" style="margin-left:auto">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                      <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
-                    </svg>
-                  </button>
-                  <button class="btn btn-outline-secondary" onclick="document.documentElement.getAttribute('dir')==='rtl' ? DraggableUtils.decrementPage() : DraggableUtils.incrementPage()">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                      <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
-                    </svg>
-                  </button>
+                  <div class="button-group">
+                    <button class="btn btn-outline-secondary" onclick="DraggableUtils.deleteDraggableCanvas(DraggableUtils.getLastInteracted())">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+                       <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6Z"/>
+                        <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1ZM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118ZM2.5 3h11V2h-11v1Z"/>
+                      </svg>
+                    </button>
+                  </div>
+                  <div class="button-group">
+                    <button class="btn btn-outline-secondary zoomButton"  id="zoomIn">Zoom In</button>
+                    <button class="btn btn-outline-secondary zoomButton"  id="zoomOut">Zoom Out</button>
+                  </div>
+                  <div class="button-group">
+                    <button class="btn btn-outline-secondary" onclick="document.documentElement.getAttribute('dir')==='rtl' ? DraggableUtils.incrementPage() : DraggableUtils.decrementPage()" style="margin-left:auto">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+                      </svg>
+                    </button>
+                      <button class="btn btn-outline-secondary" onclick="document.documentElement.getAttribute('dir')==='rtl' ? DraggableUtils.decrementPage() : DraggableUtils.incrementPage()">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                          <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+                        </svg>
+                      </button>
+                  </div>
                 </div>
               </div>
 
@@ -266,6 +276,56 @@
                   link.click();
                 });
               </script>
+              <script>
+                var pdfContainer = document.getElementById('pdf-canvas');
+
+                // Initial scale
+                var scale = 1;
+
+
+                // Set transform origin
+                pdfContainer.style.transformOrigin = '50% 50%';
+
+                // Event listener for zoom in button
+                document.getElementById('zoomIn').addEventListener('mousedown', function() {
+                  zoomInterval = setInterval(function() {
+                    scale += 0.1;
+                    pdfContainer.style.transform = 'scale(' + scale + ')';
+                  }, 100); // Zoom in every 100ms
+                });
+
+                document.getElementById('zoomIn').addEventListener('mouseup', function() {
+                  clearInterval(zoomInterval); // Stop zooming in
+                });
+
+                document.getElementById('zoomIn').addEventListener('click', function() {
+                  scale += 0.1;
+                  pdfContainer.style.transform = 'scale(' + scale + ')';
+                });
+
+                // Event listener for zoom out button
+                document.getElementById('zoomOut').addEventListener('mousedown', function() {
+                  zoomInterval = setInterval(function() {
+                    if (scale > 1) { //Don't allow to zoom out more than original size
+                      scale -= 0.1;
+                      pdfContainer.style.transform = 'scale(' + scale + ')';
+                    }
+                  }, 100); // Zoom out every 100ms
+                });
+
+                document.getElementById('zoomOut').addEventListener('mouseup', function() {
+                  clearInterval(zoomInterval); // Stop zooming out
+                });
+
+                document.getElementById('zoomOut').addEventListener('click', function() {
+                  if (scale > 1) {
+                    scale -= 0.1;
+                    pdfContainer.style.transform = 'scale(' + scale + ')';
+                  }
+                });
+
+              </script>
+
             </div>
           </div>
         </div>

--- a/src/main/resources/templates/sign.html
+++ b/src/main/resources/templates/sign.html
@@ -242,8 +242,19 @@
                     </button>
                   </div>
                   <div class="button-group">
-                    <button class="btn btn-outline-secondary zoomButton"  id="zoomIn">Zoom In</button>
-                    <button class="btn btn-outline-secondary zoomButton"  id="zoomOut">Zoom Out</button>
+                    <!-- Zoom In Button -->
+                    <button class="btn btn-outline-secondary zoomButton" id="zoomIn">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-zoom-in" viewBox="0 0 16 16">
+                        <path d="M15.5 14l-3.79-3.79a6 6 0 1 0-.7.7l3.79 3.79v.5l.7.71L16 14.5v-.5h-.5zM6 10a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm1-7a.5.5 0 0 1 .5.5v1.5h1.5a.5.5 0 0 1 0 1H7.5v1.5a.5.5 0 0 1-1 0V6H5a.5.5 0 0 1 0-1h1.5V3.5a.5.5 0 0 1 .5-.5z"/>
+                      </svg>
+                    </button>
+
+                    <!-- Zoom Out Button -->
+                    <button class="btn btn-outline-secondary zoomButton" id="zoomOut">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-zoom-out" viewBox="0 0 16 16">
+                        <path d="M15.5 14l-3.79-3.79a6 6 0 1 0-.7.7l3.79 3.79v.5l.7.71L16 14.5v-.5h-.5zM6 10a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm-2-5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H4a.5.5 0 0 1-.5-.5z"/>
+                      </svg>
+                    </button>
                   </div>
                   <div class="button-group">
                     <button class="btn btn-outline-secondary" onclick="document.documentElement.getAttribute('dir')==='rtl' ? DraggableUtils.incrementPage() : DraggableUtils.decrementPage()" style="margin-left:auto">

--- a/src/main/resources/templates/sign.html
+++ b/src/main/resources/templates/sign.html
@@ -269,7 +269,8 @@
                 document.getElementById("download-pdf").addEventListener('click', async() => {
                   const pdfWidth = DraggableUtils.pdfCanvas.width;
                   const pdfHeight = DraggableUtils.pdfCanvas.height;
-                  const modifiedPdf = await DraggableUtils.getOverlayedPdfDocument(scale, pdfWidth, pdfHeight);
+                  const pdfViewer = document.getElementById('pdf-viewer');
+                  const modifiedPdf = await DraggableUtils.getOverlayedPdfDocument(scale, pdfViewer);
                   const modifiedPdfBytes = await modifiedPdf.save();
                   const blob = new Blob([modifiedPdfBytes], { type: 'application/pdf' });
                   const link = document.createElement('a');

--- a/src/main/resources/templates/sign.html
+++ b/src/main/resources/templates/sign.html
@@ -281,7 +281,7 @@
                   const pdfWidth = DraggableUtils.pdfCanvas.width;
                   const pdfHeight = DraggableUtils.pdfCanvas.height;
                   const pdfViewer = document.getElementById('pdf-viewer');
-                  const modifiedPdf = await DraggableUtils.getOverlayedPdfDocument(scale, pdfViewer);
+                  const modifiedPdf = await DraggableUtils.getOverlayedPdfDocumentZoomed(scale, pdfViewer);
                   const modifiedPdfBytes = await modifiedPdf.save();
                   const blob = new Blob([modifiedPdfBytes], { type: 'application/pdf' });
                   const link = document.createElement('a');


### PR DESCRIPTION
# Sign Zoom Handles
 
 Opening this Draft PR regarding the issue #1247 . I implemented a basic zoom functionality but have not been able to get the calculation of the position 100% correct when the signature is placed while zooming. (Placement is correct when no zoom is used)
Here is an example of what i mean:

![image](https://github.com/Stirling-Tools/Stirling-PDF/assets/166131967/b1a17c84-f2b8-4848-a6f4-98606716eb6e)
As you can see the signature is alittle bit to high and a little bit too far left. This error is getting worse with increasing zoom. At this point i do not have an explanation for it anymore. So if anyone would like to pick this up and work on it, please do!

This is how i am calculating the position: (example for x coordinate)
![image](https://github.com/Stirling-Tools/Stirling-PDF/assets/166131967/7dd805f1-7b1e-4e59-bf1c-f6f1705bab5e)
The Blue Part is the actual Document. The white part is the part of the document that is visible in the viewport when you are zooming. 

I would be happy about some help or as I already said if some one wants to work on this it would be fine for me as well.




## Checklist:

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
