### PR TITLE
Optimierung der SAML2-Integration und Verbesserung der Zertifikats- und Fehlerbehandlung

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/saml2/CertificateUtils.java
+++ b/src/main/java/stirling/software/SPDF/config/security/saml2/CertificateUtils.java
@@ -1,48 +1,42 @@
 package stirling.software.SPDF.config.security.saml2;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Base64;
 
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
 import org.springframework.core.io.Resource;
-import org.springframework.util.FileCopyUtils;
 
 public class CertificateUtils {
 
     public static X509Certificate readCertificate(Resource certificateResource) throws Exception {
-        String certificateString =
-                new String(
-                        FileCopyUtils.copyToByteArray(certificateResource.getInputStream()),
-                        StandardCharsets.UTF_8);
-        String certContent =
-                certificateString
-                        .replace("-----BEGIN CERTIFICATE-----", "")
-                        .replace("-----END CERTIFICATE-----", "")
-                        .replaceAll("\\R", "")
-                        .replaceAll("\\s+", "");
-        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        byte[] decodedCert = Base64.getDecoder().decode(certContent);
-        return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(decodedCert));
+        try (PemReader pemReader =
+                new PemReader(
+                        new InputStreamReader(
+                                certificateResource.getInputStream(), StandardCharsets.UTF_8))) {
+            PemObject pemObject = pemReader.readPemObject();
+            byte[] decodedCert = pemObject.getContent();
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(decodedCert));
+        }
     }
 
     public static RSAPrivateKey readPrivateKey(Resource privateKeyResource) throws Exception {
-        String privateKeyString =
-                new String(
-                        FileCopyUtils.copyToByteArray(privateKeyResource.getInputStream()),
-                        StandardCharsets.UTF_8);
-        String privateKeyContent =
-                privateKeyString
-                        .replace("-----BEGIN PRIVATE KEY-----", "")
-                        .replace("-----END PRIVATE KEY-----", "")
-                        .replaceAll("\\R", "")
-                        .replaceAll("\\s+", "");
-        KeyFactory kf = KeyFactory.getInstance("RSA");
-        byte[] decodedKey = Base64.getDecoder().decode(privateKeyContent);
-        return (RSAPrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(decodedKey));
+        try (PemReader pemReader =
+                new PemReader(
+                        new InputStreamReader(
+                                privateKeyResource.getInputStream(), StandardCharsets.UTF_8))) {
+            PemObject pemObject = pemReader.readPemObject();
+            byte[] decodedKey = pemObject.getContent();
+            return (RSAPrivateKey)
+                    KeyFactory.getInstance("RSA")
+                            .generatePrivate(new PKCS8EncodedKeySpec(decodedKey));
+        }
     }
 }

--- a/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/AccountWebController.java
@@ -89,10 +89,9 @@ public class AccountWebController {
         }
 
         SAML2 saml2 = securityProps.getSaml2();
-        if (saml2 != null) {
-            if (saml2.getEnabled()) {
-                providerList.put("/saml2/authenticate/" + saml2.getRegistrationId(), "SAML 2");
-            }
+        if (securityProps.isSaml2Activ()
+                && applicationProperties.getSystem().getEnableAlphaFunctionality()) {
+            providerList.put("/saml2/authenticate/" + saml2.getRegistrationId(), "SAML 2");
         }
         // Remove any null keys/values from the providerList
         providerList
@@ -101,7 +100,8 @@ public class AccountWebController {
         model.addAttribute("providerlist", providerList);
 
         model.addAttribute("loginMethod", securityProps.getLoginMethod());
-        model.addAttribute("altLogin", securityProps.isAltLogin());
+        boolean altLogin = providerList.size() > 0 ? securityProps.isAltLogin() : false;
+        model.addAttribute("altLogin", altLogin);
 
         model.addAttribute("currentPage", "login");
 
@@ -163,6 +163,17 @@ public class AccountWebController {
                     break;
                 case "userIsDisabled":
                     erroroauth = "login.userIsDisabled";
+                    break;
+                case "invalid_destination":
+                    erroroauth = "login.invalid_destination";
+                    break;
+                    // Valid InResponseTo was not available from the validation context, unable to
+                    // evaluate
+                case "invalid_in_response_to":
+                    erroroauth = "login.invalid_in_response_to";
+                    break;
+                case "not_authentication_provider_found":
+                    erroroauth = "login.not_authentication_provider_found";
                     break;
                 default:
                     break;

--- a/src/main/resources/templates/addUsers.html
+++ b/src/main/resources/templates/addUsers.html
@@ -283,25 +283,5 @@
       </script>
       <th:block th:insert="~{fragments/footer.html :: footer}"></th:block>
     </div>
-    <div th:if="${altLogin}" class="modal fade" id="editUserModal" tabindex="-1" role="dialog" aria-labelledby="editUserModalLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="editUserModalLabel" th:text="#{login.ssoSignIn}"></h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-              <span class="material-symbols-rounded">close</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <div class="mb-3" th:each="provider : ${providerlist}">
-              <a th:href="@{|/oauth2/authorization/${provider.key}|}" th:text="${provider.value}" class="w-100 btn btn-lg btn-primary">OpenID Connect</a>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" th:text="#{close}"></button>
-          </div>
-        </div>
-      </div>
-    </div>
   </body>
 </html>


### PR DESCRIPTION
# Description

- Refactored `CertificateUtils` to use `PemReader` for streamlined PEM file processing.
- Simplified SAML2 login logic in `AccountWebController` by adding checks for `securityProps.isSaml2Activ()` and `EnableAlphaFunctionality`.
- Enhanced error handling for SAML2 authentication failures in `AccountWebController`.
- Removed unused modal in `addUsers.html` that displayed alternative login options.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
