### PR TITLE
Bump Pre-commit Hooks and Java Formatter to Latest Versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.11
     hooks:
       - id: ruff
         args:
@@ -22,7 +22,7 @@ repos:
         files: \.(html|css|js|py|md)$
         exclude: (.vscode|.devcontainer|src/main/resources|Dockerfile|.*/pdfjs.*|.*/thirdParty.*|bootstrap.*|.*\.min\..*|.*diff\.js)
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.3
+    rev: v8.26.0
     hooks:
       - id: gitleaks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
   "java.configuration.updateBuildConfiguration": "interactive",
   "java.format.enabled": true,
   "java.format.settings.profile": "GoogleStyle",
-  "java.format.settings.google.version": "1.26.0",
+  "java.format.settings.google.version": "1.27.0",
   "java.format.settings.google.extra": "--aosp --skip-sorting-imports --skip-javadoc-formatting",
   // (DE) Aktiviert Kommentare im Java-Format.
   // (EN) Enables comments in Java formatting.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id 'jacoco'
+    id "jacoco"
     id "org.springframework.boot" version "3.4.5"
     id "io.spring.dependency-management" version "1.1.7"
     id "org.springdoc.openapi-gradle-plugin" version "1.9.0"
@@ -376,7 +376,7 @@ spotless {
     java {
         target project.fileTree('src').include('**/*.java')
 
-        googleJavaFormat("1.26.0").aosp().reorderImports(false)
+        googleJavaFormat("1.27.0").aosp().reorderImports(false)
 
         importOrder("java", "javax", "org", "com", "net", "io", "jakarta", "lombok", "me", "stirling")
         toggleOffOn()
@@ -543,10 +543,9 @@ dependencies {
     compileOnly "org.projectlombok:lombok:$lombokVersion"
     annotationProcessor "org.projectlombok:lombok:$lombokVersion"
 
-  // Mockito (core)
+    // Mockito (core)
     testImplementation 'org.mockito:mockito-core:5.17.0'
 
-    
     testRuntimeOnly 'org.mockito:mockito-inline:5.2.0'
 }
 


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**:  
  - Updated `ruff` from v0.11.6 to v0.11.11 and `gitleaks` from v8.24.3 to v8.26.0 in `.pre-commit-config.yaml`  
  - Bumped Java formatter version from 1.26.0 to 1.27.0 in VSCode settings (`.vscode/settings.json`) and in `build.gradle` (googleJavaFormat)  
  - Standardized quoting for the `jacoco` plugin in `build.gradle`  
  - Cleaned up indentation and removed extra whitespace in test dependencies  

- **Why the change was made**:  
  To keep our linting and formatting tools up to date with the latest stable releases—bringing in bug fixes, performance improvements, and maintaining consistency across environments.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
