### PR TITLE
Update messages_zh_CN.properties

### DIFF
--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -47,7 +47,7 @@ green=绿色
 blue=蓝色
 custom=自定义...
 WorkInProgess=工作正在进行中，可能无法工作或有错误，请报告任何问题！
-poweredBy=Powered by
+poweredBy=服务来源：
 yes=是
 no=否
 changedCredsMessage=凭证已更改！
@@ -133,7 +133,7 @@ navbar.sections.edit=查看和编辑
 #  SETTINGS #
 #############
 settings.title=设置
-settings.update=可更新
+settings.update=有可用的更新
 settings.updateAvailable=当前版本为 {0}，新版本 ({1}) 可用。
 settings.appVersion=应用程序版本：
 settings.downloadOption.title=选择下载选项（单个文件非压缩文件）：


### PR DESCRIPTION
# Description

In previous translation, "Powered By" wasn't tranlate into Chinese, and the translation of "Update available" should updated so that it could be understand more easily.

Closes #1989

## Checklist

- [√] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [√] I have performed a self-review of my own code
- [√] I have commented my code, particularly in hard-to-understand areas
- [√] My changes generate no new warnings
- [√] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
