### PR TITLE
[Helm][K8S] Add rootPath helm

### DIFF
--- a/chart/stirling-pdf/templates/deployment.yaml
+++ b/chart/stirling-pdf/templates/deployment.yaml
@@ -62,8 +62,10 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
-{{- if .Values.envs }}
         env:
+        - name: SYSTEM_ROOTURIPATH
+          value: {{ .Values.rootPath}}
+{{- if .Values.envs }}
 {{ toYaml .Values.envs | indent 8 }}
 {{- end }}
 {{- if .Values.extraArgs }}
@@ -75,13 +77,13 @@ spec:
           containerPort: 8080
         livenessProbe:
           httpGet:
-            path: /
+            path: {{ .Values.rootPath}}
             port: http
 {{ toYaml .Values.probes.livenessHttpGetConfig | indent 12 }}
 {{ toYaml .Values.probes.liveness | indent 10 }}
         readinessProbe:
           httpGet:
-            path: /
+            path: {{ .Values.rootPath}}
             port: http
 {{ toYaml .Values.probes.readinessHttpGetConfig | indent 12 }}
 {{ toYaml .Values.probes.readiness | indent 10 }}

--- a/chart/stirling-pdf/values.yaml
+++ b/chart/stirling-pdf/values.yaml
@@ -15,6 +15,9 @@ secret:
 commonLabels: {}
 # team_name: dev
 
+# rootpath for the application
+rootPath: /
+
 envs: []
 # - name: UI_APP_NAME
 #   value: "Stirling PDF"
@@ -24,8 +27,6 @@ envs: []
 #   value: "Stirling PDF"
 # - name: ALLOW_GOOGLE_VISIBILITY
 #   value: "true"
-# - name: APP_ROOT_PATH
-#   value: "/"
 # - name: APP_LOCALE
 #   value: "en_GB"
 


### PR DESCRIPTION
# Description

Currently, if we want to change the root path of the application, we need to use SYSTEM_ROOTURIPATH. But we also need to update the probes endpoint.
This is why it's useful to use a new variable in values.yaml to manage them.
By default, rootPath value contain "/". If we change them, SYSTEM_ROOTURIPATH will be updated and the probes enpoint too.

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
