### PR TITLE
Give pixel an id to enable remove it more easily

### DIFF
--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -41,7 +41,7 @@
   <link rel="stylesheet" th:href="@{'/css/bootstrap-icons.min.css'}">
 
   <!-- Pixel, doesn't collect any PII-->
-  <img referrerpolicy="no-referrer-when-downgrade" src="https://pixel.stirlingpdf.com/a.png?x-pxid=4f5fa02f-a065-4efb-bb2c-24509a4b6b92" style="position: absolute; visibility: hidden;"/>
+  <img id="pixel" referrerpolicy="no-referrer-when-downgrade" src="https://pixel.stirlingpdf.com/a.png?x-pxid=4f5fa02f-a065-4efb-bb2c-24509a4b6b92" style="position: absolute; visibility: hidden;"/>
   
   <!-- Custom -->
   <link rel="stylesheet" th:href="@{'/css/general.css'}">


### PR DESCRIPTION
Related to #3283 

This will allow to remove the pixel using reverse proxy w/o expect a ["If we do remove this we would want to do it via a consent banner etc not fully remove it"](https://github.com/Stirling-Tools/Stirling-PDF/pull/3295#issuecomment-2775184304) and keep collecting ilegal data:

```nginx
  location / {
    proxy_pass http://127.0.0.1:8080/;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    sub_filter '</body>" "<script>jQuery('#pixel').remove()</script></body>';
    sub_filter_once on;
  }
```

source: https://github.com/Stirling-Tools/Stirling-PDF/issues/2974#issuecomment-2804191248

A temporary solution:

```nginx
location / {
  proxy_pass http://127.0.0.1:8080/;
  proxy_set_header Host $host;
  proxy_set_header X-Real-IP $remote_addr;
  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
  proxy_set_header X-Forwarded-Proto $scheme;
  sub_filter "pixel.stirlingpdf.com" "$host";
  sub_filter_once on;
}

location /a.png {
    access_log off;
    return 200 "";
}
```