### PR TITLE
Restrict Backup Import to Initialization Process and Refactor API Key Handling

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/InitialSecuritySetup.java
+++ b/src/main/java/stirling/software/SPDF/config/security/InitialSecuritySetup.java
@@ -36,12 +36,13 @@ public class InitialSecuritySetup {
     @PostConstruct
     public void init() {
         try {
-            if (databaseService.hasBackup()) {
-                databaseService.importDatabase();
-            }
 
             if (!userService.hasUsers()) {
-                initializeAdminUser();
+                if (databaseService.hasBackup()) {
+                    databaseService.importDatabase();
+                } else {
+                    initializeAdminUser();
+                }
             }
 
             userService.migrateOauth2ToSSO();

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -122,7 +122,7 @@ public class UserService implements UserServiceInterface {
 
     public User addApiKeyToUser(String username) {
         Optional<User> user = findByUsernameIgnoreCase(username);
-        User user =  saveUser(user);
+        User user = saveUser(user);
         darebaseService.exportDatabase();
         return user;
     }

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -123,7 +123,11 @@ public class UserService implements UserServiceInterface {
     public User addApiKeyToUser(String username) {
         Optional<User> userOpt = findByUsernameIgnoreCase(username);
         User user = saveUser(userOpt, generateApiKey());
-        databaseService.exportDatabase();
+        try {
+            databaseService.exportDatabase();
+        } catch (SQLException | UnsupportedProviderException e) {
+            log.error("Error exporting database after adding API key to user", e);
+        }
         return user;
     }
 

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -121,9 +121,9 @@ public class UserService implements UserServiceInterface {
     }
 
     public User addApiKeyToUser(String username) {
-        Optional<User> user = findByUsernameIgnoreCase(username);
-        User user = saveUser(user);
-        darebaseService.exportDatabase();
+        Optional<User> userOpt = findByUsernameIgnoreCase(username);
+        User user = saveUser(userOpt, generateApiKey());
+        databaseService.exportDatabase();
         return user;
     }
 
@@ -169,9 +169,9 @@ public class UserService implements UserServiceInterface {
         saveUser(username, authenticationType, Role.USER.getRoleId());
     }
 
-    private User saveUser(Optional<User> user) {
+    private User saveUser(Optional<User> user, String apiKey) {
         if (user.isPresent()) {
-            user.get().setApiKey(generateApiKey());
+            user.get().setApiKey(apiKey);
             return userRepository.save(user.get());
         }
         throw new UsernameNotFoundException("User not found");

--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -122,11 +122,9 @@ public class UserService implements UserServiceInterface {
 
     public User addApiKeyToUser(String username) {
         Optional<User> user = findByUsernameIgnoreCase(username);
-        if (user.isPresent()) {
-            user.get().setApiKey(generateApiKey());
-            return userRepository.save(user.get());
-        }
-        throw new UsernameNotFoundException("User not found");
+        User user =  saveUser(user);
+        darebaseService.exportDatabase();
+        return user;
     }
 
     public User refreshApiKeyForUser(String username) {
@@ -169,6 +167,14 @@ public class UserService implements UserServiceInterface {
     public void saveUser(String username, AuthenticationType authenticationType)
             throws IllegalArgumentException, SQLException, UnsupportedProviderException {
         saveUser(username, authenticationType, Role.USER.getRoleId());
+    }
+
+    private User saveUser(Optional<User> user) {
+        if (user.isPresent()) {
+            user.get().setApiKey(generateApiKey());
+            return userRepository.save(user.get());
+        }
+        throw new UsernameNotFoundException("User not found");
     }
 
     public void saveUser(String username, AuthenticationType authenticationType, String role)


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed:**
  - Updated the backup import logic in `InitialSecuritySetup` so that the database backup is only imported during initialization when there are no users present. If no backup exists, the admin user is initialized instead.
  - Refactored the API key addition in `UserService` by extracting the logic into a private helper method `saveUser(Optional<User> user)` and added a call to export the database after updating the user's API key.

- **Why the change was made:**
  - To prevent accidental or unintended backup imports outside the initialization process, ensuring the system only imports backups when necessary.
  - To improve code clarity and maintainability in the user API key management process, while ensuring that the database state is preserved via an export after key updates.

Closes https://github.com/Stirling-Tools/Stirling-PDF/discussions/3057

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
