### PR TITLE
Increase watermark coverage to fill page (#2049)

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -187,24 +187,32 @@ public class WatermarkController {
         float watermarkHeight = heightSpacer + fontSize * textLines.length;
         float pageWidth = page.getMediaBox().getWidth();
         float pageHeight = page.getMediaBox().getHeight();
-        int watermarkRows = (int) (pageHeight / watermarkHeight + 1);
-        int watermarkCols = (int) (pageWidth / watermarkWidth + 1);
 
-        // Calculating the effective line length according to the angle used
-        float effectiveHeight = watermarkHeight / (float) Math.cos(Math.toRadians(rotation));
-        int watermarkRowsRotation = (int) (pageHeight / effectiveHeight + 1);
+
+        //Calculating the new width and height depending on the angle.
+        float radians = (float) Math.toRadians(rotation);
+        float newWatermarkWidth =
+                (float)
+                        (Math.abs(watermarkWidth * Math.cos(radians))
+                                + Math.abs(watermarkHeight * Math.sin(radians)));
+        float newWatermarkHeight =
+                (float)
+                        (Math.abs(watermarkWidth * Math.sin(radians))
+                                + Math.abs(watermarkHeight * Math.cos(radians)));
+
+        //Calculating the number of rows and columns.
+        int watermarkRows = (int) (pageHeight / newWatermarkHeight + 1);
+        int watermarkCols = (int) (pageWidth / newWatermarkWidth + 1);
 
         // Add the text watermark
-        /* In the 'for' loop, is do (watermarkRowsRotation - watermarkRows) so that the watermark starts at the bottom of the page.
-        This compensate for the rotation by adjusting the starting point for inserting the watermark. */
-        for (int i = (watermarkRowsRotation - watermarkRows); i < watermarkRows; i++) {
-            for (int j = 0; j < watermarkCols; j++) {
+        for (int i = 0; i <= watermarkRows; i++) {
+            for (int j = 0; j <= watermarkCols; j++) {
                 contentStream.beginText();
                 contentStream.setTextMatrix(
                         Matrix.getRotateInstance(
                                 (float) Math.toRadians(rotation),
-                                j * watermarkWidth,
-                                i * watermarkHeight));
+                                j * newWatermarkWidth,
+                                i * newWatermarkHeight));
 
                 for (int k = 0; k < textLines.length; ++k) {
                     contentStream.showText(textLines[k]);

--- a/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -190,8 +190,14 @@ public class WatermarkController {
         int watermarkRows = (int) (pageHeight / watermarkHeight + 1);
         int watermarkCols = (int) (pageWidth / watermarkWidth + 1);
 
+        // Calculating the effective line length according to the angle used
+        float effectiveHeight = watermarkHeight / (float) Math.cos(Math.toRadians(rotation));
+        int watermarkRowsRotation = (int) (pageHeight / effectiveHeight + 1);
+
         // Add the text watermark
-        for (int i = 0; i < watermarkRows; i++) {
+        /* In the 'for' loop, is do (watermarkRowsRotation - watermarkRows) so that the watermark starts at the bottom of the page.
+        This compensate for the rotation by adjusting the starting point for inserting the watermark. */
+        for (int i = (watermarkRowsRotation - watermarkRows); i < watermarkRows; i++) {
             for (int j = 0; j < watermarkCols; j++) {
                 contentStream.beginText();
                 contentStream.setTextMatrix(


### PR DESCRIPTION
# Description

Correcting the watermark functionality and adding "Increase watermark coverage to fill page.".

**Issue:** When adding the text watermark, it was positioned starting from the bottom of the page. However, with the rotation applied, empty space was left because the watermark insertion started from the tip of the text, causing misalignment.

**Solution:** :
The following file was modified: 
- modified: `src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java`

**FIle**: `WatermarkController.java`

- The `addTextWatermark()` function was modified so that the watermark is correctly positioned, taking into account the text rotation. The effective height of the watermark was calculated using the cosine of the angle, and the starting point was adjusted to prevent the empty space that occurred in the original insertion.

![addTextWatermark](https://github.com/user-attachments/assets/f07eefe4-4b0d-40b1-a4f1-de907cc1a7af)


**Before:**
![Before](https://github.com/user-attachments/assets/9a83eeb7-43e0-4044-9d74-c46e3f178e40)


**After:**
![After](https://github.com/user-attachments/assets/17c35d32-76a8-4791-9576-8fc8157ee7cf)



Closes #2049 

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
