### PR TITLE
navbar.css: prevent overlapping of elements

### DIFF
--- a/src/main/resources/static/css/navbar.css
+++ b/src/main/resources/static/css/navbar.css
@@ -329,11 +329,14 @@ span.icon-text::after {
   }
 }
 
- .go-pro-link {
+.go-pro-link {
    position: relative;
    padding: 0.5rem 1rem;
    transition: all 0.3s ease;
- }
+   z-index: 1;
+   display: inline-block;
+   width: auto;
+}
 
 .go-pro-badge {
   display: inline-block;


### PR DESCRIPTION

# Description

go-pro-link is overlapping the settings button (de_DE)

Closes #(issue_number)

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
