### PR TITLE
Fix: Ensure backend receives false when checkbox is unchecked in split-pdf-by-chapters feature

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
@@ -60,6 +60,7 @@ public class SplitPdfByChaptersController {
             throws Exception {
         MultipartFile file = request.getFileInput();
         boolean includeMetadata = request.getIncludeMetadata();
+        System.out.println("includeMetada -> " + includeMetadata);
         Integer bookmarkLevel =
                 request.getBookmarkLevel(); // levels start from 0 (top most bookmarks)
         if (bookmarkLevel < 0) {
@@ -94,6 +95,7 @@ public class SplitPdfByChaptersController {
         }
 
         boolean allowDuplicates = request.getAllowDuplicates();
+        System.out.println("allowDuplicates -> " + allowDuplicates);
         if (!allowDuplicates) {
             /*
             duplicates are generated when multiple bookmarks correspond to the same page,

--- a/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
@@ -60,7 +60,6 @@ public class SplitPdfByChaptersController {
             throws Exception {
         MultipartFile file = request.getFileInput();
         boolean includeMetadata = request.getIncludeMetadata();
-        System.out.println("includeMetada -> " + includeMetadata);
         Integer bookmarkLevel =
                 request.getBookmarkLevel(); // levels start from 0 (top most bookmarks)
         if (bookmarkLevel < 0) {
@@ -95,7 +94,6 @@ public class SplitPdfByChaptersController {
         }
 
         boolean allowDuplicates = request.getAllowDuplicates();
-        System.out.println("allowDuplicates -> " + allowDuplicates);
         if (!allowDuplicates) {
             /*
             duplicates are generated when multiple bookmarks correspond to the same page,

--- a/src/main/resources/templates/split-pdf-by-chapters.html
+++ b/src/main/resources/templates/split-pdf-by-chapters.html
@@ -31,11 +31,13 @@
             <div class="mb-3 form-check">
               <input type="checkbox" class="form-check-input" id="includeMetadata" name="includeMetadata">
               <label class="form-check-label" for="includeMetadata" th:text="#{splitByChapters.includeMetadata}"></label>
+              <input type="hidden" name="includeMetadata" value="false" />
             </div>
 
             <div class="mb-3 form-check">
               <input type="checkbox" class="form-check-input" id="allowDuplicates" name="allowDuplicates">
               <label class="form-check-label" for="allowDuplicates" th:text="#{splitByChapters.allowDuplicates}"></label>
+              <input type="hidden" name="allowDuplicates" value="false" />
             </div>
 
             <p>


### PR DESCRIPTION
# Description

This PR resolves an issue in the "split-pdf-by-chapters" feature where the backend was not receiving a false value when the checkbox was unchecked. Instead, the backend failed to properly process the unchecked state, leading to unexpected behavior.

Closes #2233 


**Feature URL:** https://stirlingpdf.io/split-pdf-by-chapters

# Changes 

1. Implemented hidden input tags to ensure that when the checkbox is unchecked, the form sends a **false** value to the backend.
2. This fix ensures that the backend receives the correct value (false) when the checkbox is not selected


https://github.com/user-attachments/assets/c282d2bc-8bec-45e9-9691-66075d780e7b



## Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [X] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
