### PR TITLE
Fix Array.from syntax in nonmultiple file upload

### DIFF
--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -86,7 +86,7 @@ function setupFileInput(chooser) {
     if (element instanceof HTMLInputElement && element.hasAttribute("multiple")) {
       allFiles = isDragAndDrop ? allFiles : [... allFiles, ... element.files];
   } else {
-    allFiles = Array.from(isDragAndDrop ? allFiles : element.files[0]);
+    allFiles = Array.from(isDragAndDrop ? allFiles : [element.files[0]]);
   }
 
     if (!isDragAndDrop) {


### PR DESCRIPTION
# Description

- Fix Array.from syntax in non-multiple file upload as Array.from(<non-array or non-string>) returns an empty array which is the case when a file is selected from an input element (when multiple attribute isn't supported) which can be found in Array.from(element.files[0]) -> results in an empty array.


Closes #(issue_number)

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
