### PR TITLE
Fix filter flag in pipeline results

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -93,6 +93,7 @@ public class PipelineProcessor {
         ByteArrayOutputStream logStream = new ByteArrayOutputStream();
         PrintStream logPrintStream = new PrintStream(logStream);
         boolean hasErrors = false;
+        boolean filtersApplied = false;
         for (PipelineOperation pipelineOperation : config.getOperations()) {
             String operation = pipelineOperation.getOperation();
             boolean isMultiInputOperation = apiDocService.isMultiInput(operation);
@@ -134,7 +135,7 @@ public class PipelineProcessor {
                             if (operation.startsWith("filter-")
                                     && (response.getBody() == null
                                             || response.getBody().length == 0)) {
-                                result.setFiltersApplied(true);
+                                filtersApplied = true;
                                 log.info("Skipping file due to filtering {}", operation);
                                 continue;
                             }
@@ -215,7 +216,7 @@ public class PipelineProcessor {
             log.error("Errors occurred during processing. Log: {}", logStream.toString());
         }
         result.setHasErrors(hasErrors);
-        result.setFiltersApplied(hasErrors);
+        result.setFiltersApplied(filtersApplied);
         result.setOutputFiles(outputFiles);
         return result;
     }

--- a/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
+++ b/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
@@ -1,0 +1,76 @@
+package stirling.software.SPDF.controller.api.pipeline;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import jakarta.servlet.ServletContext;
+
+import stirling.software.SPDF.model.PipelineConfig;
+import stirling.software.SPDF.model.PipelineOperation;
+import stirling.software.SPDF.model.PipelineResult;
+
+@ExtendWith(MockitoExtension.class)
+class PipelineProcessorTest {
+
+    @Mock
+    ApiDocService apiDocService;
+
+    @Mock
+    UserServiceInterface userService;
+
+    @Mock
+    ServletContext servletContext;
+
+    PipelineProcessor pipelineProcessor;
+
+    @BeforeEach
+    void setUp() {
+        pipelineProcessor = spy(new PipelineProcessor(apiDocService, userService, servletContext));
+    }
+
+    @Test
+    void runPipelineWithFilterSetsFlag() throws Exception {
+        PipelineOperation op = new PipelineOperation();
+        op.setOperation("filter-page-count");
+        op.setParameters(Map.of());
+        PipelineConfig config = new PipelineConfig();
+        config.setOperations(List.of(op));
+
+        Resource file = new ByteArrayResource("data".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "test.pdf";
+            }
+        };
+
+        List<Resource> files = List.of(file);
+
+        when(apiDocService.isMultiInput("filter-page-count")).thenReturn(false);
+        when(apiDocService.getExtensionTypes(false, "filter-page-count")).thenReturn(List.of("pdf"));
+
+        doReturn(new ResponseEntity<byte[]>(null, HttpStatus.OK))
+                .when(pipelineProcessor)
+                .sendWebRequest(anyString(), any());
+
+        PipelineResult result = pipelineProcessor.runPipelineAgainstFiles(files, config);
+
+        assertTrue(result.isFiltersApplied(), "Filter flag should be true when operation filters file");
+        assertFalse(result.isHasErrors(), "No errors should occur");
+        assertTrue(result.getOutputFiles().isEmpty(), "Filtered file list should be empty");
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix `filtersApplied` overwriting bug in `PipelineProcessor`
- test that filter operations correctly set the flag

## Testing
- `gradle test --offline` *(fails: plugin org.gradle.toolchains.foojay-resolver-convention not found)*