### PR TITLE
fix: correct fetch path for popularity.txt in homecard.js

### DIFF
--- a/stirling-pdf/src/main/resources/static/js/homecard.js
+++ b/stirling-pdf/src/main/resources/static/js/homecard.js
@@ -218,7 +218,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     });
   }
   try {
-    const response = await fetch('files/popularity.txt');
+    const response = await fetch('/files/popularity.txt');
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }


### PR DESCRIPTION
# Description of Changes

- **What was changed**: Adjusted the fetch path from `'files/popularity.txt'` to `'/files/popularity.txt'` in `homecard.js`.
- **Why the change was made**: Without the leading slash, the fetch was treated as a relative path which could fail depending on the current URL path. The change ensures it always resolves to the root-relative `/files/popularity.txt`.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
