### PR TITLE
expand: check language properties

### DIFF
--- a/.github/scripts/check_language_properties.py
+++ b/.github/scripts/check_language_properties.py
@@ -11,6 +11,8 @@ adjusting the format.
 Usage:
     python check_language_properties.py --reference-file <path_to_reference_file> --branch <branch_name> [--actor <actor_name>] [--files <list_of_changed_files>]
 """
+# Sample for Windows:
+# python .github/scripts/check_language_properties.py --reference-file src\main\resources\messages_en_GB.properties --branch "" --files src\main\resources\messages_de_DE.properties src\main\resources\messages_uk_UA.properties
 
 import copy
 import glob
@@ -164,8 +166,14 @@ def check_for_differences(reference_file, file_list, branch, actor):
         basename_current_file = os.path.basename(os.path.join(branch, file_path))
         if (
             basename_current_file == basename_reference_file
-            or not file_path.startswith(
-                os.path.join("src", "main", "resources", "messages_")
+            or (
+                # only local windows command
+                not file_path.startswith(
+                    os.path.join("", "src", "main", "resources", "messages_")
+                )
+                and not file_path.startswith(
+                    os.path.join(os.getcwd(), "src", "main", "resources", "messages_")
+                )
             )
             or not file_path.endswith(".properties")
             or not basename_current_file.startswith("messages_")
@@ -276,6 +284,12 @@ if __name__ == "__main__":
         help="Branch name.",
     )
     parser.add_argument(
+        "--check-file",
+        type=str,
+        required=False,
+        help="List of changed files, separated by spaces.",
+    )
+    parser.add_argument(
         "--files",
         nargs="+",
         required=False,
@@ -293,11 +307,14 @@ if __name__ == "__main__":
 
     file_list = args.files
     if file_list is None:
-        file_list = glob.glob(
-            os.path.join(
-                os.getcwd(), "src", "main", "resources", "messages_*.properties"
+        if args.check_file:
+            file_list = [args.check_file]
+        else:
+            file_list = glob.glob(
+                os.path.join(
+                    os.getcwd(), "src", "main", "resources", "messages_*.properties"
+                )
             )
-        )
         update_missing_keys(args.reference_file, file_list)
     else:
         check_for_differences(args.reference_file, file_list, args.branch, args.actor)

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,6 +1,7 @@
 name: Update Translations
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
     paths:

--- a/HowToAddNewLanguage.md
+++ b/HowToAddNewLanguage.md
@@ -60,3 +60,13 @@ ignore = [
 - After adding the new tags to `messages_en_GB.properties`, add and translate them in the respective language file (e.g., `messages_pl_PL.properties`).
 
 Make sure to place the entry under the correct language section. This helps maintain the accuracy of translation progress statistics and ensures that the translation tool or scripts do not misinterpret the completion rate.
+
+### Use this code to perform a local check
+
+#### Windows command
+
+```ps
+python .github/scripts/check_language_properties.py --reference-file src\main\resources\messages_en_GB.properties --branch "" --files src\main\resources\messages_pl_PL.properties
+
+python .github/scripts/check_language_properties.py --reference-file src\main\resources\messages_en_GB.properties --branch "" --check-file src\main\resources\messages_pl_PL.properties
+```


### PR DESCRIPTION
# Description

Improvement in `check_language_properties.py`:

Added support for local Windows commands to check language properties files with an updated script.
Added a new optional argument `--check-file` to specify a single file to check, replacing the need to process all files in the directory.
Adjusted file path handling to better support Windows paths.

Update to `update-translations.yml`:

Added `workflow_dispatch` trigger to allow manual execution of the workflow.

Documentation update in `HowToAddNewLanguage.md`:

Added instructions for running the language properties check locally on Windows, including example commands.
These changes streamline the process of checking language properties files and provide additional flexibility for local testing and manual workflow triggering.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have attached images of the change if it is UI based
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If my code has heavily changed functionality I have updated relevant docs on [Stirling-PDFs doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/)
- [x] My changes generate no new warnings
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)
