### PR TITLE
Fix highlighter

### DIFF
--- a/src/main/resources/templates/view-pdf.html
+++ b/src/main/resources/templates/view-pdf.html
@@ -360,15 +360,14 @@ See https://github.com/adobe-type-tools/cmap-resources
             </div>
             <div id="toolbarViewerRight">
               <div id="editorModeButtons" class="splitToolbarButton toggled" role="radiogroup">
-                <button id="editorHighlight" class="toolbarButton" hidden="true" disabled="disabled" title="Highlight"
-                  role="radio" aria-checked="false" aria-controls="editorHighlightParamsToolbar" tabindex="31"
-                  data-l10n-id="pdfjs-editor-highlight-button">
-                  <span data-l10n-id="pdfjs-editor-highlight-button-label">Highlight</span>
-                </button>
                 <a id="backToHome" class="toolbarButton hiddenMediumView" title="Back to Main Page" role="radio"
-                  aria-checked="false" tabindex="32" th:href="@{'/'}">
+                  aria-checked="false" tabindex="31" th:href="@{'/'}">
                   <span data-l10n-id="pdfjs-open-file-button-label">Back to Main Page</span>
                 </a>
+                <button id="editorHighlight" class="toolbarButton hiddenMediumView" title="Highlight" role="radio"
+                aria-checked="false" tabindex="32" aria-expanded="false" aria-controls="editorHighlightParamsToolbar">
+                 <span data-l10n-id="pdfjs-editor-highlight-button-label">Highlight</span>
+               </button>
                 <button id="openFile" class="toolbarButton hiddenMediumView" title="Open File" role="radio"
                   aria-checked="false" tabindex="33" data-l10n-id="pdfjs-open-file-button">
                   <span data-l10n-id="pdfjs-open-file-button-label">Open</span>
@@ -389,7 +388,6 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
 
               <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
-
               <button id="editorFreeText" class="toolbarButton hiddenMediumView" title="Text" tabindex="41"
                 data-l10n-id="pdfjs-editor-free-text-button">
                 <span data-l10n-id="pdfjs-editor-free-text-button-label">Text</span>


### PR DESCRIPTION
# Description of Changes

- Added the missing highlighter icon to the View PDF section

Closes #(2873)
https://github.com/Stirling-Tools/Stirling-PDF/issues/2873

---

## Checklist

### General

- [✅](https://emojipedia.org/check-mark-button)] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [✅](https://emojipedia.org/check-mark-button) ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [✅](https://emojipedia.org/check-mark-button) ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [✅] I have performed a self-review of my own code
- [✅] My changes generate no new warnings


### UI Changes (if applicable)

![image](https://github.com/user-attachments/assets/b7700669-ac26-4b08-aa5d-ea35110eb19e)

