### PR TITLE
fix: added missing language string en_GB, sl_SI

### DIFF
--- a/src/main/resources/messages_en_GB.properties
+++ b/src/main/resources/messages_en_GB.properties
@@ -623,6 +623,7 @@ redact.showAttatchments=Show Attachments
 redact.showLayers=Show Layers (double-click to reset all layers to the default state)
 redact.colourPicker=Colour Picker
 redact.findCurrentOutlineItem=Find current outline item
+redact.applyChanges=Apply Changes
 
 #showJS
 showJS.title=Show Javascript

--- a/src/main/resources/messages_sl_SI.properties
+++ b/src/main/resources/messages_sl_SI.properties
@@ -623,6 +623,7 @@ redact.showAttatchments=Prikaži priloge
 redact.showLayers=Prikaži plasti (dvokliknite za ponastavitev vseh plasti na privzeto stanje)
 redact.colourPicker=Izbirnik barv
 redact.findCurrentOutlineItem=Poišči trenutno postavko orisa
+redact.applyChanges=Uporabi spremembe
 
 #showJS
 showJS.title=Prikaži Javascript


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- added missing language string: redact.applyChanges=Apply Changes

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
