### PR TITLE
fix desktop client stuck at 90%

### DIFF
--- a/src/main/java/stirling/software/SPDF/UI/impl/DesktopBrowser.java
+++ b/src/main/java/stirling/software/SPDF/UI/impl/DesktopBrowser.java
@@ -93,8 +93,21 @@ public class DesktopBrowser implements WebBrowser {
                                     setupMainFrame();
                                     setupLoadHandler();
 
-                                    // Show the frame immediately but transparent
-                                    frame.setVisible(true);
+                                    // Force initialize UI after 7 seconds if not already done
+                                    Timer timeoutTimer =
+                                            new Timer(
+                                                    7000,
+                                                    e -> {
+                                                        log.warn(
+                                                                "Loading timeout reached. Forcing"
+                                                                        + " UI transition.");
+                                                        if (!browserInitialized) {
+                                                            // Force UI initialization
+                                                            forceInitializeUI();
+                                                        }
+                                                    });
+                                    timeoutTimer.setRepeats(false);
+                                    timeoutTimer.start();
                                 });
                     } catch (Exception e) {
                         log.error("Error initializing JCEF browser: ", e);
@@ -238,8 +251,8 @@ public class DesktopBrowser implements WebBrowser {
                             boolean canGoBack,
                             boolean canGoForward) {
                         log.debug(
-                                "Loading state change - isLoading: {}, canGoBack: {}, canGoForward: {}, "
-                                        + "browserInitialized: {}, Time elapsed: {}ms",
+                                "Loading state change - isLoading: {}, canGoBack: {}, canGoForward:"
+                                        + " {}, browserInitialized: {}, Time elapsed: {}ms",
                                 isLoading,
                                 canGoBack,
                                 canGoForward,
@@ -248,7 +261,8 @@ public class DesktopBrowser implements WebBrowser {
 
                         if (!isLoading && !browserInitialized) {
                             log.info(
-                                    "Browser finished loading, preparing to initialize UI components");
+                                    "Browser finished loading, preparing to initialize UI"
+                                            + " components");
                             browserInitialized = true;
                             SwingUtilities.invokeLater(
                                     () -> {
@@ -289,10 +303,12 @@ public class DesktopBrowser implements WebBrowser {
                                                                         browser.getUIComponent()
                                                                                 .requestFocus();
                                                                         log.info(
-                                                                                "Browser component focused");
+                                                                                "Browser component"
+                                                                                        + " focused");
                                                                     } catch (Exception ex) {
                                                                         log.error(
-                                                                                "Error focusing browser",
+                                                                                "Error focusing"
+                                                                                        + " browser",
                                                                                 ex);
                                                                     }
                                                                 });
@@ -414,5 +430,68 @@ public class DesktopBrowser implements WebBrowser {
         if (client != null) client.dispose();
         if (cefApp != null) cefApp.dispose();
         if (loadingWindow != null) loadingWindow.dispose();
+    }
+
+    public static void forceInitializeUI() {
+        try {
+            if (loadingWindow != null) {
+                log.info("Forcing start of UI initialization sequence");
+
+                // Close loading window first
+                loadingWindow.setVisible(false);
+                loadingWindow.dispose();
+                loadingWindow = null;
+                log.info("Loading window disposed");
+
+                // Then setup the main frame
+                frame.setVisible(false);
+                frame.dispose();
+                frame.setOpacity(1.0f);
+                frame.setUndecorated(false);
+                frame.pack();
+                frame.setSize(UIScaling.scaleWidth(1280), UIScaling.scaleHeight(800));
+                frame.setLocationRelativeTo(null);
+                log.debug("Frame reconfigured");
+
+                // Show the main frame
+                frame.setVisible(true);
+                frame.requestFocus();
+                frame.toFront();
+                log.info("Main frame displayed and focused");
+
+                // Focus the browser component if available
+                if (browser != null) {
+                    Timer focusTimer =
+                            new Timer(
+                                    100,
+                                    e -> {
+                                        try {
+                                            browser.getUIComponent().requestFocus();
+                                            log.info("Browser component focused");
+                                        } catch (Exception ex) {
+                                            log.error(
+                                                    "Error focusing browser during force ui"
+                                                            + " initialization.",
+                                                    ex);
+                                        }
+                                    });
+                    focusTimer.setRepeats(false);
+                    focusTimer.start();
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error during Forced UI initialization.", e);
+            // Attempt cleanup on error
+            if (loadingWindow != null) {
+                loadingWindow.dispose();
+                loadingWindow = null;
+            }
+            if (frame != null) {
+                frame.setVisible(true);
+                frame.setOpacity(1.0f);
+                frame.setUndecorated(false);
+                frame.requestFocus();
+            }
+        }
     }
 }

--- a/src/main/java/stirling/software/SPDF/UI/impl/DesktopBrowser.java
+++ b/src/main/java/stirling/software/SPDF/UI/impl/DesktopBrowser.java
@@ -96,7 +96,7 @@ public class DesktopBrowser implements WebBrowser {
                                     // Force initialize UI after 7 seconds if not already done
                                     Timer timeoutTimer =
                                             new Timer(
-                                                    7000,
+                                                    2500,
                                                     e -> {
                                                         log.warn(
                                                                 "Loading timeout reached. Forcing"


### PR DESCRIPTION
So I have added a timer to force show the desktop client after 7seconds of intiliazation (if not already visible) because it gets stuck at 90% sometimes

#2487 #2595 

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [X] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation 
-- No functionality change.
### UI Changes (if applicable)

- [X] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)


- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.



https://github.com/user-attachments/assets/e889701e-bb21-4a06-b221-98a0faad6f2e

