### PR TITLE
MacOS `x86_64` installer fix 🙏🏾

### DIFF
--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   release:
     types: [created]
+  push:
+      branches: [ "mac-x86_64-installer-fix" ]
 
 permissions:
   contents: read
@@ -169,6 +171,23 @@ jobs:
           DOCKER_ENABLE_SECURITY: false
           STIRLING_PDF_DESKTOP_UI: true
           BROWSER_OPEN: true
+
+      - name: ☕ Set up JDK (x86_64)
+        if: matrix.os == 'macos-latest'
+        run: |
+          curl -L -o jdk.tar.gz https://cdn.azul.com/zulu/bin/zulu17.56.15-ca-jdk17.0.14-macosx_x64.tar.gz
+          mkdir -p zulu17
+          tar -xzf jdk.tar.gz -C zulu17 --strip-components=1
+          echo "JAVA_HOME=$PWD/zulu17" >> $GITHUB_ENV
+          echo "$PWD/zulu17/bin" >> $GITHUB_PATH
+
+      -   name: Verify JDK architecture
+          if: matrix.os == 'macos-latest'
+          run: file $JAVA_HOME/bin/java
+
+      -   name: Build project and run jpackage (x86_64)
+          if: matrix.os == 'macos-latest'
+          run: arch -x86_64 ./gradlew clean build jpackageMacX64
 
       # Rename and collect artifacts based on OS
       - name: Prepare artifacts

--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -4,8 +4,11 @@ on:
   workflow_dispatch:
   release:
     types: [created]
-  push:
-      branches: [ "mac-x86_64-installer-fix" ]
+    inputs:
+      test_mode:
+        description: "Run in test mode (skips release step)"
+        required: false
+        default: "false"
 
 permissions:
   contents: read
@@ -287,6 +290,7 @@ jobs:
             !cosign.*
 
   create-release:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_mode != 'true'
     needs: [read_versions, sign_verify, sign_verify-portable]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -187,7 +187,7 @@ jobs:
 
       -   name: Build project and run jpackage (x86_64)
           if: matrix.os == 'macos-latest'
-          run: arch -x86_64 ./gradlew clean build jpackageMacX64
+          run: arch -x86_64 ./gradlew jpackageMacX64
 
       # Rename and collect artifacts based on OS
       - name: Prepare artifacts
@@ -200,7 +200,7 @@ jobs:
             mv "./build/jpackage/Stirling-PDF-${{ needs.read_versions.outputs.version }}.exe" "./binaries/Stirling-PDF-win-installer.exe"
           elif [ "${{ matrix.os }}" = "macos-latest" ]; then
             mv "./build/jpackage/Stirling-PDF-${{ needs.read_versions.outputs.versionMac }}.dmg" "./binaries/Stirling-PDF-mac-installer.dmg"
-            mv "./build/jpackage/Stirling-PDF-x86_64-${{ needs.read_versions.outputs.versionMac }}.dmg" "./binaries/Stirling-PDF-mac-x86_64-installer.dmg"
+            mv "./build/jpackage/x86_64/Stirling-PDF (x86_64)-${{ needs.read_versions.outputs.versionMac }}.dmg" "./binaries/Stirling-PDF-mac-x86_64-installer.dmg"
           else
             mv "./build/jpackage/stirling-pdf_${{ needs.read_versions.outputs.version }}-1_amd64.deb" "./binaries/Stirling-PDF-linux-installer.deb"
           fi
@@ -283,7 +283,7 @@ jobs:
           name: ${{ matrix.platform }}signed
           path: |
             ./Stirling-PDF-${{ matrix.platform }}installer.*
-            ./Stirling-PDF-${{ matrix.platform }}-x86_64-installer.*
+            ./Stirling-PDF-${{ matrix.platform }}x86_64-installer.*
             !cosign.*
 
   create-release:

--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,7 @@ tasks.register('jpackageMacX64') {
     }
 }
 
-jpackage.finalizedBy(jpackageMacX64)
+//jpackage.finalizedBy(jpackageMacX64)
 
 tasks.register('downloadTempJre') {
     group = 'distribution'

--- a/build.gradle
+++ b/build.gradle
@@ -164,14 +164,12 @@ jpackage {
         appVersion = getMacVersion(project.version.toString())
         icon = "src/main/resources/static/favicon.icns"
         type = "dmg"
-        macPackageIdentifier = "com.stirling.software.pdf"
-        macPackageName = "Stirling-PDF-aarch64"
+        macPackageIdentifier = "Stirling-PDF"
+        macPackageName = "Stirling-PDF"
         macAppCategory = "public.app-category.productivity"
         macSign = false // Enable signing
         macAppStore = false // Not targeting App Store initially
-//
-//        //installDir = "Applications"
-//
+
 //        // Add license and other documentation to DMG
 //        /*macDmgContent = [
 //            "README.md",
@@ -252,16 +250,16 @@ tasks.register('jpackageMacX64') {
         def result = exec {
             commandLine 'jpackage',
                     '--type', 'dmg',
-                    '--name', 'Stirling-PDF-x86_64',
+                    '--name', 'Stirling-PDF (x86_64)',
                     '--input', 'build/libs',
                     '--main-jar', "Stirling-PDF-${project.version}.jar",
-                    '--main-class', 'stirling.software.SPDF.SPDFApplication',
+                    '--main-class', 'org.springframework.boot.loader.launch.JarLauncher',
                     '--runtime-image', file(jrePath + "/zulu-17.jre/Contents/Home"),
-                    '--dest', 'build/jpackage',
+                    '--dest', 'build/jpackage/x86_64',
                     '--icon', 'src/main/resources/static/favicon.icns',
                     '--app-version', getMacVersion(project.version.toString()),
-                    '--mac-package-name', 'Stirling-PDF',
-                    '--mac-package-identifier', 'com.stirling.software.pdf',
+                    '--mac-package-name', 'Stirling-PDF (x86_64)',
+                    '--mac-package-identifier', 'Stirling-PDF (x86_64)',
                     '--mac-app-category', 'public.app-category.productivity'
             standardOutput = outputStream
             errorOutput = errorStream


### PR DESCRIPTION
- Forced Gradle to build MacOS `x86_64` distribution with `x86_64` architecture in workflows
- Corrected pathing for signed artefacts

![Screenshot 2025-04-11 at 12 31 48](https://github.com/user-attachments/assets/04741c41-0f2c-4ccd-9e36-50aa351d414c)

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
