### PR TITLE
fix metadata change on get-info

### DIFF
--- a/src/main/java/stirling/software/SPDF/service/CustomPDFDocumentFactory.java
+++ b/src/main/java/stirling/software/SPDF/service/CustomPDFDocumentFactory.java
@@ -257,7 +257,6 @@ public class CustomPDFDocumentFactory {
     }
 
     private void postProcessDocument(PDDocument doc) throws IOException {
-        pdfMetadataService.setDefaultMetadata(doc);
         removePassword(doc);
     }
 


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- Fixed the behavior, that the metadata of a pdf was changed when using the "Get info on PDF" function. Notably the Producer and ModificationDate are updated currently, wich is not in line with the description "Get Info".

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
