### PR TITLE
Multiple images in one page

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
@@ -90,10 +90,11 @@ public class ConvertImgPDFController {
         MultipartFile[] file = request.getFileInput();
         String fitOption = request.getFitOption();
         String colorType = request.getColorType();
+        String templateOptions = request.getTemplateOption();
         boolean autoRotate = request.isAutoRotate();
 
         // Convert the file to PDF and get the resulting bytes
-        byte[] bytes = PdfUtils.imageToPdf(file, fitOption, autoRotate, colorType);
+        byte[] bytes = PdfUtils.imageToPdf(file, fitOption, templateOptions, autoRotate, colorType);
         return WebResponseUtils.bytesToWebResponse(
                 bytes,
                 file[0].getOriginalFilename().replaceFirst("[.][^.]+$", "") + "_converted.pdf");

--- a/src/main/java/stirling/software/SPDF/controller/api/misc/FakeScanControllerWIP.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/FakeScanControllerWIP.java
@@ -43,6 +43,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import stirling.software.SPDF.model.api.PDFFile;
 import stirling.software.SPDF.utils.PdfUtils;
+import stirling.software.SPDF.utils.PdfUtils.TemplateOpcions;
 import stirling.software.SPDF.utils.WebResponseUtils;
 
 @RestController
@@ -80,7 +81,13 @@ public class FakeScanControllerWIP {
             // PDPageContentStream contentStream = new PDPageContentStream(newDocument, new
             // PDPage());
             PDImageXObject pdImage = JPEGFactory.createFromImage(newDocument, img);
-            PdfUtils.addImageToDocument(newDocument, pdImage, "maintainAspectRatio", false);
+            PdfUtils.addImageToDocument(
+                    newDocument,
+                    pdImage,
+                    "maintainAspectRatio",
+                    false,
+                    1,
+                    TemplateOpcions.TWO_IMAGES);
         }
 
         newDocument.save(baos);

--- a/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToPdfRequest.java
+++ b/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToPdfRequest.java
@@ -16,13 +16,23 @@ public class ConvertToPdfRequest {
 
     @Schema(
             description = "Option to determine how the image will fit onto the page",
-            allowableValues = {"fillPage", "fitDocumentToImage", "maintainAspectRatio"})
+            allowableValues = {
+                "fillPage",
+                "fitDocumentToImage",
+                "maintainAspectRatio",
+                "Templates"
+            })
     private String fitOption;
 
     @Schema(
             description = "The color type of the output image(s)",
             allowableValues = {"color", "greyscale", "blackwhite"})
     private String colorType;
+
+    @Schema(
+            description = "Option to determine how the image will fit onto the page",
+            allowableValues = {"1x2", "2x2", "2x3"})
+    private String templateOption;
 
     @Schema(
             description = "Whether to automatically rotate the images to better fit the PDF page",

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -1124,3 +1124,11 @@ error.showStack=Покажи проследяване на стека
 error.copyStack=Копиране на проследяване на стека
 error.githubSubmit=GitHub - Изпратете запитване
 error.discordSubmit=Discord - Изпратете запитване за поддръжка
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -1124,3 +1124,11 @@ error.showStack=Zobrazit stopu zásobníku
 error.copyStack=Kopírovat stopu zásobníku
 error.githubSubmit=GitHub - Odeslat požadavek
 error.discordSubmit=Discord - Odeslat příspěvek podpory
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -1124,3 +1124,11 @@ error.showStack=Stack-Trace anzeigen
 error.copyStack=Stack-Trace kopieren
 error.githubSubmit=GitHub - Ein Ticket einreichen
 error.discordSubmit=Discord - Unterstützungsbeitrag einreichen
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -1124,3 +1124,11 @@ error.showStack=Εμφάνιση Stack Trace
 error.copyStack=Αντιγραφή Stack Trace
 error.githubSubmit=GitHub - Υποβάλετε ένα ticket
 error.discordSubmit=Discord - Υποβάλετε ένα Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -1124,3 +1124,11 @@ error.showStack=Mostrar seguimiento de pila
 error.copyStack=Mostrar seguimiento de pila
 error.githubSubmit=GitHub - Enviar un ticket
 error.discordSubmit=Discord - Enviar mensaje de soporte
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -1124,3 +1124,11 @@ error.showStack=Afficher la  Stack Trace
 error.copyStack=Copier la Stack Trace
 error.githubSubmit=GitHub - Créer un ticket
 error.discordSubmit=Discord - Poster un message de demande d’assistance
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -1124,3 +1124,11 @@ error.showStack=Prikaži Stack Trace
 error.copyStack=Kopiraj Stack Trace
 error.githubSubmit=GitHub - Pošaljite ticket
 error.discordSubmit=Discord - Pošalji objavu podrške
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -1124,3 +1124,11 @@ error.showStack=Mostra traccia dello stack
 error.copyStack=Copia traccia dello stack
 error.githubSubmit=GitHub: invia un ticket
 error.discordSubmit=Discord: invia post di supporto
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -1124,3 +1124,11 @@ error.showStack=スタックトレースを表示
 error.copyStack=スタックトレースをコピー
 error.githubSubmit=GitHub - チケットを提出
 error.discordSubmit=Discord - サポート投稿を提出
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -1124,3 +1124,11 @@ error.showStack=스택 추적 보기
 error.copyStack=스택 추적 복사
 error.githubSubmit=GitHub - 티켓 제출
 error.discordSubmit=Discord - 문의 게시
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -1124,3 +1124,11 @@ error.showStack=Geeft tracering weer
 error.copyStack=Kopieer tracering
 error.githubSubmit=GitHub - Dien een ticket in
 error.discordSubmit=Discord - Maak een support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_no_NB.properties
+++ b/src/main/resources/messages_no_NB.properties
@@ -1124,3 +1124,11 @@ error.showStack=Vis stakksporing
 error.copyStack=Kopier stakksporing
 error.githubSubmit=GitHub - Send inn en billett
 error.discordSubmit=Discord - Send inn støtteinnlegg
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -1124,3 +1124,11 @@ error.showStack=Pokaż Stack Trace
 error.copyStack=Kopiuj Stack Trace
 error.githubSubmit=GitHub - wyślij zgłoszenie
 error.discordSubmit=Discord - wyślij posta z prośbą o pomoc
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -1124,3 +1124,11 @@ error.showStack=Показать стек вызовов
 error.copyStack=Скопировать стек вызовов
 error.githubSubmit=GitHub - Отправить заявку
 error.discordSubmit=Discord - Отправить запрос в поддержку
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -1124,3 +1124,11 @@ error.showStack=Zobraziť sledovanie zásobníka
 error.copyStack=Kopírovať sledovanie zásobníka
 error.githubSubmit=GitHub - Podajte tiket
 error.discordSubmit=Discord - Podajte príspevok na podporu
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -1124,3 +1124,11 @@ error.showStack=Show Stack Trace
 error.copyStack=Copy Stack Trace
 error.githubSubmit=GitHub - Submit a ticket
 error.discordSubmit=Discord - Submit Support post
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_th_TH.properties
+++ b/src/main/resources/messages_th_TH.properties
@@ -1124,3 +1124,11 @@ error.showStack=แสดง Stack Trace
 error.copyStack=คัดลอก Stack Trace
 error.githubSubmit=GitHub - ส่งตั๋ว
 error.discordSubmit=Discord - ส่งโพสต์การสนับสนุน
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -1124,3 +1124,11 @@ error.showStack=Yığın İzlemesini Göster
 error.copyStack=Yığın İzini Kopyala
 error.githubSubmit=GitHub - Hata gönderin
 error.discordSubmit=Discord - Destek gönderisi gönderin
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -1124,3 +1124,11 @@ error.showStack=Показати стек викликів
 error.copyStack=Скопіювати стек викликів
 error.githubSubmit=GitHub - Надіслати запит
 error.discordSubmit=Discord - Надіслати повідомлення підтримки
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -1124,3 +1124,11 @@ error.showStack=显示堆栈跟踪
 error.copyStack=复制堆栈跟踪
 error.githubSubmit=GitHub - 提交工单
 error.discordSubmit=Discord - 提交支持帖子
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -1124,3 +1124,11 @@ error.showStack=顯示堆疊追蹤
 error.copyStack=複製堆疊追蹤
 error.githubSubmit=GitHub - 提交工單
 error.discordSubmit=Discord - 提交支援帖子
+
+#Template strings image to pdf
+
+imageToPDF.templates=Templates
+imageToPDF.selectLabel.templates=Templates Options (Enabled only when templates are selected in fitOptions)
+imageToPDF.selectText.templates.1=1x2
+imageToPDF.selectText.templates.2=2x2
+imageToPDF.selectText.templates.3=2x3

--- a/src/main/resources/templates/convert/img-to-pdf.html
+++ b/src/main/resources/templates/convert/img-to-pdf.html
@@ -25,6 +25,16 @@
                     <option value="fillPage" th:text="#{imageToPDF.fillPage}">Fill Page</option>
                     <option value="fitDocumentToImage" th:text="#{imageToPDF.fitDocumentToImage}">Fit Document to Image</option>
                     <option value="maintainAspectRatio" th:text="#{imageToPDF.maintainAspectRatio}">Maintain Aspect Ratio</option>
+                    <option value="templates" th:text="#{imageToPDF.templates}">templates</option>
+                  </select>
+                </div>
+
+                <div class="mb-3">
+                  <label for="templateOption" th:text="#{imageToPDF.selectLabel.templates}">Templates option</label>
+                  <select class="form-control" id="templateOption" name="templateOption">
+                    <option value="1x2" th:text="#{imageToPDF.selectText.templates.1}">1x2</option>
+                    <option value="2x2" th:text="#{imageToPDF.selectText.templates.2}">2x2</option>
+                    <option value="2x3" th:text="#{imageToPDF.selectText.templates.3}">2x3</option>
                   </select>
                 </div>
 
@@ -55,9 +65,13 @@
                   $('#fileInput-input').on('change', function() {
                     var files = document.getElementById("fileInput-input").files;
                     var conversionType = document.getElementById("conversionType");
+                    var fitOption = document.getElementById("fitOption");
                     console.log("files.length=" + files.length)
                     if (files.length > 1) {
                       conversionType.disabled = false;
+                      if (fitOption.value === 'templates') { // if templates is selected and files are more than 1 then enable templateOption
+                        document.getElementById("templateOption").disabled = false;
+                      }
                     } else {
                       conversionType.disabled = true;
                     }
@@ -73,6 +87,18 @@
                       override.value = "multi";
                     }
                   });
+
+                  $('#fitOption').change(function() {
+                    var selectedValue = $(this).val();
+                    var files = document.getElementById("fileInput-input").files;
+                    var templateOption = document.getElementById("templateOption");
+                    if (selectedValue === 'templates' && files.length > 1) {
+                      templateOption.disabled = false;
+                    } else {
+                      templateOption.disabled = true;
+                    }
+                  });
+
                 </script>
               </form>
             </div>

--- a/src/test/java/stirling/software/SPDF/utils/PdfUtilsTest.java
+++ b/src/test/java/stirling/software/SPDF/utils/PdfUtilsTest.java
@@ -6,8 +6,10 @@ import org.apache.pdfbox.pdmodel.PDResources;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import stirling.software.SPDF.model.PdfMetadata;
+import stirling.software.SPDF.utils.PdfUtils.TemplateOpcions;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -56,5 +58,209 @@ public class PdfUtilsTest {
         PdfMetadata metadata = PdfUtils.extractMetadataFromPdf(document);
 
         assertNotNull(metadata);
+    }
+
+    // add tests for templates 
+   @Test
+    public void testGetImagePositionTwoImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int slotWidth = 50;
+        int slotHeight = 100;
+        int offset = 5;
+
+        // Test for image 1
+        ArrayList<Integer> position1 = PdfUtils.getImagePosition(1, TemplateOpcions.TWO_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position1.size());
+        assertEquals(0 + offset, position1.get(0));
+        assertEquals(pageHeight - slotHeight - offset, position1.get(1));
+
+        // Test for image 2
+        ArrayList<Integer> position2 = PdfUtils.getImagePosition(2, TemplateOpcions.TWO_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position2.size());
+        assertEquals((pageWidth / 2) + offset, position2.get(0));
+        assertEquals(pageHeight - slotHeight - offset, position2.get(1));
+    }
+
+    @Test
+    public void testGetImagePositionFourImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int slotWidth = 50;
+        int slotHeight = 100;
+        int offset = 5;
+
+        // Test for image 1
+        ArrayList<Integer> position1 = PdfUtils.getImagePosition(1, TemplateOpcions.FOUR_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position1.size());
+        assertEquals(0 + offset, position1.get(0));
+        assertEquals(pageHeight - slotHeight - offset, position1.get(1));
+
+        // Test for image 2
+        ArrayList<Integer> position2 = PdfUtils.getImagePosition(2, TemplateOpcions.FOUR_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position2.size());
+        assertEquals((pageWidth / 2) + offset, position2.get(0));
+        assertEquals(pageHeight - slotHeight - offset, position2.get(1));
+
+        // Test for image 3
+        ArrayList<Integer> position3 = PdfUtils.getImagePosition(3, TemplateOpcions.FOUR_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position3.size());
+        assertEquals(0 + offset, position3.get(0));
+        assertEquals((pageHeight - 2 * slotHeight) - offset, position3.get(1));
+
+        // Test for image 4
+        ArrayList<Integer> position4 = PdfUtils.getImagePosition(4, TemplateOpcions.FOUR_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position4.size());
+        assertEquals((pageWidth / 2) + offset, position4.get(0));
+        assertEquals((pageHeight - 2 * slotHeight) - offset, position4.get(1));
+    }
+
+    @Test
+    public void testGetImagePositionSixImages() {
+        int pageWidth = 150;
+        int pageHeight = 200;
+        int slotWidth = 50;
+        int slotHeight = 100;
+        int offset = 5;
+
+        // Test for image 1
+        ArrayList<Integer> position1 = PdfUtils.getImagePosition(1, TemplateOpcions.SIX_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position1.size());
+        assertEquals(0 + offset, position1.get(0));
+        assertEquals(pageHeight - slotHeight - offset, position1.get(1));
+
+        // Test for image 2
+        ArrayList<Integer> position2 = PdfUtils.getImagePosition(2, TemplateOpcions.SIX_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position2.size());
+        assertEquals((pageWidth / 3) + offset, position2.get(0));
+        assertEquals(pageHeight - slotHeight - offset, position2.get(1));
+
+        // Test for image 3
+        ArrayList<Integer> position3 = PdfUtils.getImagePosition(3, TemplateOpcions.SIX_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position3.size());
+        assertEquals((2 * pageWidth / 3) + offset, position3.get(0));
+        assertEquals(pageHeight - slotHeight - offset, position3.get(1));
+
+        // Test for image 4
+        ArrayList<Integer> position4 = PdfUtils.getImagePosition(4, TemplateOpcions.SIX_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position4.size());
+        assertEquals(0 + offset, position4.get(0));
+        assertEquals((pageHeight - 2 * slotHeight) - offset, position4.get(1));
+
+        // Test for image 5
+        ArrayList<Integer> position5 = PdfUtils.getImagePosition(5, TemplateOpcions.SIX_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position5.size());
+        assertEquals((pageWidth / 3) + offset, position5.get(0));
+        assertEquals((pageHeight - 2 * slotHeight) - offset, position5.get(1));
+
+        // Test for image 6
+        ArrayList<Integer> position6 = PdfUtils.getImagePosition(6, TemplateOpcions.SIX_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        assertEquals(2, position6.size());
+        assertEquals((2 * pageWidth / 3) + offset, position6.get(0));
+        assertEquals((pageHeight - 2 * slotHeight) - offset, position6.get(1));
+    }
+
+    @Test
+    public void testInvalidImageNumber() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int slotWidth = 50;
+        int slotHeight = 100;
+
+        // Test for invalid image number in TWO_IMAGES template
+        Exception exception1 = assertThrows(IllegalArgumentException.class, () -> {
+            PdfUtils.getImagePosition(3, TemplateOpcions.TWO_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        });
+        assertEquals("Invalid image number for template 1x2", exception1.getMessage());
+
+        // Test for invalid image number in FOUR_IMAGES template
+        Exception exception2 = assertThrows(IllegalArgumentException.class, () -> {
+            PdfUtils.getImagePosition(5, TemplateOpcions.FOUR_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        });
+        assertEquals("Invalid image number for template 2x2", exception2.getMessage());
+
+        // Test for invalid image number in SIX_IMAGES template
+        Exception exception3 = assertThrows(IllegalArgumentException.class, () -> {
+            PdfUtils.getImagePosition(7, TemplateOpcions.SIX_IMAGES, pageWidth, pageHeight, slotWidth, slotHeight);
+        });
+        assertEquals("Invalid image number for template 2x2", exception3.getMessage());
+    }
+
+    @Test
+    public void testGetSlotWidthTwoImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int offset = 5;
+
+        int slotWidth = PdfUtils.get_slot_width(pageWidth, pageHeight, TemplateOpcions.TWO_IMAGES);
+        assertEquals((pageWidth / 2) - offset, slotWidth);
+    }
+
+    @Test
+    public void testGetSlotWidthFourImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int offset = 5;
+
+        int slotWidth = PdfUtils.get_slot_width(pageWidth, pageHeight, TemplateOpcions.FOUR_IMAGES);
+        assertEquals((pageWidth / 2) - offset, slotWidth);
+    }
+
+    @Test
+    public void testGetSlotWidthSixImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int offset = 5;
+
+        int slotWidth = PdfUtils.get_slot_width(pageWidth, pageHeight, TemplateOpcions.SIX_IMAGES);
+        assertEquals((pageWidth / 3) - offset, slotWidth);
+    }
+
+    @Test
+    public void testGetSlotHeightTwoImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int imageWidth = 50;
+        int imageHeight = 100;
+        int offset = 5;
+
+        int slotWidth = (pageWidth / 2) - offset;
+        float aspectRatio = (float) imageWidth / (float) imageHeight;
+        int expectedSlotHeight = (int) (slotWidth / aspectRatio);
+
+        int slotHeight = PdfUtils.get_slot_height(pageWidth, pageHeight, imageWidth, imageHeight, TemplateOpcions.TWO_IMAGES);
+        assertEquals(expectedSlotHeight, slotHeight);
+    }
+
+    @Test
+    public void testGetSlotHeightFourImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int imageWidth = 50;
+        int imageHeight = 100;
+        int offset = 5;
+
+        int slotWidth = (pageWidth / 2) - offset;
+        float aspectRatio = (float) imageWidth / (float) imageHeight;
+        int expectedSlotHeight = (int) (slotWidth / aspectRatio);
+
+        int slotHeight = PdfUtils.get_slot_height(pageWidth, pageHeight, imageWidth, imageHeight, TemplateOpcions.FOUR_IMAGES);
+        assertEquals(expectedSlotHeight, slotHeight);
+    }
+
+    @Test
+    public void testGetSlotHeightSixImages() {
+        int pageWidth = 100;
+        int pageHeight = 200;
+        int imageWidth = 50;
+        int imageHeight = 100;
+        int offset = 5;
+
+        int slotWidth = (pageWidth / 3) - offset;
+        float aspectRatio = (float) imageWidth / (float) imageHeight;
+        int expectedSlotHeight = (int) (slotWidth / aspectRatio);
+
+        int slotHeight = PdfUtils.get_slot_height(pageWidth, pageHeight, imageWidth, imageHeight, TemplateOpcions.SIX_IMAGES);
+        assertEquals(expectedSlotHeight, slotHeight);
     }
 }


### PR DESCRIPTION
# Description

This pull address the following user request. [request](https://github.com/Stirling-Tools/Stirling-PDF/issues/1400)

[AFFECTED UI LINK: ](http://localhost:8080/img-to-pdf)

New Feature: Add multiple images in one page.

- Template Selection: Users can choose from a set of predefined templates that dictate how images are organised on each page. Available templates include:
    - 1x2 (Two per page): Two images will be arranged on each page. (from left to right)
    - 2x2 (Four per page): Four images will be arranged on each page. (from left to right)
    - 2x3 (Six per page): Six images will be arranged on each page. (from left to right)
   
- Handling Fewer Images: If fewer images are selected than the number of slots in the chosen template, the extra slots will be left empty. Only the selected images will be displayed.

- Size and Spacing: The size and spacing of images will be automatically adjusted according to the selected template, maintaining the aspect ratio of each image. Users will not need to make any manual adjustments, as the templates will optimize the layout to fit the specified number of images per page.

Closes #(1400)

Exemple:

UI: 
  
<img width="725" alt="Screenshot 2024-08-25 at 20 52 07" src="https://github.com/user-attachments/assets/c6aeab28-bde4-477b-a1a4-3b7d469db839">

Output for 1x2 ( 1 row two colomn ):

<img width="1254" alt="Screenshot 2024-08-25 at 20 57 18" src="https://github.com/user-attachments/assets/46ae5f15-222e-4e34-b62d-e80bd6d4eb72">

    
## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
