### PR TITLE
fix: handle empty tab groups in tab-container.js (closes #2479)

### DIFF
--- a/src/main/resources/static/js/tab-container.js
+++ b/src/main/resources/static/js/tab-container.js
@@ -4,6 +4,7 @@ TabContainer = {
     const unloadedGroups = [...groups].filter((g) => !g.initialised);
     unloadedGroups.forEach((group) => {
       const containers = group.querySelectorAll('.tab-container');
+      if (containers.length === 0) return;
       const tabTitles = [...containers].map((c) => c.getAttribute('data-title'));
       const tabList = document.createElement('div');
       tabList.classList.add('tab-buttons');


### PR DESCRIPTION
# Description of Changes  

## What was changed  
- Added safety check to skip tab group initialization when no `.tab-container` elements are present  
- Modified `initTabGroups()` method to return early if `containers.length === 0`  

## Why the change was made  
- Fixes NullPointerException (#2479) when tab groups exist without containers  
- Prevents runtime errors in edge cases where empty/misconfigured tab groups exist  
- Maintains existing functionality while adding graceful degradation  

## Challenges encountered  

Closes #2479  

---  

## Checklist  

### General  

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)  
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md)  
- [x] I have performed a self-review of my own code  
- [x] My changes generate no new warnings  

### Documentation  

- [ ] I have updated relevant docs (Not required - no functional changes to API/behavior)  

### UI Changes  

- [ ] Not applicable (Pure JavaScript fix with no visual changes)  

### Testing  

- [x] Manual testing performed: 

---