### PR TITLE
Issue1632 remove images

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
+++ b/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
@@ -137,6 +137,7 @@ public class EndpointConfiguration {
         addEndpointToGroup("Other", "auto-rename");
         addEndpointToGroup("Other", "get-info-on-pdf");
         addEndpointToGroup("Other", "show-javascript");
+        addEndpointToGroup("Other", "remove-image-pdf");
 
         // CLI
         addEndpointToGroup("CLI", "compress-pdf");
@@ -221,6 +222,7 @@ public class EndpointConfiguration {
         addEndpointToGroup("Java", "split-pdf-by-sections");
         addEndpointToGroup("Java", REMOVE_BLANKS);
         addEndpointToGroup("Java", "pdf-to-text");
+        addEndpointToGroup("Java", "remove-image-pdf");
 
         // Javascript
         addEndpointToGroup("Javascript", "pdf-organizer");

--- a/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.swagger.v3.oas.annotations.Operation;
+
 import stirling.software.SPDF.model.api.PDFFile;
 import stirling.software.SPDF.service.PdfImageRemovalService;
 import stirling.software.SPDF.utils.WebResponseUtils;
@@ -25,7 +27,11 @@ public class PdfImageRemovalController {
         this.pdfImageRemovalService = pdfImageRemovalService;
     }
 
-    @PostMapping("/remove-images")
+    @PostMapping(consumes = "multipart/form-data", value = "/remove-image-pdf")
+    @Operation(
+            summary = "Remove images from file to reduce the file size.",
+            description =
+                    "This endpoint remove images from file to reduce the file size.Input:PDF Output:PDF Type:MISO")
     public ResponseEntity<byte[]> removeImages(@ModelAttribute PDFFile file) throws IOException {
 
         MultipartFile pdf = file.getFileInput();

--- a/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
@@ -1,0 +1,48 @@
+package stirling.software.SPDF.controller.api;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import stirling.software.SPDF.model.api.PDFFile;
+import stirling.software.SPDF.service.PdfImageRemovalService;
+import stirling.software.SPDF.utils.WebResponseUtils;
+
+@RestController
+@RequestMapping("/api/v1/general")
+public class PdfImageRemovalController {
+
+    @Autowired private PdfImageRemovalService pdfImageRemovalService;
+
+    // Constructor injection for PdfImageRemover service
+    public PdfImageRemovalController(PdfImageRemovalService pdfImageRemovalService) {
+        this.pdfImageRemovalService = pdfImageRemovalService;
+    }
+
+    @PostMapping("/remove-images")
+    public ResponseEntity<byte[]> removeImages(@ModelAttribute PDFFile file) throws IOException {
+
+        MultipartFile pdf = file.getFileInput();
+
+        byte[] pdfBytes = pdf.getBytes();
+
+        PDDocument document = Loader.loadPDF(pdfBytes);
+
+        PDDocument modifiedDocument = pdfImageRemovalService.removeImagesFromPdf(document);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        modifiedDocument.save(outputStream);
+        modifiedDocument.close();
+
+        // Return the modified PDF as a response
+        String fileName = "removed-images.pdf";
+        return WebResponseUtils.bytesToWebResponse(outputStream.toByteArray(), fileName);
+    }
+}

--- a/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
@@ -16,17 +16,37 @@ import stirling.software.SPDF.model.api.PDFFile;
 import stirling.software.SPDF.service.PdfImageRemovalService;
 import stirling.software.SPDF.utils.WebResponseUtils;
 
+
+/**
+ * Controller class for handling PDF image removal requests.
+ * Provides an endpoint to remove images from a PDF file to reduce its size.
+ */
 @RestController
 @RequestMapping("/api/v1/general")
 public class PdfImageRemovalController {
 
+    // Service for removing images from PDFs
     @Autowired private PdfImageRemovalService pdfImageRemovalService;
 
-    // Constructor injection for PdfImageRemover service
+    /**
+     * Constructor for dependency injection of PdfImageRemovalService.
+     *
+     * @param pdfImageRemovalService The service used for removing images from PDFs.
+     */
     public PdfImageRemovalController(PdfImageRemovalService pdfImageRemovalService) {
         this.pdfImageRemovalService = pdfImageRemovalService;
     }
 
+    /**
+     * Endpoint to remove images from a PDF file.
+     *
+     * This method processes the uploaded PDF file, removes all images, and returns
+     * the modified PDF file with a new name indicating that images were removed.
+     *
+     * @param file The PDF file with images to be removed.
+     * @return ResponseEntity containing the modified PDF file as byte array with appropriate content type and filename.
+     * @throws IOException If an error occurs while processing the PDF file.
+     */
     @PostMapping(consumes = "multipart/form-data", value = "/remove-image-pdf")
     @Operation(
             summary = "Remove images from file to reduce the file size.",
@@ -35,19 +55,28 @@ public class PdfImageRemovalController {
     public ResponseEntity<byte[]> removeImages(@ModelAttribute PDFFile file) throws IOException {
 
         MultipartFile pdf = file.getFileInput();
+
+        // Convert the MultipartFile to a byte array
         byte[] pdfBytes = pdf.getBytes();
+
+        // Load the PDF document from the byte array
         PDDocument document = Loader.loadPDF(pdfBytes);
 
+        // Remove images from the PDF document using the service
         PDDocument modifiedDocument = pdfImageRemovalService.removeImagesFromPdf(document);
 
+        // Create a ByteArrayOutputStream to hold the modified PDF data
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
+        // Save the modified PDF document to the output stream
         modifiedDocument.save(outputStream);
         modifiedDocument.close();
 
+        // Generate a new filename for the modified PDF
         String mergedFileName =
                 pdf.getOriginalFilename().replaceFirst("[.][^.]+$", "") + "_removed_images.pdf";
 
+        // Convert the byte array to a web response and return it
         return WebResponseUtils.bytesToWebResponse(outputStream.toByteArray(), mergedFileName);
     }
 }

--- a/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
@@ -29,9 +29,7 @@ public class PdfImageRemovalController {
     public ResponseEntity<byte[]> removeImages(@ModelAttribute PDFFile file) throws IOException {
 
         MultipartFile pdf = file.getFileInput();
-
         byte[] pdfBytes = pdf.getBytes();
-
         PDDocument document = Loader.loadPDF(pdfBytes);
 
         PDDocument modifiedDocument = pdfImageRemovalService.removeImagesFromPdf(document);
@@ -41,8 +39,9 @@ public class PdfImageRemovalController {
         modifiedDocument.save(outputStream);
         modifiedDocument.close();
 
-        // Return the modified PDF as a response
-        String fileName = "removed-images.pdf";
-        return WebResponseUtils.bytesToWebResponse(outputStream.toByteArray(), fileName);
+        String mergedFileName =
+                pdf.getOriginalFilename().replaceFirst("[.][^.]+$", "") + "_removed_images.pdf";
+
+        return WebResponseUtils.bytesToWebResponse(outputStream.toByteArray(), mergedFileName);
     }
 }

--- a/src/main/java/stirling/software/SPDF/controller/web/GeneralWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/GeneralWebController.java
@@ -310,4 +310,11 @@ public class GeneralWebController {
         model.addAttribute("currentPage", "auto-split-pdf");
         return "auto-split-pdf";
     }
+
+    @GetMapping("/remove-image-pdf")
+    @Hidden
+    public String removeImagePdfForm(Model model) {
+        model.addAttribute("currentPage", "remove-image-pdf");
+        return "remove-image-pdf";
+    }
 }

--- a/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
+++ b/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
@@ -6,6 +6,7 @@ import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,11 +18,10 @@ public class PdfImageRemovalService {
             PDResources resources = page.getResources();
             for (COSName name : resources.getXObjectNames()) {
                 if (resources.isImageXObject(name)) {
-                    resources.getXObject(name).getCOSObject().clear();
+                    resources.put(name, (PDXObject) null);
                 }
             }
         }
-
         return document;
     }
 }

--- a/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
+++ b/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
@@ -1,0 +1,27 @@
+package stirling.software.SPDF.service;
+
+import java.io.IOException;
+
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PdfImageRemovalService {
+
+    public PDDocument removeImagesFromPdf(PDDocument document) throws IOException {
+
+        for (PDPage page : document.getPages()) {
+            PDResources resources = page.getResources();
+            for (COSName name : resources.getXObjectNames()) {
+                if (resources.isImageXObject(name)) {
+                    resources.getXObject(name).getCOSObject().clear();
+                }
+            }
+        }
+
+        return document;
+    }
+}

--- a/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
+++ b/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
@@ -9,15 +9,31 @@ import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service class responsible for removing image objects from a PDF document.
+ */
 @Service
 public class PdfImageRemovalService {
 
+    /**
+     * Removes all image objects from the provided PDF document.
+     *
+     * This method iterates over each page in the document and removes any
+     * image XObjects found in the page's resources.
+     *
+     * @param document The PDF document from which images will be removed.
+     * @return The modified PDF document with images removed.
+     * @throws IOException If an error occurs while processing the PDF document.
+     */
     public PDDocument removeImagesFromPdf(PDDocument document) throws IOException {
-
+        // Iterate over each page in the PDF document
         for (PDPage page : document.getPages()) {
             PDResources resources = page.getResources();
+            // Iterate over all XObject names in the page's resources
             for (COSName name : resources.getXObjectNames()) {
+                // Check if the XObject is an image
                 if (resources.isImageXObject(name)) {
+                    // Remove the image XObject by setting it to null
                     resources.put(name, (PDXObject) null);
                 }
             }

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -461,6 +461,10 @@ home.BookToPDF.title=Book to PDF
 home.BookToPDF.desc=Converts Books/Comics formats to PDF using calibre
 BookToPDF.tags=Book,Comic,Calibre,Convert,manga,amazon,kindle,epub,mobi,azw3,docx,rtf,txt,html,lit,fb2,pdb,lrf
 
+home.removeImagePdf.title=Remove image
+home.removeImagePdf.desc=Remove image from PDF to reduce file size
+removeImagePdf.tags=Remove Image,Page operations,Back end,server side
+
 
 ###########################
 #                         #
@@ -1124,3 +1128,10 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+
+#remove-image
+removeImage.title=Remove image
+removeImage.header=Remove image
+removeImage.removeImage=Remove image
+removeImage.submit=Remove image

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -461,6 +461,10 @@ home.BookToPDF.title=Book to PDF
 home.BookToPDF.desc=Converts Books/Comics formats to PDF using calibre
 BookToPDF.tags=Book,Comic,Calibre,Convert,manga,amazon,kindle
 
+home.removeImagePdf.title=Remove image
+home.removeImagePdf.desc=Remove image from PDF to reduce file size
+removeImagePdf.tags=Remove Image,Page operations,Back end,server side
+
 
 ###########################
 #                         #
@@ -1124,3 +1128,10 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+
+#remove-image
+removeImage.title=Remove image
+removeImage.header=Remove image
+removeImage.removeImage=Remove image
+removeImage.submit=Remove image

--- a/src/main/resources/static/css/removeImage.css
+++ b/src/main/resources/static/css/removeImage.css
@@ -1,0 +1,22 @@
+.filename {
+    flex-grow: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-right: 10px;
+}
+
+.arrows {
+    flex-shrink: 0;
+    display: flex;
+    justify-content: flex-end;
+}
+.arrows .btn {
+    margin: 0 3px;
+}
+
+.move-up span,
+.move-down span {
+    font-weight: bold;
+    font-size: 1.2em;
+}

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -195,6 +195,9 @@
                         <div
                           th:replace="~{fragments/navbarEntry :: navbarEntry ('get-info-on-pdf', 'info', 'home.getPdfInfo.title', 'home.getPdfInfo.desc', 'getPdfInfo.tags', 'other')}">
                         </div>
+                        <div
+                                th:replace="~{fragments/navbarEntry :: navbarEntry ('remove-image-pdf','info', 'home.removeImagePdf.title', 'home.removeImagePdf.desc', 'removeImagePdf.tags', 'other')}">
+                        </div>
                       </div>
                       <!-- Advance menu items -->
                       <div class="col-lg-2 col-sm-6 py px-xl-1 px-2">

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -229,6 +229,9 @@
           <div
             th:replace="~{fragments/card :: card(id='stamp', cardTitle=#{home.AddStampRequest.title}, cardText=#{home.AddStampRequest.desc}, cardLink='stamp', toolIcon='approval', tags=#{AddStampRequest.tags}, toolGroup='security')}">
           </div>
+          <div
+            th:replace="~{fragments/card :: card(id='remove-image-pdf', cardTitle=#{home.removeImagePdf.title}, cardText=#{home.removeImagePdf.desc}, cardLink='remove-image-pdf', toolIcon='approval', tags=#{removeImagePdf.tags}, toolGroup='other')}">
+          </div>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/remove-image-pdf.html
+++ b/src/main/resources/templates/remove-image-pdf.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}" th:dir="#{language.direction}" th:data-language="${#locale.toString()}"
+      xmlns:th="https://www.thymeleaf.org">
+<head>
+    <th:block
+            th:insert="~{fragments/common :: head(title=#{removeImage.title}, header=#{removeImage.header})}"></th:block>
+    <link rel="stylesheet" th:href="@{'/css/removeImage.css'}">
+</head>
+
+<body>
+<th:block th:insert="~{fragments/common :: game}"></th:block>
+<div id="page-container">
+    <div id="content-wrap">
+        <th:block th:insert="~{fragments/navbar.html :: navbar}"></th:block>
+        <br><br>
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-md-6 bg-card">
+                    <div class="tool-header">
+                        <span class="material-symbols-rounded tool-header-icon word">description</span>
+                        <span class="tool-header-text" th:text="#{removeImage.header}"></span>
+                    </div>
+                        <form action="api/v1/general/remove-image-pdf" method="post" enctype="multipart/form-data">
+                        <div th:replace="~{fragments/common :: fileSelector(name='fileInput', multiple=false, accept='application/pdf')}"></div>
+
+                        <br>
+                        <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{removeImage.submit}"></button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <th:block th:insert="~{fragments/footer.html :: footer}"></th:block>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# Description

This pull request introduces a new feature that allows users to remove images from PDF file. The primary objective of this feature is to provide a way to streamline PDF documents by removing unnecessary image content, which is particularly useful for users dealing with text-heavy PDFs. This feature is valuable for reducing file size and eliminating visual clutter, making the content more manageable and focused on the text.

Closes #1632

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
