### PR TITLE
Fix startup errors on ultra-lite image

### DIFF
--- a/Dockerfile-ultra-lite
+++ b/Dockerfile-ultra-lite
@@ -15,6 +15,7 @@ ENV DOCKER_ENABLE_SECURITY=false \
 # Copy necessary files
 COPY scripts/download-security-jar.sh /scripts/download-security-jar.sh
 COPY scripts/init-without-ocr.sh /scripts/init-without-ocr.sh
+COPY scripts/installFonts.sh /scripts/installFonts.sh
 COPY pipeline /pipeline
 COPY build/libs/*.jar app.jar
 
@@ -37,7 +38,7 @@ RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /et
     chmod +x /scripts/*.sh && \
     addgroup -S stirlingpdfgroup && adduser -S stirlingpdfuser -G stirlingpdfgroup && \
     chown -R stirlingpdfuser:stirlingpdfgroup $HOME /scripts  /configs /customFiles /pipeline && \
-    chown stirlingpdfuser:stirlingpdfgroup /app.jar    
+    chown stirlingpdfuser:stirlingpdfgroup /app.jar
 
 # Set environment variables
 ENV ENDPOINTS_GROUPS_TO_REMOVE=CLI

--- a/Dockerfile-ultra-lite
+++ b/Dockerfile-ultra-lite
@@ -34,7 +34,7 @@ RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /et
         su-exec \
         openjdk21-jre && \
     # User permissions
-    mkdir /configs /logs /customFiles && \
+    mkdir -p /configs /logs /customFiles /usr/share/fonts/opentype/noto && \
     chmod +x /scripts/*.sh && \
     addgroup -S stirlingpdfgroup && adduser -S stirlingpdfuser -G stirlingpdfgroup && \
     chown -R stirlingpdfuser:stirlingpdfgroup $HOME /scripts  /configs /customFiles /pipeline && \


### PR DESCRIPTION
# Description
Currently, when starting the ultra-lite container and some errors/warnings are thrown.

```
/scripts/init-without-ocr.sh: line 24: /scripts/installFonts.sh: No such file or directory
chown: /usr/share/fonts/opentype/noto: No such file or directory
[WARN] Chown failed, running as host user
```

Those are fixed by
 - adding `installFonts.sh`
 - creating the empty directory `/usr/share/fonts/opentype/noto`

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
