### PR TITLE
Restricting file input to .md files for Markdown to PDF conversion

### DIFF
--- a/src/main/resources/templates/convert/markdown-to-pdf.html
+++ b/src/main/resources/templates/convert/markdown-to-pdf.html
@@ -18,7 +18,7 @@
                 <span class="tool-header-text" th:text="#{MarkdownToPDF.header}"></span>
               </div>
               <form method="post" enctype="multipart/form-data" th:action="@{'/api/v1/convert/markdown/pdf'}">
-                <div th:replace="~{fragments/common :: fileSelector(name='fileInput', multipleInputsForSingleRequest=false, accept='text/markdown')}"></div>
+                <div th:replace="~{fragments/common :: fileSelector(name='fileInput', multipleInputsForSingleRequest=false, accept='.md')}"></div>
                 <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{MarkdownToPDF.submit}"></button>
               </form>
               <p class="mt-3" th:text="#{MarkdownToPDF.help}"></p>


### PR DESCRIPTION
# Description

This PR restricts the file input for the "Markdown to PDF" feature to accept only .md files. Previously, the input allowed all file types, which could lead to errors if unsupported file types were selected.

Closes #2218 

# Details

**Feature URL:**  https://stirlingpdf.io/markdown-to-pdf

**Issue:** The current file input for the "Markdown to PDF" feature allows users to upload any type of file, not just .md (Markdown) files. 

**Solution:** This pull request resolves the issue by restricting the file input to accept only .md files


https://github.com/user-attachments/assets/83968889-4fc1-4d21-b414-cbe0e5d13c92




## Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
