### PR TITLE
Enforce `Locale.US` for Consistent Decimal Formatting in Byte-Size Output

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/web/UploadLimitService.java
+++ b/src/main/java/stirling/software/SPDF/controller/web/UploadLimitService.java
@@ -1,5 +1,6 @@
 package stirling.software.SPDF.controller.web;
 
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +53,6 @@ public class UploadLimitService {
         if (bytes < 1024) return bytes + " B";
         int exp = (int) (Math.log(bytes) / Math.log(1024));
         String pre = "KMGTPE".charAt(exp - 1) + "B";
-        return String.format("%.1f %s", bytes / Math.pow(1024, exp), pre);
+        return String.format(Locale.US, "%.1f %s", bytes / Math.pow(1024, exp), pre);
     }
 }

--- a/src/test/java/stirling/software/SPDF/controller/web/UploadLimitServiceTest.java
+++ b/src/test/java/stirling/software/SPDF/controller/web/UploadLimitServiceTest.java
@@ -1,0 +1,79 @@
+package stirling.software.SPDF.controller.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import stirling.software.SPDF.model.ApplicationProperties;
+
+class UploadLimitServiceTest {
+
+    private UploadLimitService uploadLimitService;
+    private ApplicationProperties applicationProperties;
+    private ApplicationProperties.System systemProps;
+
+    @BeforeEach
+    void setUp() {
+        applicationProperties = mock(ApplicationProperties.class);
+        systemProps = mock(ApplicationProperties.System.class);
+        when(applicationProperties.getSystem()).thenReturn(systemProps);
+
+        uploadLimitService = new UploadLimitService();
+        // inject mock
+        try {
+            var field = UploadLimitService.class.getDeclaredField("applicationProperties");
+            field.setAccessible(true);
+            field.set(uploadLimitService, applicationProperties);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ParameterizedTest(name = "getUploadLimit case #{index}: input={0}, expected={2}")
+    @MethodSource("uploadLimitParams")
+    void shouldComputeUploadLimitCorrectly(String input, boolean validFormat, long expected) {
+        when(systemProps.getFileUploadLimit()).thenReturn(validFormat ? input : input);
+
+        long result = uploadLimitService.getUploadLimit();
+        assertEquals(expected, result);
+    }
+
+    static Stream<Arguments> uploadLimitParams() {
+        return Stream.of(
+                // empty or null input yields 0
+                Arguments.of(null, false, 0L),
+                Arguments.of("", false, 0L),
+                // invalid formats
+                Arguments.of("1234MB", false, 0L),
+                Arguments.of("5TB", false, 0L),
+                // valid formats
+                Arguments.of("10KB", true, 10 * 1024L),
+                Arguments.of("2MB", true, 2 * 1024 * 1024L),
+                Arguments.of("1GB", true, 1L * 1024 * 1024 * 1024),
+                Arguments.of("5mb", true, 5 * 1024 * 1024L),
+                Arguments.of("0MB", true, 0L));
+    }
+
+    @ParameterizedTest(name = "getReadableUploadLimit case #{index}: rawValue={0}, expected={1}")
+    @MethodSource("readableLimitParams")
+    void shouldReturnReadableFormat(String rawValue, String expected) {
+        when(systemProps.getFileUploadLimit()).thenReturn(rawValue);
+        String result = uploadLimitService.getReadableUploadLimit();
+        assertEquals(expected, result);
+    }
+
+    static Stream<Arguments> readableLimitParams() {
+        return Stream.of(
+                Arguments.of(null, "0 B"),
+                Arguments.of("", "0 B"),
+                Arguments.of("1KB", "1.0 KB"),
+                Arguments.of("2MB", "2.0 MB"));
+    }
+}


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  - Added `import java.util.Locale;`  
  - Updated the `String.format` call in `humanReadableByteCount` to use `Locale.US`  

- **Why the change was made**  
  By default, `String.format` uses the JVM’s default locale, which in some environments (e.g., Germany) formats decimals with a comma. Tests expected a dot (`.`) as the decimal separator (e.g., `"1.0 KB"`), so we force `Locale.US` to ensure consistent output across all locales.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
