### PR TITLE
readjusting the x and y coordinates of the image in the add image function (#2246)

### DIFF
--- a/src/main/resources/static/js/draggable-utils.js
+++ b/src/main/resources/static/js/draggable-utils.js
@@ -579,25 +579,23 @@ const DraggableUtils = {
         let x = draggablePositionPdf.x;
         let y = heightAdjusted - draggablePositionPdf.y - draggablePositionPdf.height;
 
-        let originx = x + draggablePositionPdf.width / 2;
-        let originy = heightAdjusted - draggablePositionPdf.y - draggablePositionPdf.height / 2;
-
         if (normalizedAngle === 90) {
-          x = draggablePositionPdf.y + draggablePositionPdf.height;
-          y = draggablePositionPdf.x;
+          x = draggablePositionPdf.y - (draggablePositionPdf.height / 6);
+          y = draggablePositionPdf.x + (draggablePositionPdf.width / 8);
         } else if (normalizedAngle === 180) {
-          x = widthAdjusted - draggablePositionPdf.x;
-          y = draggablePositionPdf.y + draggablePositionPdf.height;
+          x = widthAdjusted - draggablePositionPdf.x - draggablePositionPdf.width;
+          y = draggablePositionPdf.y;
         } else if (normalizedAngle === 270) {
-          x = heightAdjusted - draggablePositionPdf.y - draggablePositionPdf.height;
-          y = widthAdjusted - draggablePositionPdf.x;
+          x = (heightAdjusted) - draggablePositionPdf.y - (draggablePositionPdf.height + (draggablePositionPdf.height / 6));
+          y = widthAdjusted - draggablePositionPdf.x - (draggablePositionPdf.width - (draggablePositionPdf.width / 8));
         }
+
         // let angle = draggablePositionPixels.angle % 360;
         // if (angle < 0) angle += 360; // Normalize to positive angle
-        const radians = -draggablePositionPixels.angle; // Convert angle to radians
+        const radians = -draggablePositionPixels.angle + (rotation.angle * Math.PI) / 180;
         page.pushOperators(
           PDFLib.pushGraphicsState(),
-          PDFLib.concatTransformationMatrix(1, 0, 0, 1, originx, originy),
+          PDFLib.concatTransformationMatrix(1, 0, 0, 1, x + draggablePositionPdf.width / 2, y + draggablePositionPdf.height / 2),
           PDFLib.concatTransformationMatrix(
             Math.cos(radians),
             Math.sin(radians),
@@ -606,7 +604,7 @@ const DraggableUtils = {
             0,
             0
           ),
-          PDFLib.concatTransformationMatrix(1, 0, 0, 1, -1 * originx, -1 * originy)
+          PDFLib.concatTransformationMatrix(1, 0, 0, 1, -1 * (x + draggablePositionPdf.width / 2), -1 * (y + draggablePositionPdf.height / 2))
         );
         page.drawImage(pdfImageObject, {
           x: x,


### PR DESCRIPTION
# Description of Changes

Fixing the issue where images were distorted when added to pages with a non-zero angle.

**Issue:** The problem occurred whenever a page with an angle other than 0 was added. The image did not account for the page's rotation, only the image's rotation.

**Solution:**
The following file was modified:

- Modified: `src/main/resources/static/js/draggable-utils.js`

**File:** `draggable-utils.js`

The `getOverlayedPdfDocument()` function has been modified. It was necessary to modify the calculation to consider the page angle.

Closes #2246 

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
