### PR TITLE
Support domain `User` instances in `getCurrentUsername` method

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/UserService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/UserService.java
@@ -423,6 +423,8 @@ public class UserService implements UserServiceInterface {
 
         if (principal instanceof UserDetails detailsUser) {
             return detailsUser.getUsername();
+        } else if (principal instanceof stirling.software.SPDF.model.User domainUser) {
+            return domainUser.getUsername();
         } else if (principal instanceof OAuth2User oAuth2User) {
             return oAuth2User.getAttribute(
                     applicationProperties.getSecurity().getOauth2().getUseAsUsername());


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  The `getCurrentUsername()` method in `UserService` now recognizes and handles principals of type `stirling.software.SPDF.model.User`. Previously, only `UserDetails` and `OAuth2User` were supported; any `User` domain object was falling through to the default case and not returning the expected username.

- **Why the change was made**  
  In order to allow our custom domain `User` entities to be used directly as the authenticated principal (for example, when loading a user via JWT or session), we need to extract the username from that object. This makes authentication flows more consistent and prevents unexpected `null` or fallback values when the principal is our own `User` type.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
