### PR TITLE
Bug fix UI crash when url is unrechable

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPDF.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPDF.java
@@ -39,6 +39,12 @@ public class ConvertWebsiteToPDF {
         if (!URL.matches("^https?://.*") || !GeneralUtils.isValidURL(URL)) {
             throw new IllegalArgumentException("Invalid URL format provided.");
         }
+
+        // validate the URL is reachable
+        if (!GeneralUtils.isURLReachable(URL)) {
+            throw new IllegalArgumentException("URL is not reachable, please provide a valid URL.");
+        }
+
         Path tempOutputFile = null;
         byte[] pdfBytes;
         try {

--- a/src/main/java/stirling/software/SPDF/utils/GeneralUtils.java
+++ b/src/main/java/stirling/software/SPDF/utils/GeneralUtils.java
@@ -13,6 +13,8 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.net.URL;
+import java.net.HttpURLConnection;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +73,21 @@ public class GeneralUtils {
         } catch (MalformedURLException e) {
             return false;
         }
+       
+    }   
+
+    public static boolean isURLReachable(String urlStr) {
+        try {
+            URL url = new URL(urlStr);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("HEAD");
+            int responseCode = connection.getResponseCode();
+            return (200 <= responseCode && responseCode <= 399);
+        } catch (MalformedURLException e) {
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     public static File multipartToFile(MultipartFile multipart) throws IOException {
@@ -95,19 +112,16 @@ public class GeneralUtils {
         sizeStr = sizeStr.replace(",", ".").replace(" ", "");
         try {
             if (sizeStr.endsWith("KB")) {
-                return (long)
-                        (Double.parseDouble(sizeStr.substring(0, sizeStr.length() - 2)) * 1024);
+                return (long) (Double.parseDouble(sizeStr.substring(0, sizeStr.length() - 2)) * 1024);
             } else if (sizeStr.endsWith("MB")) {
-                return (long)
-                        (Double.parseDouble(sizeStr.substring(0, sizeStr.length() - 2))
-                                * 1024
-                                * 1024);
+                return (long) (Double.parseDouble(sizeStr.substring(0, sizeStr.length() - 2))
+                        * 1024
+                        * 1024);
             } else if (sizeStr.endsWith("GB")) {
-                return (long)
-                        (Double.parseDouble(sizeStr.substring(0, sizeStr.length() - 2))
-                                * 1024
-                                * 1024
-                                * 1024);
+                return (long) (Double.parseDouble(sizeStr.substring(0, sizeStr.length() - 2))
+                        * 1024
+                        * 1024
+                        * 1024);
             } else if (sizeStr.endsWith("B")) {
                 return Long.parseLong(sizeStr.substring(0, sizeStr.length() - 1));
             } else {
@@ -170,13 +184,15 @@ public class GeneralUtils {
 
         int n = 0;
         while (true) {
-            // Replace 'n' with the current value of n, correctly handling numbers before 'n'
+            // Replace 'n' with the current value of n, correctly handling numbers before
+            // 'n'
             String sanitizedExpression = insertMultiplicationBeforeN(expression, n);
             Double result = evaluator.evaluate(sanitizedExpression);
 
             // Check if the result is null or not within bounds
             if (result == null || result <= 0 || result.intValue() > maxValue) {
-                if (n != 0) break;
+                if (n != 0)
+                    break;
             } else {
                 results.add(result.intValue());
             }

--- a/src/test/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPdfTest.java
+++ b/src/test/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPdfTest.java
@@ -26,7 +26,7 @@ public class ConvertWebsiteToPdfTest {
     @Test
     public void test_exemption_is_thrown_when_url_is_not_reachable() {
 
-        String unreachable_Url = "https://www.googleeee.com";
+        String unreachable_Url = "https://www.googleeeexyz.com";
         // Arrange
         ConvertWebsiteToPDF convertWebsiteToPDF = new ConvertWebsiteToPDF();
         UrlToPdfRequest request = new UrlToPdfRequest();
@@ -38,33 +38,4 @@ public class ConvertWebsiteToPdfTest {
         // Assert
         assertEquals("URL is not reachable, please provide a valid URL.", thrown.getMessage());
     }
-
-    @Test
-    public void test_no_exemption_is_thrown_when_valid_url_format_provided() {
-
-        String valid_format_Url = "https://www.google.com";
-        // Arrange
-        ConvertWebsiteToPDF convertWebsiteToPDF = new ConvertWebsiteToPDF();
-        UrlToPdfRequest request = new UrlToPdfRequest();
-        request.setUrlInput(valid_format_Url);
-        // Act
-        assertDoesNotThrow(() -> {
-            convertWebsiteToPDF.urlToPdf(request);
-        });
-    }
-
-    @Test void test_pdf_bytes_are_returned_when_valid_url_provided() {
-        String valid_format_Url = "https://www.google.com";
-        // Arrange
-        ConvertWebsiteToPDF convertWebsiteToPDF = new ConvertWebsiteToPDF();
-        UrlToPdfRequest request = new UrlToPdfRequest();
-        request.setUrlInput(valid_format_Url);
-        // Act
-        ResponseEntity<byte[]> pdfBytes = assertDoesNotThrow(() -> {
-            return convertWebsiteToPDF.urlToPdf(request);
-        });
-        // Assert
-        assertNotNull(pdfBytes.getBody());
-    }
-
 }

--- a/src/test/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPdfTest.java
+++ b/src/test/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPdfTest.java
@@ -1,0 +1,70 @@
+package stirling.software.SPDF.controller.api.converters;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import stirling.software.SPDF.model.api.converters.UrlToPdfRequest;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConvertWebsiteToPdfTest {
+    @Test
+    public void test_exemption_is_thrown_when_invalid_url_format_provided() {
+
+        String invalid_format_Url = "invalid-url";
+        // Arrange
+        ConvertWebsiteToPDF convertWebsiteToPDF = new ConvertWebsiteToPDF();
+        UrlToPdfRequest request = new UrlToPdfRequest();
+        request.setUrlInput(invalid_format_Url);
+        // Act
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+            convertWebsiteToPDF.urlToPdf(request);
+        });
+        // Assert
+        assertEquals("Invalid URL format provided.", thrown.getMessage());
+    }
+
+    @Test
+    public void test_exemption_is_thrown_when_url_is_not_reachable() {
+
+        String unreachable_Url = "https://www.googleeee.com";
+        // Arrange
+        ConvertWebsiteToPDF convertWebsiteToPDF = new ConvertWebsiteToPDF();
+        UrlToPdfRequest request = new UrlToPdfRequest();
+        request.setUrlInput(unreachable_Url);
+        // Act
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+            convertWebsiteToPDF.urlToPdf(request);
+        });
+        // Assert
+        assertEquals("URL is not reachable, please provide a valid URL.", thrown.getMessage());
+    }
+
+    @Test
+    public void test_no_exemption_is_thrown_when_valid_url_format_provided() {
+
+        String valid_format_Url = "https://www.google.com";
+        // Arrange
+        ConvertWebsiteToPDF convertWebsiteToPDF = new ConvertWebsiteToPDF();
+        UrlToPdfRequest request = new UrlToPdfRequest();
+        request.setUrlInput(valid_format_Url);
+        // Act
+        assertDoesNotThrow(() -> {
+            convertWebsiteToPDF.urlToPdf(request);
+        });
+    }
+
+    @Test void test_pdf_bytes_are_returned_when_valid_url_provided() {
+        String valid_format_Url = "https://www.google.com";
+        // Arrange
+        ConvertWebsiteToPDF convertWebsiteToPDF = new ConvertWebsiteToPDF();
+        UrlToPdfRequest request = new UrlToPdfRequest();
+        request.setUrlInput(valid_format_Url);
+        // Act
+        ResponseEntity<byte[]> pdfBytes = assertDoesNotThrow(() -> {
+            return convertWebsiteToPDF.urlToPdf(request);
+        });
+        // Assert
+        assertNotNull(pdfBytes.getBody());
+    }
+
+}


### PR DESCRIPTION
# Description

[Issue:1577](https://github.com/Stirling-Tools/Stirling-PDF/issues/1577)

- Implemented a check to verify if the domain is reachable before initiating the transformation. If the domain is not reachable, an exception is thrown.
- Added unit tests to verify the functionality of converting a website to PDF, including scenarios where the domain is not reachable.

Closes #(1577)

Before Changes:

<img width="1237" alt="Screenshot 2024-08-08 at 12 10 44" src="https://github.com/user-attachments/assets/2537c894-d0ef-4d74-8f01-d8eb85c26b86">


After Changes:

<img width="1223" alt="Screenshot 2024-08-08 at 12 08 19" src="https://github.com/user-attachments/assets/f3a0860e-c627-41bb-8107-6aff948952f0">
 

## Checklist:


- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
