### PR TITLE
docs(readme): fix typo SECURITY_ENABLE_LOGIN to  SECURITY_ENABLELOGIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ For those wanting to use Stirling-PDF's backend API to link with their own custo
 
 - User must have the folder `./configs` volumed within Docker so that it is retained during updates.
 - Docker users must download the security jar version by setting `DOCKER_ENABLE_SECURITY` to `true` in environment variables.
-- Then either enable login via the `settings.yml` file or set `SECURITY_ENABLE_LOGIN` to `true`.
+- Then either enable login via the `settings.yml` file or set `SECURITY_ENABLELOGIN` to `true`.
 - Now the initial user will be generated with username `admin` and password `stirling`. On login, you will be forced to change the password to a new one. You can also use the environment variables `SECURITY_INITIALLOGIN_USERNAME` and `SECURITY_INITIALLOGIN_PASSWORD` to set your own credentials straight away (recommended to remove them after user creation).
 
 Once the above has been done, on restart, a new `stirling-pdf-DB.mv.db` will show if everything worked.


### PR DESCRIPTION
# Description

`SECURITY_ENABLELOGIN` is the right name.

Closes #(issue_number)

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
