### PR TITLE
Update README.md adjusting system to security as shown later in the readme for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ Environment variables are also supported and would override the settings file
 For example in the settings.yml you have
 
 ```yaml
-system:
+security:
   enableLogin: 'true'
 ```
 
-To have this via an environment variable you would have ``SYSTEM_ENABLELOGIN``
+To have this via an environment variable you would have ``SECURITY_ENABLELOGIN``
 
 The Current list of settings is
 


### PR DESCRIPTION
This is a minor modification to the readme file changing system to security in the first occurrence of the config/env variable as shown further down in the readme for enabling login. It is the first instance seen and is slightly confusing