### PR TITLE
Fix: Replace pull_request with pull_request_target in SonarQube Workflow for Fork Analysis

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,3 +1,5 @@
+name: Run Sonarqube
+
 on:
   push:
     branches:
@@ -10,13 +12,11 @@ on:
 permissions:
   pull-requests: read
   actions: read
-name: Run Sonarqube
+
 jobs:
   sonarqube:
     runs-on: ubuntu-latest
     steps:
-
-
       - name: Harden Runner
         uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -2,8 +2,9 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches: [ "main" ]
+  pull_request_target:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

This update changes the workflow trigger for SonarQube from using the `pull_request` event to `pull_request_target` for the "main" branch. By doing so, the workflow runs in the context of the base repository, ensuring that the required secrets (like `SONAR_TOKEN`) are available during execution—even when analyzing code from forked repositories. This change enables full Sonar analysis for PRs from forks while being mindful of potential security implications.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
