### PR TITLE
Fix: Expand and de-clutter menus for matching search results in homepage #2264

### DIFF
--- a/src/main/resources/static/js/homecard.js
+++ b/src/main/resources/static/js/homecard.js
@@ -1,24 +1,33 @@
 function filterCards() {
   var input = document.getElementById("searchBar");
   var filter = input.value.toUpperCase();
-  var cards = document.querySelectorAll(".feature-card");
+  let featureGroups = document.querySelectorAll(".feature-group");
 
-  for (var i = 0; i < cards.length; i++) {
-    var card = cards[i];
-    var title = card.querySelector("h5.card-title").innerText;
-    var text = card.querySelector("p.card-text").innerText;
+  for (const featureGroup of featureGroups) {
+    var cards = featureGroup.querySelectorAll(".feature-card");
 
-    // Get the navbar tags associated with the card
-    var navbarItem = document.querySelector(`a.dropdown-item[href="${card.id}"]`);
-    var navbarTags = navbarItem ? navbarItem.getAttribute("data-bs-tags") : "";
+    let groupMatchesFilter = false;
+    for (var i = 0; i < cards.length; i++) {
+      var card = cards[i];
+      var title = card.querySelector("h5.card-title").innerText;
+      var text = card.querySelector("p.card-text").innerText;
 
-    var content = title + " " + text + " " + navbarTags;
+      // Get the navbar tags associated with the card
+      var navbarItem = document.querySelector(`a.dropdown-item[href="${card.id}"]`);
+      var navbarTags = navbarItem ? navbarItem.getAttribute("data-bs-tags") : "";
 
-    if (content.toUpperCase().indexOf(filter) > -1) {
-      card.style.display = "";
-    } else {
-      card.style.display = "none";
+      var content = title + " " + text + " " + navbarTags;
+
+      if (content.toUpperCase().indexOf(filter) > -1) {
+        card.style.display = "";
+        groupMatchesFilter = true;
+      } else {
+        card.style.display = "none";
+      }
     }
+
+    if (!groupMatchesFilter) featureGroup.style.display = "none";
+    else featureGroup.style.display = "";
   }
 }
 

--- a/src/main/resources/static/js/homecard.js
+++ b/src/main/resources/static/js/homecard.js
@@ -1,7 +1,9 @@
 function filterCards() {
   var input = document.getElementById("searchBar");
   var filter = input.value.toUpperCase();
+
   let featureGroups = document.querySelectorAll(".feature-group");
+  const collapsedGroups = getCollapsedGroups();
 
   for (const featureGroup of featureGroups) {
     var cards = featureGroup.querySelectorAll(".feature-card");
@@ -26,8 +28,29 @@ function filterCards() {
       }
     }
 
-    if (!groupMatchesFilter) featureGroup.style.display = "none";
-    else featureGroup.style.display = "";
+    if (!groupMatchesFilter) {
+      featureGroup.style.display = "none";
+    } else {
+      featureGroup.style.display = "";
+      resetOrTemporarilyExpandGroup(featureGroup, filter, collapsedGroups);
+    }
+  }
+}
+
+function getCollapsedGroups() {
+  return localStorage.getItem("collapsedGroups") ? JSON.parse(localStorage.getItem("collapsedGroups")) : [];
+}
+
+function resetOrTemporarilyExpandGroup(featureGroup, filterKeywords = "", collapsedGroups = []) {
+  const shouldResetCollapse = filterKeywords.trim() === "";
+  if (shouldResetCollapse) {
+    // Resetting the group's expand/collapse to its original state (as in collapsed groups)
+    const isCollapsed = collapsedGroups.indexOf(featureGroup.id) != -1;
+    expandCollapseToggle(featureGroup, !isCollapsed);
+  } else {
+    // Temporarily expands feature group without affecting the actual/stored collapsed groups
+    featureGroup.classList.remove("collapsed");
+    featureGroup.querySelector(".header-expand-button").classList.remove("collapsed");
   }
 }
 


### PR DESCRIPTION
# Description

- Fix a bug where menus (accordions/feature groups) did not automatically expand on the homepage when search results matched.
- De-clutter search results by hiding empty menus.

**UI Change:**

- Image:

![image](https://github.com/user-attachments/assets/7f4cb07e-d8e7-436c-bbce-496ee00f5ab2)


- GIF:

![fix-search-bar-homepage-menu-collapse](https://github.com/user-attachments/assets/db6c3f0a-9d54-49dd-99e2-a2aed5648908)

Closes #2264

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
