### PR TITLE
Fix insertFileButton referencing the old addPdfs method.

### DIFF
--- a/src/main/resources/static/js/multitool/PdfActionsManager.js
+++ b/src/main/resources/static/js/multitool/PdfActionsManager.js
@@ -70,12 +70,12 @@ class PdfActionsManager {
 
   insertFileButtonCallback(e) {
     var imgContainer = this.getPageContainer(e.target);
-    this.addPdfs(imgContainer);
+    this.addFiles(imgContainer);
   }
 
-  setActions({ movePageTo, addPdfs, rotateElement }) {
+  setActions({ movePageTo, addFiles, rotateElement }) {
     this.movePageTo = movePageTo;
-    this.addPdfs = addPdfs;
+    this.addFiles = addFiles;
     this.rotateElement = rotateElement;
 
     this.moveUpButtonCallback = this.moveUpButtonCallback.bind(this);
@@ -153,7 +153,7 @@ class PdfActionsManager {
     const insertFileButtonRight = document.createElement("button");
     insertFileButtonRight.classList.add("btn", "btn-primary", "pdf-actions_insert-file-button");
     insertFileButtonRight.innerHTML = `<span class="material-symbols-rounded">add</span>`;
-    insertFileButtonRight.onclick = () => addPdfs();
+    insertFileButtonRight.onclick = () => addFiles();
     insertFileButtonRightContainer.appendChild(insertFileButtonRight);
 
     div.appendChild(insertFileButtonRightContainer);


### PR DESCRIPTION
# Description

Fixes insertFileButton inside pages-container in multi-tools. It used to reference the old addPdfs method, thus not working.

Closes #1807

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
