### PR TITLE
Fix allowing multiple files to be dropped onto a single file input

### DIFF
--- a/src/main/resources/static/js/fileInput.js
+++ b/src/main/resources/static/js/fileInput.js
@@ -47,14 +47,16 @@ function setupFileInput(chooser) {
     const dt = e.dataTransfer;
     const files = dt.files;
 
-    for (let i = 0; i < files.length; i++) {
-      allFiles.push(files[i]);
+    const fileInput = document.getElementById(elementId);
+    if (fileInput?.hasAttribute("multiple")) {
+      files.forEach(file => allFiles.push(file));
+    } else if (fileInput) {
+      allFiles = [files[0]];
     }
 
     const dataTransfer = new DataTransfer();
     allFiles.forEach((file) => dataTransfer.items.add(file));
 
-    const fileInput = document.getElementById(elementId);
     fileInput.files = dataTransfer.files;
 
     if (overlay) {


### PR DESCRIPTION
# Description

- Fix a bug that allowed multiple files to be dropped onto a single-file input element by accepting only the first file.

Closes #2358

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
