### PR TITLE
Fix missing upload button

### DIFF
--- a/src/main/resources/static/css/fileSelect.css
+++ b/src/main/resources/static/css/fileSelect.css
@@ -84,7 +84,7 @@
   z-index: 2;
 }
 
-input[type="file"] {
+.input-container input[type="file"] {
   display: none;
 }
 


### PR DESCRIPTION
# Description

The code snippet `input[type=file]{ display: none;}` was unintentionally hiding the upload button everywhere, to fix this, it was changed to only target input within `.input-container`.

Closes #2390

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
