### PR TITLE
Fix deserialization failure in Change Metadata

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/misc/MetadataController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/MetadataController.java
@@ -14,6 +14,8 @@ import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +28,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import stirling.software.SPDF.model.api.misc.MetadataRequest;
 import stirling.software.SPDF.utils.WebResponseUtils;
+import stirling.software.SPDF.utils.propertyeditor.StringToMapPropertyEditor;
 
 @RestController
 @RequestMapping("/api/v1/misc")
@@ -42,6 +45,11 @@ public class MetadataController {
         }
         // Return the original string if it's not "undefined"
         return entry;
+    }
+
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.registerCustomEditor(Map.class, "allRequestParams", new StringToMapPropertyEditor());
     }
 
     @PostMapping(consumes = "multipart/form-data", value = "/update-metadata")

--- a/src/main/java/stirling/software/SPDF/utils/propertyeditor/StringToMapPropertyEditor.java
+++ b/src/main/java/stirling/software/SPDF/utils/propertyeditor/StringToMapPropertyEditor.java
@@ -1,0 +1,26 @@
+package stirling.software.SPDF.utils.propertyeditor;
+
+import java.beans.PropertyEditorSupport;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class StringToMapPropertyEditor extends PropertyEditorSupport {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void setAsText(String text) throws IllegalArgumentException {
+        try {
+            TypeReference<HashMap<String, String>> typeRef =
+                    new TypeReference<HashMap<String, String>>() {};
+            Map<String, String> map = objectMapper.readValue(text, typeRef);
+            setValue(map);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Failed to convert java.lang.String to java.util.Map");
+        }
+    }
+}

--- a/src/main/resources/templates/misc/change-metadata.html
+++ b/src/main/resources/templates/misc/change-metadata.html
@@ -164,13 +164,13 @@
                     keyInput.type = "text";
                     keyInput.placeholder = 'Key';
                     keyInput.className = "form-control";
-                    keyInput.name = "customKey" + count;
+                    keyInput.name = `allRequestParams[customKey${count}]`;
 
                     const valueInput = document.createElement("input");
                     valueInput.type = "text";
                     valueInput.placeholder = 'Value';
                     valueInput.className = "form-control";
-                    valueInput.name = "customValue" + count;
+                    valueInput.name = `allRequestParams[customValue${count}]`;
                     count = count + 1;
 
                     const formGroup = document.createElement("div");


### PR DESCRIPTION
# Description

## Problem

- When a user attempted to add custom metadata (in JSON format), the user receives 400 with an exception indicating failure to convert java.lang.String to java.util.Map
- When a user attempted to add custom metadata (in frontend), after submission, no change occurred in the metadata as the Map was empty.

## Solution
- Implement a custom property editor to convert string (allRequestParams) to Map, this way the user wouldn't get 400 anymore.
- Bind input field names with the Map by using the format for setting Map names (mapName[key] ), example:
allRequestParams[customKey1], allRequestParams[customValue1].

Closes #2346

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
