### PR TITLE
Fix: page break insertion functionality in Multi Tool

### DIFF
--- a/src/main/resources/static/js/multitool/PdfContainer.js
+++ b/src/main/resources/static/js/multitool/PdfContainer.js
@@ -165,43 +165,14 @@ class PdfContainer {
 
 
   async addFilesBlank(nextSiblingElement) {
-    const pdfContent = `
-      %PDF-1.4
-      1 0 obj
-      << /Type /Catalog /Pages 2 0 R >>
-      endobj
-      2 0 obj
-      << /Type /Pages /Kids [3 0 R] /Count 1 >>
-      endobj
-      3 0 obj
-      << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 5 0 R >>
-      endobj
-      5 0 obj
-      << /Length 44 >>
-      stream
-      0 0 0 595 0 842 re
-      W
-      n
-      endstream
-      endobj
-      xref
-      0 6
-      0000000000 65535 f
-      0000000010 00000 n
-      0000000071 00000 n
-      0000000121 00000 n
-      0000000205 00000 n
-      0000000400 00000 n
-      trailer
-      << /Size 6 /Root 1 0 R >>
-      startxref
-      278
-      %%EOF
-    `;
-    const blob = new Blob([pdfContent], { type: 'application/pdf' });
-    const url = URL.createObjectURL(blob);
-    const file = new File([blob], "blank_page.pdf", { type: "application/pdf" });
-    await this.addPdfFile(file, nextSiblingElement);
+    let doc = await PDFLib.PDFDocument.create();
+    let docBytes = await doc.save();
+
+    const url = URL.createObjectURL(new Blob([docBytes], { type: 'application/pdf' }));
+
+    const renderer = await this.toRenderer(url);
+
+    await this.addPdfFile(renderer, doc, nextSiblingElement);
   }
 
 


### PR DESCRIPTION
# Description

## Problem:
- Clicking on "Insert Page Break" button didn't insert any page breaks in Multi Tool.

Closes #2349

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
