### PR TITLE
Use setup-bot token for GitHub Actions and fix GH_APP_ID secret reference

### DIFF
--- a/.github/workflows/check_properties.yml
+++ b/.github/workflows/check_properties.yml
@@ -36,6 +36,7 @@ jobs:
         id: get-pr-data
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.setup-bot.outputs.token }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const repoOwner = context.payload.repository.owner.login;
@@ -56,7 +57,7 @@ jobs:
       - name: Fetch PR changed files
         id: fetch-pr-changes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.setup-bot.outputs.token }}
         run: |
           echo "Fetching PR changed files..."
           echo "Getting list of changed files from PR..."
@@ -66,6 +67,7 @@ jobs:
         id: determine-file
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.setup-bot.outputs.token }}
           script: |
             const fs = require("fs");
             const path = require("path");
@@ -206,6 +208,7 @@ jobs:
         if: env.SCRIPT_OUTPUT != ''
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.setup-bot.outputs.token }}
           script: |
             const { GITHUB_REPOSITORY, SCRIPT_OUTPUT } = process.env;
             const [repoOwner, repoName] = GITHUB_REPOSITORY.split('/');

--- a/.github/workflows/sync_files.yml
+++ b/.github/workflows/sync_files.yml
@@ -30,7 +30,7 @@ jobs:
         id: setup-bot
         uses: ./.github/actions/setup-bot
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Set up Python


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- **What was changed**  
  - In **`.github/workflows/check_properties.yml`**, each `actions/github-script` step now uses the GitHub App token output (`${{ steps.setup-bot.outputs.token }}`) instead of relying on the default `secrets.GITHUB_TOKEN`.  
  - In **`.github/workflows/sync_files.yml`**, the `app-id` input for the `setup-bot` action was corrected to use `${{ secrets.GH_APP_ID }}` instead of `${{ vars.GH_APP_ID }}`.

- **Why the change was made**  
  - To ensure all workflow steps authenticate through the GitHub App with least-privilege tokens, improving security and avoiding permission issues with the default token or inaccessible repo variables.  
  - To maintain consistency across workflows by centralizing authentication to the App’s token output.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
