### PR TITLE
Fix file clear for errors

### DIFF
--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -95,7 +95,6 @@
         }
 
       } catch (error) {
-        clearFileInput();
         clearTimeout(timeoutId);
         showGameBtn.style.display = "none";
         submitButton.textContent = originalButtonText;
@@ -117,13 +116,13 @@
       return null;
     }
   }
-  
+
   async function handleSingleDownload(url, formData, isMulti = false, isZip = false) {
     const startTime = performance.now();
     const file = formData.get('fileInput');
     let success = false;
     let errorMessage = null;
-    
+
     try {
       const response = await fetch(url, { method: "POST", body: formData });
       const contentType = response.headers.get("content-type");
@@ -146,7 +145,7 @@
 
       const blob = await response.blob();
       success = true;
-      
+
       if (contentType.includes("application/pdf") || contentType.includes("image/")) {
         clearFileInput();
         return handleResponse(blob, filename, !isMulti, isZip);
@@ -158,12 +157,11 @@
     } catch (error) {
       success = false;
       errorMessage = error.message;
-      clearFileInput();
       console.error("Error in handleSingleDownload:", error);
       throw error;
     } finally {
       const processingTime = performance.now() - startTime;
-      
+
       // Capture analytics
       const pageCount = file && file.type === 'application/pdf' ? await getPDFPageCount(file) : null;
       if(analyticsEnabled) {
@@ -191,7 +189,7 @@
 
     return filename;
   }
-  
+
   async function handleJsonResponse(response) {
     const json = await response.json();
     const errorMessage = JSON.stringify(json, null, 2);

--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -39,7 +39,9 @@
       const originalButtonText = submitButton.textContent;
       var boredWaiting = localStorage.getItem("boredWaiting") || "disabled";
 
-      showGameBtn.style.display = "none";
+      if (showGameBtn) {
+        showGameBtn.style.display = "none";
+      }
 
       // Remove empty file entries
       for (let [key, value] of formData.entries()) {
@@ -73,8 +75,10 @@
 
         clearFileInput();
         clearTimeout(timeoutId);
-        showGameBtn.style.display = "none";
-        showGameBtn.style.marginTop = "";
+        if (showGameBtn) {
+          showGameBtn.style.display = "none";
+          showGameBtn.style.marginTop = "";
+        }
         submitButton.textContent = originalButtonText;
         submitButton.disabled = false;
 


### PR DESCRIPTION
# Description
Prevents file input from being cleared when an error occurs while processing the file
Fixes a bug that prevents the fetch request from being sent when a "Bored waiting" button can't be found.

Closes #

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
