### PR TITLE
Button in wrong language

### DIFF
--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -74,6 +74,7 @@ sponsor=Спонсор
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -72,6 +72,8 @@ donate=Направете дарение
 color=Цвят
 sponsor=Спонсор
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -74,6 +74,7 @@ sponsor=Sponzor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -72,6 +72,8 @@ donate=Přispějte
 color=Barva
 sponsor=Sponzor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Die Info
 AddFiles=Datei(en) hinzufügen
 NoFile=Keine Datei(en) ausgewählt
+FilesSelected=Dateien ausgewählt
 
 
 

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -72,6 +72,8 @@ donate=Spenden
 color=Farbe
 sponsor=Sponsor
 info=Die Info
+AddFiles=Datei(en) hinzufügen
+NoFile=Keine Datei(en) ausgewählt
 
 
 

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -72,6 +72,8 @@ donate=Δωρισε
 color=Χρώμα
 sponsor=Yποστηρικτής
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -74,6 +74,7 @@ sponsor=Yποστηρικτής
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -72,6 +72,9 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
+
 
 
 

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -72,7 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
-openFileExplorer=Open File Explorer
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -72,6 +72,7 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+openFileExplorer=Open File Explorer
 
 
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -74,6 +74,7 @@ sponsor=Patrocinador
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -72,6 +72,8 @@ donate=Donar
 color=Color
 sponsor=Patrocinador
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -72,6 +72,8 @@ donate=Faire un don
 color=Couleur
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -72,6 +72,8 @@ donate=Donazione
 color=Colore
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -74,6 +74,7 @@ sponsor=スポンサー
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -72,6 +72,8 @@ donate=寄付する
 color=色
 sponsor=スポンサー
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -74,6 +74,7 @@ sponsor=스폰서
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -72,6 +72,8 @@ donate=기부하기
 color=색상
 sponsor=스폰서
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -74,6 +74,7 @@ sponsor=Спонсор
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -72,6 +72,8 @@ donate=Пожертвовать
 color=Цвет
 sponsor=Спонсор
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -72,6 +72,8 @@ donate=Darovať
 color=Farba
 sponsor=Sponzorovať
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -74,6 +74,7 @@ sponsor=Sponzorovať
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -74,6 +74,7 @@ sponsor=Bağış
 info=Bilgi
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -72,6 +72,8 @@ donate=Bağış Yapın
 color=Renk
 sponsor=Bağış
 info=Bilgi
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -72,6 +72,8 @@ donate=Donate
 color=Color
 sponsor=Sponsor
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -74,6 +74,7 @@ sponsor=Sponsor
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -74,6 +74,7 @@ sponsor=赞助
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -72,6 +72,8 @@ donate=捐款
 color=颜色
 sponsor=赞助
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -74,6 +74,7 @@ sponsor=贊助
 info=Info
 AddFiles=Add File(s)
 NoFile=No File(s) selected
+FilesSelected=Files selected
 
 
 

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -72,6 +72,8 @@ donate=捐贈
 color=顏色
 sponsor=贊助
 info=Info
+AddFiles=Add File(s)
+NoFile=No File(s) selected
 
 
 

--- a/src/main/resources/static/css/fileSelect.css
+++ b/src/main/resources/static/css/fileSelect.css
@@ -31,20 +31,28 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  padding-right: 75%; /* Adjust this value based on the width of the pseudo-element and desired buffer */
+  padding-right: 75%;
   position: relative;
   overflow: hidden;
   background: linear-gradient(to right, #E9ECEF 25%, #F1F3FD 25%);
-  color: black; /* Adjust text color as needed */
-  border: none; /* Remove border if not needed */
+  color: black;
+  border: none;
 }
 
 .file-chooser-button::after {
   content: '';
   position: absolute;
-  right: 75%; /* This positions the line at 20% from the left */
+  left: 25%; /* Adjust this value to where you want the line */
   top: 0;
   bottom: 0;
   width: 1px;
-  background-color: #000; /* Line color */
+  background-color: #000;
+}
+
+.file-name-right {
+  position: absolute;
+  left: 26%; /* Position it to the right of the line */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/main/resources/static/css/fileSelect.css
+++ b/src/main/resources/static/css/fileSelect.css
@@ -8,3 +8,22 @@
   overflow-y: auto;
   white-space: pre-wrap;
 }
+#input{
+  display: none;
+}
+
+#file-name {
+  display: block;
+  background-color: #f8f9fa;
+  color: #212529;
+  padding: 10px;
+  margin-top: 10px;
+  border-radius: 5px;
+}
+.custom-file-chooser .mb-3 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+

--- a/src/main/resources/static/css/fileSelect.css
+++ b/src/main/resources/static/css/fileSelect.css
@@ -37,6 +37,25 @@
   background: linear-gradient(to right, #E9ECEF 25%, #F1F3FD 25%);
   color: black;
   border: none;
+  box-shadow: none !important; /* Removes the box shadow */
+}
+
+/* State after a file is added */
+.file-chooser-button.file-added {
+  color: black; /* Ensures text color remains black after file is added */
+  box-shadow: none !important; /* Removes the box shadow */
+}
+
+
+.file-chooser-button:hover {
+  color: black; /* Ensures text color remains black on hover */
+  box-shadow: none !important; /* Removes the box shadow */
+}
+.file-chooser-button:not(.file-added):hover {
+  background-color: var(--md-sys-color-primary); /* Keeps the background color unchanged */
+  box-shadow: none !important; /* Removes the box shadow */
+  border-color: var(--md-sys-color-primary); /* Keeps the border color unchanged */
+  color: black; /* Ensures text color remains black on hover */
 }
 
 .file-chooser-button::after {
@@ -48,6 +67,7 @@
   width: 1px;
   background-color: #000;
 }
+
 
 .file-name-right {
   position: absolute;

--- a/src/main/resources/static/css/fileSelect.css
+++ b/src/main/resources/static/css/fileSelect.css
@@ -26,4 +26,25 @@
   gap: 10px;
 }
 
+.file-chooser-button {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-right: 75%; /* Adjust this value based on the width of the pseudo-element and desired buffer */
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(to right, #E9ECEF 25%, #F1F3FD 25%);
+  color: black; /* Adjust text color as needed */
+  border: none; /* Remove border if not needed */
+}
 
+.file-chooser-button::after {
+  content: '';
+  position: absolute;
+  right: 75%; /* This positions the line at 20% from the left */
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background-color: #000; /* Line color */
+}

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -7,6 +7,11 @@ function setupFileInput(chooser) {
   const filesSelected = chooser.getAttribute("data-bs-files-selected");
   const pdfPrompt = chooser.getAttribute("data-bs-pdf-prompt");
 
+  const button = chooser.querySelector('.file-chooser-button');
+  if (button) {
+    button.innerHTML = `<span class="button-label">Open File Explorer</span><span class="file-name-right">No file selected</span>`;
+  }
+
   let allFiles = [];
   let overlay;
   let dragCounter = 0;
@@ -97,8 +102,7 @@ function setupFileInput(chooser) {
     if (files.length > 0) {
       button.innerHTML = `<span class="button-label">Open File Explorer</span><span class="file-name-right">${fileNames}</span>`;
     } else {
-      button.setAttribute('data-filename', '');
-      button.textContent = 'Open File Explorer          No file selected';
+      button.innerHTML = `<span class="button-label">Open File Explorer</span><span class="file-name-right">No file selected</span>`;
     }
     if (fileNames.length === 1) {
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -104,21 +104,19 @@ function setupFileInput(chooser) {
     const button = document.querySelector('.file-chooser-button');
     const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
     const noFileText = button.getAttribute('data-no-file-text'); // Thymeleaf property for "No File Selected" text
+    const selectedText = button.getAttribute('data-selected-text'); // Thymeleaf property for "Selected" text
 
-    // Update the button's inner HTML based on file selection
-    if (files.length > 0) {
-      button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${fileNames.join(', ')}</span>`;
-    } else {
-      button.innerHTML = `<span class="button-label" >${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
-    }
     if (fileNames.length === 1) {
+      button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${fileNames.join(', ')}</span>`;
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);
     } else if (fileNames.length > 1) {
+      button.innerHTML = `<span class="button-label" >${addFilesText}</span><span class="file-name-right">${fileNames.length + " " + selectedText}</span>`;
       $(inputElement)
         .siblings(".custom-file-label")
         .addClass("selected")
         .html(fileNames.length + " " + filesSelected);
     } else {
+      button.innerHTML = `<span class="button-label" >${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(pdfPrompt);
     }
   }

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -6,7 +6,7 @@ function setupFileInput(chooser) {
   const elementId = chooser.getAttribute("data-bs-element-id");
   const filesSelected = chooser.getAttribute("data-bs-files-selected");
   const pdfPrompt = chooser.getAttribute("data-bs-pdf-prompt");
-  const button = document.querySelector('.file-chooser-button');
+  const button = chooser.querySelector('.file-chooser-button');
   const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
   const noFileText = button.getAttribute('data-no-file-text'); // Thymeleaf property for "No File Selected" text
   button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
@@ -86,10 +86,10 @@ function setupFileInput(chooser) {
 
   $("#" + elementId).on("change", function (e) {
     allFiles = Array.from(e.target.files);
-    handleFileInputChange(this);
+    handleFileInputChange(this, button);
   });
 
-  function handleFileInputChange(inputElement) {
+  function handleFileInputChange(inputElement, button) {
     const files = allFiles;
     const fileNames = files.map((f) => f.name);
     const selectedFilesContainer = $(inputElement).siblings(".selected-files");
@@ -99,7 +99,6 @@ function setupFileInput(chooser) {
     });
     console.log("test");
     // Retrieve the button and its data attributes for dynamic texts
-    const button = document.querySelector('.file-chooser-button');
     const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
     const noFileText = button.getAttribute('data-no-file-text'); // Thymeleaf property for "No File Selected" text
     const selectedText = button.getAttribute('data-selected-text'); // Thymeleaf property for "Selected" text
@@ -124,6 +123,6 @@ function setupFileInput(chooser) {
   document.addEventListener("fileRemoved", function (e) {
     const fileName = e.detail;
     allFiles = allFiles.filter(file => file.name !== fileName);
-    handleFileInputChange();
+    handleFileInputChange(this, button);
   });
 }

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -6,10 +6,12 @@ function setupFileInput(chooser) {
   const elementId = chooser.getAttribute("data-bs-element-id");
   const filesSelected = chooser.getAttribute("data-bs-files-selected");
   const pdfPrompt = chooser.getAttribute("data-bs-pdf-prompt");
+  const button = document.querySelector('.file-chooser-button');
+  const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
+  const noFileText = button.getAttribute('data-no-file-text'); // Thymeleaf property for "No File Selected" text
 
-  const button = chooser.querySelector('.file-chooser-button');
   if (button) {
-    button.innerHTML = `<span class="button-label">Open File Explorer</span><span class="file-name-right">No file selected</span>`;
+    button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
   }
 
   let allFiles = [];
@@ -98,11 +100,16 @@ function setupFileInput(chooser) {
     fileNames.forEach((fileName) => {
       selectedFilesContainer.append("<div>" + fileName + "</div>");
     });
+    // Retrieve the button and its data attributes for dynamic texts
     const button = document.querySelector('.file-chooser-button');
+    const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
+    const noFileText = button.getAttribute('data-no-file-text'); // Thymeleaf property for "No File Selected" text
+
+    // Update the button's inner HTML based on file selection
     if (files.length > 0) {
-      button.innerHTML = `<span class="button-label">Open File Explorer</span><span class="file-name-right">${fileNames}</span>`;
+      button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${fileNames.join(', ')}</span>`;
     } else {
-      button.innerHTML = `<span class="button-label">Open File Explorer</span><span class="file-name-right">No file selected</span>`;
+      button.innerHTML = `<span class="button-label" >${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
     }
     if (fileNames.length === 1) {
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -124,5 +124,6 @@ function setupFileInput(chooser) {
   document.addEventListener("fileRemoved", function (e) {
     const fileName = e.detail;
     allFiles = allFiles.filter(file => file.name !== fileName);
+    handleFileInputChange();
   });
 }

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -9,10 +9,7 @@ function setupFileInput(chooser) {
   const button = document.querySelector('.file-chooser-button');
   const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
   const noFileText = button.getAttribute('data-no-file-text'); // Thymeleaf property for "No File Selected" text
-
-  if (button) {
-    button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
-  }
+  button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
 
   let allFiles = [];
   let overlay;
@@ -100,6 +97,7 @@ function setupFileInput(chooser) {
     fileNames.forEach((fileName) => {
       selectedFilesContainer.append("<div>" + fileName + "</div>");
     });
+    console.log("test");
     // Retrieve the button and its data attributes for dynamic texts
     const button = document.querySelector('.file-chooser-button');
     const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
@@ -108,9 +106,11 @@ function setupFileInput(chooser) {
 
     if (fileNames.length === 1) {
       button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${fileNames.join(', ')}</span>`;
+      button.classList.add('file-added');
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);
     } else if (fileNames.length > 1) {
       button.innerHTML = `<span class="button-label" >${addFilesText}</span><span class="file-name-right">${fileNames.length + " " + selectedText}</span>`;
+      button.classList.add('file-added');
       $(inputElement)
         .siblings(".custom-file-label")
         .addClass("selected")

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -93,6 +93,17 @@ function setupFileInput(chooser) {
     fileNames.forEach((fileName) => {
       selectedFilesContainer.append("<div>" + fileName + "</div>");
     });
+    var fileName = fileNames[0];
+    var spanElement = $('#file-name');
+    spanElement.text(fileName);
+    // Check if the span element contains any text
+    if (spanElement.text().trim() === '') {
+      // If it doesn't contain any text, hide it
+      spanElement.css('display', 'none');
+    } else {
+      // If it does contain text, show it
+      spanElement.css('display', 'block');
+    }
     if (fileNames.length === 1) {
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);
     } else if (fileNames.length > 1) {

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -93,16 +93,13 @@ function setupFileInput(chooser) {
     fileNames.forEach((fileName) => {
       selectedFilesContainer.append("<div>" + fileName + "</div>");
     });
-    var fileName = fileNames[0];
-    var spanElement = $('#file-name');
-    spanElement.text(fileName);
-    // Check if the span element contains any text
-    if (spanElement.text().trim() === '') {
-      // If it doesn't contain any text, hide it
-      spanElement.css('display', 'none');
+    const button = document.querySelector('.file-chooser-button');
+    if (files.length > 0) {
+      button.setAttribute('data-filename', fileNames);
+      button.textContent = `Open File Explorer | ${fileNames}`;
     } else {
-      // If it does contain text, show it
-      spanElement.css('display', 'block');
+      button.setAttribute('data-filename', '');
+      button.textContent = 'Open File Explorer          No file selected';
     }
     if (fileNames.length === 1) {
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -97,7 +97,6 @@ function setupFileInput(chooser) {
     fileNames.forEach((fileName) => {
       selectedFilesContainer.append("<div>" + fileName + "</div>");
     });
-    console.log("test");
     // Retrieve the button and its data attributes for dynamic texts
     const addFilesText = button.getAttribute('data-add-files-text'); // Thymeleaf property for "Add Files" text
     const noFileText = button.getAttribute('data-no-file-text'); // Thymeleaf property for "No File Selected" text
@@ -106,17 +105,11 @@ function setupFileInput(chooser) {
     if (fileNames.length === 1) {
       button.innerHTML = `<span class="button-label">${addFilesText}</span><span class="file-name-right">${fileNames.join(', ')}</span>`;
       button.classList.add('file-added');
-      $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);
     } else if (fileNames.length > 1) {
       button.innerHTML = `<span class="button-label" >${addFilesText}</span><span class="file-name-right">${fileNames.length + " " + selectedText}</span>`;
       button.classList.add('file-added');
-      $(inputElement)
-        .siblings(".custom-file-label")
-        .addClass("selected")
-        .html(fileNames.length + " " + filesSelected);
     } else {
       button.innerHTML = `<span class="button-label" >${addFilesText}</span><span class="file-name-right">${noFileText}</span>`;
-      $(inputElement).siblings(".custom-file-label").addClass("selected").html(pdfPrompt);
     }
   }
   //Listen for event of file being removed and the filter it out of the allFiles array

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -95,8 +95,7 @@ function setupFileInput(chooser) {
     });
     const button = document.querySelector('.file-chooser-button');
     if (files.length > 0) {
-      button.setAttribute('data-filename', fileNames);
-      button.textContent = `Open File Explorer | ${fileNames}`;
+      button.innerHTML = `<span class="button-label">Open File Explorer</span><span class="file-name-right">${fileNames}</span>`;
     } else {
       button.setAttribute('data-filename', '');
       button.textContent = 'Open File Explorer          No file selected';

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -156,6 +156,7 @@
     <div class="mb-3">
       <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'" style="display: none;">
       <button type="button" class="btn btn-primary" th:text="#{openFileExplorer}" onclick="this.previousElementSibling.click();"></button>
+      <span id="file-name" class="filename" style="display: none;"></span><!-- This span will hold the name of the selected file -->
     </div>
     <div class="selected-files"></div>
   </div>

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -155,7 +155,7 @@
   <div class="custom-file-chooser" th:attr="data-bs-unique-id=${name}, data-bs-element-id=${name+'-input'}, data-bs-files-selected=#{filesSelected}, data-bs-pdf-prompt=#{pdfPrompt}">
     <div class="mb-3">
       <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'" style="display: none;">
-      <button type="button" class="btn btn-primary file-chooser-button" onclick="this.previousElementSibling.click();" data-filename="">Open File Explorer</button>
+      <button type="button" class="btn btn-primary file-chooser-button" onclick="this.previousElementSibling.click();" data-filename="" th:text="#{AddFiles}" th:data-add-files-text="#{AddFiles}" th:data-no-file-text="#{NoFile}">#{AddFiles}</button>
     </div>
     <div class="selected-files"></div>
   </div>

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -152,12 +152,13 @@
                 </script>
                 <script src="js/downloader.js"></script>
 
-                <div class="custom-file-chooser" th:attr="data-bs-unique-id=${name}, data-bs-element-id=${name+'-input'}, data-bs-files-selected=#{filesSelected}, data-bs-pdf-prompt=#{pdfPrompt}">
-                  <div class="mb-3">
-                    <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'">
-                  </div>
-                  <div class="selected-files"></div>
-                </div>
+  <div class="custom-file-chooser" th:attr="data-bs-unique-id=${name}, data-bs-element-id=${name+'-input'}, data-bs-files-selected=#{filesSelected}, data-bs-pdf-prompt=#{pdfPrompt}">
+    <div class="mb-3">
+      <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'" style="display: none;">
+      <button type="button" class="btn btn-primary" th:text="#{openFileExplorer}" onclick="this.previousElementSibling.click();"></button>
+    </div>
+    <div class="selected-files"></div>
+  </div>
 
                 <div class="progressBarContainer" style="display: none; position: relative;">
                   <div class="progress" style="height: 1rem;">

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -155,7 +155,7 @@
   <div class="custom-file-chooser" th:attr="data-bs-unique-id=${name}, data-bs-element-id=${name+'-input'}, data-bs-files-selected=#{filesSelected}, data-bs-pdf-prompt=#{pdfPrompt}">
     <div class="mb-3">
       <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'" style="display: none;">
-      <button type="button" class="btn btn-primary file-chooser-button" onclick="this.previousElementSibling.click();" data-filename="" th:text="#{AddFiles}" th:data-add-files-text="#{AddFiles}" th:data-no-file-text="#{NoFile}">#{AddFiles}</button>
+      <button type="button" class="btn btn-primary file-chooser-button" onclick="this.previousElementSibling.click();" data-filename="" th:text="#{AddFiles}" th:data-add-files-text="#{AddFiles}" th:data-no-file-text="#{NoFile}" th:data-selected-text="#{FilesSelected}">#{AddFiles}</button>
     </div>
     <div class="selected-files"></div>
   </div>

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -155,8 +155,7 @@
   <div class="custom-file-chooser" th:attr="data-bs-unique-id=${name}, data-bs-element-id=${name+'-input'}, data-bs-files-selected=#{filesSelected}, data-bs-pdf-prompt=#{pdfPrompt}">
     <div class="mb-3">
       <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'" style="display: none;">
-      <button type="button" class="btn btn-primary" th:text="#{openFileExplorer}" onclick="this.previousElementSibling.click();"></button>
-      <span id="file-name" class="filename" style="display: none;"></span><!-- This span will hold the name of the selected file -->
+      <button type="button" class="btn btn-primary file-chooser-button" onclick="this.previousElementSibling.click();" data-filename="">Open File Explorer</button>
     </div>
     <div class="selected-files"></div>
   </div>

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -152,6 +152,7 @@
                 </script>
                 <script src="js/downloader.js"></script>
 
+  <!-- Laying a button over the original file input form, that looks exactly the same way to enable translatable messages -->
   <div class="custom-file-chooser" th:attr="data-bs-unique-id=${name}, data-bs-element-id=${name+'-input'}, data-bs-files-selected=#{filesSelected}, data-bs-pdf-prompt=#{pdfPrompt}">
     <div class="mb-3">
       <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'" style="display: none;">


### PR DESCRIPTION
# Made File Input Form translatable

The File Input form that is used by all pages, except view pdf and the multitool was not translatable. Since the form default form can not be made translatabel, I implemented a button that goes over it and looks exactly the same, that calls the file input form when clicked. The functionality and style of the button is identical to the original form. For refernece see picture of the new button:
![image](https://github.com/Stirling-Tools/Stirling-PDF/assets/166131967/bab188f3-b819-4b61-9f1c-ece1b15a5cde)


Closes #1260 

## Checklist:

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
