### PR TITLE
fix signature logo not loading and add option to disable it

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -104,7 +105,7 @@ public class CertSignController {
             super(keystore, pin);
             ClassPathResource resource = new ClassPathResource("static/images/signature.png");
             try (InputStream is = resource.getInputStream()) {
-                logoFile = File.createTempFile("signature", ".png");
+                logoFile = Files.createTempFile("signature", ".png").toFile();
                 FileUtils.copyInputStreamToFile(is, logoFile);
             } catch (IOException e) {
                 logger.error("Failed to load image signature file");

--- a/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
+++ b/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
@@ -50,4 +50,7 @@ public class SignPDFWithCertRequest extends PDFFile {
             description =
                     "The page number where the signature should be visible. This is required if showSignature is set to true")
     private Integer pageNumber;
+
+    @Schema(description = "Whether to visually show a signature logo along with the signature")
+    private boolean showLogo;
 }

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -750,6 +750,7 @@ certSign.showSig=Show Signature
 certSign.reason=Reason
 certSign.location=Location
 certSign.name=Name
+certSign.showLogo=Show Logo
 certSign.submit=Sign PDF
 
 

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -750,6 +750,7 @@ certSign.showSig=Show Signature
 certSign.reason=Reason
 certSign.location=Location
 certSign.name=Name
+certSign.showLogo=Show Logo
 certSign.submit=Sign PDF
 
 

--- a/src/main/resources/templates/security/cert-sign.html
+++ b/src/main/resources/templates/security/cert-sign.html
@@ -71,7 +71,11 @@
                     <label for="name" th:text="#{certSign.name}"></label> <input type="text" class="form-control" id="name" name="name">
                   </div>
                   <div class="mb-3">
-                    <label for="pageNumber" th:text="#{pageNum}"></label> <input type="number" class="form-control" id="pageNumber" name="pageNumber" min="1">
+                    <label for="pageNumber" th:text="#{pageNum}"></label> <input type="number" class="form-control" id="pageNumber" name="pageNumber" min="1" value="1">
+                  </div>
+                  <div class="form-check mb-3">
+                    <input type="checkbox" id="showLogo" name="showLogo" checked />
+                    <label th:text="#{certSign.showLogo}" for="showLogo"></label>
                   </div>
                 </div>
                 <div class="mb-3 text-left">


### PR DESCRIPTION
# Description

Fix the signature logo not loading correctly in jar/docker runtimes.
Add option to disable rendering the logo with the signature.

Closes #2141 

## Checklist

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
