### PR TITLE
Fix/full invert crash 2942

### DIFF
--- a/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
+++ b/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
@@ -117,8 +117,6 @@ public class InvertFullColorStrategy extends ReplaceAndInvertColorStrategy {
     private File convertToBufferedImageTpFile(BufferedImage image) throws IOException {
         File file = File.createTempFile("image", ".png");
         ImageIO.write(image, "png", file);
-        //Ensures temp file is deleted when jvm terminates
-        file.deleteOnExit();
         return file;
     }
 }

--- a/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
+++ b/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
@@ -30,52 +30,69 @@ public class InvertFullColorStrategy extends ReplaceAndInvertColorStrategy {
     @Override
     public InputStreamResource replace() throws IOException {
 
-        // Create a temporary file, with the original filename from the multipart file
-        File file = Files.createTempFile("temp", getFileInput().getOriginalFilename()).toFile();
+        File file = null;
+        try {
+            // Create a temporary file, with the original filename from the multipart file
+            file = Files.createTempFile("temp", getFileInput().getOriginalFilename()).toFile();
 
-        // Transfer the content of the multipart file to the file
-        getFileInput().transferTo(file);
+            // Transfer the content of the multipart file to the file
+            getFileInput().transferTo(file);
 
-        // Load the uploaded PDF
-        PDDocument document = Loader.loadPDF(file);
+            // Load the uploaded PDF
+            PDDocument document = Loader.loadPDF(file);
 
-        // Render each page and invert colors
-        PDFRenderer pdfRenderer = new PDFRenderer(document);
-        for (int page = 0; page < document.getNumberOfPages(); page++) {
-            BufferedImage image =
-                    pdfRenderer.renderImageWithDPI(page, 300); // Render page at 300 DPI
+            // Render each page and invert colors
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            for (int page = 0; page < document.getNumberOfPages(); page++) {
+                BufferedImage image =
+                        pdfRenderer.renderImageWithDPI(page, 300); // Render page at 300 DPI
 
-            // Invert the colors
-            invertImageColors(image);
+                // Invert the colors
+                invertImageColors(image);
 
-            // Create a new PDPage from the inverted image
-            PDPage pdPage = document.getPage(page);
-            PDImageXObject pdImage =
-                    PDImageXObject.createFromFileByContent(
-                            convertToBufferedImageTpFile(image), document);
+                // Create a new PDPage from the inverted image
+                PDPage pdPage = document.getPage(page);
+                File tempImageFile = null;
+                try {
+                    tempImageFile = convertToBufferedImageTpFile(image);
+                    PDImageXObject pdImage =
+                            PDImageXObject.createFromFileByContent(tempImageFile, document);
 
-            PDPageContentStream contentStream =
-                    new PDPageContentStream(
-                            document, pdPage, PDPageContentStream.AppendMode.OVERWRITE, true);
-            contentStream.drawImage(
-                    pdImage,
-                    0,
-                    0,
-                    pdPage.getMediaBox().getWidth(),
-                    pdPage.getMediaBox().getHeight());
-            contentStream.close();
+                    PDPageContentStream contentStream =
+                            new PDPageContentStream(
+                                    document,
+                                    pdPage,
+                                    PDPageContentStream.AppendMode.OVERWRITE,
+                                    true);
+                    contentStream.drawImage(
+                            pdImage,
+                            0,
+                            0,
+                            pdPage.getMediaBox().getWidth(),
+                            pdPage.getMediaBox().getHeight());
+                    contentStream.close();
+                } finally {
+                    if (tempImageFile != null && tempImageFile.exists()) {
+                        Files.delete(tempImageFile.toPath());
+                    }
+                }
+            }
+
+            // Save the modified PDF to a ByteArrayOutputStream
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            document.save(byteArrayOutputStream);
+            document.close();
+
+            // Prepare the modified PDF for download
+            ByteArrayInputStream inputStream =
+                    new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+            InputStreamResource resource = new InputStreamResource(inputStream);
+            return resource;
+        } finally {
+            if (file != null && file.exists()) {
+                Files.delete(file.toPath());
+            }
         }
-
-        // Save the modified PDF to a ByteArrayOutputStream
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        document.save(byteArrayOutputStream);
-        document.close();
-
-        // Prepare the modified PDF for download
-        ByteArrayInputStream inputStream =
-                new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
-        InputStreamResource resource = new InputStreamResource(inputStream);
-        return resource;
     }
 
     // Method to invert image colors

--- a/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
+++ b/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
@@ -100,6 +100,8 @@ public class InvertFullColorStrategy extends ReplaceAndInvertColorStrategy {
     private File convertToBufferedImageTpFile(BufferedImage image) throws IOException {
         File file = File.createTempFile("image", ".png");
         ImageIO.write(image, "png", file);
+        //Ensures temp file is deleted when jvm terminates
+        file.deleteOnExit();
         return file;
     }
 }

--- a/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
+++ b/src/main/java/stirling/software/SPDF/utils/misc/InvertFullColorStrategy.java
@@ -98,7 +98,7 @@ public class InvertFullColorStrategy extends ReplaceAndInvertColorStrategy {
 
     // Helper method to convert BufferedImage to InputStream
     private File convertToBufferedImageTpFile(BufferedImage image) throws IOException {
-        File file = new File("image.png");
+        File file = File.createTempFile("image", ".png");
         ImageIO.write(image, "png", file);
         return file;
     }


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- What was changed
  - Modified the `convertToBufferedImageTpFile` to use `File.createTempFile()` instead of writing to `"image.png"` in the current directory.
   - This change ensures the file is saved in the default temporary directory, preventing permission issues.

- Why the change was made
  - Previously, the method attempted to save the file in the current working directory, which caused permission errors (`java.io.FileNotFoundException: image.png (Permission denied)`).
 
- Any challenges encountered

Closes #2942

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
