### PR TITLE
fix(pdf): resolve compression error and file overwrite issues

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
@@ -5,6 +5,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,7 +95,9 @@ public class CompressController {
                     }
                 }
             }
-            doc.save(pdfFile.toString());
+            Path tempOutput = Files.createTempFile("output_", ".pdf");
+            doc.save(tempOutput.toString());
+            Files.move(tempOutput, pdfFile, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 
@@ -188,7 +191,7 @@ public class CompressController {
                     optimizeLevel =
                             incrementOptimizeLevel(
                                     optimizeLevel, outputFileSize, expectedOutputSize);
-                    if (autoMode && optimizeLevel > 9) {
+                    if (autoMode && optimizeLevel >= 9) {
                         log.info("Maximum compression level reached in auto mode");
                         sizeMet = true;
                     }


### PR DESCRIPTION
# Description of Changes

- **What was changed:**
  - Modified the file handling logic to avoid overwriting the source PDF while it is being read, which previously led to corrupted output files.
  -Modified the logic where optimizeLevel is 9 and we are chacking for optimizeLevel < 9.
- **Why the change was made:**
  - The original compression process would stuck when dealing with larger files, failing to meet the specified target size limits.
  - Overwriting the input file during processing was causing warnings and potential file corruption, which could lead to instability and incorrect outputs.

- **Any challenges encountered:**

Closes #2930

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally
