### PR TITLE
Deprecate `EnterpriseEdition`

### DIFF
--- a/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
+++ b/src/main/java/stirling/software/SPDF/model/ApplicationProperties.java
@@ -394,6 +394,7 @@ public class ApplicationProperties {
 
     // TODO: Remove post migration
     @Data
+    @Deprecated(since = "0.45.0")
     public static class EnterpriseEdition {
         private boolean enabled;
         @ToString.Exclude private String key;


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**:  
  Added the `@Deprecated(since = "0.45.0")` annotation to the `EnterpriseEdition` inner class within `ApplicationProperties`.

- **Why the change was made**:  
  This class is marked for removal after the migration process. Deprecating it now provides a clear signal to developers and automated tools that this class should no longer be used, easing future maintenance and cleanup.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
