### PR TITLE
fix(stamp): radius styles of color input

### DIFF
--- a/src/main/resources/static/css/theme/componentes.css
+++ b/src/main/resources/static/css/theme/componentes.css
@@ -792,6 +792,23 @@ textarea.form-control {
   box-shadow: 0 0 0 0.25rem var(--md-sys-color-outline-variant);
 }
 
+.form-control-color {
+  padding: 0;
+  height: 2.4rem;
+  width: 2.4rem;
+}
+
+.form-control input[type="color"] {
+  opacity: 0;
+  height: 2.4rem;
+  width: 2.4rem;
+  box-sizing: border-box;
+ }
+
+ .form-control input[type="color"]:hover{
+   cursor: pointer;
+ }
+
 /* Navbar Components */
 .navbar-brand {
   color: var(--md-sys-color-on-surface) !important;

--- a/src/main/resources/templates/misc/stamp.html
+++ b/src/main/resources/templates/misc/stamp.html
@@ -119,7 +119,22 @@
 
                 <div class="mb-3">
                   <label for="customColor" class="form-label" th:text="#{AddStampRequest.customColor}">Custom Color</label>
-                  <input type="color" class="form-control form-control-color" id="customColor" name="customColor" value="#d3d3d3">
+                  <div class="form-control form-control-color" style="background-color: #d3d3d3;">
+                    <input type="color" id="customColor" name="customColor" value="#d3d3d3">
+                  </div>
+                  <script>
+                    let colorInput = document.getElementById("customColor");
+                    if (colorInput) {
+                      let colorInputContainer = colorInput.parentElement;
+                      if (colorInputContainer) {
+                        colorInput.onchange = function() {
+                          colorInputContainer.style.backgroundColor = colorInput.value;
+                        }
+                        colorInputContainer.style.backgroundColor = colorInput.value;
+                      }
+                    }
+
+                  </script>
                 </div>
 
                 <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{AddStampRequest.submit}"></button>


### PR DESCRIPTION
# Description

The bootstrap color input styles do not play nicely with a large border-radius on color inputs (generate a large off-set backdrop). As styling of color inputs requires usage of vendor prefixes (which likely break in the future), this change makes the input transparent and adds a styled container, including JS code that makes the container reflect the selected code. Styles are idempotent (should not have impact on future color inputs) and scripts are regional (only on the stamp page). Demo:


https://github.com/user-attachments/assets/fed9606b-ae6f-466c-8e2d-b184a8bc2658


Closes 1830

## Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
