### PR TITLE
Fix pdfa conversion

### DIFF
--- a/scripts/replace_translation_line.sh
+++ b/scripts/replace_translation_line.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+translation_key="pdfToPDFA.credit"
+old_value="OCRmyPDF"
+new_value="ghostscript"
+
+for file in ../src/main/resources/messages_*.properties; do
+  sed -i "/^$translation_key=/s/$old_value/$new_value/" "$file"
+  echo "Updated $file"
+done

--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
@@ -58,7 +58,7 @@ public class ConvertPDFToPDFA {
         // Prepare the ghostscript command
         List<String> command = new ArrayList<>();
         command.add("gs");
-        command.add("-dPDFA=" + (outputFormat.equals("pdfa") ? "2" : "1"));
+        command.add("-dPDFA=" + ("pdfa".equals(outputFormat) ? "2" : "1"));
         command.add("-dNOPAUSE");
         command.add("-dBATCH");
         command.add("-sColorConversionStrategy=UseDeviceIndependentColor");

--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
@@ -1,22 +1,15 @@
 package stirling.software.SPDF.controller.api.converters;
 
-import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
-import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
-import org.apache.pdfbox.pdmodel.interactive.form.PDField;
-import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +22,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import stirling.software.SPDF.model.api.converters.PdfToPdfARequest;
-import stirling.software.SPDF.service.CustomPDDocumentFactory;
 import stirling.software.SPDF.utils.ProcessExecutor;
 import stirling.software.SPDF.utils.ProcessExecutor.ProcessExecutorResult;
 import stirling.software.SPDF.utils.WebResponseUtils;
@@ -40,13 +32,6 @@ import stirling.software.SPDF.utils.WebResponseUtils;
 public class ConvertPDFToPDFA {
 
     private static final Logger logger = LoggerFactory.getLogger(ConvertPDFToPDFA.class);
-
-    private final CustomPDDocumentFactory pdfDocumentFactory;
-
-    @Autowired
-    public ConvertPDFToPDFA(CustomPDDocumentFactory pdfDocumentFactory) {
-        this.pdfDocumentFactory = pdfDocumentFactory;
-    }
 
     @PostMapping(consumes = "multipart/form-data", value = "/pdf/pdfa")
     @Operation(
@@ -61,32 +46,7 @@ public class ConvertPDFToPDFA {
         // Convert MultipartFile to byte[]
         byte[] pdfBytes = inputFile.getBytes();
 
-        // Load the PDF document
-        PDDocument document = pdfDocumentFactory.load(pdfBytes);
-
-        // Get the document catalog
-        PDDocumentCatalog catalog = document.getDocumentCatalog();
-
-        // Get the AcroForm
-        PDAcroForm acroForm = catalog.getAcroForm();
-        if (acroForm != null) {
-            // Remove signature fields safely
-            List<PDField> fieldsToRemove =
-                    acroForm.getFields().stream()
-                            .filter(field -> field instanceof PDSignatureField)
-                            .collect(Collectors.toList());
-
-            if (!fieldsToRemove.isEmpty()) {
-                acroForm.flatten(fieldsToRemove, false);
-
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                document.save(baos);
-                pdfBytes = baos.toByteArray();
-            }
-        }
-        document.close();
-
-        // Save the uploaded (and possibly modified) file to a temporary location
+        // Save the uploaded file to a temporary location
         Path tempInputFile = Files.createTempFile("input_", ".pdf");
         try (OutputStream outputStream = new FileOutputStream(tempInputFile.toFile())) {
             outputStream.write(pdfBytes);
@@ -95,28 +55,37 @@ public class ConvertPDFToPDFA {
         // Prepare the output file path
         Path tempOutputFile = Files.createTempFile("output_", ".pdf");
 
-        // Prepare the OCRmyPDF command
+        // Prepare the ghostscript command
         List<String> command = new ArrayList<>();
-        command.add("ocrmypdf");
-        command.add("--skip-text");
-        command.add("--tesseract-timeout=0");
-        command.add("--output-type");
-        command.add(outputFormat.toString());
-        command.add(tempInputFile.toString());
+        command.add("gs");
+        command.add("-dPDFA=" + (outputFormat.equals("pdfa") ? "2" : "1"));
+        command.add("-dNOPAUSE");
+        command.add("-dBATCH");
+        command.add("-sColorConversionStrategy=UseDeviceIndependentColor");
+        command.add("-sDEVICE=pdfwrite");
+        command.add("-dPDFACompatibilityPolicy=2");
+        command.add("-o");
         command.add(tempOutputFile.toString());
+        command.add(tempInputFile.toString());
 
         ProcessExecutorResult returnCode =
-                ProcessExecutor.getInstance(ProcessExecutor.Processes.OCR_MY_PDF)
+                ProcessExecutor.getInstance(ProcessExecutor.Processes.GHOSTSCRIPT)
                         .runCommandWithOutputHandling(command);
 
+        if (returnCode.getRc() != 0) {
+            logger.info(
+                    outputFormat + " conversion failed with return code: " + returnCode.getRc());
+        }
+
         try {
-            PDDocument doc = pdfDocumentFactory.load(tempOutputFile.toFile());
+            byte[] pdfBytesOutput = Files.readAllBytes(tempOutputFile);
             // Return the optimized PDF as a response
             String outputFilename =
                     Filenames.toSimpleFileName(inputFile.getOriginalFilename())
                                     .replaceFirst("[.][^.]+$", "")
                             + "_PDFA.pdf";
-            return WebResponseUtils.pdfDocToWebResponse(doc, outputFilename);
+            return WebResponseUtils.bytesToWebResponse(
+                    pdfBytesOutput, outputFilename, MediaType.APPLICATION_PDF);
         } finally {
             // Clean up the temporary files
             Files.deleteIfExists(tempInputFile);

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=تغيير
 #pdfToPDFA
 pdfToPDFA.title=PDF إلى PDF/A
 pdfToPDFA.header=PDF إلى PDF/A
-pdfToPDFA.credit=تستخدم هذه الخدمة OCRmyPDF لتحويل PDF/A.
+pdfToPDFA.credit=تستخدم هذه الخدمة ghostscript لتحويل PDF/A.
 pdfToPDFA.submit=تحويل
 pdfToPDFA.tip=لا يعمل حاليًا لمدخلات متعددة في وقت واحد
 pdfToPDFA.outputFormat=تنسيق الإخراج

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Промени
 #pdfToPDFA
 pdfToPDFA.title=PDF към PDF/A
 pdfToPDFA.header=PDF към PDF/A
-pdfToPDFA.credit=Тази услуга използва OCRmyPDF за PDF/A преобразуване.
+pdfToPDFA.credit=Тази услуга използва ghostscript за PDF/A преобразуване.
 pdfToPDFA.submit=Преобразуване
 pdfToPDFA.tip=В момента не работи за няколко входа наведнъж
 pdfToPDFA.outputFormat=Изходен формат

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Canvia
 #pdfToPDFA
 pdfToPDFA.title=PDF a PDF/A
 pdfToPDFA.header=PDF a PDF/A
-pdfToPDFA.credit=Utilitza OCRmyPDF per la conversió a PDF/A
+pdfToPDFA.credit=Utilitza ghostscript per la conversió a PDF/A
 pdfToPDFA.submit=Converteix
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Změnit
 #pdfToPDFA
 pdfToPDFA.title=PDF na PDF/A
 pdfToPDFA.header=PDF na PDF/A
-pdfToPDFA.credit=Tato služba používá OCRmyPDF pro konverzi do formátu PDF/A
+pdfToPDFA.credit=Tato služba používá ghostscript pro konverzi do formátu PDF/A
 pdfToPDFA.submit=Převést
 pdfToPDFA.tip=V současné době nepracuje pro více vstupů najednou
 pdfToPDFA.outputFormat=Výstupní formát

--- a/src/main/resources/messages_da_DK.properties
+++ b/src/main/resources/messages_da_DK.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Ændre
 #pdfToPDFA
 pdfToPDFA.title=PDF Til PDF/A
 pdfToPDFA.header=PDF Til PDF/A
-pdfToPDFA.credit=Denne tjeneste bruger OCRmyPDF til PDF/A-konvertering
+pdfToPDFA.credit=Denne tjeneste bruger ghostscript til PDF/A-konvertering
 pdfToPDFA.submit=Konvertér
 pdfToPDFA.tip=Fungerer i øjeblikket ikke for flere input på én gang
 pdfToPDFA.outputFormat=Outputformat

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Ändern
 #pdfToPDFA
 pdfToPDFA.title=PDF zu PDF/A
 pdfToPDFA.header=PDF zu PDF/A
-pdfToPDFA.credit=Dieser Dienst verwendet OCRmyPDF für die PDF/A-Konvertierung
+pdfToPDFA.credit=Dieser Dienst verwendet ghostscript für die PDF/A-Konvertierung
 pdfToPDFA.submit=Konvertieren
 pdfToPDFA.tip=Dieser Dienst kann nur einzelne Eingangsdateien verarbeiten.
 pdfToPDFA.outputFormat=Ausgabeformat

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Αλλαγή
 #pdfToPDFA
 pdfToPDFA.title=PDF σε PDF/A
 pdfToPDFA.header=PDF σε PDF/A
-pdfToPDFA.credit=Αυτή η υπηρεσία χρησιμοποιεί OCRmyPDF για PDF/A μετατροπή
+pdfToPDFA.credit=Αυτή η υπηρεσία χρησιμοποιεί ghostscript για PDF/A μετατροπή
 pdfToPDFA.submit=Μετατροπή
 pdfToPDFA.tip=Προς το παρόν δεν λειτουργεί για πολλαπλές εισόδους ταυτόχρονα
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Change
 #pdfToPDFA
 pdfToPDFA.title=PDF To PDF/A
 pdfToPDFA.header=PDF To PDF/A
-pdfToPDFA.credit=This service uses OCRmyPDF for PDF/A conversion
+pdfToPDFA.credit=This service uses ghostscript for PDF/A conversion
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Change
 #pdfToPDFA
 pdfToPDFA.title=PDF To PDF/A
 pdfToPDFA.header=PDF To PDF/A
-pdfToPDFA.credit=This service uses OCRmyPDF for PDF/A conversion
+pdfToPDFA.credit=This service uses ghostscript for PDF/A conversion
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Cambiar
 #pdfToPDFA
 pdfToPDFA.title=PDF a PDF/A
 pdfToPDFA.header=PDF a PDF/A
-pdfToPDFA.credit=Este servicio usa OCRmyPDF para la conversión a PDF/A
+pdfToPDFA.credit=Este servicio usa ghostscript para la conversión a PDF/A
 pdfToPDFA.submit=Convertir
 pdfToPDFA.tip=Actualmente no funciona para múltiples entrada a la vez
 pdfToPDFA.outputFormat=Formato de salida

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Aldatu
 #pdfToPDFA
 pdfToPDFA.title=PDFa PDF/A bihurtu
 pdfToPDFA.header=PDFa PDF/A bihurtu
-pdfToPDFA.credit=Zerbitzu honek OCRmyPDF erabiltzen du PDFak PDF/A bihurtzeko
+pdfToPDFA.credit=Zerbitzu honek ghostscript erabiltzen du PDFak PDF/A bihurtzeko
 pdfToPDFA.submit=Bihurtu
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Modifier
 #pdfToPDFA
 pdfToPDFA.title=PDF en PDF/A
 pdfToPDFA.header=PDF en PDF/A
-pdfToPDFA.credit=Ce service utilise OCRmyPDF pour la conversion en PDF/A.
+pdfToPDFA.credit=Ce service utilise ghostscript pour la conversion en PDF/A.
 pdfToPDFA.submit=Convertir
 pdfToPDFA.tip=Ne fonctionne actuellement pas pour plusieurs entrées à la fois
 pdfToPDFA.outputFormat=Format de sortie

--- a/src/main/resources/messages_ga_IE.properties
+++ b/src/main/resources/messages_ga_IE.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Athrú
 #pdfToPDFA
 pdfToPDFA.title=PDF Go PDF/A
 pdfToPDFA.header=PDF Go PDF/A
-pdfToPDFA.credit=Úsáideann an tseirbhís seo OCRmyPDF chun PDF/A a thiontú
+pdfToPDFA.credit=Úsáideann an tseirbhís seo ghostscript chun PDF/A a thiontú
 pdfToPDFA.submit=Tiontaigh
 pdfToPDFA.tip=Faoi láthair ní oibríonn sé le haghaidh ionchuir iolracha ag an am céanna
 pdfToPDFA.outputFormat=Formáid aschuir

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=बदलें
 #pdfToPDFA
 pdfToPDFA.title=PDF से PDF/A में
 pdfToPDFA.header=PDF से PDF/A में
-pdfToPDFA.credit=इस सेवा में PDF/A परिवर्तन के लिए OCRmyPDF का उपयोग किया जाता है।
+pdfToPDFA.credit=इस सेवा में PDF/A परिवर्तन के लिए ghostscript का उपयोग किया जाता है।
 pdfToPDFA.submit=परिवर्तित करें
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Promijeniti
 #pdfToPDFA
 pdfToPDFA.title=PDF u PDF/A
 pdfToPDFA.header=PDF u PDF/A
-pdfToPDFA.credit=Ova usluga koristi OCRmyPDF za PDF/A pretvorbu
+pdfToPDFA.credit=Ova usluga koristi ghostscript za PDF/A pretvorbu
 pdfToPDFA.submit=Pretvoriti
 pdfToPDFA.tip=Trenutno ne radi za više unosa odjednom
 pdfToPDFA.outputFormat=Izlazni format

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Módosítás
 #pdfToPDFA
 pdfToPDFA.title=PDF >> PDF/A
 pdfToPDFA.header=PDF >> PDF/A
-pdfToPDFA.credit=Ez a szolgáltatás az OCRmyPDF-t használja a PDF/A konverzióhoz
+pdfToPDFA.credit=Ez a szolgáltatás az ghostscript-t használja a PDF/A konverzióhoz
 pdfToPDFA.submit=Konvertálás
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Ganti
 #pdfToPDFA
 pdfToPDFA.title=PDF Ke PDF/A
 pdfToPDFA.header=PDF ke PDF/A
-pdfToPDFA.credit=Layanan ini menggunakan OCRmyPDF untuk konversi PDF/A.
+pdfToPDFA.credit=Layanan ini menggunakan ghostscript untuk konversi PDF/A.
 pdfToPDFA.submit=Konversi
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Cambia proprietà
 #pdfToPDFA
 pdfToPDFA.title=Da PDF a PDF/A
 pdfToPDFA.header=Da PDF a PDF/A
-pdfToPDFA.credit=Questo servizio utilizza OCRmyPDF per la conversione in PDF/A.
+pdfToPDFA.credit=Questo servizio utilizza ghostscript per la conversione in PDF/A.
 pdfToPDFA.submit=Converti
 pdfToPDFA.tip=Attualmente non funziona per più input contemporaneamente
 pdfToPDFA.outputFormat=Formato di output

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=変更
 #pdfToPDFA
 pdfToPDFA.title=PDFをPDF/Aに変換
 pdfToPDFA.header=PDFをPDF/Aに変換
-pdfToPDFA.credit=本サービスはPDF/Aの変換にOCRmyPDFを使用しています。
+pdfToPDFA.credit=本サービスはPDF/Aの変換にghostscriptを使用しています。
 pdfToPDFA.submit=変換
 pdfToPDFA.tip=現在、一度に複数の入力に対して機能しません
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=변경
 #pdfToPDFA
 pdfToPDFA.title=PDF를 PDF/A로
 pdfToPDFA.header=PDF 문서를 PDF/A로 변환
-pdfToPDFA.credit=이 서비스는 PDF/A 변환을 위해 OCRmyPDF 문서를 사용합니다.
+pdfToPDFA.credit=이 서비스는 PDF/A 변환을 위해 ghostscript 문서를 사용합니다.
 pdfToPDFA.submit=변환
 pdfToPDFA.tip=현재 한 번에 여러 입력에 대해 작동하지 않습니다.
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Wijzigen
 #pdfToPDFA
 pdfToPDFA.title=PDF naar PDF/A
 pdfToPDFA.header=PDF naar PDF/A
-pdfToPDFA.credit=Deze service gebruikt OCRmyPDF voor PDF/A-conversie
+pdfToPDFA.credit=Deze service gebruikt ghostscript voor PDF/A-conversie
 pdfToPDFA.submit=Converteren
 pdfToPDFA.tip=Werkt momenteel niet voor meerdere inputs tegelijkertijd.
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_no_NB.properties
+++ b/src/main/resources/messages_no_NB.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Endre
 #pdfToPDFA
 pdfToPDFA.title=PDF til PDF/A
 pdfToPDFA.header=PDF til PDF/A
-pdfToPDFA.credit=Denne tjenesten bruker OCRmyPDF for PDF/A-konvertering
+pdfToPDFA.credit=Denne tjenesten bruker ghostscript for PDF/A-konvertering
 pdfToPDFA.submit=Konverter
 pdfToPDFA.tip=Fungere for øyeblikket ikke for flere innganger samtidig
 pdfToPDFA.outputFormat=Utdataformat

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Zmień
 #pdfToPDFA
 pdfToPDFA.title=PDF na PDF/A
 pdfToPDFA.header=PDF na PDF/A
-pdfToPDFA.credit=Ta usługa używa OCRmyPDF do konwersji PDF/A
+pdfToPDFA.credit=Ta usługa używa ghostscript do konwersji PDF/A
 pdfToPDFA.submit=Konwertuj
 pdfToPDFA.tip=Tylko jeden plik na raz
 pdfToPDFA.outputFormat=Format wyjściowy:

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Alterar
 #pdfToPDFA
 pdfToPDFA.title=PDF para PDF/A
 pdfToPDFA.header=PDF para PDF/A
-pdfToPDFA.credit=Este serviço usa OCRmyPDF para conversão de PDF/A
+pdfToPDFA.credit=Este serviço usa ghostscript para conversão de PDF/A
 pdfToPDFA.submit=Converter
 pdfToPDFA.tip=Atualmente não funciona para múltiplas entradas ao mesmo tempo
 pdfToPDFA.outputFormat=Formato de saída

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Mudar
 #pdfToPDFA
 pdfToPDFA.title=PDF para PDF/A
 pdfToPDFA.header=PDF para PDF/A
-pdfToPDFA.credit=Este serviço usa OCRmyPDF para Conversão de PDF/A
+pdfToPDFA.credit=Este serviço usa ghostscript para Conversão de PDF/A
 pdfToPDFA.submit=Converter
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Schimbă
 #pdfToPDFA
 pdfToPDFA.title=PDF către PDF/A
 pdfToPDFA.header=PDF către PDF/A
-pdfToPDFA.credit=Acest serviciu utilizează OCRmyPDF pentru conversia în PDF/A
+pdfToPDFA.credit=Acest serviciu utilizează ghostscript pentru conversia în PDF/A
 pdfToPDFA.submit=Convertește
 pdfToPDFA.tip=În prezent nu funcționează pentru mai multe intrări simultan
 pdfToPDFA.outputFormat=Format de ieșire

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Изменить
 #pdfToPDFA
 pdfToPDFA.title=PDF в PDF/A
 pdfToPDFA.header=PDF в PDF/A
-pdfToPDFA.credit=Этот сервис использует OCRmyPDF для преобразования PDF/A
+pdfToPDFA.credit=Этот сервис использует ghostscript для преобразования PDF/A
 pdfToPDFA.submit=Конвертировать
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Zmeniť
 #pdfToPDFA
 pdfToPDFA.title=PDF na PDF/A
 pdfToPDFA.header=PDF na PDF/A
-pdfToPDFA.credit=Táto služba používa OCRmyPDF na konverziu PDF/A
+pdfToPDFA.credit=Táto služba používa ghostscript na konverziu PDF/A
 pdfToPDFA.submit=Konvertovať
 pdfToPDFA.tip=Momentálne nefunguje pre viacero vstupov naraz
 pdfToPDFA.outputFormat=Výstupný formát

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Promeni
 #pdfToPDFA
 pdfToPDFA.title=PDF u PDF/A
 pdfToPDFA.header=PDF u PDF/A
-pdfToPDFA.credit=Ova usluga koristi OCRmyPDF za konverziju u PDF/A format
+pdfToPDFA.credit=Ova usluga koristi ghostscript za konverziju u PDF/A format
 pdfToPDFA.submit=Konvertuj
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Ändra
 #pdfToPDFA
 pdfToPDFA.title=PDF till PDF/A
 pdfToPDFA.header=PDF till PDF/A
-pdfToPDFA.credit=Denna tjänst använder OCRmyPDF för PDF/A-konvertering
+pdfToPDFA.credit=Denna tjänst använder ghostscript för PDF/A-konvertering
 pdfToPDFA.submit=Konvertera
 pdfToPDFA.tip=Fungerar för närvarande inte för flera inmatningar samtidigt
 pdfToPDFA.outputFormat=Utdataformat

--- a/src/main/resources/messages_th_TH.properties
+++ b/src/main/resources/messages_th_TH.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=เปลี่ยน
 #pdfToPDFA
 pdfToPDFA.title=PDF เป็น PDF/A
 pdfToPDFA.header=PDF เป็น PDF/A
-pdfToPDFA.credit=บริการนี้ใช้ OCRmyPDF สำหรับการแปลง PDF/A
+pdfToPDFA.credit=บริการนี้ใช้ ghostscript สำหรับการแปลง PDF/A
 pdfToPDFA.submit=แปลง
 pdfToPDFA.tip=ปัจจุบันไม่ทำงานสำหรับการป้อนข้อมูลหลายรายการพร้อมกัน
 pdfToPDFA.outputFormat=รูปแบบผลลัพธ์

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Değiştir
 #pdfToPDFA
 pdfToPDFA.title=PDF'den PDF/A'ya
 pdfToPDFA.header=PDF'den PDF/A'ya
-pdfToPDFA.credit=Bu hizmet PDF/A dönüşümü için OCRmyPDF kullanır
+pdfToPDFA.credit=Bu hizmet PDF/A dönüşümü için ghostscript kullanır
 pdfToPDFA.submit=Dönüştür
 pdfToPDFA.tip=Şu anda aynı anda birden fazla giriş için çalışmıyor
 pdfToPDFA.outputFormat=Çıkış formatı

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Змінити
 #pdfToPDFA
 pdfToPDFA.title=PDF в PDF/A
 pdfToPDFA.header=PDF в PDF/A
-pdfToPDFA.credit=Цей сервіс використовує OCRmyPDF для перетворення у формат PDF/A
+pdfToPDFA.credit=Цей сервіс використовує ghostscript для перетворення у формат PDF/A
 pdfToPDFA.submit=Конвертувати
 pdfToPDFA.tip=Наразі не працює для кількох вхідних файлів одночасно
 pdfToPDFA.outputFormat=Вихідний формат

--- a/src/main/resources/messages_vi_VN.properties
+++ b/src/main/resources/messages_vi_VN.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=Thay đổi
 #pdfToPDFA
 pdfToPDFA.title=PDF sang PDF/A
 pdfToPDFA.header=PDF sang PDF/A
-pdfToPDFA.credit=Dịch vụ này sử dụng OCRmyPDF để chuyển đổi PDF/A
+pdfToPDFA.credit=Dịch vụ này sử dụng ghostscript để chuyển đổi PDF/A
 pdfToPDFA.submit=Chuyển đổi
 pdfToPDFA.tip=Hiện tại không hoạt động với nhiều đầu vào cùng lúc
 pdfToPDFA.outputFormat=Định dạng đầu ra

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=更改
 #pdfToPDFA
 pdfToPDFA.title=PDF转PDF/A
 pdfToPDFA.header=将PDF转换为PDF/A
-pdfToPDFA.credit=此服务使用OCRmyPDF进行PDF/A转换
+pdfToPDFA.credit=此服务使用ghostscript进行PDF/A转换
 pdfToPDFA.submit=转换
 pdfToPDFA.tip=目前不支持上传多个
 pdfToPDFA.outputFormat=输出格式

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -1023,7 +1023,7 @@ changeMetadata.submit=變更
 #pdfToPDFA
 pdfToPDFA.title=PDF 轉 PDF/A
 pdfToPDFA.header=PDF 轉 PDF/A
-pdfToPDFA.credit=此服務使用 OCRmyPDF 進行 PDF/A 轉換
+pdfToPDFA.credit=此服務使用 ghostscript 進行 PDF/A 轉換
 pdfToPDFA.submit=轉換
 pdfToPDFA.tip=目前不支援上傳多個
 pdfToPDFA.outputFormat=輸出格式


### PR DESCRIPTION
# Description

Fix pdfa conversion

When returning the response back to the client, loading the file using `pdfDocumentFactory` doesn't work (I think it processes the pdf, which makes it invalid pdf/a) so the output file was read as a byte array.

Closes #1638 

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
