### PR TITLE
Fix: Draw image with the original PDF page dimensions

### DIFF
--- a/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
+++ b/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
@@ -352,12 +352,17 @@ public class PdfUtils {
         pdfRenderer.setSubsamplingAllowed(true);
         for (int page = 0; page < document.getNumberOfPages(); ++page) {
             BufferedImage bim = pdfRenderer.renderImageWithDPI(page, 300, ImageType.RGB);
-            PDPage newPage = new PDPage(new PDRectangle(bim.getWidth(), bim.getHeight()));
+            PDPage originalPage = document.getPage(page);
+
+            float width = originalPage.getMediaBox().getWidth();
+            float height = originalPage.getMediaBox().getHeight();
+
+            PDPage newPage = new PDPage(new PDRectangle(width, height));
             imageDocument.addPage(newPage);
             PDImageXObject pdImage = LosslessFactory.createFromImage(imageDocument, bim);
             PDPageContentStream contentStream =
                     new PDPageContentStream(imageDocument, newPage, AppendMode.APPEND, true, true);
-            contentStream.drawImage(pdImage, 0, 0);
+            contentStream.drawImage(pdImage, 0, 0, width, height);
             contentStream.close();
         }
         return imageDocument;


### PR DESCRIPTION
# Description

- Draw the converted image with the original PDF page dimensions to avoid page resizing due to high DPI and unspecified dimensions for drawImage

Closes #2486

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
