### PR TITLE
Fix issue #2511: Fix broken ZIP issue by adding zipOut.finish()

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
@@ -100,6 +100,8 @@ public class SplitPdfBySectionsController {
 
                 if (sectionNum == horiz * verti) pageNum++;
             }
+
+            zipOut.finish();
             data = Files.readAllBytes(zipFile);
             return WebResponseUtils.bytesToWebResponse(
                     data, filename + "_split.zip", MediaType.APPLICATION_OCTET_STREAM);


### PR DESCRIPTION

---

# Description of Changes

### What was changed
- Added `zipOut.finish()` to ensure the ZIP file is properly finalized after writing all entries.
- This ensures the central directory metadata is written, fixing the issue where the ZIP file was incomplete or broken.

### Why the change was made
- The issue (#2511) reported that splitting a PDF resulted in a broken ZIP file. The root cause was the missing central directory due to improper stream finalization.
- Adding `zipOut.finish()` explicitly ensures the ZIP file is correctly structured and can be extracted without errors.

### Challenges encountered

Closes #2511

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
  - Tested with various PDFs to ensure the ZIP file is created correctly.
  - Verified ZIP integrity using `unzip -t` and manual extraction.

---