### PR TITLE
Validate H2 datasource configuration in DatabaseService

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/database/DatabaseService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/database/DatabaseService.java
@@ -240,8 +240,32 @@ public class DatabaseService implements DatabaseInterface {
     private boolean isH2Database() {
         ApplicationProperties.Datasource datasource =
                 applicationProperties.getSystem().getDatasource();
-        return !datasource.isEnableCustomDatabase()
-                || datasource.getType().equalsIgnoreCase(ApplicationProperties.Driver.H2.name());
+
+        boolean isTypeH2 =
+                datasource.getType().equalsIgnoreCase(ApplicationProperties.Driver.H2.name());
+        boolean isDBUrlH2 =
+                datasource.getCustomDatabaseUrl().contains("h2")
+                        || datasource.getCustomDatabaseUrl().contains("H2");
+
+        if (isTypeH2 && !isDBUrlH2) {
+            log.warn(
+                    "Datasource type is H2, but the URL does not contain 'h2'. "
+                            + "Please check your configuration.");
+            throw new IllegalStateException(
+                    "Datasource type is H2, but the URL does not contain 'h2'. Please check your"
+                            + " configuration.");
+        } else if (!isTypeH2 && isDBUrlH2) {
+            log.warn(
+                    "Datasource URL contains 'h2', but the type is not H2. "
+                            + "Please check your configuration.");
+            throw new IllegalStateException(
+                    "Datasource URL contains 'h2', but the type is not H2. Please check your"
+                            + " configuration.");
+        }
+
+        boolean isH2 = isTypeH2 && isDBUrlH2;
+
+        return !datasource.isEnableCustomDatabase() || isH2;
     }
 
     /**


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  Updated the `isH2Database()` method in `DatabaseService.java` to perform additional consistency checks between the configured datasource type and the JDBC URL:
  - Compute `isTypeH2` based on `datasource.getType().equalsIgnoreCase("H2")`.
  - Compute `isDBUrlH2` by checking if `datasource.getCustomDatabaseUrl()` contains “h2” (case-insensitive).
  - Log a warning and throw `IllegalStateException` when the type is H2 but URL doesn’t contain “h2”, or vice versa.
  - Return the original boolean logic (`!enableCustomDatabase || isH2`) only when both type and URL agree.

- **Why the change was made**  
  To prevent runtime misconfigurations where the declared database driver (H2) does not match the actual JDBC URL (or vice versa), providing early, clear feedback to users and avoiding obscure errors later in startup.


Closes #3428

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
