### PR TITLE
Fix split by chapter error messaging

### DIFF
--- a/src/main/resources/static/js/downloader.js
+++ b/src/main/resources/static/js/downloader.js
@@ -267,6 +267,15 @@
           console.error('Throwing error banner, response was not okay');
           return handleJsonResponse(response);
         }
+        let text = '';
+        try {
+          text = await response.text();
+        } catch (e) {
+          console.error('Failed reading error text', e);
+        }
+        if (text && text.trim().length > 0) {
+          throw new Error(text);
+        }
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 


### PR DESCRIPTION
## Summary
- display backend error text when downloads fail

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_683dc5816a848328a459ffcc2ffd2da5