### PR TITLE
Fix for MacOS x86_64 Installer

### DIFF
--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -175,6 +175,7 @@ jobs:
         id: prepare
         shell: bash
         run: |
+          ls -lah ./build/jpackage/
           mkdir ./binaries
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             mv "./build/jpackage/Stirling-PDF-${{ needs.read_versions.outputs.version }}.exe" "./binaries/Stirling-PDF-win-installer.exe"

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ jpackage {
         icon = "src/main/resources/static/favicon.icns"
         type = "dmg"
         macPackageIdentifier = "com.stirling.software.pdf"
-        macPackageName = "Stirling-PDF_aarch64"
+        macPackageName = "Stirling-PDF-aarch64"
         macAppCategory = "public.app-category.productivity"
         macSign = false // Enable signing
         macAppStore = false // Not targeting App Store initially
@@ -230,6 +230,8 @@ tasks.register('jpackageMacX64') {
     group = 'distribution'
     description = 'Packages app for MacOS x86_64'
 
+    println "Running jpackageMacX64 task"
+
     if (OperatingSystem.current().isMacOsX()) {
         println "MacOS detected. Downloading temp JRE."
         dependsOn("downloadTempJre")
@@ -270,11 +272,11 @@ tasks.register('jpackageMacX64') {
         def stderr = errorStream.toString("UTF-8")
 
         if (!stdout.isBlank()) {
-            println "📝 jpackage stdout:\n$stdout"
+            println "jpackage stdout:\n$stdout"
         }
 
         if (result.exitValue != 0) {
-            throw new GradleException("❌ jpackage failed with exit code ${result.exitValue}.\n\n$stderr")
+            throw new GradleException("jpackage failed with exit code ${result.exitValue}.\n\n$stderr")
         }
     }
 }
@@ -322,7 +324,7 @@ tasks.register('cleanTempJre') {
         def path = project.ext.tempJrePath
 
         if (path && new File("$path").exists()) {
-            println "🧹 Cleaning up temporary JRE: $path"
+            println "Cleaning up temporary JRE: $path"
             new File("$path").parentFile.deleteDir()
         }
     }


### PR DESCRIPTION
-  Updated workflow step to log jpackage dir

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
