### PR TITLE
Validate H2 Database Type and URL Consistency for Custom Databases

### DIFF
--- a/src/main/java/stirling/software/SPDF/config/security/database/DatabaseService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/database/DatabaseService.java
@@ -246,15 +246,16 @@ public class DatabaseService implements DatabaseInterface {
         boolean isDBUrlH2 =
                 datasource.getCustomDatabaseUrl().contains("h2")
                         || datasource.getCustomDatabaseUrl().contains("H2");
+        boolean isCustomDatabase = datasource.isEnableCustomDatabase();
 
-        if (isTypeH2 && !isDBUrlH2) {
+        if (isTypeH2 && !isDBUrlH2 && isCustomDatabase) {
             log.warn(
                     "Datasource type is H2, but the URL does not contain 'h2'. "
                             + "Please check your configuration.");
             throw new IllegalStateException(
                     "Datasource type is H2, but the URL does not contain 'h2'. Please check your"
                             + " configuration.");
-        } else if (!isTypeH2 && isDBUrlH2) {
+        } else if (!isTypeH2 && isDBUrlH2 && isCustomDatabase) {
             log.warn(
                     "Datasource URL contains 'h2', but the type is not H2. "
                             + "Please check your configuration.");
@@ -265,7 +266,7 @@ public class DatabaseService implements DatabaseInterface {
 
         boolean isH2 = isTypeH2 && isDBUrlH2;
 
-        return !datasource.isEnableCustomDatabase() || isH2;
+        return !isCustomDatabase || isH2;
     }
 
     /**

--- a/src/main/java/stirling/software/SPDF/config/security/database/DatabaseService.java
+++ b/src/main/java/stirling/software/SPDF/config/security/database/DatabaseService.java
@@ -248,22 +248,23 @@ public class DatabaseService implements DatabaseInterface {
                         || datasource.getCustomDatabaseUrl().contains("H2");
         boolean isCustomDatabase = datasource.isEnableCustomDatabase();
 
-        if (isTypeH2 && !isDBUrlH2 && isCustomDatabase) {
-            log.warn(
-                    "Datasource type is H2, but the URL does not contain 'h2'. "
-                            + "Please check your configuration.");
-            throw new IllegalStateException(
-                    "Datasource type is H2, but the URL does not contain 'h2'. Please check your"
-                            + " configuration.");
-        } else if (!isTypeH2 && isDBUrlH2 && isCustomDatabase) {
-            log.warn(
-                    "Datasource URL contains 'h2', but the type is not H2. "
-                            + "Please check your configuration.");
-            throw new IllegalStateException(
-                    "Datasource URL contains 'h2', but the type is not H2. Please check your"
-                            + " configuration.");
+        if (isCustomDatabase) {
+            if (isTypeH2 && !isDBUrlH2) {
+                log.warn(
+                        "Datasource type is H2, but the URL does not contain 'h2'. "
+                                + "Please check your configuration.");
+                throw new IllegalStateException(
+                        "Datasource type is H2, but the URL does not contain 'h2'. Please check"
+                                + " your configuration.");
+            } else if (!isTypeH2 && isDBUrlH2) {
+                log.warn(
+                        "Datasource URL contains 'h2', but the type is not H2. "
+                                + "Please check your configuration.");
+                throw new IllegalStateException(
+                        "Datasource URL contains 'h2', but the type is not H2. Please check your"
+                                + " configuration.");
+            }
         }
-
         boolean isH2 = isTypeH2 && isDBUrlH2;
 
         return !isCustomDatabase || isH2;


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  Introduced a local `isCustomDatabase` flag (based on `datasource.isEnableCustomDatabase()`) to ensure that the H2-specific URL/type consistency checks (and corresponding warnings/exceptions) only run when a custom database configuration is enabled. Refactored the return statement to use this flag (`return !isCustomDatabase || isH2;`) instead of calling `isEnableCustomDatabase()` directly.

- **Why the change was made**  
  Previously, even when custom database support was disabled, the method would still validate H2 configuration and potentially throw an `IllegalStateException`. By guarding those checks, we avoid spurious warnings or exceptions in default (non-custom) setups and make the method’s behavior more predictable.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
