### PR TITLE
Fix collapsed menu issue on page reload

### DIFF
--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -65,6 +65,7 @@
   overflow: hidden;
   margin: -20px;
   padding: 20px;
+  box-sizing:content-box;
 }
 
 .feature-group-container.animated-group {

--- a/src/main/resources/static/js/homecard.js
+++ b/src/main/resources/static/js/homecard.js
@@ -268,7 +268,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const parent = header.parentNode;
     const container = header.parentNode.querySelector(".feature-group-container");
     if (parent.id !== "groupFavorites") {
-      container.style.maxHeight = container.clientHeight + "px";
+      container.style.maxHeight = container.scrollHeight + "px";
     }
     header.onclick = () => {
       expandCollapseToggle(parent);


### PR DESCRIPTION
# Description

This PR addresses an issue with the collapsible menu where the menu wouldn't expand properly after a page reload. The root cause was the incorrect calculation of `max-height`.

Closes #2265 


# Key Changes:

1. Fixed the calculation of `max-height` by using the scrollHeight property.
2. Updated the CSS `box-sizing` property to content-box to ensure padding is included in the element's overall size, resolving layout issues when expanding the menu.

These changes ensure that the menu expands and collapses smoothly, both after a reload and on user interaction.


https://github.com/user-attachments/assets/3a2082bf-86f3-4308-8975-942840666731



## Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [X] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
