### PR TITLE
Fix: Analytics Initialization Behavior

### DIFF
--- a/src/main/java/stirling/software/SPDF/service/PostHogService.java
+++ b/src/main/java/stirling/software/SPDF/service/PostHogService.java
@@ -207,8 +207,7 @@ public class PostHogService {
 
     private void addIfNotEmpty(Map<String, Object> map, String key, Object value) {
         if (value != null) {
-            if (value instanceof String) {
-                String strValue = (String) value;
+            if (value instanceof String strValue) {
                 if (!StringUtils.isBlank(strValue)) {
                     map.put(key, strValue.trim());
                 }

--- a/src/main/resources/settings.yml.template
+++ b/src/main/resources/settings.yml.template
@@ -85,7 +85,7 @@ system:
   showUpdateOnlyAdmin: false # only admins can see when a new update is available, depending on showUpdate it must be set to 'true'
   customHTMLFiles: false # enable to have files placed in /customFiles/templates override the existing template HTML files
   tessdataDir: /usr/share/tessdata # path to the directory containing the Tessdata files. This setting is relevant for Windows systems. For Windows users, this path should be adjusted to point to the appropriate directory where the Tessdata files are stored.
-  enableAnalytics: 'true' # set to 'true' to enable analytics, set to 'false' to disable analytics; for enterprise users, this is set to true
+  enableAnalytics: 'undefined' # set to 'true' to enable analytics, set to 'false' to disable analytics; for enterprise users, this is set to true
   disableSanitize: false # set to true to disable Sanitize HTML; (can lead to injections in HTML)
   datasource:
     enableCustomDatabase: false # Enterprise users ONLY, set this property to 'true' if you would like to use your own custom database configuration


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

What was changed:

- Modified the default value of enableAnalytics in settings.yml.template from `true` to `undefined`.

Why the change was made:

- The analytics setting was updated to prevent the value from defaulting to true during initialization, which suppressed the display of the prompt dialog. Changing it to `undefined` ensures that the user is explicitly prompted to enable or disable analytics, thereby improving user control.

Closes #(issue_number)

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
