### PR TITLE
Update Google Java Format to v1.26.0 across devcontainer, VSCode, and Gradle configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,7 +49,7 @@
                 "java.configuration.updateBuildConfiguration": "interactive",
                 "java.format.enabled": true,
                 "java.format.settings.profile": "GoogleStyle",
-                "java.format.settings.google.version": "1.25.2",
+                "java.format.settings.google.version": "1.26.0",
                 "java.format.settings.google.extra": "--aosp --skip-sorting-imports --skip-javadoc-formatting",
                 "java.saveActions.cleanup": true,
                 "java.cleanup.actions": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
   "java.configuration.updateBuildConfiguration": "interactive",
   "java.format.enabled": true,
   "java.format.settings.profile": "GoogleStyle",
-  "java.format.settings.google.version": "1.25.2",
+  "java.format.settings.google.version": "1.26.0",
   "java.format.settings.google.extra": "--aosp --skip-sorting-imports --skip-javadoc-formatting",
   // (DE) Aktiviert Kommentare im Java-Format.
   // (EN) Enables comments in Java formatting.

--- a/build.gradle
+++ b/build.gradle
@@ -365,7 +365,7 @@ spotless {
     java {
         target project.fileTree('src').include('**/*.java')
 
-        googleJavaFormat("1.25.2").aosp().reorderImports(false)
+        googleJavaFormat("1.26.0").aosp().reorderImports(false)
 
         importOrder("java", "javax", "org", "com", "net", "io", "jakarta", "lombok", "me", "stirling")
         toggleOffOn()


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  Updated `java.format.settings.google.version` from `1.25.2` to `1.26.0` in:  
  - `.devcontainer/devcontainer.json`  
  - `.vscode/settings.json`  
  - `build.gradle` (Spotless plugin configuration)

- **Why the change was made**  
  Bump to the latest Google Java Format release (v1.26.0) to pick up formatting improvements, bug fixes, and maintain consistency across all development environments.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
