### PR TITLE
Fix TemplateResolver and LibreOfficeListener bugs

### DIFF
--- a/src/main/java/stirling/software/SPDF/LibreOfficeListener.java
+++ b/src/main/java/stirling/software/SPDF/LibreOfficeListener.java
@@ -31,7 +31,8 @@ public class LibreOfficeListener {
         log.info("waiting for listener to start");
         try (Socket socket = new Socket()) {
             socket.connect(
-                    new InetSocketAddress("localhost", 2002), 1000); // Timeout after 1 second
+                    new InetSocketAddress("localhost", LISTENER_PORT),
+                    1000); // Timeout after 1 second
             return true;
         } catch (Exception e) {
             return false;

--- a/src/main/java/stirling/software/SPDF/config/FileFallbackTemplateResolver.java
+++ b/src/main/java/stirling/software/SPDF/config/FileFallbackTemplateResolver.java
@@ -44,7 +44,7 @@ public class FileFallbackTemplateResolver extends AbstractConfigurableTemplateRe
             }
         } catch (IOException e) {
             // Log the exception to help with debugging issues loading external templates
-            log.warn("Unable to read template from file system", e);
+            log.warn("Unable to read template '{}' from file system", resourceName, e);
         }
 
         InputStream inputStream =

--- a/src/main/java/stirling/software/SPDF/config/FileFallbackTemplateResolver.java
+++ b/src/main/java/stirling/software/SPDF/config/FileFallbackTemplateResolver.java
@@ -11,8 +11,11 @@ import org.thymeleaf.templateresolver.AbstractConfigurableTemplateResolver;
 import org.thymeleaf.templateresource.FileTemplateResource;
 import org.thymeleaf.templateresource.ITemplateResource;
 
+import lombok.extern.slf4j.Slf4j;
+
 import stirling.software.SPDF.model.InputStreamTemplateResource;
 
+@Slf4j
 public class FileFallbackTemplateResolver extends AbstractConfigurableTemplateResolver {
 
     private final ResourceLoader resourceLoader;
@@ -40,7 +43,8 @@ public class FileFallbackTemplateResolver extends AbstractConfigurableTemplateRe
                 return new FileTemplateResource(resource.getFile().getPath(), characterEncoding);
             }
         } catch (IOException e) {
-
+            // Log the exception to help with debugging issues loading external templates
+            log.warn("Unable to read template from file system", e);
         }
 
         InputStream inputStream =

--- a/src/main/java/stirling/software/SPDF/model/InputStreamTemplateResource.java
+++ b/src/main/java/stirling/software/SPDF/model/InputStreamTemplateResource.java
@@ -39,7 +39,6 @@ public class InputStreamTemplateResource implements ITemplateResource {
 
     @Override
     public boolean exists() {
-        // TODO Auto-generated method stub
-        return false;
+        return inputStream != null;
     }
 }


### PR DESCRIPTION
## Summary
- log missing exceptions in FileFallbackTemplateResolver
- implement exists check for InputStreamTemplateResource
- use LISTENER_PORT constant when verifying LibreOffice listener

## Testing
- `./gradlew build --no-daemon`
- `./gradlew test --no-daemon`
