### PR TITLE
Fix ConcurrentModificationException by modifying resources outside the iteration.

### DIFF
--- a/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
+++ b/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
@@ -1,6 +1,8 @@
 package stirling.software.SPDF.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -16,7 +18,7 @@ public class PdfImageRemovalService {
     /**
      * Removes all image objects from the provided PDF document.
      *
-     * This method iterates over each page in the document and removes any image XObjects found
+     * <p>This method iterates over each page in the document and removes any image XObjects found
      * in the page's resources.
      *
      * @param document The PDF document from which images will be removed.
@@ -27,13 +29,21 @@ public class PdfImageRemovalService {
         // Iterate over each page in the PDF document
         for (PDPage page : document.getPages()) {
             PDResources resources = page.getResources();
+            // Collect the XObject names to remove
+            List<COSName> namesToRemove = new ArrayList<>();
+
             // Iterate over all XObject names in the page's resources
             for (COSName name : resources.getXObjectNames()) {
                 // Check if the XObject is an image
                 if (resources.isImageXObject(name)) {
-                    // Remove the image XObject by setting it to null
-                    resources.put(name, (PDXObject) null);
+                    // Collect the name for removal
+                    namesToRemove.add(name);
                 }
+            }
+
+            // Now, modify the resources by removing the collected names
+            for (COSName name : namesToRemove) {
+                resources.put(name, (PDXObject) null);
             }
         }
         return document;


### PR DESCRIPTION


# Description
When removing images from this file:
[The 'Sift' strategy_ A four-step method for spotting misinformation.pdf](https://github.com/user-attachments/files/16662454/The.Sift.strategy_.A.four-step.method.for.spotting.misinformation.pdf)
, a ConcurrentModificationException occurs.
Fixed the problem by
- Changed  to use a list to collect XObject names before removal.
- Avoids ConcurrentModificationException by modifying resources outside the iteration.



## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
