### PR TITLE
Fix: incorrect `setAttribute` syntax for `tooltip` `data-title`

### DIFF
--- a/src/main/resources/static/js/navbar.js
+++ b/src/main/resources/static/js/navbar.js
@@ -48,7 +48,7 @@ window.tooltipSetup = () => {
   tooltipElements.forEach((element) => {
     const tooltipText = element.getAttribute('title');
     element.removeAttribute('title');
-    element.setAttribute('data-title, tooltipText');
+    element.setAttribute('data-title', 'tooltipText');
     const customTooltip = document.createElement('div');
     customTooltip.className = 'btn-tooltip';
     customTooltip.textContent = tooltipText;


### PR DESCRIPTION
# Description of Changes

### Summary
- Fixed incorrect syntax in `setAttribute` method in `navbar.js`, where an invalid argument format was used.
- Corrected `setAttribute('data-title, tooltipText');` to `setAttribute('data-title', tooltipText);`, ensuring the tooltip text is correctly assigned.

### Why the Change?
- The incorrect attribute assignment prevented tooltips from displaying properly.
- Ensures proper tooltip functionality in the navigation bar.

### Challenges Encountered
- Debugging the tooltip rendering issue and ensuring correct attribute assignment.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
