### PR TITLE
chore: Improve VSCode Java Project Configuration with Explicit Source Paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,4 +86,9 @@
   "spring.initializr.defaultLanguage": "Java",
   "spring.initializr.defaultGroupId": "stirling.software.SPDF",
   "spring.initializr.defaultArtifactId": "SPDF",
+  "java.project.sourcePaths": [
+    "stirling-pdf/src/main/java",
+    "common/src/main/java",
+    "proprietary/src/main/java"
+  ],
 }


### PR DESCRIPTION
# Description of Changes

- **What was changed**:  
  Added `"java.project.sourcePaths"` configuration to `.vscode/settings.json` to explicitly define the Java source directories:  
  - `stirling-pdf/src/main/java`  
  - `common/src/main/java`  
  - `proprietary/src/main/java`

- **Why the change was made**:  
  Ensures VSCode correctly recognizes all relevant source folders for Java compilation, navigation, and language features—especially important for multi-module setups.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
