### PR TITLE
Add: Translation Support for `Sort by:` in Home Page

### DIFF
--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -273,6 +273,7 @@ home.legacyHomepage=Old homepage
 home.newHomePage=Try our new homepage!
 home.alphabetical=Alphabetical
 home.globalPopularity=Global Popularity
+home.sortBy=Sort by:
 
 home.multiTool.title=PDF Multi Tool
 home.multiTool.desc=Merge, Rotate, Rearrange, Split, and Remove pages

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -58,7 +58,7 @@
               <div style="display: flex; column-gap: 3rem; flex-wrap: wrap; margin-left:1rem">
                 <div
                 style="height:2.5rem;  display: flex; align-items: center; cursor: pointer; justify-content: center;">
-                <label for="sort-options">Sort by:</label>
+                <label for="sort-options" th:text="home.sortBy">Sort by:</label>
                 <select id="sort-options" style="border:none;">
                   <option value="alphabetical" th:text="#{home.alphabetical}"> </option>
                   <!-- <option value="personal">Your most used</option> -->

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -58,7 +58,7 @@
               <div style="display: flex; column-gap: 3rem; flex-wrap: wrap; margin-left:1rem">
                 <div
                 style="height:2.5rem;  display: flex; align-items: center; cursor: pointer; justify-content: center;">
-                <label for="sort-options" th:text="home.sortBy">Sort by:</label>
+                <label for="sort-options" th:text="#{home.sortBy}">Sort by:</label>
                 <select id="sort-options" style="border:none;">
                   <option value="alphabetical" th:text="#{home.alphabetical}"> </option>
                   <!-- <option value="personal">Your most used</option> -->


### PR DESCRIPTION
# Description of Changes

### Summary
- Added a new translation key `home.sortBy` in `messages_en_GB.properties` for "Sort by:".
- Updated `home.html` to use the new translation key via `th:text="#{home.sortBy}"`.
- Ensures the "Sort by:" label is properly localized and can be translated into different languages.

### Why the Change?
- Improves internationalization (i18n) by allowing the "Sort by:" label to be translated.
- Keeps consistency with other translatable UI elements.

### Challenges Encountered
- Ensuring that all relevant parts of the UI correctly reference the translation key.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
