### PR TITLE
User Friendly Merge File Selction

### DIFF
--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -788,6 +788,7 @@ merge.header=دمج ملفات PDF متعددة (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=دمج
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -788,6 +788,7 @@ merge.header=Обединяване на множество PDF файлове (
 merge.sortByName=Сортиране по име
 merge.sortByDate=Сортиране по дата
 merge.submit=Обединяване
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -788,6 +788,7 @@ merge.header=Fusiona múltiples PDFs (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=Fusiona
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -788,7 +788,7 @@ merge.header=Sloučit více PDF (2+)
 merge.sortByName=Seřadit podle názvu
 merge.sortByDate=Seřadit podle data
 merge.submit=Sloučit
-
+merge.duplicateWarning=(Duplicate)
 
 #pdfOrganiser
 pdfOrganiser.title=Organizér stránek

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -788,6 +788,7 @@ merge.header=Mehrere PDFs zusammenführen (2+)
 merge.sortByName=Nach Namen sortieren
 merge.sortByDate=Nach Datum sortieren
 merge.submit=Zusammenführen
+merge.duplicateWarning=(Duplikat)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -788,6 +788,7 @@ merge.header=Συγχώνευση πολλαπλών PDFs (2+)
 merge.sortByName=Ταξινόμηση με βάση το Όνομα
 merge.sortByDate=Ταξινόμηση με βάση την Ημερομηνία
 merge.submit=Συγχώνευση
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -788,7 +788,7 @@ merge.header=Merge multiple PDFs (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=Merge
-
+merge.duplicateWarning=(Duplicate)
 
 #pdfOrganiser
 pdfOrganiser.title=Page Organiser
@@ -858,6 +858,7 @@ imageToPDF.selectText.2=Auto rotate PDF
 imageToPDF.selectText.3=Multi file logic (Only enabled if working with multiple images)
 imageToPDF.selectText.4=Merge into single PDF
 imageToPDF.selectText.5=Convert to separate PDFs
+
 
 
 #pdfToImage

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -788,6 +788,7 @@ merge.header=Merge multiple PDFs (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=Merge
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -788,6 +788,7 @@ merge.header=Unir múltiples PDFs (2+)
 merge.sortByName=Ordenar por nombre
 merge.sortByDate=Ordenar por fecha
 merge.submit=Unir
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -788,6 +788,7 @@ merge.header=Elkartu zenbait PDF  (2+)
 merge.sortByName=Sort by nameOrdenatu izenaren arabera
 merge.sortByDate=Ordenatu dataren arabera
 merge.submit=Elkartu
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -788,6 +788,7 @@ merge.header=Fusionner plusieurs PDF
 merge.sortByName=Trier par nom
 merge.sortByDate=Trier par date
 merge.submit=Fusionner
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -788,6 +788,7 @@ merge.header=एक से अधिक PDF एक साथ मर्ज कर
 merge.sortByName=नाम से क्रमबद्ध करें
 merge.sortByDate=तारीख से क्रमबद्ध करें
 merge.submit=मर्ज करें
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -788,6 +788,7 @@ merge.header=Több PDF összevonása (2+)
 merge.sortByName=Név szerinti rendezés
 merge.sortByDate=Dátum szerinti rendezés
 merge.submit=Összevonás
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -788,6 +788,7 @@ merge.header=Gabungkan beberapa PDFs (2+)
 merge.sortByName=Sortir berdasarkan nama
 merge.sortByDate=Sortir berdasrkan tanggal
 merge.submit=Gabungkan
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -788,6 +788,7 @@ merge.header=Unisci 2 o più PDF
 merge.sortByName=Ordina per nome
 merge.sortByDate=Ordina per data
 merge.submit=Unisci
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -788,6 +788,7 @@ merge.header=複数のPDFを結合 (2ファイル以上)
 merge.sortByName=名前で並べ替え
 merge.sortByDate=日付で並べ替え
 merge.submit=結合
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -788,6 +788,7 @@ merge.header=여러 개의 PDF 병합 (2개 이상)
 merge.sortByName=이름순 정렬
 merge.sortByDate=날짜순 정렬
 merge.submit=병합
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -788,6 +788,7 @@ merge.header=Meerdere PDF's samenvoegen (2+)
 merge.sortByName=Sorteer op naam
 merge.sortByDate=Sorteer op datum
 merge.submit=Samenvoegen
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -788,6 +788,7 @@ merge.header=Połącz wiele dokumentów PDF (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=Połącz
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -788,6 +788,7 @@ merge.header=Mesclar Vários PDFs (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=Mesclar
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -788,6 +788,7 @@ merge.header=Juntar Vários PDFs (2+)
 merge.sortByName=Ordenar por nome
 merge.sortByDate=Ordenar por data
 merge.submit=Juntar
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -788,6 +788,7 @@ merge.header=Unirea mai multor PDF-uri (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=Unire
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -788,6 +788,7 @@ merge.header=Объединение нескольких PDF-файлов (2+)
 merge.sortByName=Сортировка по имени
 merge.sortByDate=Сортировка по дате
 merge.submit=Объединить
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -788,6 +788,7 @@ merge.header=Zlúčiť viacero PDF (2+)
 merge.sortByName=Zoradiť podľa názvu
 merge.sortByDate=Zoradiť podľa dátumu
 merge.submit=Zlúčiť
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -788,6 +788,7 @@ merge.header=Spajanje više PDF fajlova (2+)
 merge.sortByName=Sortiraj po imenu
 merge.sortByDate=Sortiraj po datumu
 merge.submit=Spajanje
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -788,6 +788,7 @@ merge.header=Slå samman flera PDF-filer (2+)
 merge.sortByName=Sort by name
 merge.sortByDate=Sort by date
 merge.submit=Slå samman
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -788,6 +788,7 @@ merge.header=Çoklu PDF'leri Birleştir (2+)
 merge.sortByName=İsme göre sırala
 merge.sortByDate=Tarihe göre sırala
 merge.submit=Birleştir
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -788,6 +788,7 @@ merge.header=Об'єднання кількох PDF-файлів (2+)
 merge.sortByName=Сортування за ім'ям
 merge.sortByDate=Сортування за датою
 merge.submit=Об'єднати
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -788,6 +788,7 @@ merge.header=合并多个PDF（2个以上）。
 merge.sortByName=按名称排序
 merge.sortByDate=按日期排序
 merge.submit=合并
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -788,6 +788,7 @@ merge.header=合併多個 PDF
 merge.sortByName=依名稱排序
 merge.sortByDate=依日期排序
 merge.submit=合併
+merge.duplicateWarning=(Duplicate)
 
 
 #pdfOrganiser

--- a/src/main/resources/static/css/merge.css
+++ b/src/main/resources/static/css/merge.css
@@ -26,3 +26,7 @@
   font-weight: bold;
   font-size: 1.2em;
 }
+.duplicate-warning {
+  color: red;
+  font-weight: bold;
+}

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -72,7 +72,7 @@ function setupFileInput(chooser) {
 
     // When adding files
     $("#" + elementId).on("change", function (e) {
-      if (window.multiple){
+      if (window.multiple && !window.path.endsWith("/pipeline")){
         // Get newly Added Files
         const newFiles = Array.from(e.target.files).map(file => {
           return {

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -1,16 +1,13 @@
 document.addEventListener("DOMContentLoaded", function () {
   document.querySelectorAll(".custom-file-chooser").forEach(setupFileInput);
 });
-
 function setupFileInput(chooser) {
   const elementId = chooser.getAttribute("data-bs-element-id");
   const filesSelected = chooser.getAttribute("data-bs-files-selected");
   const pdfPrompt = chooser.getAttribute("data-bs-pdf-prompt");
-
   let allFiles = [];
   let overlay;
   let dragCounter = 0;
-
   const dragenterListener = function () {
     dragCounter++;
     if (!overlay) {
@@ -31,7 +28,6 @@ function setupFileInput(chooser) {
       document.getElementById("content-wrap").appendChild(overlay);
     }
   };
-
   const dragleaveListener = function () {
     dragCounter--;
     if (dragCounter === 0) {
@@ -41,7 +37,6 @@ function setupFileInput(chooser) {
       }
     }
   };
-
   const dropListener = function (e) {
     e.preventDefault();
     const dt = e.dataTransfer;
@@ -56,82 +51,78 @@ function setupFileInput(chooser) {
     const fileInput = document.getElementById(elementId);
     fileInput.files = dataTransfer.files;
 
+
     if (overlay) {
       overlay.remove();
       overlay = null;
     }
-
     dragCounter = 0;
-
     fileInput.dispatchEvent(new Event("change", { bubbles: true }));
   };
-
-  ["dragenter", "dragover", "dragleave", "drop"].forEach((eventName) => {
-    document.body.addEventListener(eventName, preventDefaults, false);
-  });
-
-  function preventDefaults(e) {
-    e.preventDefault();
-    e.stopPropagation();
-  }
-
-  document.body.addEventListener("dragenter", dragenterListener);
-  document.body.addEventListener("dragleave", dragleaveListener);
-  document.body.addEventListener("drop", dropListener);
-
-  // When adding files
-  $("#" + elementId).on("change", function (e) {
-    // Get newly Added Files
-    const newFiles = Array.from(e.target.files).map(file => {
-      return {
-        file: file,
-        uniqueId: file.name + Date.now()// Assign a unique identifier to each file
-      };
+    ["dragenter", "dragover", "dragleave", "drop"].forEach((eventName) => {
+      document.body.addEventListener(eventName, preventDefaults, false);
     });
+    function preventDefaults(e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    document.body.addEventListener("dragenter", dragenterListener);
+    document.body.addEventListener("dragleave", dragleaveListener);
+    document.body.addEventListener("drop", dropListener);
 
-    // Add new files to existing files
-    allFiles = [...allFiles, ...newFiles];
+    // When adding files
+    $("#" + elementId).on("change", function (e) {
+      // Get newly Added Files
+      const newFiles = Array.from(e.target.files).map(file => {
+        return {
+          file: file,
+          uniqueId: file.name + Date.now()// Assign a unique identifier to each file
+        };
+      });
 
-    // Update the file input's files property
-    const dataTransfer = new DataTransfer();
-    allFiles.forEach((fileObj) => dataTransfer.items.add(fileObj.file));
-    e.target.files = dataTransfer.files;
+      // Add new files to existing files
+      allFiles = [...allFiles, ...newFiles];
 
-    handleFileInputChange(this);
+      // Update the file input's files property
+      const dataTransfer = new DataTransfer();
+      allFiles.forEach((fileObj) => dataTransfer.items.add(fileObj.file));
+      e.target.files = dataTransfer.files;
 
-    // Call the displayFiles function with the allFiles array
-    displayFiles(allFiles)
-    // Dispatch a custom event with the allFiles array
-    var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
-    document.dispatchEvent(filesUpdated);
-  });
+      handleFileInputChange(this);
+
+      // Call the displayFiles function with the allFiles array
+      displayFiles(allFiles)
+      // Dispatch a custom event with the allFiles array
+      var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
+      document.dispatchEvent(filesUpdated);
+    });
 
 // Listen for event of file being removed and then filter it out of the allFiles array
-  document.addEventListener("fileRemoved", function (e) {
-    const fileId = e.detail;
-    allFiles = allFiles.filter(fileObj => fileObj.uniqueId !== fileId); // Remove the file from the allFiles array using the unique identifier
-    // Dispatch a custom event with the allFiles array
-    var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
-    document.dispatchEvent(filesUpdated);
-  });
-
-  function handleFileInputChange(inputElement) {
-    const files = allFiles;
-    const fileNames = files.map((f) => f.name);
-    const selectedFilesContainer = $(inputElement).siblings(".selected-files");
-    selectedFilesContainer.empty();
-    fileNames.forEach((fileName) => {
-      selectedFilesContainer.append("<div>" + fileName + "</div>");
+    document.addEventListener("fileRemoved", function (e) {
+      const fileId = e.detail;
+      allFiles = allFiles.filter(fileObj => fileObj.uniqueId !== fileId); // Remove the file from the allFiles array using the unique identifier
+      // Dispatch a custom event with the allFiles array
+      var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
+      document.dispatchEvent(filesUpdated);
     });
-    if (fileNames.length === 1) {
-      $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);
-    } else if (fileNames.length > 1) {
-      $(inputElement)
+
+    function handleFileInputChange(inputElement) {
+      const files = allFiles;
+      const fileNames = files.map((f) => f.name);
+      const selectedFilesContainer = $(inputElement).siblings(".selected-files");
+      selectedFilesContainer.empty();
+      fileNames.forEach((fileName) => {
+        selectedFilesContainer.append("<div>" + fileName + "</div>");
+      });
+      if (fileNames.length === 1) {
+        $(inputElement).siblings(".custom-file-label").addClass("selected").html(fileNames[0]);
+      } else if (fileNames.length > 1) {
+        $(inputElement)
         .siblings(".custom-file-label")
         .addClass("selected")
         .html(fileNames.length + " " + filesSelected);
-    } else {
-      $(inputElement).siblings(".custom-file-label").addClass("selected").html(pdfPrompt);
+      } else {
+        $(inputElement).siblings(".custom-file-label").addClass("selected").html(pdfPrompt);
+      }
     }
-  }
-}
+    }

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -72,30 +72,36 @@ function setupFileInput(chooser) {
 
     // When adding files
     $("#" + elementId).on("change", function (e) {
-      // Get newly Added Files
-      const newFiles = Array.from(e.target.files).map(file => {
-        return {
-          file: file,
-          uniqueId: file.name + Date.now()// Assign a unique identifier to each file
-        };
-      });
+      if (window.multiple){
+        // Get newly Added Files
+        const newFiles = Array.from(e.target.files).map(file => {
+          return {
+            file: file,
+            uniqueId: file.name + Date.now()// Assign a unique identifier to each file
+          };
+        });
 
-      // Add new files to existing files
-      allFiles = [...allFiles, ...newFiles];
+        // Add new files to existing files
+        allFiles = [...allFiles, ...newFiles];
 
-      // Update the file input's files property
-      const dataTransfer = new DataTransfer();
-      allFiles.forEach((fileObj) => dataTransfer.items.add(fileObj.file));
-      e.target.files = dataTransfer.files;
+        // Update the file input's files property
+        const dataTransfer = new DataTransfer();
+        allFiles.forEach((fileObj) => dataTransfer.items.add(fileObj.file));
+        e.target.files = dataTransfer.files;
 
-      handleFileInputChange(this);
+        handleFileInputChange(this);
 
-      // Call the displayFiles function with the allFiles array
-      displayFiles(allFiles)
-      // Dispatch a custom event with the allFiles array
-      var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
-      document.dispatchEvent(filesUpdated);
+        // Call the displayFiles function with the allFiles array
+        displayFiles(allFiles)
+        // Dispatch a custom event with the allFiles array
+        var filesUpdated = new CustomEvent("filesUpdated", {detail: allFiles});
+        document.dispatchEvent(filesUpdated);
+      }else {
+        allFiles = Array.from(e.target.files);
+        handleFileInputChange(this);
+      }
     });
+
 
 // Listen for event of file being removed and then filter it out of the allFiles array
     document.addEventListener("fileRemoved", function (e) {

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -47,12 +47,11 @@ function setupFileInput(chooser) {
     const dt = e.dataTransfer;
     const files = dt.files;
 
-    for (let i = 0; i < files.length; i++) {
-      allFiles.push(files[i]);
-    }
-
+    //Do not Update allFiles array here to prevent duplication, the change event listener will take care of that
     const dataTransfer = new DataTransfer();
-    allFiles.forEach((file) => dataTransfer.items.add(file));
+    for (let i = 0; i < files.length; i++) {
+      dataTransfer.items.add(files[i]);
+    }
 
     const fileInput = document.getElementById(elementId);
     fileInput.files = dataTransfer.files;
@@ -80,9 +79,40 @@ function setupFileInput(chooser) {
   document.body.addEventListener("dragleave", dragleaveListener);
   document.body.addEventListener("drop", dropListener);
 
+  // When adding files
   $("#" + elementId).on("change", function (e) {
-    allFiles = Array.from(e.target.files);
+    // Get newly Added Files
+    const newFiles = Array.from(e.target.files).map(file => {
+      return {
+        file: file,
+        uniqueId: file.name + Date.now()// Assign a unique identifier to each file
+      };
+    });
+
+    // Add new files to existing files
+    allFiles = [...allFiles, ...newFiles];
+
+    // Update the file input's files property
+    const dataTransfer = new DataTransfer();
+    allFiles.forEach((fileObj) => dataTransfer.items.add(fileObj.file));
+    e.target.files = dataTransfer.files;
+
     handleFileInputChange(this);
+
+    // Call the displayFiles function with the allFiles array
+    displayFiles(allFiles)
+    // Dispatch a custom event with the allFiles array
+    var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
+    document.dispatchEvent(filesUpdated);
+  });
+
+// Listen for event of file being removed and then filter it out of the allFiles array
+  document.addEventListener("fileRemoved", function (e) {
+    const fileId = e.detail;
+    allFiles = allFiles.filter(fileObj => fileObj.uniqueId !== fileId); // Remove the file from the allFiles array using the unique identifier
+    // Dispatch a custom event with the allFiles array
+    var filesUpdated = new CustomEvent("filesUpdated", { detail: allFiles });
+    document.dispatchEvent(filesUpdated);
   });
 
   function handleFileInputChange(inputElement) {
@@ -104,9 +134,4 @@ function setupFileInput(chooser) {
       $(inputElement).siblings(".custom-file-label").addClass("selected").html(pdfPrompt);
     }
   }
-  //Listen for event of file being removed and the filter it out of the allFiles array
-  document.addEventListener("fileRemoved", function (e) {
-    const fileName = e.detail;
-    allFiles = allFiles.filter(file => file.name !== fileName);
-  });
 }

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -2,15 +2,27 @@ let currentSort = {
   field: null,
   descending: false,
 };
+//New Array to keep track of unique id
+let filesWithUniqueId = [];
+let processedFiles = [];
 
 document.getElementById("fileInput-input").addEventListener("change", function () {
-  var files = this.files;
+  var files = Array.from(this.files).map(file => {
+    return {
+      file: file,
+      uniqueId: file.name + Date.now()
+    };
+  });
+  filesWithUniqueId = files;
   displayFiles(files);
 });
+//Get Files Updated Event from FileInput
+document.addEventListener("filesUpdated", function (e) {
+  filesWithUniqueId = e.detail;
+  displayFiles(filesWithUniqueId);
+});
 
-/**
- * @param {FileList} files
- */
+
 function displayFiles(files) {
   const list = document.getElementById("selectedFiles");
 
@@ -18,12 +30,30 @@ function displayFiles(files) {
     list.removeChild(list.firstChild);
   }
 
+  // Clear the processedFiles array
+  processedFiles = [];
+
   for (let i = 0; i < files.length; i++) {
     const item = document.createElement("li");
     item.className = "list-group-item";
+    item.dataset.id = files[i].uniqueId; // Assign the uniqueId to the list item
+    const fileNameDiv = document.createElement("div");
+    fileNameDiv.className = "filename";
+    fileNameDiv.textContent = files[i].file.name;
+
+    // Check for duplicates and add a warning if necessary
+    const duplicateFiles = files.filter(file => file.file.name === files[i].file.name);
+    if (duplicateFiles.length > 1) {
+      const warning = document.createElement("span");
+      warning.className = "duplicate-warning";
+      warning.textContent = "(Duplicate)";
+      fileNameDiv.appendChild(warning);
+    }
+
+
     item.innerHTML = `
             <div class="d-flex justify-content-between align-items-center w-100">
-                <div class="filename">${files[i].name}</div>
+                ${fileNameDiv.outerHTML}
                 <div class="arrows d-flex">
                     <button class="btn btn-secondary move-up"><span>&uarr;</span></button>
                     <button class="btn btn-secondary move-down"><span>&darr;</span></button>
@@ -33,7 +63,6 @@ function displayFiles(files) {
         `;
     list.appendChild(item);
   }
-
   attachMoveButtons();
 }
 
@@ -50,7 +79,6 @@ function attachMoveButtons() {
       }
     });
   }
-
   var moveDownButtons = document.querySelectorAll(".move-down");
   for (var i = 0; i < moveDownButtons.length; i++) {
     moveDownButtons[i].addEventListener("click", function (event) {
@@ -66,20 +94,21 @@ function attachMoveButtons() {
 
   var removeButtons = document.querySelectorAll(".remove-file");
   for (var i = 0; i < removeButtons.length; i++) {
+    // When the delete button is clicked
     removeButtons[i].addEventListener("click", function (event) {
       event.preventDefault();
       var parent = this.closest(".list-group-item");
-      //Get name of removed file
-      var fileName = parent.querySelector(".filename").innerText;
+      var fileId = parent.dataset.id; // Get the unique identifier of the file to be deleted
       parent.remove();
+      // Remove the file from the filesWithUniqueId array
+      filesWithUniqueId = filesWithUniqueId.filter(fileObj => fileObj.uniqueId !== fileId);
       updateFiles();
-      //Dispatch a custom event with the name of the removed file
-      var event = new CustomEvent("fileRemoved", { detail: fileName });
-      document.dispatchEvent(event);
+      // Dispatch a custom event with the unique identifier of the file to be deleted
+      var fileRemoved = new CustomEvent("fileRemoved", { detail: fileId });
+      document.dispatchEvent(fileRemoved);
     });
   }
 }
-
 document.getElementById("sortByNameBtn").addEventListener("click", function () {
   if (currentSort.field === "name" && !currentSort.descending) {
     currentSort.descending = true;
@@ -90,7 +119,6 @@ document.getElementById("sortByNameBtn").addEventListener("click", function () {
     sortFiles((a, b) => a.name.localeCompare(b.name));
   }
 });
-
 document.getElementById("sortByDateBtn").addEventListener("click", function () {
   if (currentSort.field === "lastModified" && !currentSort.descending) {
     currentSort.descending = true;
@@ -103,30 +131,29 @@ document.getElementById("sortByDateBtn").addEventListener("click", function () {
 });
 
 function sortFiles(comparator) {
-  // Convert FileList to array and sort
-  const sortedFilesArray = Array.from(document.getElementById("fileInput-input").files).sort(comparator);
+  // Sort the filesWithUniqueId array
+  const sortedFilesArray = filesWithUniqueId.sort((a, b) => comparator(a.file, b.file));
 
   // Refresh displayed list
   displayFiles(sortedFilesArray);
 
   // Update the files property
   const dataTransfer = new DataTransfer();
-  sortedFilesArray.forEach((file) => dataTransfer.items.add(file));
+  sortedFilesArray.forEach((fileObj) => dataTransfer.items.add(fileObj.file));
   document.getElementById("fileInput-input").files = dataTransfer.files;
 }
+
 
 function updateFiles() {
   var dataTransfer = new DataTransfer();
   var liElements = document.querySelectorAll("#selectedFiles li");
-  const files = document.getElementById("fileInput-input").files;
 
   for (var i = 0; i < liElements.length; i++) {
-    var fileNameFromList = liElements[i].querySelector(".filename").innerText;
-    var fileFromFiles;
-    for (var j = 0; j < files.length; j++) {
-      var file = files[j];
-      if (file.name === fileNameFromList) {
-        dataTransfer.items.add(file);
+    var fileIdFromList = liElements[i].dataset.id; // Get the unique identifier from the list item
+    for (var j = 0; j < filesWithUniqueId.length; j++) {
+      var fileObj = filesWithUniqueId[j];
+      if (fileObj.uniqueId === fileIdFromList) {
+        dataTransfer.items.add(fileObj.file);
         break;
       }
     }

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -46,7 +46,8 @@ function displayFiles(files) {
     if (duplicateFiles.length > 1) {
       const warning = document.createElement("span");
       warning.className = "duplicate-warning";
-      warning.textContent = "(Duplicate)";
+      // Retrieve the translated message from the data attribute
+      warning.textContent =  " "+document.getElementById("duplicateWarningMessage").dataset.duplicateWarning;
       fileNameDiv.appendChild(warning);
     }
 

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -147,7 +147,7 @@
 <th:block th:fragment="fileSelector(name, multiple)" th:with="accept=${accept} ?: '*/*', inputText=${inputText} ?: #{pdfPrompt}, remoteCall=${remoteCall} ?: true, notRequired=${notRequired} ?: false">
                 <script th:inline="javascript">
                   const pdfPasswordPrompt = /*[[#{error.pdfPassword}]]*/ '';
-                  const multiple = [[${multiple}]] || false;
+                  window.multiple = [[${multiple}]] || false;
                   const remoteCall = [[${remoteCall}]] || true;
                 </script>
                 <script src="js/downloader.js"></script>

--- a/src/main/resources/templates/merge-pdfs.html
+++ b/src/main/resources/templates/merge-pdfs.html
@@ -38,5 +38,6 @@
       </div>
       <th:block th:insert="~{fragments/footer.html :: footer}"></th:block>
     </div>
+    <span id="duplicateWarningMessage" style="display: none;" th:data-duplicate-warning="#{merge.duplicateWarning}"></span>
   </body>
 </html>


### PR DESCRIPTION
# Regarding reverted PR #1204 

This PR implements the same changes as the one mentioned above. But it distinguishes file input forms by using the multiple variable of the form. As of right now merge is the only page where these changes are useful in my opinion. If in the future a feature is implemented where these changes are useful, they can be used by setting multiple to true in the Form. At this moment the pipeline page is the only other page where multiple is set to true, but since these changes would not be user friendly for the pipeline page I made sure it is not affected. 
Also I made sure that the Duplicate warning is dynamic and translatable this time. 



## Checklist:

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
