### PR TITLE
Fix img to pdf merge conversion type

### DIFF
--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -75,9 +75,10 @@
           // Check if any PDF files are encrypted and handle decryption if necessary
           const decryptedFiles = await checkAndDecryptFiles(url, files);
           files = decryptedFiles;
+          formData.delete('fileInput'); // Reset fileInput and Append
           // Append decrypted files to formData
           decryptedFiles.forEach((file, index) => {
-            formData.set(`fileInput`, file);
+            formData.append(`fileInput`, file);
           });
         }
 

--- a/src/main/resources/templates/convert/img-to-pdf.html
+++ b/src/main/resources/templates/convert/img-to-pdf.html
@@ -51,15 +51,11 @@
                 <br>
                 <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{imageToPDF.submit}"></button>
                 <script>
-                  $('#fileInput-input').on('change', function() {
+                    $('#fileInput-input').on('file-input-change', () => {
                     var files = document.getElementById("fileInput-input").files;
                     var conversionType = document.getElementById("conversionType");
                     console.log("files.length=" + files.length)
-                    if (files.length > 1) {
-                      conversionType.disabled = false;
-                    } else {
-                      conversionType.disabled = true;
-                    }
+                    conversionType.disabled = files.length <= 1;
                   });
 
                   $('#conversionType').change(function() {


### PR DESCRIPTION
# Description

### Root cause:
- After decrypting the files, the operation "set" was used instead of "append" for inputs files in FormData in download.js

### Solution
1. Remove fileInput entry from FormData to avoid duplicate values.
2. Append files to the FormData instead of setting them on each operation (as "set" would replace the existing values with the latest one).

Closes #2456

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [ ] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
