### PR TITLE
Exclude Internal API User from Total User Count

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -475,6 +475,12 @@ public class UserService implements UserServiceInterface {
 
     @Override
     public long getTotalUsersCount() {
-        return userRepository.count();
+        // Count all users in the database
+        long userCount = userRepository.count();
+        // Exclude the internal API user from the count
+        if (findByUsernameIgnoreCase(Role.INTERNAL_API_USER.getRoleId()).isPresent()) {
+            userCount -= 1;
+        }
+        return userCount;
     }
 }


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**:  
  Modified the `getTotalUsersCount()` method in `UserService` to subtract one user from the count if the internal API user is present in the database. This ensures that the internal service account does not skew user metrics.

- **Why the change was made**:  
  To prevent the internal API user (used for backend operations) from being included in total user statistics, which should reflect only real user accounts.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
