### PR TITLE
Fix NullPointerException by Enabling Constructor Injection for Color Replacement Components

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/misc/ReplaceAndInvertColorController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/misc/ReplaceAndInvertColorController.java
@@ -25,7 +25,7 @@ import stirling.software.SPDF.service.misc.ReplaceAndInvertColorService;
 @RequiredArgsConstructor
 public class ReplaceAndInvertColorController {
 
-    private ReplaceAndInvertColorService replaceAndInvertColorService;
+    private final ReplaceAndInvertColorService replaceAndInvertColorService;
 
     @PostMapping(consumes = "multipart/form-data", value = "/replace-invert-pdf")
     @Operation(

--- a/src/main/java/stirling/software/SPDF/service/misc/ReplaceAndInvertColorService.java
+++ b/src/main/java/stirling/software/SPDF/service/misc/ReplaceAndInvertColorService.java
@@ -16,7 +16,7 @@ import stirling.software.SPDF.utils.misc.ReplaceAndInvertColorStrategy;
 @Service
 @RequiredArgsConstructor
 public class ReplaceAndInvertColorService {
-    private ReplaceAndInvertColorFactory replaceAndInvertColorFactory;
+    private final ReplaceAndInvertColorFactory replaceAndInvertColorFactory;
 
     public InputStreamResource replaceAndInvertColor(
             MultipartFile file,


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  Added the `final` modifier to the `ReplaceAndInvertColorService` field in `ReplaceAndInvertColorController` and to the `ReplaceAndInvertColorFactory` field in `ReplaceAndInvertColorService`. This ensures that Lombok’s `@RequiredArgsConstructor` generates constructors for these dependencies, enabling proper constructor-based injection instead of leaving them null.

- **Why the change was made**  
  Without the `final` keyword, Lombok does not include non-final fields in the generated constructor, causing Spring to leave them uninitialized and resulting in a `NullPointerException` during runtime when invoking `replaceAndInvert` on the factory/service.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
