### PR TITLE
Text color selection for watermark

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -69,6 +69,7 @@ public class WatermarkController {
         float opacity = request.getOpacity();
         int widthSpacer = request.getWidthSpacer();
         int heightSpacer = request.getHeightSpacer();
+        String customColor = request.getCustomColor();
         boolean convertPdfToImage = request.isConvertPDFToImage();
 
         // Load the input PDF
@@ -97,7 +98,8 @@ public class WatermarkController {
                         widthSpacer,
                         heightSpacer,
                         fontSize,
-                        alphabet);
+                        alphabet,
+                        customColor);
             } else if ("image".equalsIgnoreCase(watermarkType)) {
                 addImageWatermark(
                         contentStream,
@@ -136,7 +138,8 @@ public class WatermarkController {
             int widthSpacer,
             int heightSpacer,
             float fontSize,
-            String alphabet)
+            String alphabet,
+            String colorString)
             throws IOException {
         String resourceDir = "";
         PDFont font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
@@ -173,7 +176,18 @@ public class WatermarkController {
         }
 
         contentStream.setFont(font, fontSize);
-        contentStream.setNonStrokingColor(Color.LIGHT_GRAY);
+
+        Color redactColor;
+        try {
+            if (!colorString.startsWith("#")) {
+                colorString = "#" + colorString;
+            }
+            redactColor = Color.decode(colorString);
+        } catch (NumberFormatException e) {
+
+            redactColor = Color.LIGHT_GRAY;
+        }
+        contentStream.setNonStrokingColor(redactColor);
 
         String[] textLines = watermarkText.split("\\\\n");
         float maxLineWidth = 0;

--- a/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
+++ b/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
@@ -45,6 +45,9 @@ public class AddWatermarkRequest extends PDFFile {
     @Schema(description = "The height spacer between watermark elements", example = "50")
     private int heightSpacer;
 
+    @Schema(description = "The color for watermark", defaultValue = "#d3d3d3")
+    private String customColor = "#d3d3d3";
+
     @Schema(description = "Convert the redacted PDF to an image", defaultValue = "false")
     private boolean convertPDFToImage;
 }

--- a/src/main/resources/messages_ar_AR.properties
+++ b/src/main/resources/messages_ar_AR.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=تشفير
 #watermark
 watermark.title=إضافة علامة مائية
 watermark.header=إضافة علامة مائية
+watermark.customColor=لون نص مخصص
 watermark.selectText.1=حدد PDF لإضافة العلامة المائية إليه:
 watermark.selectText.2=نص العلامة المائية:
 watermark.selectText.3=حجم الخط:

--- a/src/main/resources/messages_az_AZ.properties
+++ b/src/main/resources/messages_az_AZ.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Şifrlə
 #watermark
 watermark.title=Watermark Əlavə Et
 watermark.header=Watermark Əlavə Et
-watermark.customColor=FərdiMətnRəngi
+watermark.customColor=Fərdi Mətn Rəngi
 watermark.selectText.1=Watermark əlavə olunacaq PDF-i seç
 watermark.selectText.2=Watermark Mətni:
 watermark.selectText.3=Şrift Ölçüsü:

--- a/src/main/resources/messages_az_AZ.properties
+++ b/src/main/resources/messages_az_AZ.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Şifrlə
 #watermark
 watermark.title=Watermark Əlavə Et
 watermark.header=Watermark Əlavə Et
+watermark.customColor=FərdiMətnRəngi
 watermark.selectText.1=Watermark əlavə olunacaq PDF-i seç
 watermark.selectText.2=Watermark Mətni:
 watermark.selectText.3=Şrift Ölçüsü:

--- a/src/main/resources/messages_bg_BG.properties
+++ b/src/main/resources/messages_bg_BG.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Шифроване
 #watermark
 watermark.title=Добавяне на воден знак
 watermark.header=Добавяне на воден знак
+watermark.customColor=Персонализиран цвят на текста
 watermark.selectText.1=Изберете PDF, към който да добавите воден знак:
 watermark.selectText.2=Текст на воден знак:
 watermark.selectText.3=Размер на шрифта:

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Encripta
 #watermark
 watermark.title=Afegir Marca d'Aigua
 watermark.header=Afegir Marca d'Aigua
-watermark.customColor=ColordeTextPersonalitzat
+watermark.customColor=Color de Text Personalitzat
 watermark.selectText.1=Selecciona el PDF per afegir la Marca d'Aigua:
 watermark.selectText.2=Text de la Marca d'Aigua
 watermark.selectText.3=Mida de la Font:

--- a/src/main/resources/messages_ca_CA.properties
+++ b/src/main/resources/messages_ca_CA.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Encripta
 #watermark
 watermark.title=Afegir Marca d'Aigua
 watermark.header=Afegir Marca d'Aigua
+watermark.customColor=ColordeTextPersonalitzat
 watermark.selectText.1=Selecciona el PDF per afegir la Marca d'Aigua:
 watermark.selectText.2=Text de la Marca d'Aigua
 watermark.selectText.3=Mida de la Font:

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Šifrovat
 #watermark
 watermark.title=Přidat vodoznak
 watermark.header=Přidat vodoznak
-watermark.customColor=Vlastníbarvatextu
+watermark.customColor=Vlastní barva textu
 watermark.selectText.1=Vyberte PDF, ke kterému chcete přidat vodoznak:
 watermark.selectText.2=Text vodoznaku:
 watermark.selectText.3=Velikost písma:

--- a/src/main/resources/messages_cs_CZ.properties
+++ b/src/main/resources/messages_cs_CZ.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Šifrovat
 #watermark
 watermark.title=Přidat vodoznak
 watermark.header=Přidat vodoznak
+watermark.customColor=Vlastníbarvatextu
 watermark.selectText.1=Vyberte PDF, ke kterému chcete přidat vodoznak:
 watermark.selectText.2=Text vodoznaku:
 watermark.selectText.3=Velikost písma:

--- a/src/main/resources/messages_da_DK.properties
+++ b/src/main/resources/messages_da_DK.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Kryptér
 #watermark
 watermark.title=Tilføj Vandmærke
 watermark.header=Tilføj Vandmærke
+watermark.customColor=BrugerdefineretTekstfarve
 watermark.selectText.1=Vælg PDF til at tilføje vandmærke:
 watermark.selectText.2=Vandmærketekst:
 watermark.selectText.3=Skriftstørrelse:

--- a/src/main/resources/messages_da_DK.properties
+++ b/src/main/resources/messages_da_DK.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Kryptér
 #watermark
 watermark.title=Tilføj Vandmærke
 watermark.header=Tilføj Vandmærke
-watermark.customColor=BrugerdefineretTekstfarve
+watermark.customColor=Brugerdefineret Tekstfarve
 watermark.selectText.1=Vælg PDF til at tilføje vandmærke:
 watermark.selectText.2=Vandmærketekst:
 watermark.selectText.3=Skriftstørrelse:

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Verschlüsseln
 #watermark
 watermark.title=Wasserzeichen hinzufügen
 watermark.header=Wasserzeichen hinzufügen
-watermark.customColor=BenutzerdefinierteTextfarbe
+watermark.customColor=Benutzerdefinierte Textfarbe
 watermark.selectText.1=PDF auswählen, dem ein Wasserzeichen hinzugefügt werden soll:
 watermark.selectText.2=Wasserzeichen Text:
 watermark.selectText.3=Schriftgröße:

--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Verschlüsseln
 #watermark
 watermark.title=Wasserzeichen hinzufügen
 watermark.header=Wasserzeichen hinzufügen
+watermark.customColor=BenutzerdefinierteTextfarbe
 watermark.selectText.1=PDF auswählen, dem ein Wasserzeichen hinzugefügt werden soll:
 watermark.selectText.2=Wasserzeichen Text:
 watermark.selectText.3=Schriftgröße:

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Κρυπτογράφηση
 #watermark
 watermark.title=Προσθήκη Υδατογραφήματος
 watermark.header=Προσθήκη Υδατογραφήματος
-watermark.customColor=Προσαρμοσμένοχρώμακειμένου
+watermark.customColor=Προσαρμοσμένο χρώμα κειμένου
 watermark.selectText.1=Επιλέξτε PDF για την προσθήκη του υδατογραφήματος:
 watermark.selectText.2=Κείμενο Υδατογραφήματος:
 watermark.selectText.3=Μέγεθος Κειμένου:

--- a/src/main/resources/messages_el_GR.properties
+++ b/src/main/resources/messages_el_GR.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Κρυπτογράφηση
 #watermark
 watermark.title=Προσθήκη Υδατογραφήματος
 watermark.header=Προσθήκη Υδατογραφήματος
+watermark.customColor=Προσαρμοσμένοχρώμακειμένου
 watermark.selectText.1=Επιλέξτε PDF για την προσθήκη του υδατογραφήματος:
 watermark.selectText.2=Κείμενο Υδατογραφήματος:
 watermark.selectText.3=Μέγεθος Κειμένου:

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Encrypt
 #watermark
 watermark.title=Add Watermark
 watermark.header=Add Watermark
+watermark.customColor=CustomTextColour
 watermark.selectText.1=Select PDF to add watermark to:
 watermark.selectText.2=Watermark Text:
 watermark.selectText.3=Font Size:

--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Encrypt
 #watermark
 watermark.title=Add Watermark
 watermark.header=Add Watermark
-watermark.customColor=CustomTextColour
+watermark.customColor=Custom Text Colour
 watermark.selectText.1=Select PDF to add watermark to:
 watermark.selectText.2=Watermark Text:
 watermark.selectText.3=Font Size:

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Encrypt
 #watermark
 watermark.title=Add Watermark
 watermark.header=Add Watermark
+watermark.customColor=Custom Text Color
 watermark.selectText.1=Select PDF to add watermark to:
 watermark.selectText.2=Watermark Text:
 watermark.selectText.3=Font Size:

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Encriptar
 #watermark
 watermark.title=Añadir marca de agua
 watermark.header=Añadir marca de agua
+watermark.customColor=Personalizarcolordetexto
 watermark.selectText.1=Seleccionar PDF para añadir marca de agua:
 watermark.selectText.2=Texto de la marca de agua:
 watermark.selectText.3=Tamaño de la Fuente:

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Encriptar
 #watermark
 watermark.title=Añadir marca de agua
 watermark.header=Añadir marca de agua
-watermark.customColor=Personalizarcolordetexto
+watermark.customColor=Personalizar color de texto
 watermark.selectText.1=Seleccionar PDF para añadir marca de agua:
 watermark.selectText.2=Texto de la marca de agua:
 watermark.selectText.3=Tamaño de la Fuente:

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Enkriptatu
 #watermark
 watermark.title=Gehitu ur-marka
 watermark.header=Gehitu ur-marka
+watermark.customColor=CustomTextColor
 watermark.selectText.1=Hautatu PDFa ur-marka gehitzeko:
 watermark.selectText.2=Ur-markaren testua:
 watermark.selectText.3=Letra-tipoaren tamaina:

--- a/src/main/resources/messages_eu_ES.properties
+++ b/src/main/resources/messages_eu_ES.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Enkriptatu
 #watermark
 watermark.title=Gehitu ur-marka
 watermark.header=Gehitu ur-marka
-watermark.customColor=CustomTextColor
+watermark.customColor=Custom Text Color
 watermark.selectText.1=Hautatu PDFa ur-marka gehitzeko:
 watermark.selectText.2=Ur-markaren testua:
 watermark.selectText.3=Letra-tipoaren tamaina:

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Chiffrer
 #watermark
 watermark.title=Ajouter un filigrane
 watermark.header=Ajouter un filigrane
+watermark.customColor=Couleurdetextepersonnalisée
 watermark.selectText.1=PDF auquel ajouter un filigrane
 watermark.selectText.2=Texte du filigrane
 watermark.selectText.3=Taille de police

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Chiffrer
 #watermark
 watermark.title=Ajouter un filigrane
 watermark.header=Ajouter un filigrane
-watermark.customColor=Couleurdetextepersonnalisée
+watermark.customColor=Couleur de texte personnalisée
 watermark.selectText.1=PDF auquel ajouter un filigrane
 watermark.selectText.2=Texte du filigrane
 watermark.selectText.3=Taille de police

--- a/src/main/resources/messages_ga_IE.properties
+++ b/src/main/resources/messages_ga_IE.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Criptigh
 #watermark
 watermark.title=Cuir Uisce leis
 watermark.header=Cuir Uisce leis
-watermark.customColor=DathTéacsSaincheaptha
+watermark.customColor=Dath Téacs Saincheaptha
 watermark.selectText.1=Roghnaigh PDF chun comhartha uisce a chur leis:
 watermark.selectText.2=Téacs Comhartha Uisce:
 watermark.selectText.3=Méid cló:

--- a/src/main/resources/messages_ga_IE.properties
+++ b/src/main/resources/messages_ga_IE.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Criptigh
 #watermark
 watermark.title=Cuir Uisce leis
 watermark.header=Cuir Uisce leis
+watermark.customColor=DathTéacsSaincheaptha
 watermark.selectText.1=Roghnaigh PDF chun comhartha uisce a chur leis:
 watermark.selectText.2=Téacs Comhartha Uisce:
 watermark.selectText.3=Méid cló:

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=एन्क्रिप्ट करें
 #watermark
 watermark.title=वॉटरमार्क जोड़ें
 watermark.header=वॉटरमार्क जोड़ें
+watermark.customColor=संवैधितटेक्स्टरंग
 watermark.selectText.1=वॉटरमार्क जोड़ने के लिए पीडीएफ चुनें:
 watermark.selectText.2=वॉटरमार्क टेक्स्ट:
 watermark.selectText.3=फ़ॉन्ट साइज़:

--- a/src/main/resources/messages_hi_IN.properties
+++ b/src/main/resources/messages_hi_IN.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=एन्क्रिप्ट करें
 #watermark
 watermark.title=वॉटरमार्क जोड़ें
 watermark.header=वॉटरमार्क जोड़ें
-watermark.customColor=संवैधितटेक्स्टरंग
+watermark.customColor=संवैधित टेक्स्ट रंग
 watermark.selectText.1=वॉटरमार्क जोड़ने के लिए पीडीएफ चुनें:
 watermark.selectText.2=वॉटरमार्क टेक्स्ट:
 watermark.selectText.3=फ़ॉन्ट साइज़:

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Šifriraj
 #watermark
 watermark.title=Dodaj vodeni žig
 watermark.header=Dodaj vodeni žig
-watermark.customColor=Prilagođenabojateksta
+watermark.customColor=Prilagođena boja teksta
 watermark.selectText.1=Izaberite PDF za dodavanje vodenog žiga:
 watermark.selectText.2=Tekst vodenog žiga:
 watermark.selectText.3=Veličina fonta:

--- a/src/main/resources/messages_hr_HR.properties
+++ b/src/main/resources/messages_hr_HR.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Šifriraj
 #watermark
 watermark.title=Dodaj vodeni žig
 watermark.header=Dodaj vodeni žig
+watermark.customColor=Prilagođenabojateksta
 watermark.selectText.1=Izaberite PDF za dodavanje vodenog žiga:
 watermark.selectText.2=Tekst vodenog žiga:
 watermark.selectText.3=Veličina fonta:

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Titkosítás
 #watermark
 watermark.title=Vízjel hozzáadása
 watermark.header=Vízjel hozzáadása
-watermark.customColor=Egyéniszövegszín
+watermark.customColor=Egyéni szövegszín
 watermark.selectText.1=Válassza ki a PDF-t, amelyhez vízjelet kíván hozzáadni:
 watermark.selectText.2=Vízjel szövege:
 watermark.selectText.3=Betűméret:

--- a/src/main/resources/messages_hu_HU.properties
+++ b/src/main/resources/messages_hu_HU.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Titkosítás
 #watermark
 watermark.title=Vízjel hozzáadása
 watermark.header=Vízjel hozzáadása
+watermark.customColor=Egyéniszövegszín
 watermark.selectText.1=Válassza ki a PDF-t, amelyhez vízjelet kíván hozzáadni:
 watermark.selectText.2=Vízjel szövege:
 watermark.selectText.3=Betűméret:

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Enkripsi
 #watermark
 watermark.title=Tambahkan Watermark
 watermark.header=Tambahkan Watermark
-watermark.customColor=WarnaTeksKustom
+watermark.customColor=Warna Teks Kustom
 watermark.selectText.1=Pilih PDF untuk menambahkan watermark:
 watermark.selectText.2=Text Watermark:
 watermark.selectText.3=Ukuran Huruf:

--- a/src/main/resources/messages_id_ID.properties
+++ b/src/main/resources/messages_id_ID.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Enkripsi
 #watermark
 watermark.title=Tambahkan Watermark
 watermark.header=Tambahkan Watermark
+watermark.customColor=WarnaTeksKustom
 watermark.selectText.1=Pilih PDF untuk menambahkan watermark:
 watermark.selectText.2=Text Watermark:
 watermark.selectText.3=Ukuran Huruf:

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Crittografa
 #watermark
 watermark.title=Aggiungi Filigrana
 watermark.header=Aggiungi filigrana
-watermark.customColor=Coloretestopersonalizzato
+watermark.customColor=Colore testo personalizzato
 watermark.selectText.1=Seleziona PDF a cui aggiungere la filigrana:
 watermark.selectText.2=Testo:
 watermark.selectText.3=Dimensione carattere:

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Crittografa
 #watermark
 watermark.title=Aggiungi Filigrana
 watermark.header=Aggiungi filigrana
+watermark.customColor=Coloretestopersonalizzato
 watermark.selectText.1=Seleziona PDF a cui aggiungere la filigrana:
 watermark.selectText.2=Testo:
 watermark.selectText.3=Dimensione carattere:

--- a/src/main/resources/messages_ja_JP.properties
+++ b/src/main/resources/messages_ja_JP.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=暗号化
 #watermark
 watermark.title=透かしの追加
 watermark.header=透かしの追加
+watermark.customColor=文字色のカスタム
 watermark.selectText.1=透かしを追加するPDFを選択:
 watermark.selectText.2=透かしのテキスト:
 watermark.selectText.3=文字サイズ:

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=암호화
 #watermark
 watermark.title=워터마크 추가
 watermark.header=워터마크 추가
+watermark.customColor=사용자정의텍스트색상
 watermark.selectText.1=워터마크를 추가할 PDF 선택:
 watermark.selectText.2=워터마크 텍스트:
 watermark.selectText.3=폰트 크기:

--- a/src/main/resources/messages_ko_KR.properties
+++ b/src/main/resources/messages_ko_KR.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=암호화
 #watermark
 watermark.title=워터마크 추가
 watermark.header=워터마크 추가
-watermark.customColor=사용자정의텍스트색상
+watermark.customColor=사용자 정의 텍스트 색상
 watermark.selectText.1=워터마크를 추가할 PDF 선택:
 watermark.selectText.2=워터마크 텍스트:
 watermark.selectText.3=폰트 크기:

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Versleutelen
 #watermark
 watermark.title=Watermerk toevoegen
 watermark.header=Watermerk toevoegen
-watermark.customColor=Aangepastetekstkleur
+watermark.customColor=Aangepaste tekstkleur
 watermark.selectText.1=Selecteer PDF om watermerk toe te voegen:
 watermark.selectText.2=Watermerk tekst:
 watermark.selectText.3=Tekengrootte:

--- a/src/main/resources/messages_nl_NL.properties
+++ b/src/main/resources/messages_nl_NL.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Versleutelen
 #watermark
 watermark.title=Watermerk toevoegen
 watermark.header=Watermerk toevoegen
+watermark.customColor=Aangepastetekstkleur
 watermark.selectText.1=Selecteer PDF om watermerk toe te voegen:
 watermark.selectText.2=Watermerk tekst:
 watermark.selectText.3=Tekengrootte:

--- a/src/main/resources/messages_no_NB.properties
+++ b/src/main/resources/messages_no_NB.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Krypter
 #watermark
 watermark.title=Legg til vannmerke
 watermark.header=Legg til vannmerke
+watermark.customColor=TilpassetTekstfarge
 watermark.selectText.1=Velg PDF-fil å legge til vannmerke på:
 watermark.selectText.2=Vannmerketekst:
 watermark.selectText.3=Skriftstørrelse:

--- a/src/main/resources/messages_no_NB.properties
+++ b/src/main/resources/messages_no_NB.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Krypter
 #watermark
 watermark.title=Legg til vannmerke
 watermark.header=Legg til vannmerke
-watermark.customColor=TilpassetTekstfarge
+watermark.customColor=Tilpasset Tekstfarge
 watermark.selectText.1=Velg PDF-fil å legge til vannmerke på:
 watermark.selectText.2=Vannmerketekst:
 watermark.selectText.3=Skriftstørrelse:

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Zablokuj
 #watermark
 watermark.title=Dodaj znak wodny
 watermark.header=Dodaj znak wodny
-watermark.customColor=Własnykolortekstu
+watermark.customColor=Własny kolor tekstu
 watermark.selectText.1=Wybierz dokument PDF, do którego chcesz dodać znak wodny:
 watermark.selectText.2=Treść znaku wodnego:
 watermark.selectText.3=Rozmiar czcionki:

--- a/src/main/resources/messages_pl_PL.properties
+++ b/src/main/resources/messages_pl_PL.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Zablokuj
 #watermark
 watermark.title=Dodaj znak wodny
 watermark.header=Dodaj znak wodny
+watermark.customColor=Własnykolortekstu
 watermark.selectText.1=Wybierz dokument PDF, do którego chcesz dodać znak wodny:
 watermark.selectText.2=Treść znaku wodnego:
 watermark.selectText.3=Rozmiar czcionki:

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Criptografar
 #watermark
 watermark.title=Adicionar marca d'água
 watermark.header=Adicionar marca d'água
+watermark.customColor=Cordetextopersonalizada
 watermark.selectText.1=Selecione PDF para adicionar a marca d'água:
 watermark.selectText.2=Texto da marca d'água:
 watermark.selectText.3=Tamanho da fonte:

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Criptografar
 #watermark
 watermark.title=Adicionar marca d'água
 watermark.header=Adicionar marca d'água
-watermark.customColor=Cordetextopersonalizada
+watermark.customColor=Cor de texto personalizada
 watermark.selectText.1=Selecione PDF para adicionar a marca d'água:
 watermark.selectText.2=Texto da marca d'água:
 watermark.selectText.3=Tamanho da fonte:

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Proteger
 #watermark
 watermark.title=Adicionar Marca d'Água
 watermark.header=Adicionar Marca d'Água
-watermark.customColor=Personalizaracordotexto
+watermark.customColor=Personalizar a cor do texto
 watermark.selectText.1=Seleccione o PDF para Adicionar a Marca d'Água
 watermark.selectText.2=Texto da Marca d'Água
 watermark.selectText.3=Tamanho da Fonte

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Proteger
 #watermark
 watermark.title=Adicionar Marca d'Água
 watermark.header=Adicionar Marca d'Água
+watermark.customColor=Personalizaracordotexto
 watermark.selectText.1=Seleccione o PDF para Adicionar a Marca d'Água
 watermark.selectText.2=Texto da Marca d'Água
 watermark.selectText.3=Tamanho da Fonte

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Criptează
 #watermark
 watermark.title=Adaugă Filigran
 watermark.header=Adaugă Filigran
+watermark.customColor=CuloareTextPersonalizată
 watermark.selectText.1=Selectează PDF-ul la care să adaugi filigranul:
 watermark.selectText.2=Textul Filigranului:
 watermark.selectText.3=Mărimea fontului:

--- a/src/main/resources/messages_ro_RO.properties
+++ b/src/main/resources/messages_ro_RO.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Criptează
 #watermark
 watermark.title=Adaugă Filigran
 watermark.header=Adaugă Filigran
-watermark.customColor=CuloareTextPersonalizată
+watermark.customColor=Culoare Text Personalizată
 watermark.selectText.1=Selectează PDF-ul la care să adaugi filigranul:
 watermark.selectText.2=Textul Filigranului:
 watermark.selectText.3=Mărimea fontului:

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Шифровать
 #watermark
 watermark.title=Добавить водяной знак
 watermark.header=Добавить водяной знак
-watermark.customColor=Настроенныйцветтекста
+watermark.customColor=Настроенный цвет текста
 watermark.selectText.1=Выберите PDF, чтобы добавить водяной знак:
 watermark.selectText.2=Текст водяного знака:
 watermark.selectText.3=Размер шрифта:

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Шифровать
 #watermark
 watermark.title=Добавить водяной знак
 watermark.header=Добавить водяной знак
+watermark.customColor=Настроенныйцветтекста
 watermark.selectText.1=Выберите PDF, чтобы добавить водяной знак:
 watermark.selectText.2=Текст водяного знака:
 watermark.selectText.3=Размер шрифта:

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Zašifrovať
 #watermark
 watermark.title=Pridať vodotlač
 watermark.header=Pridať vodotlač
-watermark.customColor=Vlastnáfarbatextu
+watermark.customColor=Vlastná farba textu
 watermark.selectText.1=Vyberte PDF, do ktorého chcete pridať vodotlač:
 watermark.selectText.2=Text vodotlače:
 watermark.selectText.3=Veľkosť písma:

--- a/src/main/resources/messages_sk_SK.properties
+++ b/src/main/resources/messages_sk_SK.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Zašifrovať
 #watermark
 watermark.title=Pridať vodotlač
 watermark.header=Pridať vodotlač
+watermark.customColor=Vlastnáfarbatextu
 watermark.selectText.1=Vyberte PDF, do ktorého chcete pridať vodotlač:
 watermark.selectText.2=Text vodotlače:
 watermark.selectText.3=Veľkosť písma:

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Enkriptuj
 #watermark
 watermark.title=Dodaj vodeni žig
 watermark.header=Dodaj vodeni žig
+watermark.customColor=CustomTextColor
 watermark.selectText.1=Izaberite PDF za dodavanje vodenog žiga:
 watermark.selectText.2=Tekst vodenog žiga:
 watermark.selectText.3=Veličina fonta:

--- a/src/main/resources/messages_sr_LATN_RS.properties
+++ b/src/main/resources/messages_sr_LATN_RS.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Enkriptuj
 #watermark
 watermark.title=Dodaj vodeni žig
 watermark.header=Dodaj vodeni žig
-watermark.customColor=CustomTextColor
+watermark.customColor=Custom Text Color
 watermark.selectText.1=Izaberite PDF za dodavanje vodenog žiga:
 watermark.selectText.2=Tekst vodenog žiga:
 watermark.selectText.3=Veličina fonta:

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Kryptera
 #watermark
 watermark.title=Lägg till vattenstämpel
 watermark.header=Lägg till vattenstämpel
+watermark.customColor=Anpassadtextfärg
 watermark.selectText.1=Välj PDF för att lägga till vattenstämpel till:
 watermark.selectText.2=Vattenmärkestext:
 watermark.selectText.3=Teckenstorlek:

--- a/src/main/resources/messages_sv_SE.properties
+++ b/src/main/resources/messages_sv_SE.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Kryptera
 #watermark
 watermark.title=Lägg till vattenstämpel
 watermark.header=Lägg till vattenstämpel
-watermark.customColor=Anpassadtextfärg
+watermark.customColor=Anpassad textfärg
 watermark.selectText.1=Välj PDF för att lägga till vattenstämpel till:
 watermark.selectText.2=Vattenmärkestext:
 watermark.selectText.3=Teckenstorlek:

--- a/src/main/resources/messages_th_TH.properties
+++ b/src/main/resources/messages_th_TH.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=เข้ารหัส
 #watermark
 watermark.title=เพิ่มลายน้ำ
 watermark.header=เพิ่มลายน้ำ
+watermark.customColor=สีข้อความที่กำหนดเอง
 watermark.selectText.1=เลือก PDF เพื่อเพิ่มลายน้ำ:
 watermark.selectText.2=ข้อความลายน้ำ:
 watermark.selectText.3=ขนาดฟอนต์:

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Şifrele
 #watermark
 watermark.title=Filigran Ekle
 watermark.header=Filigran Ekle
-watermark.customColor=ÖzelMetinRengi
+watermark.customColor=Özel Metin Rengi
 watermark.selectText.1=Filigran eklemek için PDF seçin:
 watermark.selectText.2=Filigran Metni:
 watermark.selectText.3=Yazı Boyutu:

--- a/src/main/resources/messages_tr_TR.properties
+++ b/src/main/resources/messages_tr_TR.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Şifrele
 #watermark
 watermark.title=Filigran Ekle
 watermark.header=Filigran Ekle
+watermark.customColor=ÖzelMetinRengi
 watermark.selectText.1=Filigran eklemek için PDF seçin:
 watermark.selectText.2=Filigran Metni:
 watermark.selectText.3=Yazı Boyutu:

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Шифрувати
 #watermark
 watermark.title=Додати водяний знак
 watermark.header=Додати водяний знак
+watermark.customColor=Користувацькийколіртексту
 watermark.selectText.1=Виберіть PDF, щоб додати водяний знак:
 watermark.selectText.2=Текст водяного знаку:
 watermark.selectText.3=Розмір шрифту:

--- a/src/main/resources/messages_uk_UA.properties
+++ b/src/main/resources/messages_uk_UA.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Шифрувати
 #watermark
 watermark.title=Додати водяний знак
 watermark.header=Додати водяний знак
-watermark.customColor=Користувацькийколіртексту
+watermark.customColor=Користувацький колір тексту
 watermark.selectText.1=Виберіть PDF, щоб додати водяний знак:
 watermark.selectText.2=Текст водяного знаку:
 watermark.selectText.3=Розмір шрифту:

--- a/src/main/resources/messages_vi_VN.properties
+++ b/src/main/resources/messages_vi_VN.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=Mã hóa
 #watermark
 watermark.title=Thêm hình mờ
 watermark.header=Thêm hình mờ
+watermark.customColor=Màuvănbảntùychỉnh
 watermark.selectText.1=Chọn PDF để thêm hình mờ:
 watermark.selectText.2=Văn bản hình mờ:
 watermark.selectText.3=Cỡ chữ:

--- a/src/main/resources/messages_vi_VN.properties
+++ b/src/main/resources/messages_vi_VN.properties
@@ -1056,7 +1056,7 @@ addPassword.submit=Mã hóa
 #watermark
 watermark.title=Thêm hình mờ
 watermark.header=Thêm hình mờ
-watermark.customColor=Màuvănbảntùychỉnh
+watermark.customColor=Màu văn bản tùy chỉnh
 watermark.selectText.1=Chọn PDF để thêm hình mờ:
 watermark.selectText.2=Văn bản hình mờ:
 watermark.selectText.3=Cỡ chữ:

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=加密
 #watermark
 watermark.title=添加水印
 watermark.header=添加水印
+watermark.customColor=自定义文本颜色
 watermark.selectText.1=选择要添加水印的PDF：
 watermark.selectText.2=水印文本：
 watermark.selectText.3=字体大小：

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -1056,6 +1056,7 @@ addPassword.submit=加密
 #watermark
 watermark.title=新增浮水印
 watermark.header=新增浮水印
+watermark.customColor=自訂文字顏色
 watermark.selectText.1=選擇要新增浮水印的 PDF：
 watermark.selectText.2=浮水印文字：
 watermark.selectText.3=字型大小：

--- a/src/main/resources/templates/security/add-watermark.html
+++ b/src/main/resources/templates/security/add-watermark.html
@@ -92,26 +92,48 @@
                   appendPercentageSymbol();
                 </script>
 
-                <div class="mb-3">
-                  <label for="rotation" th:text="#{watermark.selectText.4}"></label>
-                  <input type="text" id="rotation" name="rotation" class="form-control" value="45">
-                </div>
-                <div class="mb-3">
-                  <label for="widthSpacer" th:text="#{watermark.selectText.5}"></label>
-                  <input type="text" id="widthSpacer" name="widthSpacer" class="form-control" value="50">
-                </div>
-                <div class="mb-3">
-                  <label for="heightSpacer" th:text="#{watermark.selectText.6}"></label>
-                  <input type="text" id="heightSpacer" name="heightSpacer" class="form-control" value="50">
-                </div>
-                <div class="mb-3 form-check">
-                  <input type="checkbox" id="convertPDFToImage" name="convertPDFToImage">
-                  <label for="convertPDFToImage" th:text="#{watermark.selectText.10}"></label>
-                </div>
-                <div class="mb-3 text-left">
-                  <input type="submit" id="submitBtn" th:value="#{watermark.submit}" class="btn btn-primary">
-                </div>
-              </form>
+                        <div class="mb-3">
+                            <label for="rotation" th:text="#{watermark.selectText.4}"></label>
+                            <input type="text" id="rotation" name="rotation" class="form-control" value="45">
+                        </div>
+                        <div class="mb-3">
+                            <label for="widthSpacer" th:text="#{watermark.selectText.5}"></label>
+                            <input type="text" id="widthSpacer" name="widthSpacer" class="form-control" value="50">
+                        </div>
+                        <div class="mb-3">
+                            <label for="heightSpacer" th:text="#{watermark.selectText.6}"></label>
+                            <input type="text" id="heightSpacer" name="heightSpacer" class="form-control" value="50">
+                        </div>
+                        <div class="mb-3">
+                            <label for="customColor" class="form-label" th:text="#{watermark.customColor}">Custom
+                                Color</label>
+                            <div class="form-control form-control-color" style="background-color: #d3d3d3;">
+                                <input type="color" id="customColor" name="customColor" value="#d3d3d3">
+                            </div>
+                            <script>
+                                let colorInput = document.getElementById("customColor");
+                                if (colorInput) {
+                                  let colorInputContainer = colorInput.parentElement;
+                                  if (colorInputContainer) {
+                                    colorInput.onchange = function() {
+                                      colorInputContainer.style.backgroundColor = colorInput.value;
+                                    }
+                                    colorInputContainer.style.backgroundColor = colorInput.value;
+                                  }
+                                }
+
+                            </script>
+                        </div>
+
+
+                        <div class="mb-3 form-check">
+                            <input type="checkbox" id="convertPDFToImage" name="convertPDFToImage">
+                            <label for="convertPDFToImage" th:text="#{watermark.selectText.10}"></label>
+                        </div>
+                        <div class="mb-3 text-left">
+                            <input type="submit" id="submitBtn" th:value="#{watermark.submit}" class="btn btn-primary">
+                        </div>
+                    </form>
 
               <script>
                 function toggleFileOption() {


### PR DESCRIPTION
# Description

This PR addresses [Feature Request #369](https://github.com/Stirling-Tools/Stirling-PDF/issues/369) by adding the ability for users to select a custom text color for watermarks in PDF documents. 

## Key Changes

### WatermarkController.java

- Added customColor support in the addWatermark method.
- Updated logic to apply the custom color to watermark text.

### AddWatermarkRequest.java
Introduced customColor field with a default value of #d3d3d3.

### Localization

Added watermark.customColor key to all existing Localization files with values matching addWatermarkRequest.customColor to ensure consistency across languages.

### add-watermark.html

- Included a color picker for customColor in the UI.
- Added JavaScript to update the color picker’s background based on user selection.

![Screenshot 2024-12-07 at 5 34 06 PM](https://github.com/user-attachments/assets/e2f0d110-9e91-475e-9a9f-2bc67d2ab19b)


Closes #369 

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
