### PR TITLE
remove redundant entries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,6 @@ java {
 repositories {
     mavenCentral()
     maven { url "https://jitpack.io" }
-    maven { url "https://build.shibboleth.net/nexus/content/repositories/releases/" }
-    maven {
-        url 'https://build.shibboleth.net/maven/releases'
-    }
     maven { url "https://build.shibboleth.net/maven/releases" }
     maven { url "https://maven.pkg.github.com/jcefmaven/jcefmaven" }
 


### PR DESCRIPTION
# Description

`https://build.shibboleth.net/nexus/content/repositories/releases/` redirects to `https://build.shibboleth.net/maven/releases`

`https://build.shibboleth.net/maven/releases` is duplicate

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
