### PR TITLE
Standardize Quoted Path Syntax in Thymeleaf `th:href` for Consistent Link Resolution

### DIFF
--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -541,7 +541,7 @@ This would generate n entries of tr for each person in exampleData
 
    ```html
    <li class="nav-item">
-       <a class="nav-link" th:href="@{/new-feature}">New Feature</a>
+       <a class="nav-link" th:href="@{'/new-feature'}">New Feature</a>
    </li>
    ```
 

--- a/src/main/resources/templates/adminSettings.html
+++ b/src/main/resources/templates/adminSettings.html
@@ -51,7 +51,7 @@
 			        <span th:text="#{adminUserSettings.changeUserRole}">Change User's Role</span>
 			    </a>
 			    
-			    <a href="/usage" th:if="${@runningEE}"
+			    <a th:href="@{'/usage'}" th:if="${@runningEE}"
 				   class="btn btn-outline-success" 
 				   th:title="#{adminUserSettings.usage}">
 				    <span class="material-symbols-rounded">analytics</span>


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  1. In `DeveloperGuide.md`, updated the example `<a>` tag to use `th:href="@{'/new-feature'}"` instead of `th:href="@{/new-feature}"`.  
  2. In `adminSettings.html`, replaced the static `href="/usage"` with a Thymeleaf attribute `th:href="@{'/usage'}"` to ensure proper URL resolution.

- **Why the change was made**  
  Consistently quoting paths in `th:href` improves readability and avoids potential parsing inconsistencies in Thymeleaf templates when resolving URLs at runtime.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
