### PR TITLE
Fix: Rename LANGS variable in init.sh to avoid clashing with LANGS env

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -16,10 +16,10 @@ fi
 # Check if TESSERACT_LANGS environment variable is set and is not empty
 if [[ -n "$TESSERACT_LANGS" ]]; then
   # Convert comma-separated values to a space-separated list
-  LANGS=$(echo $TESSERACT_LANGS | tr ',' ' ')
+  SPACE_SEPARATED_LANGS=$(echo $TESSERACT_LANGS | tr ',' ' ')
   pattern='^[a-zA-Z]{2,4}(_[a-zA-Z]{2,4})?$'
   # Install each language pack
-  for LANG in $LANGS; do
+  for LANG in $SPACE_SEPARATED_LANGS; do
      if [[ $LANG =~ $pattern ]]; then
       apk add --no-cache "tesseract-ocr-data-$LANG"
      else


### PR DESCRIPTION
# Description

Rename LANGS variable in init.sh for TESSERACT_LANGS languages as it conflicts with the variable LANGS that is responsible for installing fonts

Closes #2464

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
