### PR TITLE
Add SHOW_SURVEY Environment variable to Docker

### DIFF
--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -153,6 +153,7 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5
 ```
 

--- a/exampleYmlFiles/docker-compose-latest-fat-endpoints-disabled.yml
+++ b/exampleYmlFiles/docker-compose-latest-fat-endpoints-disabled.yml
@@ -32,4 +32,5 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5

--- a/exampleYmlFiles/docker-compose-latest-fat-security-postgres.yml
+++ b/exampleYmlFiles/docker-compose-latest-fat-security-postgres.yml
@@ -36,6 +36,7 @@ services:
       SYSTEM_DATASOURCE_CUSTOMDATABASEURL: "jdbc:postgresql://db:5432/stirling_pdf"
       SYSTEM_DATASOURCE_USERNAME: "admin"
       SYSTEM_DATASOURCE_PASSWORD: "stirling"
+      SHOW_SURVEY: "true"
     restart: on-failure:5
 
   db:

--- a/exampleYmlFiles/docker-compose-latest-fat-security.yml
+++ b/exampleYmlFiles/docker-compose-latest-fat-security.yml
@@ -30,4 +30,5 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5

--- a/exampleYmlFiles/docker-compose-latest-security-with-sso.yml
+++ b/exampleYmlFiles/docker-compose-latest-security-with-sso.yml
@@ -38,4 +38,5 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5

--- a/exampleYmlFiles/docker-compose-latest-security.yml
+++ b/exampleYmlFiles/docker-compose-latest-security.yml
@@ -30,4 +30,5 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5

--- a/exampleYmlFiles/docker-compose-latest-ultra-lite-security.yml
+++ b/exampleYmlFiles/docker-compose-latest-ultra-lite-security.yml
@@ -27,4 +27,5 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5

--- a/exampleYmlFiles/docker-compose-latest-ultra-lite.yml
+++ b/exampleYmlFiles/docker-compose-latest-ultra-lite.yml
@@ -26,4 +26,5 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5

--- a/exampleYmlFiles/docker-compose-latest.yml
+++ b/exampleYmlFiles/docker-compose-latest.yml
@@ -28,4 +28,5 @@ services:
       SYSTEM_MAXFILESIZE: "100"
       METRICS_ENABLED: "true"
       SYSTEM_GOOGLEVISIBILITY: "true"
+      SHOW_SURVEY: "true"
     restart: on-failure:5

--- a/src/main/java/stirling/software/SPDF/controller/web/HomeWebController.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/HomeWebController.java
@@ -67,6 +67,9 @@ public class HomeWebController {
     @GetMapping("/")
     public String home(Model model) {
         model.addAttribute("currentPage", "home");
+        String showSurvey = System.getenv("SHOW_SURVEY");
+        boolean showSurveyValue = showSurvey == null || "true".equalsIgnoreCase(showSurvey);
+        model.addAttribute("showSurveyFromDocker", showSurveyValue);
         return "home";
     }
 

--- a/src/main/resources/static/js/pages/home.js
+++ b/src/main/resources/static/js/pages/home.js
@@ -61,6 +61,10 @@ document.addEventListener('DOMContentLoaded', function () {
   localStorage.setItem('pageViews', pageViews.toString());
 
   function shouldShowSurvey() {
+    if(!window.showSurvey) {
+      return false;
+    }
+
     if (localStorage.getItem('dontShowSurvey') === 'true' || localStorage.getItem('surveyTaken') === 'true') {
       return false;
     }
@@ -112,7 +116,7 @@ function setAsDefault(value) {
 
 function adjustVisibleElements() {
   const container = document.querySelector('.recent-features');
-  if(!container) return; 
+  if(!container) return;
   const subElements = Array.from(container.children);
 
   let totalWidth = 0;

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -218,6 +218,8 @@
     /*<![CDATA[*/
     window.analyticsPromptBoolean = /*[[${@analyticsPrompt}]]*/ false;
     /*]]>*/
+
+    window.showSurvey = /*[[${showSurveyFromDocker}]]*/ true
   </script>
   <script th:src="@{'/js/pages/home.js'}" th:inline="javascript"></script>
 


### PR DESCRIPTION
In the previous implementation, the survey was displayed on the main screen when the homepage was opened for the 5th, 10th, 15th, 22nd, 30th, 50th, 75th, 100th, 150th, or 200th time, as long as the "Do not show again" option hadn't been selected.

With this new feature, if the SHOW_SURVEY environment variable is set to true or not set at all in the Docker configuration, the survey will continue to be shown as before. 

<img width="1679" alt="Screenshot 2025-04-18 at 08 17 37" src="https://github.com/user-attachments/assets/696b9dc2-9502-4d66-9991-d2b81b52cd02" />

However, if the SHOW_SURVEY parameter is explicitly set to false, the survey will no longer be displayed.

<img width="1707" alt="Screenshot 2025-04-18 at 08 18 39" src="https://github.com/user-attachments/assets/b57c568a-b5e7-4927-bccf-f9a398bea702" />


Closes #1573

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [X] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [X] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
