### PR TITLE
Potential fix for code scanning alert no. 224: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/resources/static/js/tab-container.js
+++ b/src/main/resources/static/js/tab-container.js
@@ -9,7 +9,7 @@ TabContainer = {
       tabList.classList.add('tab-buttons');
       tabTitles.forEach((title) => {
         const tabButton = document.createElement('button');
-        tabButton.innerHTML = title;
+        tabButton.textContent = title;
         tabButton.onclick = (e) => {
           this.setActiveTab(e.target);
         };


### PR DESCRIPTION
Potential fix for [https://github.com/Stirling-Tools/Stirling-PDF/security/code-scanning/224](https://github.com/Stirling-Tools/Stirling-PDF/security/code-scanning/224)

To fix the issue, we should avoid assigning untrusted data directly to `innerHTML`. Instead, we can use `textContent`, which safely sets the text content of an element without interpreting it as HTML. This ensures that any special characters in the `data-title` attribute are treated as plain text, preventing XSS attacks.

The fix involves replacing `tabButton.innerHTML = title;` on line 12 with `tabButton.textContent = title;`. This change ensures that the `title` is safely rendered as text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
