### PR TITLE
Removing redundant logoutUrl from oauth

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/oauth2/OAuth2Configuration.java
+++ b/src/main/java/stirling/software/SPDF/config/security/oauth2/OAuth2Configuration.java
@@ -186,7 +186,6 @@ public class OAuth2Configuration {
                         oauth.getClientSecret(),
                         oauth.getScopes(),
                         UsernameAttribute.valueOf(oauth.getUseAsUsername().toUpperCase()),
-                        oauth.getLogoutUrl(),
                         null,
                         null,
                         null);

--- a/src/main/java/stirling/software/SPDF/controller/web/OtherWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/OtherWebController.java
@@ -122,7 +122,8 @@ public class OtherWebController {
         return Arrays.stream(files)
                 .filter(file -> file.getName().endsWith(".traineddata"))
                 .map(file -> file.getName().replace(".traineddata", ""))
-                .filter(lang -> !lang.equalsIgnoreCase("osd")).sorted()
+                .filter(lang -> !lang.equalsIgnoreCase("osd"))
+                .sorted()
                 .toList();
     }
 

--- a/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
+++ b/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
@@ -230,7 +230,6 @@ public class ApplicationProperties {
             private Collection<String> scopes = new ArrayList<>();
             private String provider;
             private Client client = new Client();
-            private String logoutUrl;
 
             public void setScopes(String scopes) {
                 List<String> scopesList =

--- a/src/main/java/stirling/software/SPDF/model/provider/GitHubProvider.java
+++ b/src/main/java/stirling/software/SPDF/model/provider/GitHubProvider.java
@@ -29,7 +29,6 @@ public class GitHubProvider extends Provider {
                 clientSecret,
                 scopes,
                 useAsUsername != null ? useAsUsername : UsernameAttribute.LOGIN,
-                null,
                 AUTHORIZATION_URI,
                 TOKEN_URI,
                 USER_INFO_URI);

--- a/src/main/java/stirling/software/SPDF/model/provider/GoogleProvider.java
+++ b/src/main/java/stirling/software/SPDF/model/provider/GoogleProvider.java
@@ -30,7 +30,6 @@ public class GoogleProvider extends Provider {
                 clientSecret,
                 scopes,
                 useAsUsername,
-                null,
                 AUTHORIZATION_URI,
                 TOKEN_URI,
                 USER_INFO_URI);

--- a/src/main/java/stirling/software/SPDF/model/provider/KeycloakProvider.java
+++ b/src/main/java/stirling/software/SPDF/model/provider/KeycloakProvider.java
@@ -29,7 +29,6 @@ public class KeycloakProvider extends Provider {
                 useAsUsername,
                 null,
                 null,
-                null,
                 null);
     }
 

--- a/src/main/java/stirling/software/SPDF/model/provider/Provider.java
+++ b/src/main/java/stirling/software/SPDF/model/provider/Provider.java
@@ -25,7 +25,6 @@ public class Provider {
     private String clientSecret;
     private Collection<String> scopes;
     private UsernameAttribute useAsUsername;
-    private String logoutUrl;
     private String authorizationUri;
     private String tokenUri;
     private String userInfoUri;
@@ -38,7 +37,6 @@ public class Provider {
             String clientSecret,
             Collection<String> scopes,
             UsernameAttribute useAsUsername,
-            String logoutUrl,
             String authorizationUri,
             String tokenUri,
             String userInfoUri) {
@@ -50,7 +48,6 @@ public class Provider {
         this.scopes = scopes == null ? new ArrayList<>() : scopes;
         this.useAsUsername =
                 useAsUsername != null ? validateUsernameAttribute(useAsUsername) : EMAIL;
-        this.logoutUrl = logoutUrl;
         this.authorizationUri = authorizationUri;
         this.tokenUri = tokenUri;
         this.userInfoUri = userInfoUri;


### PR DESCRIPTION
Removed redundant logoutUrl from oauth code

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
