### PR TITLE
Set default key length to 128 bit AES in add-password.html

### DIFF
--- a/stirling-pdf/src/main/resources/templates/security/add-password.html
+++ b/stirling-pdf/src/main/resources/templates/security/add-password.html
@@ -33,7 +33,7 @@
                 <div class="mb-3">
                   <label th:text="#{addPassword.selectText.3}"></label> <select class="form-control" id="keyLength" name="keyLength">
                     <option value="40">40</option>
-                    <option value="128">128</option>
+                    <option value="128" selected>128</option>
                     <option value="256">256</option>
                   </select>
                   <small class="form-text text-muted" th:text="#{addPassword.selectText.4}"></small>


### PR DESCRIPTION
# Description of Changes

This pull request makes a minor update to the `add-password.html` template to improve the user experience by setting the default selection for the key length to `128`.

* [`stirling-pdf/src/main/resources/templates/security/add-password.html`](diffhunk://#diff-63c5e71a044226ec14b6c30b73cd94ab0b3c9b0606dc93ef4c942f2587a64822L36-R36): Updated the `<option>` element for the key length `128` to include the `selected` attribute, making it the default choice in the dropdown menu.

![image](https://github.com/user-attachments/assets/49bbf64a-7409-4259-837d-07b8d8ab280a)


Closes #3516

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.