### PR TITLE
Typing error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Stirling PDF currently supports 38!
 | Portuguese Brazilian (Português) (pt_BR)    | ![85%](https://geps.dev/progress/85)   |
 | Romanian (Română) (ro_RO)                   | ![38%](https://geps.dev/progress/38)   |
 | Russian (Русский) (ru_RU)                   | ![83%](https://geps.dev/progress/83)   |
-| Sebian Latin alphabet (Srpski) (sr_LATN_RS) | ![78%](https://geps.dev/progress/78)   |
+| Serbian Latin alphabet (Srpski) (sr_LATN_RS) | ![78%](https://geps.dev/progress/78)   |
 | Simplified Chinese (简体中文) (zh_CN)       | ![98%](https://geps.dev/progress/98)   |
 | Slovakian (Slovensky) (sk_SK)               | ![91%](https://geps.dev/progress/91)   |
 | Spanish (Español) (es_ES)                   | ![97%](https://geps.dev/progress/97)   |


### PR DESCRIPTION
# Description

There is typing error in README.md. It's written `Sebian Latin alphabet (Srpski) (sr_LATN_RS)`

It should be `Serbian Latin alphabet (Srpski) (sr_LATN_RS)`

**`r`** is missing.

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Contributor License Agreement

By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under the MPL 2.0 (Mozilla Public License Version 2.0) license.

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
