### PR TITLE
Fix issue #2842: Handle qpdf exit code 3 as success with warnings

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/misc/RepairController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/RepairController.java
@@ -61,6 +61,10 @@ public class RepairController {
                     ProcessExecutor.getInstance(ProcessExecutor.Processes.QPDF)
                             .runCommandWithOutputHandling(command);
 
+            if (!Files.exists(tempInputFile)) {
+                throw new IOException("Temporary file does not exist: " + tempInputFile);
+            }
+
             // Read the optimized PDF file
             pdfBytes = pdfDocumentFactory.loadToBytes(tempInputFile.toFile());
 

--- a/src/main/java/stirling/software/SPDF/utils/ProcessExecutor.java
+++ b/src/main/java/stirling/software/SPDF/utils/ProcessExecutor.java
@@ -232,7 +232,7 @@ public class ProcessExecutor {
                 if (!liveUpdates) {
                     log.warn("Command error output:\n" + errorMessage);
                 }
-                if (exitCode != 0) {
+                if (exitCode != 0 && exitCode != 3) {
                     throw new IOException(
                             "Command process failed with exit code "
                                     + exitCode
@@ -241,13 +241,18 @@ public class ProcessExecutor {
                 }
             }
 
-            if (exitCode != 0) {
+            if (exitCode != 0 && exitCode != 3) {
                 throw new IOException(
                         "Command process failed with exit code "
                                 + exitCode
                                 + "\nLogs: "
                                 + messages);
             }
+
+            if (exitCode == 3) {
+                log.warn("qpdf succeeded with warning: {}", messages);
+            }
+
         } finally {
             semaphore.release();
         }


### PR DESCRIPTION
# Description of Changes

Summary of the changes:

- **What was changed**:
  - Modified the `ProcessExecutor` class to accept exit code `3` from qpdf as a success with warnings.
  - Added a warning log for exit code `3` to provide better visibility into the repair process.
  - Added a file existence check in the `RepairController` to ensure the temporary file exists before proceeding.

- **Why the change was made**:
  - The repair process was failing when qpdf returned exit code `3`, even though the operation succeeded with warnings. This caused unnecessary errors for users.
  - The changes ensure that PDFs with minor structural issues (e.g., mismatched object counts) are still repaired successfully, while logging warnings for transparency.

- **Any challenges encountered**:
  - Understanding qpdf's exit codes and ensuring the changes didn’t introduce regressions.
  - Testing the changes with various PDFs to confirm the behavior for exit codes `0`, `1`, `2`, and `3`.

Closes #2842

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] I have tested my changes locally. 

### Additional Notes
- The changes align with qpdf's behavior, where exit code `3` indicates a successful operation with warnings.
- No UI changes were made, so no screenshots or videos are attached.
- Documentation updates were not required as the changes do not affect user-facing functionality.