### PR TITLE
Changed Spacing between between Buttons and Spacing of Settings Menu

### DIFF
--- a/src/main/resources/static/css/theme/componentes.css
+++ b/src/main/resources/static/css/theme/componentes.css
@@ -82,16 +82,22 @@ td {
 .modal-body,
 .modal-footer {
   background-color: var(--md-sys-color-surface-5);
-  padding: 1.5rem 2rem;
+
   border: none;
 }
 
 .modal-header {
   border-radius: 2rem 2rem 0rem 0rem;
+  padding: 1.5rem 2rem 0.5rem;
+}
+
+.modal-body{
+  padding: 0.5rem 2rem;
 }
 
 .modal-footer {
   border-radius: 0rem 0rem 2rem 2rem;
+  padding: 0.5rem 2rem 1.5rem;
 }
 
 /* Icon fill */
@@ -538,6 +544,9 @@ fieldset:disabled .btn {
 }
 
 /* Range Slider */
+.form-range{
+  margin-top: 0.25rem;
+}
 .form-range:focus::-webkit-slider-thumb {
   box-shadow: 0 0 0 1px var(--md-sys-color-surface), 0 0 0 .25rem var(--md-sys-color-primary)
 }

--- a/src/main/resources/templates/convert/file-to-pdf.html
+++ b/src/main/resources/templates/convert/file-to-pdf.html
@@ -41,9 +41,10 @@
                 <a
                   href="https://help.libreoffice.org/latest/en-US/text/shared/guide/supported_formats.html">https://help.libreoffice.org/latest/en-US/text/shared/guide/supported_formats.html</a>
               </div>
-              <br>
-              
-              <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{fileToPDF.submit}"></button>
+              <div>
+                <br/>
+                <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{fileToPDF.submit}"></button>
+              </div>
             </form>
 
           </div>

--- a/src/main/resources/templates/convert/img-to-pdf.html
+++ b/src/main/resources/templates/convert/img-to-pdf.html
@@ -40,7 +40,6 @@
                     <option value="blackwhite" th:text="#{pdfToImage.blackwhite}"></option>
                   </select>
                 </div>
-                <br>
                 <input type="hidden" id="override" name="override" value="multi">
                 <div class="mb-3">
                   <label th:text=#{imageToPDF.selectText.3}></label>
@@ -49,7 +48,7 @@
                     <option value="convert" th:text=#{imageToPDF.selectText.5} selected></option>
                   </select>
                 </div>
-                <br><br>
+                <br>
                 <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{imageToPDF.submit}"></button>
                 <script>
                   $('#fileInput-input').on('change', function() {

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -415,7 +415,7 @@
             </select>
           </div>
           <div class="mb-3">
-            <label for="zipThreshold" th:utext="#{settings.zipThreshold}"></label>
+            <label for="zipThreshold" th:utext="#{settings.zipThreshold}"></label><br/>
             <input type="range" class="form-range" min="1" max="9" step="1" id="zipThreshold" value="4">
             <span id="zipThresholdValue" class="ms-2"></span>
           </div>


### PR DESCRIPTION
# Description

Closes #1860 
Changed padding for Modal-header, body and footer.
Tested other forms to check, looks fine.

Added Range-slider padding. Only form where it is used is the Settings menu. Looks better

Closes #1859 
Moved br into div to not interfere with href of supported Formats

Closes #1858 
Removed unnecassary br from Image-to-pdf

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
