### PR TITLE
Fix: form data not being sent in multi

### DIFF
--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -87,7 +87,7 @@
 
         if (remoteCall === true) {
           if (override === 'multi' || (!multipleInputsForSingleRequest && files.length > 1 && override !== 'single')) {
-            await submitMultiPdfForm(url, files);
+            await submitMultiPdfForm(url, files, this);
           } else {
             await handleSingleDownload(url, formData);
           }
@@ -367,7 +367,7 @@
     return {filename, blob};
   }
 
-  async function submitMultiPdfForm(url, files) {
+  async function submitMultiPdfForm(url, files, form) {
     const zipThreshold = parseInt(localStorage.getItem('zipThreshold'), 10) || 4;
     const zipFiles = files.length > zipThreshold;
     let jszip = null;
@@ -390,7 +390,9 @@
 
     // Get existing form data
     let formData;
-    if (postForm) {
+    if (form) {
+      formData = new FormData(form);
+    } else if (postForm) {
       formData = new FormData($(postForm)[0]); // Convert the form to a jQuery object and get the raw DOM element
     } else {
       console.log('No form with POST method found.');


### PR DESCRIPTION
# Description

## Problem:
- When a form is submitted and multi downloads is expected, the file is sent successfully but not the form data/body as `let postForm = document.querySelector('form[method="POST"]');` retrieves the first form found and it's mostly the CSRF form

## Solution:
- Pass form to submitMultiPdfForm to use in FormData creation.

Closes #2490, #2488

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
