### PR TITLE
Fix id typo for "cropPdfCanvas" querySelector

### DIFF
--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -308,14 +308,14 @@
       if(editSectionElement){
         editSectionElement.style.display = "none";
       }
-      let cropPdfCanvas = document.querySelector("#crop-pdf-canvas");
+      let cropPdfCanvas = document.querySelector("#cropPdfCanvas");
       let overlayCanvas = document.querySelector("#overlayCanvas");
       if(cropPdfCanvas && overlayCanvas){
         cropPdfCanvas.width = 0;
-        cropPdfCanvas.heigth = 0;
+        cropPdfCanvas.height = 0;
 
         overlayCanvas.width = 0;
-        overlayCanvas.heigth = 0;
+        overlayCanvas.height = 0;
       }
     } else{
       console.log("Disabled for 'Merge'");


### PR DESCRIPTION
# Description
Fix a typo for querySelector("#cropPdfCanvas")


## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
