### PR TITLE
Fix: Navbar layout overflow

### DIFF
--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -12,7 +12,7 @@
     const updateAvailable =  /*[[#{settings.updateAvailable}]]*/ '';
   </script>
   <script th:src="@{'/js/githubVersion.js'}"></script>
-  <nav class="navbar navbar-expand-lg">
+  <nav class="navbar navbar-expand-xl">
     <div class="container ">
       <a class="navbar-brand" th:href="@{'/'}" style="display: flex;">
         <img class="main-icon" th:src="@{'/favicon.svg'}" alt="icon">


### PR DESCRIPTION
# Description

This PR resolves an issue where elements were getting hidden behind the navbar, resulting in a horizontal scroll bar on screens narrower than 1200px. By adjusting the navbar’s breakpoint class from navbar-expand-lg to navbar-expand-xl, the navbar now collapses sooner, preventing elements from being obscured and avoiding overflow.

Closes #2097 

# Details
**Issue:** Elements were hidden behind the navbar on smaller screens, causing layout overflow and a horizontal scroll bar.
**Solution:** Adjusted the Bootstrap class to navbar-expand-xl, ensuring the navbar collapses at a wider screen size, which keeps all elements visible and eliminates the scroll bar.


https://github.com/user-attachments/assets/838eb1a6-85c3-4583-b1c5-d45fcde1db39








## Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
