### PR TITLE
Fix error display for Split by Chapter

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
@@ -131,7 +131,7 @@ public class SplitPdfByChaptersController {
             Integer bookmarkLevel =
                     request.getBookmarkLevel(); // levels start from 0 (top most bookmarks)
             if (bookmarkLevel < 0) {
-                return ResponseEntity.badRequest().body("Invalid bookmark level".getBytes());
+                throw new IllegalArgumentException("Invalid bookmark level");
             }
             sourceDocument = pdfDocumentFactory.load(file);
 
@@ -139,7 +139,7 @@ public class SplitPdfByChaptersController {
 
             if (outline == null) {
                 log.warn("No outline found for {}", file.getOriginalFilename());
-                return ResponseEntity.badRequest().body("No outline found".getBytes());
+                throw new IllegalArgumentException("No outline found");
             }
             List<Bookmark> bookmarks = new ArrayList<>();
             try {


### PR DESCRIPTION
## Summary
- throw `IllegalArgumentException` when bookmark level is invalid or when a PDF has no outline
- rely on global error handling so frontend shows the message

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_683dc51dd31083288be3f9892889fa59