### PR TITLE
Clear file inputs after jobs

### DIFF
--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -81,6 +81,7 @@ page=Page
 pages=Pages
 loading=Loading...
 addToDoc=Add to Document
+reset=Reset
 
 legal.privacy=Privacy Policy
 legal.terms=Terms and Conditions

--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -64,6 +64,8 @@
             await handleSingleDownload(url, formData);
           }
         }
+
+        clearFileInput();
         clearTimeout(timeoutId);
         $("#submitBtn").text(originalButtonText);
 
@@ -85,6 +87,7 @@
         }
 
       } catch (error) {
+        clearFileInput();
         clearTimeout(timeoutId);
         handleDownloadError(error);
         $("#submitBtn").text(originalButtonText);
@@ -116,11 +119,15 @@
 
       const blob = await response.blob();
       if (contentType.includes("application/pdf") || contentType.includes("image/")) {
+        clearFileInput();
         return handleResponse(blob, filename, !isMulti, isZip);
       } else {
+        clearFileInput();
         return handleResponse(blob, filename, false, isZip);
       }
+
     } catch (error) {
+      clearFileInput();
       console.error("Error in handleSingleDownload:", error);
       throw error;
     }
@@ -291,4 +298,27 @@
     }
   });
 
+  // Clear file input after job
+  function clearFileInput(){
+    let pathname = document.location.pathname;
+    if(pathname != "/merge-pdfs"){
+      let formElement = document.querySelector("#fileInput-input");
+      formElement.value = '';
+      let editSectionElement = document.querySelector("#editSection");
+      if(editSectionElement){
+        editSectionElement.style.display = "none";
+      }
+      let cropPdfCanvas = document.querySelector("#crop-pdf-canvas");
+      let overlayCanvas = document.querySelector("#overlayCanvas");
+      if(cropPdfCanvas && overlayCanvas){
+        cropPdfCanvas.width = 0;
+        cropPdfCanvas.heigth = 0;
+
+        overlayCanvas.width = 0;
+        overlayCanvas.heigth = 0;
+      }
+    } else{
+      console.log("Disabled for 'Merge'");
+    }
+  }
 })();

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -21,7 +21,7 @@ async function displayFiles(files) {
   for (let i = 0; i < files.length; i++) {
     const pageCount = await getPDFPageCount(files[i]);
     const pageLabel = pageCount === 1 ? pageTranslation : pagesTranslation;
-    
+
     // Create list item
     const item = document.createElement("li");
     item.className = "list-group-item";
@@ -173,3 +173,18 @@ function updateFiles() {
   }
   document.getElementById("fileInput-input").files = dataTransfer.files;
 }
+
+document.querySelector("#resetFileInputBtn").addEventListener("click", ()=>{
+  let formElement = document.querySelector("#fileInput-input");
+    formElement.value = '';
+    clearLiElements();
+    updateFiles();
+
+});
+
+function clearLiElements(){
+  let listGroupItemNodeList = document.querySelectorAll(".list-group-item");
+  for (let i = 0; i < listGroupItemNodeList.length; i++) {
+    listGroupItemNodeList[i].remove();
+    };
+  }

--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -28,6 +28,7 @@ class PdfContainer {
     this.toggleSelectPageVisibility = this.toggleSelectPageVisibility.bind(this);
     this.updatePagesFromCSV = this.updatePagesFromCSV.bind(this);
     this.addFilesBlankAll = this.addFilesBlankAll.bind(this)
+    this.removeAllElements = this.removeAllElements.bind(this);
 
     this.pdfAdapters = pdfAdapters;
 
@@ -53,6 +54,7 @@ class PdfContainer {
     window.updateSelectedPagesDisplay = this.updateSelectedPagesDisplay;
     window.updatePageNumbersAndCheckboxes = this.updatePageNumbersAndCheckboxes;
     window.addFilesBlankAll = this.addFilesBlankAll
+    window.removeAllElements = this.removeAllElements;
 
     const filenameInput = document.getElementById("filename-input");
     const downloadBtn = document.getElementById("export-button");
@@ -292,6 +294,16 @@ class PdfContainer {
 
       this.rotateElement(img, deg);
     }
+  }
+
+  removeAllElements(){
+    let pageContainerNodeList = document.querySelectorAll(".page-container");
+    for (var i = 0; i < pageContainerNodeList.length; i++) {
+      pageContainerNodeList[i].remove();
+    }
+    document.querySelectorAll(".enable-on-file").forEach((element) => {
+      element.disabled = true;
+    });
   }
 
   deleteSelected() {

--- a/src/main/resources/templates/merge-pdfs.html
+++ b/src/main/resources/templates/merge-pdfs.html
@@ -40,6 +40,9 @@
                 <button type="button" id="sortByDateBtn" class="btn btn-info" th:text="#{merge.sortByDate}"></button>
                 <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{merge.submit}"></button>
               </div>
+              <div class="mb-3">
+                <button type="button" id="resetFileInputBtn" class="btn btn-danger" th:text="#{reset}">Reset</button>
+              </div>
             </form>
             <span id="pageTranslation" th:text="#{page}" style="display:none;"></span>
             <span id="pagesTranslation" th:text="#{pages}" style="display:none;"></span>

--- a/src/main/resources/templates/multi-tool.html
+++ b/src/main/resources/templates/multi-tool.html
@@ -83,6 +83,9 @@
                     </span>
                   </button>
                 </div>
+                <div class="mb-3">
+                  <button type="button" id="resetFileInputBtn" class="btn btn-danger" onclick="removeAllElements()" th:text="#{reset}">Reset</button>
+                </div>
                 <div id="selected-pages-display" class="selected-pages-container hidden">
                   <div style="display:flex; height:3rem; margin-right:1rem">
                     <h5 th:text="#{multiTool.selectedPages}" style="white-space: nowrap; margin-right: 1rem;">Selected

--- a/src/main/resources/templates/rotate-pdf.html
+++ b/src/main/resources/templates/rotate-pdf.html
@@ -68,7 +68,7 @@
     fileInput.addEventListener("change", async function () {
       console.log("loading pdf");
 
-      document.querySelector("#editSection").style.display = "";
+      document.querySelector("#editSection").style.display = "block";
 
       const existingPreview = document.getElementById("pdf-preview");
       if (existingPreview) {


### PR DESCRIPTION
# Description
File inputs now automatically get cleared after jobs. Specifically for "Merge" and "Multi tool" this function is manual, users need to press the "Reset" button to clear the file inputs.
For "Rotate" and "Crop", UI gets reset after as well.

New "Reset" button for "Merge":

![merge-ui](https://github.com/user-attachments/assets/1a1e0d52-c393-4155-b656-2bf6ae610761)


Closes #2172 

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
