### PR TITLE
Update add-watermark.html

### DIFF
--- a/src/main/resources/templates/security/add-watermark.html
+++ b/src/main/resources/templates/security/add-watermark.html
@@ -108,7 +108,7 @@
                   <input type="checkbox" id="convertPDFToImage" name="convertPDFToImage">
                   <label for="convertPDFToImage" th:text="#{watermark.selectText.10}"></label>
                 </div>
-                <div class="mb-3 text-center">
+                <div class="mb-3 text-left">
                   <input type="submit" id="submitBtn" th:value="#{watermark.submit}" class="btn btn-primary">
                 </div>
               </form>


### PR DESCRIPTION
shifted add watermark submit button to left

# Description

aligned watermark submit  button to left by changing text align to left
![image](https://github.com/user-attachments/assets/299a22fb-3015-4d7e-b477-a7ed5eff8624)


Closes  #1881 

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
