### PR TITLE
Potential fix for code scanning alert no. 47: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/stirling/software/SPDF/utils/FileToPdf.java
+++ b/src/main/java/stirling/software/SPDF/utils/FileToPdf.java
@@ -156,7 +156,10 @@ public class FileToPdf {
                 ZipSecurity.createHardenedInputStream(new ByteArrayInputStream(fileBytes))) {
             ZipEntry entry = zipIn.getNextEntry();
             while (entry != null) {
-                Path filePath = tempDirectory.resolve(sanitizeZipFilename(entry.getName()));
+                Path filePath = tempDirectory.resolve(entry.getName()).normalize();
+                if (!filePath.startsWith(tempDirectory)) {
+                    throw new IOException("Entry is outside of the target directory: " + entry.getName());
+                }
                 if (entry.isDirectory()) {
                     Files.createDirectories(filePath); // Explicitly create the directory structure
                 } else {
@@ -188,20 +191,5 @@ public class FileToPdf {
         }
     }
 
-    static String sanitizeZipFilename(String entryName) {
-        if (entryName == null || entryName.trim().isEmpty()) {
-            return "";
-        }
-        // Remove any drive letters (e.g., "C:\") and leading forward/backslashes
-        entryName = entryName.replaceAll("^[a-zA-Z]:[\\\\/]+", "");
-        entryName = entryName.replaceAll("^[\\\\/]+", "");
-
-        // Recursively remove path traversal sequences
-        while (entryName.contains("../") || entryName.contains("..\\")) {
-            entryName = entryName.replace("../", "").replace("..\\", "");
-        }
-        // Normalize all backslashes to forward slashes
-        entryName = entryName.replaceAll("\\\\", "/");
-        return entryName;
-    }
+    // Removed sanitizeZipFilename method as it is no longer needed.
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Stirling-Tools/Stirling-PDF/security/code-scanning/47](https://github.com/Stirling-Tools/Stirling-PDF/security/code-scanning/47)

To fix the issue, we need to ensure that the resolved file paths for zip entries are strictly confined to the intended extraction directory (`tempDirectory`). This can be achieved by:
1. Normalizing the resolved file path using `toRealPath()` or `toAbsolutePath().normalize()`.
2. Verifying that the normalized path starts with the intended extraction directory path using `startsWith()`.

The `sanitizeZipFilename` method should be removed or replaced with this robust validation logic. The validation should be performed immediately after resolving the file path and before any file system operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
