### PR TITLE
chore: migrate vscode settings to editorconfig when possible

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+max_line_length = 127
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_size = 4
+
+[*.py]
+indent_size = 2
+
+[*.gradle]
+indent_size = 4
+
+[*.html]
+indent_size = 2
+insert_final_newline = false
+trim_trailing_whitespace = false
+
+[*.js]
+indent_size = 2
+
+[*.yaml]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ trim_trailing_whitespace = true
 
 [*.java]
 indent_size = 4
+max_line_length = 100
 
 [*.py]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
+end_of_line = lf
 max_line_length = 127
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,76 +1,13 @@
 {
-  "java.compile.nullAnalysis.mode": "automatic",
-  "files.eol": "auto",
-  "java.configuration.updateBuildConfiguration": "interactive",
-  "black-formatter.args": [
-    "--line-length",
-    "127"
-  ],
-  "flake8.args": [
-    "--max-line-length",
-    "127"
-  ],
-  "[java]": {
-    "editor.tabSize": 4,
-    "editor.detectIndentation": false,
-    "editor.rulers": [
-      127
-    ],
-    "editor.defaultFormatter": "josevseb.google-java-format-for-vs-code"
-  },
-  "[python]": {
-    "editor.tabSize": 2,
-    "editor.detectIndentation": false,
-    "editor.rulers": [
-      127
-    ]
-  },
-  "[gradle-build]": {
-    "editor.tabSize": 4,
-    "editor.detectIndentation": false,
-    "editor.rulers": [
-      127
-    ]
-  },
-  "[gradle]": {
-    "editor.tabSize": 4,
-    "editor.detectIndentation": false,
-    "editor.rulers": [
-      127
-    ]
-  },
-  "[html]": {
-    "editor.tabSize": 2,
-    "editor.rulers": [
-      127
-    ],
-    "files.trimFinalNewlines": false,
-    "files.insertFinalNewline": false
-  },
-  "[javascript]": {
-    "editor.tabSize": 2,
-    "editor.rulers": [
-      127
-    ]
-  },
-  "[yaml]": {
-    "files.trimFinalNewlines": false,
-    "files.insertFinalNewline": false
-  },
-  "files.insertFinalNewline": true,
-  "files.trimFinalNewlines": true,
-  "files.trimTrailingWhitespace": true,
-  "files.autoSave": "onFocusChange",
-  "files.autoSaveWhenNoErrors": true,
-  "diffEditor.maxComputationTime": 0,
   "editor.wordSegmenterLocales": "",
   "editor.guides.bracketPairs": "active",
   "editor.guides.bracketPairsHorizontal": "active",
-  "editor.indentSize": "tabSize",
-  "editor.stickyScroll.enabled": false,
-  "editor.minimap.enabled": false,
-  "editor.formatOnSave": true,
-  "editor.insertSpaces": true,
+  "cSpell.enabled": false,
+  "[java]": {
+    "editor.defaultFormatter": "josevseb.google-java-format-for-vs-code"
+  },
+  "java.compile.nullAnalysis.mode": "automatic",
+  "java.configuration.updateBuildConfiguration": "interactive",
   "java.format.enabled": true,
   "java.format.settings.profile": "GoogleStyle",
   "java.format.settings.google.version": "1.25.2",
@@ -144,5 +81,4 @@
   "spring.initializr.defaultLanguage": "Java",
   "spring.initializr.defaultGroupId": "stirling.software.SPDF",
   "spring.initializr.defaultArtifactId": "SPDF",
-  "cSpell.enabled": false,
 }


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- What was changed
Migrate generic VS Code settings to [EditorConfig](https://editorconfig.org/) so that other editors/IDEs that support EditorConfig can benefit from it.  
Removed opinionated VS Code settings regarding IDE configuration (e.g., auto-save) to allow developers to use the interface they prefer.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
