### PR TITLE
Page Scale:  add pageSize KEEP  #1798

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/ScalePagesController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/ScalePagesController.java
@@ -47,26 +47,7 @@ public class ScalePagesController {
         String targetPDRectangle = request.getPageSize();
         float scaleFactor = request.getScaleFactor();
 
-        Map<String, PDRectangle> sizeMap = new HashMap<>();
-        // Add A0 - A10
-        sizeMap.put("A0", PDRectangle.A0);
-        sizeMap.put("A1", PDRectangle.A1);
-        sizeMap.put("A2", PDRectangle.A2);
-        sizeMap.put("A3", PDRectangle.A3);
-        sizeMap.put("A4", PDRectangle.A4);
-        sizeMap.put("A5", PDRectangle.A5);
-        sizeMap.put("A6", PDRectangle.A6);
-
-        // Add other sizes
-        sizeMap.put("LETTER", PDRectangle.LETTER);
-        sizeMap.put("LEGAL", PDRectangle.LEGAL);
-
-        if (!sizeMap.containsKey(targetPDRectangle)) {
-            throw new IllegalArgumentException(
-                    "Invalid PDRectangle. It must be one of the following: A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10");
-        }
-
-        PDRectangle targetSize = sizeMap.get(targetPDRectangle);
+        PDRectangle targetSize = getTargetSize(targetPDRectangle);
 
         PDDocument sourceDocument = Loader.loadPDF(file.getBytes());
         PDDocument outputDocument = new PDDocument();
@@ -115,5 +96,36 @@ public class ScalePagesController {
                 baos.toByteArray(),
                 Filenames.toSimpleFileName(file.getOriginalFilename()).replaceFirst("[.][^.]+$", "")
                         + "_scaled.pdf");
+    }
+
+    private PDRectangle getTargetSize(String targetPDRectangle) {
+        Map<String, PDRectangle> sizeMap = getSizeMap();
+
+        if (!sizeMap.containsKey(targetPDRectangle)) {
+            throw new IllegalArgumentException(
+                    "Invalid PDRectangle. It must be one of the following: A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10");
+        }
+
+        PDRectangle targetSize = sizeMap.get(targetPDRectangle);
+
+        return targetSize;
+    }
+
+    private Map<String, PDRectangle> getSizeMap() {
+        Map<String, PDRectangle> sizeMap = new HashMap<>();
+        // Add A0 - A10
+        sizeMap.put("A0", PDRectangle.A0);
+        sizeMap.put("A1", PDRectangle.A1);
+        sizeMap.put("A2", PDRectangle.A2);
+        sizeMap.put("A3", PDRectangle.A3);
+        sizeMap.put("A4", PDRectangle.A4);
+        sizeMap.put("A5", PDRectangle.A5);
+        sizeMap.put("A6", PDRectangle.A6);
+
+        // Add other sizes
+        sizeMap.put("LETTER", PDRectangle.LETTER);
+        sizeMap.put("LEGAL", PDRectangle.LEGAL);
+
+        return sizeMap;
     }
 }

--- a/src/main/java/stirling/software/SPDF/model/api/PDFWithPageSize.java
+++ b/src/main/java/stirling/software/SPDF/model/api/PDFWithPageSize.java
@@ -11,7 +11,7 @@ public class PDFWithPageSize extends PDFFile {
 
     @Schema(
             description =
-                    "The scale of pages in the output PDF. Acceptable values are A0-A6, LETTER, LEGAL.",
-            allowableValues = {"A0", "A1", "A2", "A3", "A4", "A5", "A6", "LETTER", "LEGAL"})
+                    "The scale of pages in the output PDF. Acceptable values are A0-A6, LETTER, LEGAL, KEEP.",
+            allowableValues = {"A0", "A1", "A2", "A3", "A4", "A5", "A6", "LETTER", "LEGAL", "KEEP"})
     private String pageSize;
 }

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -680,7 +680,6 @@ scalePages.scaleFactor=مستوى التكبير (الاقتصاص) للصفحة
 scalePages.submit=إرسال
 
 
-
 #certSign
 certSign.title=توقيع الشهادة
 certSign.header=قم بتوقيع ملف PDF بشهادتك (العمل قيد التقدم)

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Подайте
 scalePages.title=Коригиране на мащаба на страницата
 scalePages.header=Коригиране на мащаба на страницата
 scalePages.pageSize=Размер на страница от документа.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Ниво на мащабиране (изрязване) на страница.
 scalePages.submit=Подайте
 

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Подайте
 scalePages.title=Коригиране на мащаба на страницата
 scalePages.header=Коригиране на мащаба на страницата
 scalePages.pageSize=Размер на страница от документа.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Ниво на мащабиране (изрязване) на страница.
 scalePages.submit=Подайте
 

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Odeslat
 scalePages.title=Upravit měřítko stránky
 scalePages.header=Upravit měřítko stránky
 scalePages.pageSize=Velikost stránky dokumentu.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Úroveň přiblížení (oříznutí) stránky.
 scalePages.submit=Odeslat
 

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Odeslat
 scalePages.title=Upravit měřítko stránky
 scalePages.header=Upravit měřítko stránky
 scalePages.pageSize=Velikost stránky dokumentu.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Úroveň přiblížení (oříznutí) stránky.
 scalePages.submit=Odeslat
 

--- a/src/main/resources/messages_da_DK.properties
+++ b/src/main/resources/messages_da_DK.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_da_DK.properties
+++ b/src/main/resources/messages_da_DK.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Indsend
 scalePages.title=Justér sidestørrelse
 scalePages.header=Justér sidestørrelse
 scalePages.pageSize=Størrelse på en side i dokumentet.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom-niveau (beskæring) af en side.
 scalePages.submit=Indsend
 

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Abschicken
 scalePages.title=Seitengröße anpassen
 scalePages.header=Seitengröße anpassen
 scalePages.pageSize=Format der Seiten des Dokuments
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoomstufe (Ausschnitt) einer Seite
 scalePages.submit=Abschicken
 

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Abschicken
 scalePages.title=Seitengröße anpassen
 scalePages.header=Seitengröße anpassen
 scalePages.pageSize=Format der Seiten des Dokuments
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoomstufe (Ausschnitt) einer Seite
 scalePages.submit=Abschicken
 

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Υποβολή
 scalePages.title=Προσαρμογή κλίμακας σελίδας
 scalePages.header=Προσαρμογή κλίμακας σελίδας
 scalePages.pageSize=Μέγεθος μιας σελίδας του εγγράφου.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Επίπεδο ζουμ (περικοπή) σελίδας.
 scalePages.submit=Υποβολή
 

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Υποβολή
 scalePages.title=Προσαρμογή κλίμακας σελίδας
 scalePages.header=Προσαρμογή κλίμακας σελίδας
 scalePages.pageSize=Μέγεθος μιας σελίδας του εγγράφου.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Επίπεδο ζουμ (περικοπή) σελίδας.
 scalePages.submit=Υποβολή
 

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Entregar
 scalePages.title=Ajustar escala de la página
 scalePages.header=Adjustar escala de la página
 scalePages.pageSize=Tamaño de la página del documento
+scalePages.keepPageSize=Mantener el tamaño de la página como en el archivo original
 scalePages.scaleFactor=Nivel de zoom (recorte) de la página
 scalePages.submit=Entregar
 

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Entregar
 scalePages.title=Ajustar escala de la página
 scalePages.header=Adjustar escala de la página
 scalePages.pageSize=Tamaño de la página del documento
-scalePages.keepPageSize=Mantener el tamaño de la página como en el archivo original
+scalePages.keepPageSize=Tamaño Original
 scalePages.scaleFactor=Nivel de zoom (recorte) de la página
 scalePages.submit=Entregar
 

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Entregatu
 scalePages.title=Doitu orrialdearen eskala
 scalePages.header=Doitu orrialdearen eskala
 scalePages.pageSize=Dokumentuaren orrialdearen tamaina
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Orriaren zoom maila (moztea)
 scalePages.submit=Entregatu
 

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Entregatu
 scalePages.title=Doitu orrialdearen eskala
 scalePages.header=Doitu orrialdearen eskala
 scalePages.pageSize=Dokumentuaren orrialdearen tamaina
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Orriaren zoom maila (moztea)
 scalePages.submit=Entregatu
 

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Fusionner
 scalePages.title=Ajuster la taille ou l’échelle
 scalePages.header=Ajuster la taille ou l’échelle
 scalePages.pageSize=Taille d’une page du document
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Niveau de zoom (recadrage) d’une page
 scalePages.submit=Ajuster
 

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Fusionner
 scalePages.title=Ajuster la taille ou l’échelle
 scalePages.header=Ajuster la taille ou l’échelle
 scalePages.pageSize=Taille d’une page du document
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Niveau de zoom (recadrage) d’une page
 scalePages.submit=Ajuster
 

--- a/src/main/resources/messages_ga_IE.properties
+++ b/src/main/resources/messages_ga_IE.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Cuir isteach
 scalePages.title=Coigeartaigh scála an leathanaigh
 scalePages.header=Coigeartaigh scála an leathanaigh
 scalePages.pageSize=Méid leathanach den doiciméad.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Leibhéal súmáil (barr) de leathanach.
 scalePages.submit=Cuir isteach
 

--- a/src/main/resources/messages_ga_IE.properties
+++ b/src/main/resources/messages_ga_IE.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Cuir isteach
 scalePages.title=Coigeartaigh scála an leathanaigh
 scalePages.header=Coigeartaigh scála an leathanaigh
 scalePages.pageSize=Méid leathanach den doiciméad.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Leibhéal súmáil (barr) de leathanach.
 scalePages.submit=Cuir isteach
 

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -674,6 +674,7 @@ pageLayout.submit=प्रस्तुत क
 scalePages.title=पृष्ठ-स्केल समायोजित करें
 scalePages.header=पृष्ठ-स्केल समायोजित करें
 scalePages.pageSize=दस्तावेज़ के पृष्ठ का आकार।
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=पृष्ठ का ज़ूम स्तर (क्रॉप)।
 scalePages.submit=प्रस्तुत करें
 

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -675,7 +675,7 @@ pageLayout.submit=प्रस्तुत क
 scalePages.title=पृष्ठ-स्केल समायोजित करें
 scalePages.header=पृष्ठ-स्केल समायोजित करें
 scalePages.pageSize=दस्तावेज़ के पृष्ठ का आकार।
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=पृष्ठ का ज़ूम स्तर (क्रॉप)।
 scalePages.submit=प्रस्तुत करें
 

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Potvrdi
 scalePages.title=Podesite veličinu stranice
 scalePages.header=Podesite veličinu stranice
 scalePages.pageSize=Veličina stranice dokumenta.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Razina zumiranja (obrezivanje) stranice.
 scalePages.submit=Potvrdi
 

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Potvrdi
 scalePages.title=Podesite veličinu stranice
 scalePages.header=Podesite veličinu stranice
 scalePages.pageSize=Veličina stranice dokumenta.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Razina zumiranja (obrezivanje) stranice.
 scalePages.submit=Potvrdi
 

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Elküldés
 scalePages.title=Oldalméret beállítása
 scalePages.header=Oldalméret beállítása
 scalePages.pageSize=A dokumentum egy oldalának mérete.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Az oldal nagyításának szintje (vágás).
 scalePages.submit=Küldés
 

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Elküldés
 scalePages.title=Oldalméret beállítása
 scalePages.header=Oldalméret beállítása
 scalePages.pageSize=A dokumentum egy oldalának mérete.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Az oldal nagyításának szintje (vágás).
 scalePages.submit=Küldés
 

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Kirim
 scalePages.title=Sesuaikan skala halaman
 scalePages.header=Sesuaikan skala halaman
 scalePages.pageSize=Ukuran halaman dokumen.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Tingkat zoom (potong) halaman.
 scalePages.submit=Kirim
 

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Kirim
 scalePages.title=Sesuaikan skala halaman
 scalePages.header=Sesuaikan skala halaman
 scalePages.pageSize=Ukuran halaman dokumen.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Tingkat zoom (potong) halaman.
 scalePages.submit=Kirim
 

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Invia
 scalePages.title=Regola la scala della pagina
 scalePages.header=Regola la scala della pagina
 scalePages.pageSize=Dimensione di una pagina del documento.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Livello di zoom (ritaglio) di una pagina.
 scalePages.submit=Invia
 

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Invia
 scalePages.title=Regola la scala della pagina
 scalePages.header=Regola la scala della pagina
 scalePages.pageSize=Dimensione di una pagina del documento.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Livello di zoom (ritaglio) di una pagina.
 scalePages.submit=Invia
 

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -675,7 +675,7 @@ pageLayout.submit=送信
 scalePages.title=ページの縮尺の調整
 scalePages.header=ページの縮尺の調整
 scalePages.pageSize=1ページのサイズ
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=1ページの拡大レベル (トリミング)。
 scalePages.submit=送信
 

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -674,6 +674,7 @@ pageLayout.submit=送信
 scalePages.title=ページの縮尺の調整
 scalePages.header=ページの縮尺の調整
 scalePages.pageSize=1ページのサイズ
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=1ページの拡大レベル (トリミング)。
 scalePages.submit=送信
 

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -675,7 +675,7 @@ pageLayout.submit=확인
 scalePages.title=페이지 배율 조절
 scalePages.header=페이지 배율 조절
 scalePages.pageSize=페이지의 크기를 조절합니다.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=페이지 배율 조절 (잘라내기)
 scalePages.submit=제출
 

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -674,6 +674,7 @@ pageLayout.submit=확인
 scalePages.title=페이지 배율 조절
 scalePages.header=페이지 배율 조절
 scalePages.pageSize=페이지의 크기를 조절합니다.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=페이지 배율 조절 (잘라내기)
 scalePages.submit=제출
 

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Indienen
 scalePages.title=Pagina-schaal aanpassen
 scalePages.header=Pagina-schaal aanpassen
 scalePages.pageSize=Grootte van een pagina van het document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoomniveau (uitsnede) van een pagina.
 scalePages.submit=Indienen
 

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Indienen
 scalePages.title=Pagina-schaal aanpassen
 scalePages.header=Pagina-schaal aanpassen
 scalePages.pageSize=Grootte van een pagina van het document.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoomniveau (uitsnede) van een pagina.
 scalePages.submit=Indienen
 

--- a/src/main/resources/messages_no_NB.properties
+++ b/src/main/resources/messages_no_NB.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Send inn
 scalePages.title=Juster side-skala
 scalePages.header=Juster side-skala
 scalePages.pageSize=Størrelse på et ark i dokumentet.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom-nivå (beskjær) for en side.
 scalePages.submit=Send inn
 

--- a/src/main/resources/messages_no_NB.properties
+++ b/src/main/resources/messages_no_NB.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Send inn
 scalePages.title=Juster side-skala
 scalePages.header=Juster side-skala
 scalePages.pageSize=Størrelse på et ark i dokumentet.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom-nivå (beskjær) for en side.
 scalePages.submit=Send inn
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Wykonaj
 scalePages.title=Dopasuj rozmiar stron
 scalePages.header=Dopasuj rozmiar stron
 scalePages.pageSize=Rozmiar stron dokumentu:
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Poziom powiększenia (przycięcia) stron:
 scalePages.submit=Wykonaj
 

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Wykonaj
 scalePages.title=Dopasuj rozmiar stron
 scalePages.header=Dopasuj rozmiar stron
 scalePages.pageSize=Rozmiar stron dokumentu:
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Poziom powiększenia (przycięcia) stron:
 scalePages.submit=Wykonaj
 

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Enviar
 scalePages.title=Ajustar Tamanho/Escala da Página
 scalePages.header=Ajustar Tamanho/Escala da Página
 scalePages.pageSize=Tamanho de uma página do documento.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Fator de zoom (corte) de uma página.
 scalePages.submit=Enviar
 

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Enviar
 scalePages.title=Ajustar Tamanho/Escala da Página
 scalePages.header=Ajustar Tamanho/Escala da Página
 scalePages.pageSize=Tamanho de uma página do documento.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Fator de zoom (corte) de uma página.
 scalePages.submit=Enviar
 

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Enviar
 scalePages.title=Ajustar Tamanho/Escala da Página
 scalePages.header=Ajustar Tamanho/Escala da Página
 scalePages.pageSize=Tamanho de uma página do documento.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Fator de zoom (corte) de uma página.
 scalePages.submit=Enviar
 

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Enviar
 scalePages.title=Ajustar Tamanho/Escala da Página
 scalePages.header=Ajustar Tamanho/Escala da Página
 scalePages.pageSize=Tamanho de uma página do documento.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Fator de zoom (corte) de uma página.
 scalePages.submit=Enviar
 

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Отправить
 scalePages.title=Отрегулировать масштаб страницы
 scalePages.header=Отрегулировать масштаб страницы
 scalePages.pageSize=Размер страницы документа.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Уровень масштабирования (обрезки) страницы.
 scalePages.submit=Отправить
 

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Отправить
 scalePages.title=Отрегулировать масштаб страницы
 scalePages.header=Отрегулировать масштаб страницы
 scalePages.pageSize=Размер страницы документа.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Уровень масштабирования (обрезки) страницы.
 scalePages.submit=Отправить
 

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Odoslať
 scalePages.title=Upraviť mierku stránky
 scalePages.header=Upraviť mierku stránky
 scalePages.pageSize=Veľkosť stránky dokumentu.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Úroveň priblíženia (orezania) stránky.
 scalePages.submit=Odoslať
 

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Odoslať
 scalePages.title=Upraviť mierku stránky
 scalePages.header=Upraviť mierku stránky
 scalePages.pageSize=Veľkosť stránky dokumentu.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Úroveň priblíženia (orezania) stránky.
 scalePages.submit=Odoslať
 

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Potvrdi
 scalePages.title=Podesi razmeru stranica
 scalePages.header=Podesi razmeru stranica
 scalePages.pageSize=Veličina stranice dokumenta.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Nivo zumiranja (rezanje) stranice.
 scalePages.submit=Potvrdi
 

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Potvrdi
 scalePages.title=Podesi razmeru stranica
 scalePages.header=Podesi razmeru stranica
 scalePages.pageSize=Veličina stranice dokumenta.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Nivo zumiranja (rezanje) stranice.
 scalePages.submit=Potvrdi
 

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Submit
 scalePages.title=Adjust page-scale
 scalePages.header=Adjust page-scale
 scalePages.pageSize=Size of a page of the document.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Zoom level (crop) of a page.
 scalePages.submit=Submit
 

--- a/src/main/resources/messages_th_TH.properties
+++ b/src/main/resources/messages_th_TH.properties
@@ -675,7 +675,7 @@ pageLayout.submit=ส่ง
 scalePages.title=ปรับสเกลหน้า
 scalePages.header=ปรับสเกลหน้า
 scalePages.pageSize=ขนาดหน้าของเอกสาร
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=ระดับการซูม (ครอบตัด) ของหน้า
 scalePages.submit=ส่ง
 

--- a/src/main/resources/messages_th_TH.properties
+++ b/src/main/resources/messages_th_TH.properties
@@ -674,6 +674,7 @@ pageLayout.submit=ส่ง
 scalePages.title=ปรับสเกลหน้า
 scalePages.header=ปรับสเกลหน้า
 scalePages.pageSize=ขนาดหน้าของเอกสาร
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=ระดับการซูม (ครอบตัด) ของหน้า
 scalePages.submit=ส่ง
 

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Gönder
 scalePages.title=Sayfa Ölçeğini Ayarla
 scalePages.header=Sayfa Ölçeğini Ayarla
 scalePages.pageSize=Belgenin bir sayfa boyutu.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Bir sayfanın yakınlaştırma seviyesi (kırpma).
 scalePages.submit=Gönder
 

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Gönder
 scalePages.title=Sayfa Ölçeğini Ayarla
 scalePages.header=Sayfa Ölçeğini Ayarla
 scalePages.pageSize=Belgenin bir sayfa boyutu.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Bir sayfanın yakınlaştırma seviyesi (kırpma).
 scalePages.submit=Gönder
 

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Відправити
 scalePages.title=Відрегулювати масштаб сторінки
 scalePages.header=Відрегулювати масштаб сторінки
 scalePages.pageSize=Розмір сторінки документа.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Рівень масштабування (обрізки) сторінки.
 scalePages.submit=Відправити
 

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Відправити
 scalePages.title=Відрегулювати масштаб сторінки
 scalePages.header=Відрегулювати масштаб сторінки
 scalePages.pageSize=Розмір сторінки документа.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Рівень масштабування (обрізки) сторінки.
 scalePages.submit=Відправити
 

--- a/src/main/resources/messages_vi_VN.properties
+++ b/src/main/resources/messages_vi_VN.properties
@@ -675,7 +675,7 @@ pageLayout.submit=Gửi
 scalePages.title=Điều chỉnh tỷ lệ trang
 scalePages.header=Điều chỉnh tỷ lệ trang
 scalePages.pageSize=Kích thước của một trang trong tài liệu.
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=Mức độ phóng to (cắt cúp) của một trang.
 scalePages.submit=Gửi
 

--- a/src/main/resources/messages_vi_VN.properties
+++ b/src/main/resources/messages_vi_VN.properties
@@ -674,6 +674,7 @@ pageLayout.submit=Gửi
 scalePages.title=Điều chỉnh tỷ lệ trang
 scalePages.header=Điều chỉnh tỷ lệ trang
 scalePages.pageSize=Kích thước của một trang trong tài liệu.
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=Mức độ phóng to (cắt cúp) của một trang.
 scalePages.submit=Gửi
 

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -674,6 +674,7 @@ pageLayout.submit=提交
 scalePages.title=调整页面缩放比例
 scalePages.header=调整页面缩放比例
 scalePages.pageSize=文档页面的尺寸。
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=页面的缩放级别（裁剪）。
 scalePages.submit=提交
 

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -675,7 +675,7 @@ pageLayout.submit=提交
 scalePages.title=调整页面缩放比例
 scalePages.header=调整页面缩放比例
 scalePages.pageSize=文档页面的尺寸。
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=页面的缩放级别（裁剪）。
 scalePages.submit=提交
 

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -675,7 +675,7 @@ pageLayout.submit=送出
 scalePages.title=調整頁面大小/比例
 scalePages.header=調整頁面大小/比例
 scalePages.pageSize=文件的頁面大小。
-scalePages.keepPageSize=Keep source file Page Size
+scalePages.keepPageSize=Original Size
 scalePages.scaleFactor=頁面的縮放級別（裁剪）。
 scalePages.submit=送出
 

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -674,6 +674,7 @@ pageLayout.submit=送出
 scalePages.title=調整頁面大小/比例
 scalePages.header=調整頁面大小/比例
 scalePages.pageSize=文件的頁面大小。
+scalePages.keepPageSize=Keep source file Page Size
 scalePages.scaleFactor=頁面的縮放級別（裁剪）。
 scalePages.submit=送出
 

--- a/src/main/resources/templates/scale-pages.html
+++ b/src/main/resources/templates/scale-pages.html
@@ -21,11 +21,12 @@
                 <div class="mb-3">
                   <label for="pageSize" th:text="#{scalePages.pageSize}"></label>
                   <select class="form-control" id="pageSize" name="pageSize">
+                    <option value="KEEP" th:text="#{scalePages.keepPageSize}" selected></option>
                     <option value="A0">A0</option>
                     <option value="A1">A1</option>
                     <option value="A2">A2</option>
                     <option value="A3">A3</option>
-                    <option value="A4" selected>A4</option>
+                    <option value="A4">A4</option>
                     <option value="A5">A5</option>
                     <option value="A6">A6</option>
                     <option value="LETTER">Letter</option>


### PR DESCRIPTION
# Description

Add `KEEP` value to `pageSize` argument which allows page scale to keep the source file's page size.

Closes #1798

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
