### PR TITLE
fix:Remove add image and Align download input file with same width as pdf file input

### DIFF
--- a/src/main/resources/templates/misc/add-image.html
+++ b/src/main/resources/templates/misc/add-image.html
@@ -45,7 +45,6 @@
               </script>
 
               <div class="tab-group show-on-file-selected">
-                <div class="tab-container" th:title="#{addImage.upload}">
                   <div th:replace="~{fragments/common :: fileSelector(name='image-upload', multipleInputsForSingleRequest=true, accept='image/*', inputText=#{imgPrompt})}"></div>
                   <script>
                     const imageUpload = document.querySelector('input[name=image-upload]');
@@ -62,7 +61,6 @@
                       }
                     });
                   </script>
-                </div>
               </div>
 
               <!-- draggables box -->


### PR DESCRIPTION
# Description

fix:Remove add image button as the button was non functional. Align download input file with same width as pdf file input

Closes #1877

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
