### PR TITLE
Make file extension checks case-insensitive in pipeline

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineDirectoryProcessor.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineDirectoryProcessor.java
@@ -208,7 +208,8 @@ public class PipelineDirectoryProcessor {
                                         // Check against allowed extensions
                                         boolean isAllowed =
                                                 allowAllFiles
-                                                        || inputExtensions.contains(extension);
+                                                        || inputExtensions.contains(
+                                                                extension.toLowerCase());
                                         if (!isAllowed) {
                                             log.info(
                                                     "Skipping file with unsupported extension: {} ({})",

--- a/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -112,7 +112,8 @@ public class PipelineProcessor {
                 for (Resource file : outputFiles) {
                     boolean hasInputFileType = false;
                     for (String extension : inputFileTypes) {
-                        if ("ALL".equals(extension) || file.getFilename().endsWith(extension)) {
+                        if ("ALL".equals(extension)
+                                || file.getFilename().toLowerCase().endsWith(extension)) {
                             hasInputFileType = true;
                             MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
                             body.add("fileInput", file);
@@ -166,7 +167,9 @@ public class PipelineProcessor {
                                     .filter(
                                             file ->
                                                     finalinputFileTypes.stream()
-                                                            .anyMatch(file.getFilename()::endsWith))
+                                                            .anyMatch(
+                                                                    file.getFilename().toLowerCase()
+                                                                            ::endsWith))
                                     .toList();
                 }
                 // Check if there are matching files


### PR DESCRIPTION
# Description of Changes

File extensions in the pipeline were being checked in a case-sensitive manner. Since supported extensions were defined in lowercase only, files with uppercase extensions were being rejected directly, and logs like the following were being printed:

<img width="1542" alt="Screenshot 2025-04-17 at 00 14 16" src="https://github.com/user-attachments/assets/a584b8d8-0a56-4a76-b409-9d6cd38f1a80" />

With this change, the uploaded file’s extension is now converted to lowercase using toLowerCase, making the extension check case-insensitive. After this change, the logs flow as expected, as shown below:

<img width="1317" alt="Screenshot 2025-04-17 at 00 49 52" src="https://github.com/user-attachments/assets/2abdcfc7-4c74-4b06-bbea-ef12e0f737b4" />

Closes #3243

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [X] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
