### PR TITLE
Fix wrong paths for Unix installations (standalone)

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/ExternalAppDepConfig.java
+++ b/src/main/java/stirling/software/SPDF/config/ExternalAppDepConfig.java
@@ -21,9 +21,9 @@ public class ExternalAppDepConfig {
 
                 {
                     put("soffice", List.of("LibreOffice"));
-                    put("/opt/venv/bin/weasyprint", List.of("Weasyprint"));
+                    put("weasyprint", List.of("Weasyprint"));
                     put("pdftohtml", List.of("Pdftohtml"));
-                    put("/opt/venv/bin/unoconvert", List.of("Unoconv"));
+                    put("unoconvert", List.of("Unoconv"));
                     put("qpdf", List.of("qpdf"));
                     put("tesseract", List.of("tesseract"));
                 }


### PR DESCRIPTION
On standalone Unix installations, these paths:

/opt/venv/bin/weasyprint
/opt/venv/bin/unoconvert

are invalid, causing the Markdown To PDF, Url To PDF, Html To PDF, and File To PDF features to be disabled.
