### PR TITLE
Enhance AppUpdateService: Add `@Configuration` Annotation for Improved Spring Boot Integration

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/AppUpdateService.java
+++ b/src/main/java/stirling/software/SPDF/config/AppUpdateService.java
@@ -4,13 +4,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Service;
 
 import stirling.software.SPDF.config.interfaces.ShowAdminInterface;
 import stirling.software.SPDF.model.ApplicationProperties;
 
 @Configuration
-@Service
 class AppUpdateService {
 
     private final ApplicationProperties applicationProperties;

--- a/src/main/java/stirling/software/SPDF/config/AppUpdateService.java
+++ b/src/main/java/stirling/software/SPDF/config/AppUpdateService.java
@@ -2,12 +2,14 @@ package stirling.software.SPDF.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 import stirling.software.SPDF.config.interfaces.ShowAdminInterface;
 import stirling.software.SPDF.model.ApplicationProperties;
 
+@Configuration
 @Service
 class AppUpdateService {
 


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

The AppUpdateService class now includes the `@Configuration` annotation in addition to the existing `@Service` annotation.

This update ensures that the class is properly registered as a configuration class within the Spring application context, thereby improving bean management and integration.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
