### PR TITLE
Fix: string comparison and formatting inconsistencies in `CompressController`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,12 +289,15 @@ tasks.wrapper {
 //    options.compilerArgs << "-Xlint:deprecation"
 //}
 configurations.all {
+    // Remove all commons-logging dependencies so that only spring-jcl is used
+    exclude group: 'commons-logging', module: 'commons-logging'
+    // Exclude Tomcat
     exclude group: "org.springframework.boot", module: "spring-boot-starter-tomcat"
 }
 dependencies {
 
     //tmp for security bumps
-	implementation 'ch.qos.logback:logback-core:1.5.17'
+    implementation 'ch.qos.logback:logback-core:1.5.17'
     implementation 'ch.qos.logback:logback-classic:1.5.17'
 
 

--- a/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
@@ -209,7 +209,7 @@ public class CompressController {
                     // First get the actual size of the original image by encoding it to the chosen
                     // format
                     ByteArrayOutputStream originalImageStream = new ByteArrayOutputStream();
-                    if (format.equals("jpeg")) {
+                    if ("jpeg".equals(format)) {
                         // Get the best available JPEG writer (prioritizes TwelveMonkeys if
                         // available)
                         Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpeg");
@@ -252,7 +252,7 @@ public class CompressController {
 
                     // Now compress the scaled image
                     ByteArrayOutputStream compressedImageStream = new ByteArrayOutputStream();
-                    if (format.equals("jpeg")) {
+                    if ("jpeg".equals(format)) {
                         Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName(format);
                         if (writers.hasNext()) {
                             ImageWriter writer = writers.next();
@@ -337,11 +337,12 @@ public class CompressController {
                     totalImages,
                     compressedImages,
                     skippedImages);
+            String formattedOverallImageReduction = String.format("%.1f", overallImageReduction);
             log.info(
-                    "Total original image size: {}, compressed: {} (reduced by {:.1f}%)",
+                    "Total original image size: {}, compressed: {} (reduced by {}%)",
                     GeneralUtils.formatBytes(totalOriginalBytes),
                     GeneralUtils.formatBytes(totalCompressedBytes),
-                    overallImageReduction);
+                    formattedOverallImageReduction);
 
             // Save the document
             log.info("Saving compressed PDF to {}", pdfFile.toString());
@@ -350,11 +351,12 @@ public class CompressController {
             // Log overall file size reduction
             long compressedFileSize = Files.size(pdfFile);
             double overallReduction = 100.0 - ((compressedFileSize * 100.0) / originalFileSize);
+            String formattedOverallReduction = String.format("%.1f", overallReduction);
             log.info(
-                    "Overall PDF compression: {} → {} (reduced by {:.1f}%)",
+                    "Overall PDF compression: {} → {} (reduced by {}%)",
                     GeneralUtils.formatBytes(originalFileSize),
                     GeneralUtils.formatBytes(compressedFileSize),
-                    overallReduction);
+                    formattedOverallReduction);
         }
     }
 
@@ -476,9 +478,10 @@ public class CompressController {
                     }
                     long postQpdfSize = Files.size(tempOutputFile);
                     double qpdfReduction = 100.0 - ((postQpdfSize * 100.0) / preQpdfSize);
+                    String formattedQpdfReduction = String.format("%.1f", qpdfReduction);
                     log.info(
                             "Post-QPDF file size: {} (reduced by {:.1f}%)",
-                            GeneralUtils.formatBytes(postQpdfSize), qpdfReduction);
+                            GeneralUtils.formatBytes(postQpdfSize), formattedQpdfReduction);
 
                 } else {
                     tempOutputFile = tempInputFile;

--- a/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
@@ -337,12 +337,11 @@ public class CompressController {
                     totalImages,
                     compressedImages,
                     skippedImages);
-            String formattedOverallImageReduction = String.format("%.1f", overallImageReduction);
             log.info(
                     "Total original image size: {}, compressed: {} (reduced by {}%)",
                     GeneralUtils.formatBytes(totalOriginalBytes),
                     GeneralUtils.formatBytes(totalCompressedBytes),
-                    formattedOverallImageReduction);
+                    String.format("%.1f", overallImageReduction));
 
             // Save the document
             log.info("Saving compressed PDF to {}", pdfFile.toString());
@@ -351,12 +350,11 @@ public class CompressController {
             // Log overall file size reduction
             long compressedFileSize = Files.size(pdfFile);
             double overallReduction = 100.0 - ((compressedFileSize * 100.0) / originalFileSize);
-            String formattedOverallReduction = String.format("%.1f", overallReduction);
             log.info(
                     "Overall PDF compression: {} → {} (reduced by {}%)",
                     GeneralUtils.formatBytes(originalFileSize),
                     GeneralUtils.formatBytes(compressedFileSize),
-                    formattedOverallReduction);
+                    String.format("%.1f", overallReduction));
         }
     }
 
@@ -478,10 +476,9 @@ public class CompressController {
                     }
                     long postQpdfSize = Files.size(tempOutputFile);
                     double qpdfReduction = 100.0 - ((postQpdfSize * 100.0) / preQpdfSize);
-                    String formattedQpdfReduction = String.format("%.1f", qpdfReduction);
                     log.info(
-                            "Post-QPDF file size: {} (reduced by {:.1f}%)",
-                            GeneralUtils.formatBytes(postQpdfSize), formattedQpdfReduction);
+                            "Post-QPDF file size: {} (reduced by {}%)",
+                            GeneralUtils.formatBytes(postQpdfSize), String.format("%.1f", qpdfReduction));
 
                 } else {
                     tempOutputFile = tempInputFile;


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- Replaced `format.equals("jpeg")` with `"jpeg".equals(format)` to prevent potential `NullPointerException`
- Standardized percentage reduction logging by formatting values before passing them into the log statement
- Fixed inconsistent formatting in log messages by replacing `{:.1f}%` with pre-formatted string values

`63.32 MB → 61.77 MB (reduced by {:.1f}%)` -> `63.32 MB → 61.77 MB (reduced by 2.5%)`

These changes improve code robustness and ensure consistent logging output.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
