### PR TITLE
Update messages_fr_FR.properties to fix translation mistake

### DIFF
--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -1094,8 +1094,8 @@ imageToPDF.selectText.5=Convertir en PDF séparés
 
 
 #pdfToImage
-pdfToImage.title=Image en PDF
-pdfToImage.header=Image en PDF
+pdfToImage.title=PDF en Image
+pdfToImage.header=PDF en Image
 pdfToImage.selectText=Format d'image
 pdfToImage.singleOrMultiple=Type de résultat
 pdfToImage.single=Une seule grande image


### PR DESCRIPTION
# Description of Changes

Fixed incorrect French translations: changed 'Image en PDF' to 'PDF en Image' for title and header in messages_fr_FR.properties.

Closes #3357

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [X] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
