### PR TITLE
[Bugfix] A variety of tools miss PDFLib

### DIFF
--- a/src/main/resources/templates/convert/pdf-to-csv.html
+++ b/src/main/resources/templates/convert/pdf-to-csv.html
@@ -34,7 +34,6 @@
                 <canvas id="overlayCanvas" style="position: absolute; top: 0; left: 0; z-index: 2; width: 100%"></canvas>
               </div>
               <script type="module" th:src="@{'/pdfjs-legacy/pdf.mjs'}"></script>
-              <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
               <script type="module" th:src="@{'/js/pages/pdf-to-csv.js'}">
               </script>
             </div>

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -24,7 +24,8 @@
     <script>
       window.stirlingPDF = window.stirlingPDF || {};
     </script>
-	<script th:src="@{'/js/fetch-utils.js'}"></script>
+    <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
+    <script th:src="@{'/js/fetch-utils.js'}"></script>
     <!-- jQuery -->
     <script th:src="@{'/js/thirdParty/jquery.min.js'}"></script>
     <script th:src="@{'/js/thirdParty/jquery.validate.min.js'}"></script>
@@ -60,7 +61,6 @@
     <link rel="stylesheet" th:href="@{'/css/footer.css'}">
 
     <link rel="preload" th:href="@{'/fonts/google-symbol.woff2'}" as="font" type="font/woff2" crossorigin="anonymous">
-
 
     <script th:src="@{'/js/thirdParty/fontfaceobserver.standalone.js'}"></script>
 

--- a/src/main/resources/templates/merge-pdfs.html
+++ b/src/main/resources/templates/merge-pdfs.html
@@ -5,7 +5,6 @@
 <head>
   <th:block th:insert="~{fragments/common :: head(title=#{merge.title}, header=#{merge.header})}"></th:block>
   <link rel="stylesheet" th:href="@{'/css/merge.css'}">
-  <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
 </head>
 
 <body>

--- a/src/main/resources/templates/misc/add-image.html
+++ b/src/main/resources/templates/misc/add-image.html
@@ -30,7 +30,6 @@
               <!-- draggables box -->
               <div id="box-drag-container" class="show-on-file-selected">
                 <canvas id="pdf-canvas"></canvas>
-                <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
                 <script th:src="@{'/js/draggable-utils.js'}"></script>
                 <div class="draggable-buttons-box ignore-rtl">
                   <button class="btn btn-outline-secondary" onclick="DraggableUtils.deleteDraggableCanvas(DraggableUtils.getLastInteracted())">

--- a/src/main/resources/templates/misc/adjust-contrast.html
+++ b/src/main/resources/templates/misc/adjust-contrast.html
@@ -54,7 +54,6 @@
               </div>
               </form>
               <script type="module" th:src="@{'/pdfjs-legacy/pdf.mjs'}"></script>
-              <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
               <script type="module" th:src="@{'/js/pages/adjust-contrast.js'}"></script>
             </div>
           </div>

--- a/src/main/resources/templates/misc/extract-images.html
+++ b/src/main/resources/templates/misc/extract-images.html
@@ -2,7 +2,6 @@
 <html th:lang="${#locale.language}" th:dir="#{language.direction}" th:data-language="${#locale.toString()}" xmlns:th="https://www.thymeleaf.org">
   <head>
   <th:block th:insert="~{fragments/common :: head(title=#{extractImages.title}, header=#{extractImages.header})}"></th:block>
-  <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
   </head>
 
   <body>

--- a/src/main/resources/templates/misc/remove-annotations.html
+++ b/src/main/resources/templates/misc/remove-annotations.html
@@ -28,7 +28,6 @@
       </div>
       <th:block th:insert="~{fragments/footer.html :: footer}"></th:block>
     </div>
-    <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
     <script th:src="@{'/js/local-pdf-input-download.js'}"></script>
     <script>
       document.getElementById('pdfForm').addEventListener('submit', async (e) => {

--- a/src/main/resources/templates/misc/replace-color.html
+++ b/src/main/resources/templates/misc/replace-color.html
@@ -4,7 +4,6 @@
 
 <head>
     <th:block th:insert="~{fragments/common :: head(title=#{replace-color.title}, header=#{replace-color.header})}"></th:block>
-    <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
 </head>
 
 <body>

--- a/src/main/resources/templates/multi-tool.html
+++ b/src/main/resources/templates/multi-tool.html
@@ -145,7 +145,6 @@
     <th:block th:insert="~{fragments/footer.html :: footer}"></th:block>
   </div>
   <script type="module" th:src="@{'/pdfjs-legacy/pdf.mjs'}"></script>
-  <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
   <script>
     window.selectedPages = [];
     window.selectPage = false;

--- a/src/main/resources/templates/overlay-pdf.html
+++ b/src/main/resources/templates/overlay-pdf.html
@@ -2,7 +2,6 @@
 <html th:lang="${#locale.language}" th:dir="#{language.direction}" th:data-language="${#locale.toString()}" xmlns:th="https://www.thymeleaf.org">
   <head>
   <th:block th:insert="~{fragments/common :: head(title=#{split-by-size-or-count.title}, header=#{split-by-size-or-count.header})}"></th:block>
-  <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
   </head>
 
   <body>

--- a/src/main/resources/templates/pipeline.html
+++ b/src/main/resources/templates/pipeline.html
@@ -14,7 +14,6 @@
       th:href="@{'/css/pipeline.css'}"
       th:if="${currentPage == 'pipeline'}"
     />
-    <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
     <script th:inline="javascript">
       const saveSettings = /*[[#{pipelineOptions.saveSettings}]]*/ "";
       const deletePipelineText = /*[[#{pipeline.deletePrompt}]]*/ "Are you sure you want to delete pipeline";
@@ -194,7 +193,7 @@
                   </div>
                 </div>
                 <script th:src="@{'/js/fetch-utils.js'}"></script>
-                <script th:src="@{'/js/pipeline.js'}"></script>\
+                <script th:src="@{'/js/pipeline.js'}"></script>
             </div>
           </div>
         </div>

--- a/src/main/resources/templates/sign.html
+++ b/src/main/resources/templates/sign.html
@@ -172,7 +172,6 @@
             <!-- draggables box -->
             <div id="box-drag-container" class="show-on-file-selected">
               <canvas id="pdf-canvas"></canvas>
-              <script th:src="@{'/js/thirdParty/pdf-lib.min.js'}"></script>
               <script th:src="@{'/js/draggable-utils.js'}"></script>
               <div class="draggable-buttons-box ignore-rtl">
                 <button class="btn btn-outline-secondary"


### PR DESCRIPTION
# Description

`Error checking encryption: ReferenceError: PDFLib is not defined`

e.g. http://127.0.0.1:8080/show-javascript

1. insert a PDF
2. look in the browser console

**_There should be no negative behavior when loading PDF-Lib everywhere._**

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
