### PR TITLE
fix(ui): make div for table container responsive

### DIFF
--- a/src/main/resources/templates/addUsers.html
+++ b/src/main/resources/templates/addUsers.html
@@ -60,7 +60,7 @@
               <div th:if="${deleteMessage}" class="alert alert-danger">
                 <span th:text="#{${deleteMessage}}">Default message if not found</span>
               </div>
-              <div class="bg-card mt-3 mb-3">
+              <div class="bg-card mt-3 mb-3 table-responsive">
                 <table class="table table-striped table-hover">
                   <thead>
                     <tr>


### PR DESCRIPTION
# Description

Added bootstrap `table-responsive` class to the div container to prevent the table overflowing in small-width devices (horizontal scroll is enabled instead if it does not fit).

Before:

![before](https://github.com/user-attachments/assets/72328dfb-e8e8-4d25-bb09-b0d41577e655)


After:

![after](https://github.com/user-attachments/assets/721d77bc-ce2d-4860-9d25-19fe9b1a6b26)

Closes #2621 

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
