### PR TITLE
Fix: Left-align the submit button on each card for pdf operation

### DIFF
--- a/src/main/resources/templates/misc/adjust-contrast.html
+++ b/src/main/resources/templates/misc/adjust-contrast.html
@@ -44,7 +44,9 @@
                   </div>
                   <br>
                   <canvas id="contrast-pdf-canvas"></canvas>
+                  <div class="mb-3 text-left">
                   <button id="download-button" class="btn btn-primary" th:text="#{adjustContrast.download}"></button>
+                  </div>
                 </div>
               </div>
 

--- a/src/main/resources/templates/pipeline.html
+++ b/src/main/resources/templates/pipeline.html
@@ -67,7 +67,7 @@
                       th:replace="~{fragments/common :: fileSelector(name='fileInput', multipleInputsForSingleRequest=true)}"
                     ></div>
                   </div>
-                  <div class="element-margin">
+                  <div class="element-margin text-start">
                     <button
                       class="btn btn-primary"
                       id="submitConfigBtn"
@@ -164,7 +164,7 @@
                         class="btn btn-danger"
                         th:text="#{delete}"
                       ></button>
-                      
+
                       <button
                         id="saveBrowserPipelineBtn"
                         class="btn btn-success"

--- a/src/main/resources/templates/security/add-password.html
+++ b/src/main/resources/templates/security/add-password.html
@@ -74,7 +74,7 @@
                   </div>
                 </div>
                 <br>
-                <div class="mb-3 text-center">
+                <div class="mb-3 text-left">
                   <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{addPassword.submit}"></button>
                 </div>
               </form>

--- a/src/main/resources/templates/security/cert-sign.html
+++ b/src/main/resources/templates/security/cert-sign.html
@@ -74,7 +74,7 @@
                     <label for="pageNumber" th:text="#{pageNum}"></label> <input type="number" class="form-control" id="pageNumber" name="pageNumber" min="1" disabled>
                   </div>
                 </div>
-                <div class="mb-3 text-center">
+                <div class="mb-3 text-left">
                   <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{certSign.submit}"></button>
                 </div>
               </form>

--- a/src/main/resources/templates/security/change-permissions.html
+++ b/src/main/resources/templates/security/change-permissions.html
@@ -58,7 +58,7 @@
                   </div>
                 </div>
                 <br>
-                <div class="mb-3 text-center">
+                <div class="mb-3 text-left">
                   <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{permissions.submit}"></button>
                 </div>
               </form>

--- a/src/main/resources/templates/security/remove-cert-sign.html
+++ b/src/main/resources/templates/security/remove-cert-sign.html
@@ -21,7 +21,7 @@
                   <label th:text="#{removeCertSign.selectPDF}"></label>
                   <div th:replace="~{fragments/common :: fileSelector(name='fileInput', multipleInputsForSingleRequest=false, accept='application/pdf')}"></div>
                 </div>
-                <div class="mb-3 text-center">
+                <div class="mb-3 text-left">
                   <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{removeCertSign.submit}"></button>
                 </div>
               </form>

--- a/src/main/resources/templates/security/remove-password.html
+++ b/src/main/resources/templates/security/remove-password.html
@@ -26,7 +26,7 @@
                   <input type="password" class="form-control" id="password" name="password">
                 </div>
                 <br>
-                <div class="mb-3 text-center">
+                <div class="mb-3 text-left">
                   <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{removePassword.submit}"></button>
                 </div>
               </form>

--- a/src/main/resources/templates/security/sanitize-pdf.html
+++ b/src/main/resources/templates/security/sanitize-pdf.html
@@ -41,7 +41,7 @@
                   <label for="removeFonts" th:text="#{sanitizePDF.selectText.5}"></label>
                 </div>
                 <br>
-                <div class="mb-3 text-center">
+                <div class="mb-3 text-left">
                   <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{sanitizePDF.submit}"></button>
                 </div>
               </form>


### PR DESCRIPTION
# Description

Left aligned submit button for cards( Pipeline, Adjust contrast, Add password , Remove password, Change permission, Sign with certificate, Remove certificate sign, Sanitize ) on pdf operations.

Updated the HTML structure for the submit button, updated the necessary classes from (text-center) to (text-left) to ensure it aligns with the input fields.

Closes #1881 

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
