### PR TITLE
Adding customizable `logoutUrl` for generic oAuth2 / OpenId connect

### DIFF
--- a/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
+++ b/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
@@ -183,6 +183,7 @@ public class ApplicationProperties {
             @ToString.Exclude private String clientSecret;
             private Boolean autoCreateUser = false;
             private Boolean blockRegistration = false;
+            private String logoutUrl;
             private String useAsUsername;
             private Collection<String> scopes = new ArrayList<>();
             private String provider;

--- a/src/main/resources/settings.yml.template
+++ b/src/main/resources/settings.yml.template
@@ -47,6 +47,7 @@ security:
     useAsUsername: email # default is 'email'; custom fields can be used as the username
     scopes: openid, profile, email # specify the scopes for which the application will request permissions
     provider: google # set this to your OAuth provider's name, e.g., 'google' or 'keycloak'
+    logoutUrl: '' # logout URL to call at he issuer, may be used with 3 variables, for instance : '/connect/logout?id_token_hint={tokenId}&client_id={clientId}&post_logout_redirect_uri={redirectUrl}'
   saml2:
     enabled: false # currently in alpha, not recommended for use yet, enableAlphaFunctionality must be set to true
     autoCreateUser: false # set to 'true' to allow auto-creation of non-existing users


### PR DESCRIPTION
# Description

Adding a option to call a logout URL on the remote issuer for oauth/OIDC.

Closes #(issue_number)

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
