### PR TITLE
Enable Java Formatting - Use `build` code formatting in VS Code IDE

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,7 +40,7 @@
     "files.insertFinalNewline": false
   },
   "diffEditor.maxComputationTime": 0,
-  "editor.wordSegmenterLocales": null,
+  "editor.wordSegmenterLocales": "",
   "editor.guides.bracketPairs": "active",
   "editor.guides.bracketPairsHorizontal": "active",
   "files.insertFinalNewline": true,
@@ -50,6 +50,9 @@
   "editor.stickyScroll.enabled": false,
   "editor.minimap.enabled": false,
   "editor.formatOnSave": true,
+  "java.format.enabled": true,
+  "java.format.settings.profile": "GoogleStyle",
+  "java.format.settings.google.version": "1.25.2",
   "java.format.settings.google.mode": "jar-file",
   "java.format.settings.google.extra": "--aosp --skip-sorting-imports"
 }


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

This PR updates the VSCode settings by making the following changes:

- Changed the value of `editor.wordSegmenterLocales` from `null` to an empty string (`""`). This adjustment helps to avoid potential issues with locale detection in the editor.
- Added new Java formatting settings:
  - Enabled Java formatting with `"java.format.enabled": true`
  - Set the formatting profile to `"GoogleStyle"`
  - Specified the Google Java formatting version as `"1.25.2"`

These changes improve consistency and enforce coding standards in the development environment by aligning Java code formatting with the Google style guide.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
