### PR TITLE
fix: Allow Entry overflow when text is too long

### DIFF
--- a/src/main/resources/templates/fragments/navbarEntry.html
+++ b/src/main/resources/templates/fragments/navbarEntry.html
@@ -4,7 +4,7 @@ th:if="${@endpointConfiguration.isEndpointEnabled(endpoint)}">
     th:data-bs-link="@{${endpoint}}"
     th:classappend="${endpoint.equals(currentPage)} ?  ${toolGroup} + ' active' : '' + ${toolGroup}"
     th:data-bs-tags="#{${tagKey}}" th:data-bs-title='#{${titleKey}}'>
-    <div style="height:2.7rem; align-items: center;display: flex;" th:title="#{${descKey}}" class="icon" alt="icon"
+    <div style="min-height:2.7rem; align-items: center;display: flex;" th:title="#{${descKey}}" class="icon" alt="icon"
       th:class="@{${toolGroup}}">
       <span class="material-symbols-rounded nav-icon" th:text="@{${toolIcon}}" style=" align-items:center; display: flex; justify-content: center; height:2.7rem; width:2.7rem"></span>
       <span class="icon-text" th:text="#{${titleKey}}"></span>

--- a/src/main/resources/templates/fragments/navbarEntryCustom.html
+++ b/src/main/resources/templates/fragments/navbarEntryCustom.html
@@ -4,7 +4,7 @@
     th:data-bs-link="@{${endpoint}}"
     th:classappend="${endpoint.equals(currentPage)} ?  ${toolGroup} + ' active' : '' + ${toolGroup}"
     th:data-bs-tags="#{${tagKey}}" th:data-bs-title='#{${titleKey}}'>
-    <div style="height:2.5rem;align-items: center;display: flex" th:title="#{${descKey}}" class="icon" alt="icon"
+    <div style="min-height:2.5rem;align-items: center;display: flex" th:title="#{${descKey}}" class="icon" alt="icon"
       th:class="@{${toolGroup}}">
       <svg class="nav-icon"
         style="height: 2.7rem; width:2.7rem; align-items:center; display: flex; justify-content: center;">


### PR DESCRIPTION
# Description of Changes

In the French language, some entries on the home page have overlapping when the text is on 3 lines.

Before : 
![image](https://github.com/user-attachments/assets/38cf2912-47dc-42a4-9634-9069345840c4)

After : 

![image](https://github.com/user-attachments/assets/5ea43d9b-3f77-46d8-a603-aa2796c13306)


---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
