### PR TITLE
[Fix] Handle missing end page in PDF split range

### DIFF
--- a/src/main/java/stirling/software/SPDF/utils/GeneralUtils.java
+++ b/src/main/java/stirling/software/SPDF/utils/GeneralUtils.java
@@ -285,7 +285,10 @@ public class GeneralUtils {
             String[] rangeParts = part.split("-");
             try {
                 int start = Integer.parseInt(rangeParts[0]);
-                int end = Integer.parseInt(rangeParts[1]);
+                int end =
+                        (rangeParts.length > 1 && !rangeParts[1].isEmpty())
+                                ? Integer.parseInt(rangeParts[1])
+                                : totalPages;
                 for (int i = start; i <= end; i++) {
                     if (i >= 1 && i <= totalPages) {
                         partResult.add(i - 1 + offset);


### PR DESCRIPTION
## Summary of Changes

**What was changed:**
- Updated the `handlePart` method to handle cases where the end page is not specified (e.g., '1-').
- The method now defaults to the last page of the PDF, improving the feature's usability.

**Why the change was made:**
- Users often forget the total page count when splitting PDFs. The new feature ensures that when only the starting page is specified, the range defaults to the last page, preventing errors like `ArrayIndexOutOfBoundsException`.

**Any challenges encountered:**
- No significant challenges encountered while implementing this feature.

**Closes #1576**

---

## Checklist

### General
- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) 
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


### Testing
- [x] I have tested my changes locally.
