### PR TITLE
[fix]: check for encryption in PageNumbers

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
@@ -67,15 +67,6 @@ public class SplitPdfByChaptersController {
         }
         PDDocument sourceDocument = Loader.loadPDF(file.getBytes());
 
-        // checks if the document is encrypted by an empty user password
-        if (sourceDocument.isEncrypted()) {
-            try {
-                sourceDocument.setAllSecurityToBeRemoved(true);
-                logger.info("Removing security from the source document ");
-            } catch (Exception e) {
-                logger.warn("Cannot decrypt the pdf");
-            }
-        }
         PDDocumentOutline outline = sourceDocument.getDocumentCatalog().getDocumentOutline();
 
         if (outline == null) {

--- a/src/main/java/stirling/software/SPDF/service/CustomPDDocumentFactory.java
+++ b/src/main/java/stirling/software/SPDF/service/CustomPDDocumentFactory.java
@@ -7,6 +7,8 @@ import java.io.InputStream;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +19,8 @@ import stirling.software.SPDF.model.api.PDFFile;
 
 @Component
 public class CustomPDDocumentFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(CustomPDDocumentFactory.class);
 
     private final PdfMetadataService pdfMetadataService;
 
@@ -71,6 +75,7 @@ public class CustomPDDocumentFactory {
     public PDDocument load(byte[] input) throws IOException {
         PDDocument document = Loader.loadPDF(input);
         pdfMetadataService.setDefaultMetadata(document);
+        removezeropassword(document);
         return document;
     }
 
@@ -93,6 +98,18 @@ public class CustomPDDocumentFactory {
     private PDDocument load(byte[] bytes, String password) throws IOException {
         PDDocument document = Loader.loadPDF(bytes, password);
         pdfMetadataService.setDefaultMetadata(document);
+        return document;
+    }
+
+    private PDDocument removezeropassword(PDDocument document) throws IOException {
+        if (document.isEncrypted()) {
+            try {
+                logger.info("Removing security from the source document");
+                document.setAllSecurityToBeRemoved(true);
+            } catch (Exception e) {
+                logger.warn("Cannot decrypt the pdf");
+            }
+        }
         return document;
     }
 


### PR DESCRIPTION
# Description

This commit fixes a crash occurring when trying to add page numbers to a document which is encrypted by an empty password.

Closes -

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
