### PR TITLE
chore(ci): fix helm lint check

### DIFF
--- a/.github/workflows/lint-helm-charts.yml
+++ b/.github/workflows/lint-helm-charts.yml
@@ -29,7 +29,7 @@ jobs:
         - name: Run pre-commit
           uses: pre-commit/action@v3.0.1
           with:
-            extra_args: helm-docs-built
+            extra_args: helm-docs-built --chart-search-root=chart
 
         - name: Set up chart-testing
           uses: helm/chart-testing-action@v2

--- a/.github/workflows/lint-helm-charts.yml
+++ b/.github/workflows/lint-helm-charts.yml
@@ -26,10 +26,10 @@ jobs:
           with:
             python-version: '3.10'
 
-        - name: Run pre-commit
-          uses: pre-commit/action@v3.0.1
+        - name: Ensure documentation is updated
+          uses: docker://jnorwood/helm-docs:v1.14.2
           with:
-            extra_args: helm-docs-built --chart-search-root=chart
+            args: --chart-search-root=chart
 
         - name: Set up chart-testing
           uses: helm/chart-testing-action@v2

--- a/.github/workflows/sync_files.yml
+++ b/.github/workflows/sync_files.yml
@@ -26,10 +26,10 @@ jobs:
         run: pip install pyyaml
       - name: Sync versions
         run: python .github/scripts/gradle_to_chart.py
-      - name: Run pre-commit helm-docs-built
-        uses: pre-commit/action@v3.0.1
+      - name: Ensure documentation is updated
+        uses: docker://jnorwood/helm-docs:v1.14.2
         with:
-          extra_args: helm-docs-built
+          args: --chart-search-root=chart
       - name: Set up git config
         run: |
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
# Description

Fix helm lint CI. I though the action would use the `.pre-commit-config.yaml` but is not. This update avoid installing pre-commit and all hooks when only one is needed.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
