### PR TITLE
Fixed reduce extra space between input field & button #1829

### DIFF
--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -177,7 +177,8 @@ async function submitMultiPdfForm(url, files) {
   const zipThreshold = parseInt(localStorage.getItem("zipThreshold"), 10) || 4;
   const zipFiles = files.length > zipThreshold;
   let jszip = null;
-  // Show the progress bar
+  // Add Space below Progress Bar before Showing
+  $('.progressBarContainer').after($('<br>'));
   $(".progressBarContainer").show();
   // Initialize the progress bar
 

--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -32,6 +32,7 @@ $(document).ready(function () {
       const showGameBtn = document.getElementById("show-game-btn");
       if (boredWaiting === "enabled" && showGameBtn) {
         showGameBtn.style.display = "block";
+        showGameBtn.parentNode.insertBefore(document.createElement('br'), showGameBtn.nextSibling);
       }
     }, 5000);
 

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -92,7 +92,7 @@
           const downloadCompleteText = /*[[#{downloadComplete}]]*/ 'Download Complete';
           window.downloadCompleteText = downloadCompleteText;
           // Create the 'show-game-btn' button
-          var gameButton = $('<button type="button" class="btn btn-primary" id="show-game-btn" style="display:none;">' + boredWaitingText + '</button><br><br>');
+          var gameButton = $('<button type="button" class="btn btn-primary" id="show-game-btn" style="display:none;">' + boredWaitingText + '</button>');
 
           // Insert the 'show-game-btn' just above the submit button
           submitButton.before(gameButton);


### PR DESCRIPTION
# Description
There is Extra space above submit button in pages which had "Bored Waiting?" Button. I removed the <br> tag and added them only when "Bored Waiting?" button or Progress Bar Appears.

Closes #1829 
<img width="744" alt="Screenshot 2024-09-08 at 10 49 58 PM" src="https://github.com/user-attachments/assets/31ee086f-926c-4bd6-b756-7faa7407389a">
<img width="766" alt="Screenshot 2024-09-08 at 10 50 25 PM" src="https://github.com/user-attachments/assets/7e337cb7-db51-4502-8b81-f01ad0425171">

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
