### PR TITLE
Removed conflicting Oracle Java extension from devcontainer and VS Code config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -112,7 +112,7 @@
                 "ms-python.flake8", // Flake8 linter for Python to enforce code quality
                 "ms-python.python", // Official Microsoft Python extension with IntelliSense, debugging, and Jupyter support
                 "ms-vscode-remote.vscode-remote-extensionpack", // Remote Development Pack for SSH, WSL, and Containers
-                "Oracle.oracle-java", // Oracle Java extension with additional features for Java development
+                // "Oracle.oracle-java", // Oracle Java extension with additional features for Java development
                 "streetsidesoftware.code-spell-checker", // Spell checker for code to avoid typos
                 "vmware.vscode-boot-dev-pack", // Developer tools for Spring Boot by VMware
                 "vscjava.vscode-java-pack", // Java Extension Pack with essential Java tools for VS Code

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
     "ms-python.flake8", // Flake8 linter for Python to enforce code quality
     "ms-python.python", // Official Microsoft Python extension with IntelliSense, debugging, and Jupyter support
     "ms-vscode-remote.vscode-remote-extensionpack", // Remote Development Pack for SSH, WSL, and Containers
-    "Oracle.oracle-java", // Oracle Java extension with additional features for Java development
+    // "Oracle.oracle-java", // Oracle Java extension with additional features for Java development
     "streetsidesoftware.code-spell-checker", // Spell checker for code to avoid typos
     "vmware.vscode-boot-dev-pack", // Developer tools for Spring Boot by VMware
     "vscjava.vscode-java-pack", // Java Extension Pack with essential Java tools for VS Code


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- Commented out the `Oracle.oracle-java` extension in `.devcontainer/devcontainer.json` and `.vscode/extensions.json`.
- Reason: The Oracle Java extension conflicts with **Language Support for Java™ by Red Hat**, which is already included in the `vscjava.vscode-java-pack`.
- This cleanup improves developer experience by avoiding extension conflicts and potential Java tooling issues in VS Code.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
