### PR TITLE
Add document splitting functionality to the multi-tools page

### DIFF
--- a/src/main/resources/static/css/multi-tool.css
+++ b/src/main/resources/static/css/multi-tool.css
@@ -20,7 +20,7 @@ label {
   display: flex;
   gap: 10px;
   align-items: start;
-  background-color: var(--md-sys-color-surface-5); 
+  background-color: var(--md-sys-color-surface-5);
   border: none;
   backdrop-filter: blur(2px);
   top: 10px;
@@ -127,6 +127,10 @@ label {
   margin-bottom: 16px;
 }
 
+.page-container.cutBefore {
+  border-left: 1px dashed var(--md-sys-color-on-surface);
+}
+
 /* Pushes the last item to the left */
 .page-container:last-child {
   margin-right: auto;
@@ -171,8 +175,9 @@ label {
 .page-container:last-child:lang(nqo),
 /* N'Ko */
 .page-container:last-child:lang(bqi)
+
 /* Bakhtiari */
-{
+  {
   margin-left: auto !important;
   margin-right: 0 !important;
 }

--- a/src/main/resources/static/css/multi-tool.css
+++ b/src/main/resources/static/css/multi-tool.css
@@ -127,12 +127,12 @@ label {
   margin-bottom: 16px;
 }
 
-.page-container.cutBefore {
+.page-container.split-before {
   border-left: 1px dashed var(--md-sys-color-on-surface);
   padding-left: -1px;
 }
 
-.page-container.cutBefore:first-child {
+.page-container.split-before:first-child {
   border-left: none;
 }
 

--- a/src/main/resources/static/css/multi-tool.css
+++ b/src/main/resources/static/css/multi-tool.css
@@ -129,6 +129,15 @@ label {
 
 .page-container.cutBefore {
   border-left: 1px dashed var(--md-sys-color-on-surface);
+  padding-left: -1px;
+}
+
+.page-container.cutBefore:first-child {
+  border-left: none;
+}
+
+.page-container:first-child .pdf-actions_split-file-button {
+  display: none;
 }
 
 /* Pushes the last item to the left */

--- a/src/main/resources/static/css/pdfActions.css
+++ b/src/main/resources/static/css/pdfActions.css
@@ -117,3 +117,12 @@ html[dir="rtl"] .pdf-actions_container:last-child>.pdf-actions_insert-file-butto
   aspect-ratio: 1;
   border-radius: 100px;
 }
+
+.pdf-actions_split-file-button {
+  position: absolute;
+  top: 25%;
+  right: 50%;
+  translate: 0 -50%;
+  aspect-ratio: 1;
+  border-radius: 100px;
+}

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -142,6 +142,23 @@ class PdfActionsManager {
 
     div.appendChild(insertFileButtonContainer);
 
+    const splitFileButtonContainer = document.createElement("div");
+
+    insertFileButtonContainer.classList.add(
+      "pdf-actions_split-file-button-container",
+      leftDirection,
+      `align-top-${leftDirection}`,
+    );
+
+    const splitFileButton = document.createElement("button");
+    splitFileButton.classList.add("btn", "btn-primary", "pdf-actions_split-file-button");
+    splitFileButton.innerHTML = `<span class="material-symbols-rounded">cut</span>`;
+    //splitFileButton.onclick = this.splitFileButtonCallback;
+    insertFileButtonContainer.appendChild(splitFileButton);
+
+    div.appendChild(splitFileButtonContainer);
+
+
     // add this button to every element, but only show it on the last one :D
     const insertFileButtonRightContainer = document.createElement("div");
     insertFileButtonRightContainer.classList.add(

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -145,24 +145,13 @@ class PdfActionsManager {
     insertFileButton.onclick = this.insertFileButtonCallback;
     insertFileButtonContainer.appendChild(insertFileButton);
 
-    div.appendChild(insertFileButtonContainer);
-
-    const splitFileButtonContainer = document.createElement("div");
-
-    insertFileButtonContainer.classList.add(
-      "pdf-actions_split-file-button-container",
-      leftDirection,
-      `align-top-${leftDirection}`,
-    );
-
     const splitFileButton = document.createElement("button");
     splitFileButton.classList.add("btn", "btn-primary", "pdf-actions_split-file-button");
     splitFileButton.innerHTML = `<span class="material-symbols-rounded">cut</span>`;
     splitFileButton.onclick = this.splitFileButtonCallback;
     insertFileButtonContainer.appendChild(splitFileButton);
 
-    div.appendChild(splitFileButtonContainer);
-
+    div.appendChild(insertFileButtonContainer);
 
     // add this button to every element, but only show it on the last one :D
     const insertFileButtonRightContainer = document.createElement("div");

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -75,7 +75,7 @@ class PdfActionsManager {
 
   splitFileButtonCallback(e) {
     var imgContainer = this.getPageContainer(e.target);
-    console.log("Added separator before page " + (Array.from(imgContainer.parentNode.children).indexOf(imgContainer) + 1));
+    imgContainer.classList.toggle("cutBefore");
   }
 
   setActions({ movePageTo, addPdfs, rotateElement }) {

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -89,6 +89,7 @@ class PdfActionsManager {
     this.rotateCWButtonCallback = this.rotateCWButtonCallback.bind(this);
     this.deletePageButtonCallback = this.deletePageButtonCallback.bind(this);
     this.insertFileButtonCallback = this.insertFileButtonCallback.bind(this);
+    this.splitFileButtonCallback = this.splitFileButtonCallback.bind(this);
   }
 
   adapt(div) {

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -75,7 +75,7 @@ class PdfActionsManager {
 
   splitFileButtonCallback(e) {
     var imgContainer = this.getPageContainer(e.target);
-    console.log("Added separator before page " + (Array.from(imgContainer.parentNode.children).indexOf(imgContainer) + 1))
+    console.log("Added separator before page " + (Array.from(imgContainer.parentNode.children).indexOf(imgContainer) + 1));
   }
 
   setActions({ movePageTo, addPdfs, rotateElement }) {

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -75,7 +75,7 @@ class PdfActionsManager {
 
   splitFileButtonCallback(e) {
     var imgContainer = this.getPageContainer(e.target);
-    // this.addPdfs(imgContainer);
+    console.log("Added separator before page " + (Array.from(imgContainer.parentNode.children).indexOf(imgContainer) + 1))
   }
 
   setActions({ movePageTo, addPdfs, rotateElement }) {

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -75,7 +75,7 @@ class PdfActionsManager {
 
   splitFileButtonCallback(e) {
     var imgContainer = this.getPageContainer(e.target);
-    imgContainer.classList.toggle("cutBefore");
+    imgContainer.classList.toggle("split-before");
   }
 
   setActions({ movePageTo, addPdfs, rotateElement }) {

--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -73,6 +73,11 @@ class PdfActionsManager {
     this.addPdfs(imgContainer);
   }
 
+  splitFileButtonCallback(e) {
+    var imgContainer = this.getPageContainer(e.target);
+    // this.addPdfs(imgContainer);
+  }
+
   setActions({ movePageTo, addPdfs, rotateElement }) {
     this.movePageTo = movePageTo;
     this.addPdfs = addPdfs;
@@ -153,7 +158,7 @@ class PdfActionsManager {
     const splitFileButton = document.createElement("button");
     splitFileButton.classList.add("btn", "btn-primary", "pdf-actions_split-file-button");
     splitFileButton.innerHTML = `<span class="material-symbols-rounded">cut</span>`;
-    //splitFileButton.onclick = this.splitFileButtonCallback;
+    splitFileButton.onclick = this.splitFileButtonCallback;
     insertFileButtonContainer.appendChild(splitFileButton);
 
     div.appendChild(splitFileButtonContainer);

--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -212,6 +212,14 @@ class PdfContainer {
     }
   }
 
+  async splitPDF() {
+
+  }
+
+  async compressFiles() {
+
+  }
+
   async exportPdf() {
     const pdfDoc = await PDFLib.PDFDocument.create();
     const pageContainers = this.pagesContainer.querySelectorAll(".page-container"); // Select all .page-container elements

--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -288,40 +288,17 @@ class PdfContainer {
 
     const separators = this.pagesContainer.querySelectorAll(".split-before");
     if (separators.length !== 0) { // Send the created blob to the split-pages API endpoint if there are separators.
-      const formData = new FormData();
+
+      const fileNameBase = this.fileName ? this.fileName : "managed.pdf";
 
       const pagesArray = Array.from(this.pagesContainer.children);
-
-      let splitters = "";
+      const splitters = [];
       separators.forEach(page => {
         const pageIndex = pagesArray.indexOf(page);
         if (pageIndex !== 0) {
-          splitters += pageIndex + ",";
+          splitters.push(pageIndex);
         }
       });
-
-      formData.append("pageNumbers", splitters);
-      formData.append("fileInput", pdfBlob, this.fileName ? this.fileName : "managed.pdf");
-
-      const response = await fetch("/api/v1/general/split-pages", {
-        method: "POST",
-        body: formData,
-      })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
-          }
-
-          return response.blob();
-        })
-        .then((response) => {
-          this.downloadLink = document.createElement("a");
-          this.downloadLink.id = "download-link";
-          this.downloadLink.href = URL.createObjectURL(response);
-          this.downloadLink.setAttribute("download", this.fileName ? this.fileName + ".zip" : "managed.zip");
-          this.downloadLink.setAttribute("target", "_blank");
-          this.downloadLink.click();
-        });
 
     } else { // continue normally if there are no separators
 

--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -287,7 +287,9 @@ class PdfContainer {
       let splitters = "";
       separators.forEach(page => {
         const pageIndex = pagesArray.indexOf(page);
-        splitters += pageIndex + ",";
+        if (pageIndex !== 0) {
+          splitters += pageIndex + ",";
+        }
       });
 
       formData.append("pageNumbers", splitters);

--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -278,7 +278,7 @@ class PdfContainer {
       this.fileName = filenameInput.value;
     }
 
-    const separators = this.pagesContainer.querySelectorAll(".cutBefore");
+    const separators = this.pagesContainer.querySelectorAll(".split-before");
     if (separators.length !== 0) { // Send the created blob to the split-pages API endpoint if there are separators.
       const formData = new FormData();
 

--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -21,6 +21,7 @@ class PdfContainer {
     this.addImageFile = this.addImageFile.bind(this);
     this.nameAndArchiveFiles = this.nameAndArchiveFiles.bind(this);
     this.splitPDF = this.splitPDF.bind(this);
+    this.splitAll = this.splitAll.bind(this);
 
     this.pdfAdapters = pdfAdapters;
 
@@ -36,6 +37,7 @@ class PdfContainer {
     window.addFiles = this.addFiles;
     window.exportPdf = this.exportPdf;
     window.rotateAll = this.rotateAll;
+    window.splitAll = this.splitAll;
 
     const filenameInput = document.getElementById("filename-input");
     const downloadBtn = document.getElementById("export-button");
@@ -211,6 +213,19 @@ class PdfContainer {
       const img = child.querySelector("img");
       if (!img) continue;
       this.rotateElement(img, deg);
+    }
+  }
+
+  splitAll() {
+    const allPages = this.pagesContainer.querySelectorAll(".page-container");
+    if (this.pagesContainer.querySelectorAll(".split-before").length > 0) {
+      allPages.forEach(page => {
+        page.classList.remove("split-before");
+      });
+    } else {
+      allPages.forEach(page => {
+        page.classList.add("split-before");
+      });
     }
   }
 

--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -218,7 +218,7 @@ class PdfContainer {
     const baseDocument = await PDFLib.PDFDocument.load(baseDocBytes);
     const pageNum = baseDocument.getPages().length;
 
-    splitters.sort(); // We'll sort the separator indexes just in case querySelectorAll does something funny.
+    splitters.sort((a, b) => a - b);; // We'll sort the separator indexes just in case querySelectorAll does something funny.
     splitters.push(pageNum); // We'll also add a faux separator at the end in order to get the pages after the last separator.
 
     const splitDocuments = [];

--- a/src/main/resources/templates/multi-tool.html
+++ b/src/main/resources/templates/multi-tool.html
@@ -42,6 +42,11 @@
                       rotate_right
                     </span>
                   </button>
+                  <button class="btn btn-secondary enable-on-file" onclick="splitAll()" disabled>
+                    <span class="material-symbols-rounded">
+                      cut
+                    </span>
+                  </button>
                   <button id="export-button" class="btn btn-primary enable-on-file" onclick="exportPdf()" disabled>
                     <span class="material-symbols-rounded">
                       download


### PR DESCRIPTION
# Description

Adds document splitting functionality to the multi-tools page using the same method as split-pdfs page.

Closes #1540

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
