### PR TITLE
Standardize Alpine base image format and version across all Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Main stage
-FROM alpine:3.20.3@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
+FROM alpine:3.21.0@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45
 
 # Copy necessary files
 COPY scripts /scripts

--- a/Dockerfile-fat
+++ b/Dockerfile-fat
@@ -12,7 +12,7 @@ RUN DOCKER_ENABLE_SECURITY=true \
 ./gradlew clean build
 
 # Main stage
-FROM alpine:3.20.3
+FROM alpine:3.21.0@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45
 
 # Copy necessary files
 COPY scripts /scripts

--- a/Dockerfile-ultra-lite
+++ b/Dockerfile-ultra-lite
@@ -1,5 +1,5 @@
 # use alpine
-FROM alpine:3.21.0
+FROM alpine:3.21.0@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45
 
 ARG VERSION_TAG
 


### PR DESCRIPTION
# Description

- Update all Dockerfiles to use `alpine:3.21.0` with SHA256 checksum
- Ensure consistent image versioning, enhanced security, and reproducibility by explicitly specifying the digest.

cc #2436 #2516

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
