### PR TITLE
fix: id for releases <a> tag in footer

### DIFF
--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -6,7 +6,7 @@
     <div class="d-flex justify-content-center">
       <ul class="list-unstyled d-flex">
         <li><a class="footer-link px-2" id="licenses" target="_blank" th:href="@{'/licenses'}" th:text="#{licenses.nav}">Licenses</a></li>
-        <li><a class="footer-link px-2" id="licenses" target="_blank" th:href="@{'/releases'}" th:text="#{releases.footer}">Releases</a></li>
+        <li><a class="footer-link px-2" id="releases" target="_blank" th:href="@{'/releases'}" th:text="#{releases.footer}">Releases</a></li>
         <li><a class="footer-link px-2" id="survey" target="_blank" href="https://stirlingpdf.info/s/cm28y3niq000o56dv7liv8wsu" th:text="#{survey.nav}">Survey</a></li>
         <li th:if="${@privacyPolicy != ''}"><a class="footer-link px-2" target="_blank" th:href="${@privacyPolicy}" th:text="#{legal.privacy}">privacyPolicy</a></li>
         <li th:if="${@termsAndConditions != ''}"><a class="footer-link px-2" target="_blank" th:href="${@termsAndConditions}" th:text="#{legal.terms}">termsAndConditions</a></li>


### PR DESCRIPTION
Change a duplicated ID "licenses" in footer.html, specifically for the "Releases" link.

