### PR TITLE
chore(helm): bump chart version according to semver

### DIFF
--- a/.github/scripts/gradle_to_chart.py
+++ b/.github/scripts/gradle_to_chart.py
@@ -8,17 +8,20 @@ gradle_path = "build.gradle"
 
 def get_chart_version(path):
     """
-    Reads the appVersion from Chart.yaml.
+    Reads the version and the appVersion from Chart.yaml.
 
     Args:
         path (str): The file path to the Chart.yaml.
 
     Returns:
-        str: The appVersion if found, otherwise an empty string.
+        dict: The version under "chart" key and the appVersion under "app" key.
     """
     with open(path, encoding="utf-8") as file:
         chart_yaml = yaml.safe_load(file)
-    return chart_yaml.get("appVersion", "")
+    return {
+      "chart": chart_yaml["version"],
+      "app": chart_yaml["appVersion"]
+    }
 
 
 def get_gradle_version(path):
@@ -39,17 +42,46 @@ def get_gradle_version(path):
     return ""
 
 
-def update_chart_version(path, new_version):
+def get_new_chart_version(chart_version, old_app_version, new_app_version):
+  """
+  Get the new chart version from
+
+  Args:
+      str: The current chart version.
+      str: The current app version.
+      str: The new app version.
+
+  Returns:
+    str: The new chart version to update to.
+  """
+  chart_major, chart_minor, chart_patch = chart_version.split(".")
+
+  old_major, old_minor, old_patch = old_app_version.split(".")
+  new_major, new_minor, new_patch = new_app_version.split(".")
+
+  if old_major != new_major:
+    new_chart_version = f"{int(chart_major)+1}.0.0"
+  elif old_minor != new_minor:
+    new_chart_version = f"{chart_major}.{int(chart_minor)+1}.0"
+  elif old_patch != new_patch:
+    new_chart_version = f"{chart_major}.{chart_minor}.{int(chart_patch)+1}"
+
+  return new_chart_version
+
+
+def update_chart_version(path, new_chart_version, new_app_version):
     """
-    Updates the appVersion in Chart.yaml with a new version.
+    Updates the version and the appVersion in Chart.yaml with a new version.
 
     Args:
         path (str): The file path to the Chart.yaml.
-        new_version (str): The new version to update to.
+        new_chart_version (str): The new chart version to update to.
+        new_app_version (str): The new app version to update to.
     """
     with open(path, encoding="utf-8") as file:
         chart_yaml = yaml.safe_load(file)
-    chart_yaml["appVersion"] = new_version
+    chart_yaml["version"] = new_chart_version
+    chart_yaml["appVersion"] = new_app_version
     with open(path, "w", encoding="utf-8") as file:
         yaml.safe_dump(chart_yaml, file)
 
@@ -58,10 +90,11 @@ def update_chart_version(path, new_version):
 chart_version = get_chart_version(chart_yaml_path)
 gradle_version = get_gradle_version(gradle_path)
 
-if chart_version != gradle_version:
+if chart_version["app"] != gradle_version:
+    new_chart_version = get_new_chart_version(chart_version["chart"], chart_version["app"], gradle_version, )
     print(
-        f"Versions do not match. Updating Chart.yaml from {chart_version} to {gradle_version}."
+        f"Versions do not match. Updating Chart.yaml from {chart_version['chart']} to {new_chart_version}."
     )
-    update_chart_version(chart_yaml_path, gradle_version)
+    update_chart_version(chart_yaml_path, new_chart_version, gradle_version)
 else:
     print("Versions match. No update required.")


### PR DESCRIPTION
# Description
This is the first step for addressing [Stirling-PDF issue #2107](https://github.com/Stirling-Tools/Stirling-PDF/issues/2107).

The new script will set both the application version (as before) and the chart version (new functionality) as follows:

- When the application **major** version is updated, the **chart's major version** is incremented (minor and patch will be set to 0).
- When the application **minor** version is updated, the **chart's minor version** is incremented (patch will be set to 0).
- When the application **patch** version is updated, the **chart's patch version** is incremented.

I’ve assumed that Stirling follows Semantic Versioning (SemVer) in the Gradle file.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
