### PR TITLE
Fix: Conditional Attribute Binding for the multiple Attribute in the File Selector Fragment

### DIFF
--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -81,19 +81,19 @@
 
            // Find the file input within the form
           var fileInput = $('input[type="file"]');
-          
+
           // Find the closest enclosing form of the file input
           var form = fileInput.closest('form');
-          
+
           // Find the submit button within the form
           var submitButton = form.find('button[type="submit"], input[type="submit"]');
-          
+
           const boredWaitingText = /*[[#{bored}]]*/ 'Bored Waiting?';
           const downloadCompleteText = /*[[#{downloadComplete}]]*/ 'Download Complete';
           window.downloadCompleteText = downloadCompleteText;
           // Create the 'show-game-btn' button
           var gameButton = $('<button type="button" class="btn btn-primary" id="show-game-btn" style="display:none;">' + boredWaitingText + '</button><br><br>');
-          
+
           // Insert the 'show-game-btn' just above the submit button
           submitButton.before(gameButton);
 
@@ -147,14 +147,14 @@
 <th:block th:fragment="fileSelector(name, multiple)" th:with="accept=${accept} ?: '*/*', inputText=${inputText} ?: #{pdfPrompt}, remoteCall=${remoteCall} ?: true, notRequired=${notRequired} ?: false">
                 <script th:inline="javascript">
                   const pdfPasswordPrompt = /*[[#{error.pdfPassword}]]*/ '';
-                  const multiple = [[${multiple}]] || false;
-                  const remoteCall = [[${remoteCall}]] || true;
+                  const multiple = /*[[${multiple}]]*/ false;
+                  const remoteCall = /*[[${remoteCall}]]*/ true;
                 </script>
                 <script th:src="@{'/js/downloader.js'}"></script>
 
                 <div class="custom-file-chooser" th:attr="data-bs-unique-id=${name}, data-bs-element-id=${name+'-input'}, data-bs-files-selected=#{filesSelected}, data-bs-pdf-prompt=#{pdfPrompt}">
                   <div class="mb-3">
-                    <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" multiple th:required="${notRequired} ? null : 'required'">
+                    <input type="file" class="form-control" th:name="${name}" th:id="${name}+'-input'" th:accept="${accept}" th:attr="multiple=${multiple}" th:required="${notRequired} ? null : 'required'">
                   </div>
                   <div class="selected-files"></div>
                 </div>


### PR DESCRIPTION
# Description

**Previous State:**
The `multiple` attribute in the `<input>` element of the file selector fragment was statically defined, meaning it was either always present or always absent, regardless of the actual requirement. There was no way to dynamically set this attribute based on the `multiple` variable managed in the JavaScript code.

**Fix:**
This fix introduces conditional binding for the` multiple` attribute using Thymeleaf, based on the value of the `multiple` variable in the JavaScript. As a result, the attribute is only added if `multiple` is set to `true`, making the file selector's behavior dynamic and more flexible.

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
