### PR TITLE
Fix: input file overwrite in merge

### DIFF
--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -96,6 +96,7 @@ function setupFileInput(chooser) {
     }
 
     handleFileInputChange(this);
+    this.dispatchEvent(new CustomEvent("file-input-change", { bubbles: true }));
   });
 
   function handleFileInputChange(inputElement) {

--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -64,7 +64,7 @@ function setupFileInput(chooser) {
 
     dragCounter = 0;
 
-    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    fileInput.dispatchEvent(new CustomEvent("change", { bubbles: true, detail: {source: 'drag-drop'} }));
   };
 
   ["dragenter", "dragover", "dragleave", "drop"].forEach((eventName) => {
@@ -81,7 +81,20 @@ function setupFileInput(chooser) {
   document.body.addEventListener("drop", dropListener);
 
   $("#" + elementId).on("change", function (e) {
-    allFiles = Array.from(e.target.files);
+    let element = e.target;
+    const isDragAndDrop = e.detail?.source == 'drag-drop';
+    if (element instanceof HTMLInputElement && element.hasAttribute("multiple")) {
+      allFiles = isDragAndDrop ? allFiles : [... allFiles, ... element.files];
+  } else {
+    allFiles = Array.from(isDragAndDrop ? allFiles : element.files[0]);
+  }
+
+    if (!isDragAndDrop) {
+      let dataTransfer = new DataTransfer();
+      allFiles.forEach(file => dataTransfer.items.add(file));
+      element.files = dataTransfer.files;
+    }
+
     handleFileInputChange(this);
   });
 

--- a/src/main/resources/static/js/merge.js
+++ b/src/main/resources/static/js/merge.js
@@ -3,7 +3,7 @@ let currentSort = {
   descending: false,
 };
 
-document.getElementById("fileInput-input").addEventListener("change", function () {
+document.getElementById("fileInput-input").addEventListener("file-input-change", function () {
   var files = this.files;
   displayFiles(files);
 });


### PR DESCRIPTION
# Description

## Problem:
Each time a new file input operation takes place, all the existing file(s) are replaced with the newly selected file(s).

## Reason:
When a user tries to upload a file using \<input\> by selecting the file(s) from the file system, a "change" event is triggered, this event should be handled by appending newly selected files to existing ones and adding it as well to element.files (the input element's files).

## Solution:
1. Differentiating between drag and drop files and input uploaded approaches using "source" in event.detail.source (to handle each of them accordingly).
2. After appending the necessary files to the input element and allFiles, dispatch a "file-input-change" event to allow other components/functions/files/modules to perform their operations on all of the selected files (after appending upload/drag-drop files).

Closes #2285

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
