### PR TITLE
fix: restore original `messages_bo_CN.properties` file overwritten in PR #3614

### DIFF
--- a/stirling-pdf/src/main/resources/messages_bo_CN.properties
+++ b/stirling-pdf/src/main/resources/messages_bo_CN.properties
@@ -135,90 +135,90 @@ lang.vie=Vietnamese
 lang.yid=Yiddish
 lang.yor=Yoruba
 
-addPageNumbers.fontSize=Font Size
-addPageNumbers.fontName=Font Name
-pdfPrompt=Select PDF(s)
-multiPdfPrompt=Select PDFs (2+)
-multiPdfDropPrompt=Select (or drag & drop) all PDFs you require
-imgPrompt=Select Image(s)
-genericSubmit=Submit
+addPageNumbers.fontSize=ཡིག་གཟུགས་ཆེ་ཆུང་
+addPageNumbers.fontName=ཡིག་གཟུགས་མིང་
+pdfPrompt=PDF འདེམས་རོགས།
+multiPdfPrompt=PDF གཉིས་ཡན་འདེམས་རོགས།
+multiPdfDropPrompt=དགོས་མཁོ་འདི་ PDF ཡིག་ཆ་ཚང་མ་འདེམས་པའམ་འཐེན་རོགས།
+imgPrompt=པར་རིས་འདེམས་རོགས།
+genericSubmit=ཕུལ་བཅོས།
 uploadLimit=Maximum file size:
 uploadLimitExceededSingular=is too large. Maximum allowed size is
 uploadLimitExceededPlural=are too large. Maximum allowed size is
-processTimeWarning=Warning: This process can take up to a minute depending on file-size
-pageOrderPrompt=Custom Page Order (Enter a comma-separated list of page numbers or Functions like 2n+1) :
-pageSelectionPrompt=Custom Page Selection (Enter a comma-separated list of page numbers 1,5,6 or Functions like 2n+1) :
-goToPage=Go
-true=True
-false=False
-unknown=Unknown
-save=Save
-saveToBrowser=Save to Browser
-close=Close
-filesSelected=files selected
-noFavourites=No favourites added
-downloadComplete=Download Complete
-bored=Bored Waiting?
-alphabet=Alphabet
-downloadPdf=Download PDF
-text=Text
-font=Font
-selectFillter=-- Select --
-pageNum=Page Number
-sizes.small=Small
-sizes.medium=Medium
-sizes.large=Large
-sizes.x-large=X-Large
-error.pdfPassword=The PDF Document is passworded and either the password was not provided or was incorrect
-delete=Delete
-username=Username
-password=Password
-welcome=Welcome
-property=Property
-black=Black
-white=White
-red=Red
-green=Green
-blue=Blue
-custom=Custom...
-WorkInProgess=Work in progress, May not work or be buggy, Please report any problems!
-poweredBy=Powered by
-yes=Yes
-no=No
-changedCredsMessage=Credentials changed!
-notAuthenticatedMessage=User not authenticated.
-userNotFoundMessage=User not found.
-incorrectPasswordMessage=Current password is incorrect.
-usernameExistsMessage=New Username already exists.
-invalidUsernameMessage=Invalid username, username can only contain letters, numbers and the following special characters @._+- or must be a valid email address.
-invalidPasswordMessage=The password must not be empty and must not have spaces at the beginning or end.
-confirmPasswordErrorMessage=New Password and Confirm New Password must match.
-deleteCurrentUserMessage=Cannot delete currently logged in user.
-deleteUsernameExistsMessage=The username does not exist and cannot be deleted.
-downgradeCurrentUserMessage=Cannot downgrade current user's role
-disabledCurrentUserMessage=The current user cannot be disabled
-downgradeCurrentUserLongMessage=Cannot downgrade current user's role. Hence, current user will not be shown.
-userAlreadyExistsOAuthMessage=The user already exists as an OAuth2 user.
-userAlreadyExistsWebMessage=The user already exists as an web user.
-error=Error
-oops=Oops!
-help=Help
-goHomepage=Go to Homepage
-joinDiscord=Join our Discord server
-seeDockerHub=See Docker Hub
-visitGithub=Visit Github Repository
-donate=Donate
-color=Colour
-sponsor=Sponsor
-info=Info
-pro=Pro
+processTimeWarning=ཉེན་བཅོས། བྱ་རིམ་འདི་ཡིག་ཆའི་ཆེ་ཆུང་ལ་གཞིགས་ནས་སྐར་མ་གཅིག་བར་འགོར་སྲིད།
+pageOrderPrompt=ཤོག་ངོས་གོ་རིམ་རང་སྒྲིག（ཤོག་གྲངས་ཀྱི་ཐོ་གཞུང་ངམ་རྩིས་རྒྱག་བྱེད་ཐབས་ 2n+1 ལྟ་བུ་འཇུག་རོགས།）
+pageSelectionPrompt=ཤོག་ངོས་འདེམས་སྒྲུག（ཤོག་གྲངས་ཀྱི་ཐོ་གཞུང་ 1,5,6 འམ་རྩིས་རྒྱག་བྱེད་ཐབས་ 2n+1 ལྟ་བུ་འཇུག་རོགས།）
+goToPage=འགྲོ་བ།
+true=བདེན་པ།
+false=རྫུན་མ།
+unknown=མི་ཤེས་པ།
+save=ཉར་ཚགས།
+saveToBrowser=བཤར་ཆེ་ནང་ཉར་ཚགས།
+close=སྒོ་རིག།
+filesSelected=ཡིག་ཆབདམས་ཟིན།
+noFavourites=དགའ་མོས་གང་ཡང་སྣོན་མེད།
+downloadComplete=ཕབ་ལེན་ལེགས་གྲུབ།
+bored=སྒུག་སྡོད་སྐྱིད་པོ་མི་འདུག་གམ།
+alphabet=གསལ་བྱེད།
+downloadPdf=PDF ཕབ་ལེན།
+text=ཡི་གེ
+font=ཡིག་གཟུགས་ཌྷ
+selectFillter=-- འདེམས་རོགས། --
+pageNum=ཤོག་གིངས།
+sizes.small=ཆུང་ཆང་།
+sizes.medium=འབྲིང་ཚད།
+sizes.large=ཆེན་པོ།
+sizes.x-large=ཧ་ཅང་ཆེན་པོ།
+error.pdfPassword=PDF ཡིག་ཆར་གསང་ཚིག་བཀོད་ཡོད་པ་དང་། གསང་ཚིག་མ་བཀོད་པའམ་ནོར་འདུག
+delete=སུབ་པ།
+username=སྤྱོད་མཁན་མིང་།
+password=གསང་ཚིག།
+welcome=དགའ་བསི་ཞུ།
+property=ཁྱད་ཆོས།
+black=ནག་པོ
+white=དཀར་པོ
+red=དམར་པོ
+green=ལྗང་ཁུ།
+blue=སྔོན་པོ
+custom=མཚན་ཉིད་རང་སྒྲིག...
+WorkInProgess=ལས་ཀ་བྱེད་བཞིན་པ། ནོར་འཁྲུལ་ཡོང་སྲིད། དཀའ་ངལ་ཡོད་ཚེ་སྙན་སེང་གནང་རོགས།
+poweredBy=མཁོ་སྲོད་བྱེད་མཁན།
+yes=ཡིན།
+no=མིན།
+changedCredsMessage=ངོ་སྤྲོད་ལག་ཁྱེར་བསྒྱུར་ཟིན།
+notAuthenticatedMessage=སྤྱོད་མཁན་ར་སྤྲོད་བྱས་མེད།
+userNotFoundMessage=སྤྱོད་མཁན་རྙེད་མ་བྱུང་།
+incorrectPasswordMessage=ད་ལྟའི་གསང་ཚིག་ནོར་འདུག
+usernameExistsMessage=སྤྱོད་མཁན་མིང་གསར་པ་དེ་ཡོད་ཟིན།
+invalidUsernameMessage=སྤྱོད་མཁན་མིང་ནུས་མེད། ཡི་གེ་དང་ཨང་ཀི། དམིགས་བསལ་མཚོན་རྟགས་ @._+- ཡང་ན་གློག་འཕྲིན་ཁ་བྱང་ཚད་ལྡན་ཞིག་དགོས།
+invalidPasswordMessage=གསང་ཚིག་སྟོང་པ་ཡིན་མི་ཆོག་ལ། མགོ་མཇུག་ཏུ་བར་སྟོང་ཡོད་མི་ཆོག
+confirmPasswordErrorMessage=གསང་ཚིག་གསར་པ་དང་གསང་ཚིག་གསར་པ་ངོས་སྦྱོར་གཉིས་མཐུན་དགོས།
+deleteCurrentUserMessage=ད་ལྟ་ནང་འཛུལ་བྱས་པའི་སྤྱོད་མཁན་སུབ་མི་ཆོག
+deleteUsernameExistsMessage=སྤྱོད་མཁན་མིང་མེད་པས་སུབ་མི་ཐུབ།
+downgradeCurrentUserMessage=ད་ལྟའི་སྤྱོད་མཁན་གྱི་གོ་གནས་མར་འབེབས་མི་ཆོག
+disabledCurrentUserMessage=ད་ལྟའི་སྤྱོད་མཁན་སྤྱོད་མི་ཆོག་པ་བཟོ་མི་ཆོག
+downgradeCurrentUserLongMessage=ད་ལྟའི་སྤྱོད་མཁན་གྱི་གོ་གནས་མར་འབེབས་མི་ཆོག དེར་བརྟེན་ད་ལྟའི་སྤྱོད་མཁན་སྟོན་མི་སྲིད།
+userAlreadyExistsOAuthMessage=སྤྱོད་མཁན་འདི་ OAuth2 སྤྱོད་མཁན་ཞིག་ཏུ་ཡོད་ཟིན།
+userAlreadyExistsWebMessage=སྤྱོད་མཁན་འདི་དྲ་ཚིགས་སྤྱོད་མཁན་ཞིག་ཏུ་ཡོད་ཟིན།
+error=ནོར་འཁྲུལ།
+oops=ཨ་ཙི།
+help=རོགས་རམ།
+goHomepage=གཙོ་ངོས་སུ་ཕྱིན།
+joinDiscord=ང་ཚོའི་ Discord སྡེ་ཚན་དུ་འཛུལ།
+seeDockerHub=Docker Hub ལ་ལྟ་བ།
+visitGithub=Github མཛོད་ཁང་ལ་འཚམས་འདྲི།
+donate=ཞལ་འདེབས།
+color=ཚོན་མདོག
+sponsor=མཐུན་འགྱུར་སྦྱོར་མཁན།
+info=ཆ་འཕྲིན།
+pro=ཆེད་ལས།
 proFeatures=Pro Features
-page=Page
-pages=Pages
-loading=Loading...
-addToDoc=Add to Document
-reset=Reset
-apply=Apply
+page=ཤོག་ངོས།
+pages=ཤོག་ངོས་ཁག
+loading=འཇུག་བཞིན་པ...
+addToDoc=ཡིག་ཆར་སྣོན།
+reset=བསྐྱར་སྒྲིག
+apply=ཉེར་སྤྱོད།
 noFileSelected=No file selected. Please upload one.
 view=View
 cancel=Cancel
@@ -227,157 +227,157 @@ back.toSettings=Back to Settings
 back.toHome=Back to Home
 back.toAdmin=Back to Admin
 
-legal.privacy=Privacy Policy
-legal.terms=Terms and Conditions
-legal.accessibility=Accessibility
-legal.cookie=Cookie Policy
-legal.impressum=Impressum
+legal.privacy=གསང་དོན་སྲིད་བྱུས།
+legal.terms=བེད་སྤྱོད་ཆ་རྐྱེན།
+legal.accessibility=བེད་སྤྱོད་ནུས་པ།
+legal.cookie=Cookie སྲིད་བྱུས།
+legal.impressum=པར་འདེབས་བདག་དབང་།
 legal.showCookieBanner=Cookie Preferences
 
 ###############
 #   Pipeline  #
 ###############
-pipeline.header=Pipeline Menu (Beta)
-pipeline.uploadButton=Upload Custom
-pipeline.configureButton=Configure
-pipeline.defaultOption=Custom
-pipeline.submitButton=Submit
-pipeline.help=Pipeline Help
-pipeline.scanHelp=Folder Scanning Help
-pipeline.deletePrompt=Are you sure you want to delete pipeline
+pipeline.header=བརྒྱུད་རིམ་ཐོ་ཡིག (Beta)
+pipeline.uploadButton=མཁོ་སྤྲོད་རང་སྒྲིག
+pipeline.configureButton=སྒྲིག་འགོད།
+pipeline.defaultOption=རང་སྒྲིག
+pipeline.submitButton=ཕུལ་བ།
+pipeline.help=བརྒྱུད་རིམ་རོགས་རམ།
+pipeline.scanHelp=ཡིག་སྣོད་བཤེར་འཚོལ་རོགས་རམ།
+pipeline.deletePrompt=བརྒྱུད་རིམ་སུབ་རྒྱུ་གཏན་འཁེལ་ལམ།
 
 ######################
 #  Pipeline Options  #
 ######################
-pipelineOptions.header=Pipeline Configuration
-pipelineOptions.pipelineNameLabel=Pipeline Name
-pipelineOptions.saveSettings=Save Operation Settings
-pipelineOptions.pipelineNamePrompt=Enter pipeline name here
-pipelineOptions.selectOperation=Select Operation
-pipelineOptions.addOperationButton=Add operation
-pipelineOptions.pipelineHeader=Pipeline:
-pipelineOptions.saveButton=Download
-pipelineOptions.validateButton=Validate
+pipelineOptions.header=བརྒྱུད་རིམ་སྒྲིག་འགོད།
+pipelineOptions.pipelineNameLabel=བརྒྱུད་རིམ་མིང་།
+pipelineOptions.saveSettings=བཀོལ་སྤྱོད་སྒྲིག་འགོད་ཉར་ཚགས།
+pipelineOptions.pipelineNamePrompt=བརྒྱུད་རིམ་གྱི་མིང་འདིར་འཇུག་རོགས།
+pipelineOptions.selectOperation=བཀོལ་སྤྱོད་འདེམས་རོགས།
+pipelineOptions.addOperationButton=བཀོལ་སྤྱོད་སྣོན།
+pipelineOptions.pipelineHeader=བརྒྱུད་རིམ།
+pipelineOptions.saveButton=ཕབ་ལེན།
+pipelineOptions.validateButton=ཚད་ལྡན་ཡིན་མིན་ཞིབ་བཤེར།
 
 ########################
 #  ENTERPRISE EDITION  #
 ########################
-enterpriseEdition.button=Upgrade to Pro
-enterpriseEdition.warning=This feature is only available to Pro users.
-enterpriseEdition.yamlAdvert=Stirling PDF Pro supports YAML configuration files and other SSO features.
-enterpriseEdition.ssoAdvert=Looking for more user management features? Check out Stirling PDF Pro
+enterpriseEdition.button=ཆེད་ལས་པའི་རིམ་པར་རྒྱག
+enterpriseEdition.warning=ནུས་པ་འདི་ཆེད་ལས་པའི་སྤྱོད་མཁན་ཁོ་ནར་སྤྱོད་ཆོག
+enterpriseEdition.yamlAdvert=Stirling PDF Pro ཡིས་ YAML སྒྲིག་འགོད་ཡིག་ཆ་དང་ SSO ནུས་པ་གཞན་དག་ལ་རྒྱབ་སྐྱོར་བྱེད།
+enterpriseEdition.ssoAdvert=སྤྱོད་མཁན་དོ་དམ་ནུས་པ་མང་བ་དགོས་སམ། Stirling PDF Pro ལ་ལྟ་རོགས།
 enterpriseEdition.proTeamFeatureDisabled=Team management features require a Pro licence or higher
 
 
 #################
 #  Analytics    #
 #################
-analytics.title=Do you want make Stirling PDF better?
-analytics.paragraph1=Stirling PDF has opt in analytics to help us improve the product. We do not track any personal information or file contents.
-analytics.paragraph2=Please consider enabling analytics to help Stirling-PDF grow and to allow us to understand our users better.
-analytics.enable=Enable analytics
-analytics.disable=Disable analytics
-analytics.settings=You can change the settings for analytics in the config/settings.yml file
+analytics.title=ཁྱེད་ཀྱིས་ Stirling PDF ལེགས་སུ་གཏོང་འདོད་དམ།
+analytics.paragraph1=Stirling PDF ལ་ཐོན་རྫས་ལེགས་སུ་གཏོང་བར་རོགས་རམ་བྱེད་པའི་གདམ་ག་ཡོད་པའི་དཔྱད་ཞིབ་ཡོད། ང་ཚོས་སྒེར་གྱི་ཆ་འཕྲིན་དང་ཡིག་ཆའི་ནང་དོན་གང་ཡང་རྗེས་འདེད་མི་བྱེད།
+analytics.paragraph2=Stirling-PDF འཕེལ་རྒྱས་དང་ང་ཚོའི་སྤྱོད་མཁན་ལེགས་པོར་རྟོགས་པར་རོགས་རམ་བྱེད་པའི་ཆེད་དུ་དཔྱད་ཞིབ་སྤྱོད་འགོ་འཛུགས་རོགས།
+analytics.enable=དཔྱད་ཞིབ་སྤྱོད་འགོ་འཛུགས།
+analytics.disable=དཔྱད་ཞིབ་སྤྱོད་མཚམས་འཇོག
+analytics.settings=དཔྱད་ཞིབ་ཀྱི་སྒྲིག་འགོད་ config/settings.yml ཡིག་ཆའི་ནང་བསྒྱུར་བཅོས་བྱེད་ཆོག
 
 
 #############
 #  NAVBAR   #
 #############
-navbar.favorite=Favorites
+navbar.favorite=དགའ་མོས།
 navbar.recent=New and recently updated
-navbar.darkmode=Dark Mode
-navbar.language=Languages
-navbar.settings=Settings
-navbar.allTools=Tools
-navbar.multiTool=Multi Tool
-navbar.search=Search
-navbar.sections.organize=Organize
-navbar.sections.convertTo=Convert to PDF
-navbar.sections.convertFrom=Convert from PDF
-navbar.sections.security=Sign & Security
-navbar.sections.advance=Advanced
-navbar.sections.edit=View & Edit
-navbar.sections.popular=Popular
+navbar.darkmode=མུན་ནག་རྣམ་པ།
+navbar.language=སྐད་རིགས།
+navbar.settings=སྒྲིག་འགོད།
+navbar.allTools=ལག་ཆ།
+navbar.multiTool=ལག་ཆ་མང་པོ།
+navbar.search=འཚོལ་བཤེར།
+navbar.sections.organize=གོ་སྒྲིག
+navbar.sections.convertTo=PDF ལ་བསྒྱུར་བ།
+navbar.sections.convertFrom=PDF ནས་བསྒྱུར་བ།
+navbar.sections.security=མིང་རྟགས་དང་བདེ་འཇགས།
+navbar.sections.advance=མཐོ་རིམ།
+navbar.sections.edit=ལྟ་བ་དང་རྩོམ་སྒྲིག
+navbar.sections.popular=སྤྱི་མོས།
 
 #############
 #  SETTINGS #
 #############
-settings.title=Settings
-settings.update=Update available
-settings.updateAvailable={0} is the current installed version. A new version ({1}) is available.
-settings.appVersion=App Version:
-settings.downloadOption.title=Choose download option (For single file non zip downloads):
-settings.downloadOption.1=Open in same window
-settings.downloadOption.2=Open in new window
-settings.downloadOption.3=Download file
-settings.zipThreshold=Zip files when the number of downloaded files exceeds
-settings.signOut=Sign Out
-settings.accountSettings=Account Settings
-settings.bored.help=Enables easter egg game
-settings.cacheInputs.name=Save form inputs
-settings.cacheInputs.help=Enable to store previously used inputs for future runs
+settings.title=སྒྲིག་འགོད།
+settings.update=གསར་སྒྱུར་ཡོད།
+settings.updateAvailable={0} ནི་ད་ལྟ་སྒྲིག་འཇུག་བྱས་པའི་པར་གཞི་ཡིན། པར་གཞི་གསར་པ་ ({1}) ཡོད།
+settings.appVersion=མཉེན་ཆས་པར་གཞི།
+settings.downloadOption.title=ཕབ་ལེན་གདམ་ག་འདེམས་རོགས། (ཡིག་ཆ་རྐྱང་པ་ zip མིན་པའི་ཕབ་ལེན་ཆེད།)：
+settings.downloadOption.1=སྒེའུ་ཁུང་གཅིག་པའི་ནང་ཁ་ཕྱེ།
+settings.downloadOption.2=སྒེའུ་ཁུང་གསར་པར་ཁ་ཕྱེ།
+settings.downloadOption.3=ཡིག་ཆ་ཕབ་ལེན།
+settings.zipThreshold=ཕབ་ལེན་བྱས་པའི་ཡིག་ཆའི་གྲངས་ཀ་འདི་ལས་བརྒལ་ན་ zip བྱེད།
+settings.signOut=ཕྱིར་འབུད།
+settings.accountSettings=ཐོ་མིང་སྒྲིག་འགོད།
+settings.bored.help=སྒོ་ང་རྩེད་མོ་སྤྱོད་འགོ་རྩོམ།
+settings.cacheInputs.name=ནང་འཇུག་གི་ནང་དོན་ཉར་ཚགས།
+settings.cacheInputs.help=སྔོན་མ་བེད་སྤྱད་པའི་ནང་འཇུག་གི་ནང་དོན་མ་འོངས་པར་བེད་སྤྱོད་ཆེད་ཉར་ཚགས་བྱེད།
 
-changeCreds.title=Change Credentials
-changeCreds.header=Update Your Account Details
-changeCreds.changePassword=You are using default login credentials. Please enter a new password
-changeCreds.newUsername=New Username
-changeCreds.oldPassword=Current Password
-changeCreds.newPassword=New Password
-changeCreds.confirmNewPassword=Confirm New Password
-changeCreds.submit=Submit Changes
+changeCreds.title=ངོ་སྤྲོད་ལག་ཁྱེར་བསྒྱུར་བ།
+changeCreds.header=ཁྱེད་ཀྱི་ཐོ་མིང་ཞིབ་ཕྲ་གསར་སྒྱུར།
+changeCreds.changePassword=ཁྱེད་ཀྱིས་སྔོན་སྒྲིག་ནང་འཛུལ་ངོ་སྤྲོད་བེད་སྤྱོད་བྱེད་བཞིན་ཡོད། གསང་ཚིག་གསར་པ་འཇུག་རོགས།
+changeCreds.newUsername=སྤྱོད་མཁན་མིང་གསར་པ།
+changeCreds.oldPassword=ད་ལྟའི་གསང་ཚིག
+changeCreds.newPassword=གསང་ཚིག་གསར་པ།
+changeCreds.confirmNewPassword=གསང་ཚིག་གསར་པ་ངོས་སྦྱོར།
+changeCreds.submit=འགྱུར་བ་ཕུལ་བ།
 
 
 
-account.title=Account Settings
-account.accountSettings=Account Settings
-account.adminSettings=Admin Settings - View and Add Users
-account.userControlSettings=User Control Settings
-account.changeUsername=Change Username
-account.newUsername=New Username
-account.password=Confirmation Password
-account.oldPassword=Old password
-account.newPassword=New Password
-account.changePassword=Change Password
-account.confirmNewPassword=Confirm New Password
-account.signOut=Sign Out
-account.yourApiKey=Your API Key
-account.syncTitle=Sync browser settings with Account
-account.settingsCompare=Settings Comparison:
-account.property=Property
-account.webBrowserSettings=Web Browser Setting
-account.syncToBrowser=Sync Account -> Browser
-account.syncToAccount=Sync Account <- Browser
+account.title=ཐོ་མིང་སྒྲིག་འགོད།
+account.accountSettings=ཐོ་མིང་སྒྲིག་འགོད།
+account.adminSettings=དོ་དམ་པའི་སྒྲིག་འགོད། - སྤྱོད་མཁན་ལྟ་བ་དང་སྣོན་པ།
+account.userControlSettings=སྤྱོད་མཁན་ཚོད་འཛིན་སྒྲིག་འགོད།
+account.changeUsername=སྤྱོད་མཁན་མིང་བསྒྱུར་བ།
+account.newUsername=སྤྱོད་མཁན་མིང་གསར་པ།
+account.password=གསང་ཚིག་ངོས་སྦྱོར།
+account.oldPassword=གསང་ཚིག་རྙིང་པ།
+account.newPassword=གསང་ཚིག་གསར་པ།
+account.changePassword=གསང་ཚིག་བསྒྱུར་བ།
+account.confirmNewPassword=གསང་ཚིག་གསར་པ་ངོས་སྦྱོར།
+account.signOut=ཕྱིར་འབུད།
+account.yourApiKey=ཁྱེད་ཀྱི་ API ལྡེ་མིག
+account.syncTitle=བཤར་ཆས་སྒྲིག་འགོད་ཐོ་མིང་དང་མཉམ་བགྲོད།
+account.settingsCompare=སྒྲིག་འགོད་བསྡུར་བ།
+account.property=ཁྱད་ཆོས།
+account.webBrowserSettings=བཤར་ཆས་སྒྲིག་འགོད།
+account.syncToBrowser=མཉམ་བགྲོད་ཐོ་མིང་ -> བཤར་ཆས།
+account.syncToAccount=མཉམ་བགྲོད་ཐོ་མིང་ <- བཤར་ཆས།
 account.adminTitle=Administrator Tools
 account.adminNotif=You have admin privileges. Access system settings and user management.
 
 
-adminUserSettings.title=User Control Settings
-adminUserSettings.header=Admin User Control Settings
-adminUserSettings.admin=Admin
-adminUserSettings.user=User
-adminUserSettings.addUser=Add New User
-adminUserSettings.deleteUser=Delete User
-adminUserSettings.confirmDeleteUser=Should the user be deleted?
-adminUserSettings.confirmChangeUserStatus=Should the user be disabled/enabled?
-adminUserSettings.usernameInfo=Username can only contain letters, numbers and the following special characters @._+- or must be a valid email address.
-adminUserSettings.role=Role
-adminUserSettings.actions=Actions
-adminUserSettings.apiUser=Limited API User
-adminUserSettings.extraApiUser=Additional Limited API User
-adminUserSettings.webOnlyUser=Web Only User
-adminUserSettings.demoUser=Demo User (No custom settings)
-adminUserSettings.internalApiUser=Internal API User
-adminUserSettings.forceChange=Force user to change password on login
-adminUserSettings.submit=Save User
-adminUserSettings.changeUserRole=Change User's Role
-adminUserSettings.authenticated=Authenticated
-adminUserSettings.editOwnProfil=Edit own profile
-adminUserSettings.enabledUser=enabled user
-adminUserSettings.disabledUser=disabled user
-adminUserSettings.activeUsers=Active Users:
-adminUserSettings.disabledUsers=Disabled Users:
-adminUserSettings.totalUsers=Total Users:
-adminUserSettings.lastRequest=Last Request
+adminUserSettings.title=སྤྱོད་མཁན་ཚོད་འཛིན་སྒྲིག་འགོད།
+adminUserSettings.header=དོ་དམ་པའི་སྤྱོད་མཁན་ཚོད་འཛིན་སྒྲིག་འགོད།
+adminUserSettings.admin=དོ་དམ་པ།
+adminUserSettings.user=སྤྱོད་མཁན།
+adminUserSettings.addUser=སྤྱོད་མཁན་གསར་པ་སྣོན།
+adminUserSettings.deleteUser=སྤྱོད་མཁན་སུབ་པ།
+adminUserSettings.confirmDeleteUser=སྤྱོད་མཁན་སུབ་དགོས་སམ།
+adminUserSettings.confirmChangeUserStatus=སྤྱོད་མཁན་སྤྱོད་མི་ཆོག་པའམ་སྤྱོད་ཆོག་པ་བཟོ་དགོས་སམ།
+adminUserSettings.usernameInfo=སྤྱོད་མཁན་མིང་ནང་ཡི་གེ་དང་ཨང་ཀི། དམིགས་བསལ་མཚོན་རྟགས་ @._+- ཡང་ན་གློག་འཕྲིན་ཁ་བྱང་ཚད་ལྡན་ཞིག་དགོས།
+adminUserSettings.role=འགན་འཁུར།
+adminUserSettings.actions=བྱ་སྤྱོད།
+adminUserSettings.apiUser=ཚད་བཀག་ཅན་གྱི་ API སྤྱོད་མཁན།
+adminUserSettings.extraApiUser=ཚད་བཀག་ཅན་གྱི་ API སྤྱོད་མཁན་འཕར་མ།
+adminUserSettings.webOnlyUser=དྲ་ཚིགས་ཁོ་ནའི་སྤྱོད་མཁན།
+adminUserSettings.demoUser=བརྟག་དཔྱད་སྤྱོད་མཁན། (རང་སྒྲིག་མེད་པ།)
+adminUserSettings.internalApiUser=ནང་ཁུལ་ API སྤྱོད་མཁན།
+adminUserSettings.forceChange=ནང་འཛུལ་སྐབས་གསང་ཚིག་བསྒྱུར་དགོས་པ་བཟོ་བ།
+adminUserSettings.submit=སྤྱོད་མཁན་ཉར་ཚགས།
+adminUserSettings.changeUserRole=སྤྱོད་མཁན་གྱི་འགན་འཁུར་བསྒྱུར་བ།
+adminUserSettings.authenticated=ར་སྤྲོད་བྱས་ཟིན།
+adminUserSettings.editOwnProfil=རང་ཉིད་ཀྱི་སྤྱོད་མཁན་ཡིག་ཆ་རྩོམ་སྒྲིག
+adminUserSettings.enabledUser=སྤྱོད་ཆོག་པའི་སྤྱོད་མཁན།
+adminUserSettings.disabledUser=སྤྱོད་མི་ཆོག་པའི་སྤྱོད་མཁན།
+adminUserSettings.activeUsers=འགུལ་བཞིན་པའི་སྤྱོད་མཁན།
+adminUserSettings.disabledUsers=སྤྱོད་མི་ཆོག་པའི་སྤྱོད་མཁན།
+adminUserSettings.totalUsers=སྤྱོད་མཁན་ཁྱོན་བསྡོམས།
+adminUserSettings.lastRequest=རེ་ཞུ་མཐའ་མ།
 adminUserSettings.usage=View Usage
 adminUserSettings.teams=View/Edit Teams
 adminUserSettings.team=Team
@@ -448,38 +448,38 @@ endpointStatistics.numberOfVisits=Number of Visits
 endpointStatistics.visitsTooltip=Visits: {0} ({1}% of total)
 endpointStatistics.retry=Retry
 
-database.title=Database Import/Export
-database.header=Database Import/Export
-database.fileName=File Name
-database.creationDate=Creation Date
-database.fileSize=File Size
-database.deleteBackupFile=Delete Backup File
-database.importBackupFile=Import Backup File
-database.createBackupFile=Create Backup File
-database.downloadBackupFile=Download Backup File
-database.info_1=When importing data, it is crucial to ensure the correct structure. If you are unsure of what you are doing, seek advice and support from a professional. An error in the structure can cause application malfunctions, up to and including the complete inability to run the application.
-database.info_2=The file name does not matter when uploading. It will be renamed afterward to follow the format backup_user_yyyyMMddHHmm.sql, ensuring a consistent naming convention.
-database.submit=Import Backup
-database.importIntoDatabaseSuccessed=Import into database successed
-database.backupCreated=Database backup successful
-database.fileNotFound=File not found
-database.fileNullOrEmpty=File must not be null or empty
-database.failedImportFile=Failed to import file
-database.notSupported=This function is not available for your database connection.
+database.title=གཞི་གྲངས་མཛོད་ནང་འདྲེན་/ཕྱིར་འདྲེན།
+database.header=གཞི་གྲངས་མཛོད་ནང་འདྲེན་/ཕྱིར་འདྲེན།
+database.fileName=ཡིག་ཆའི་མིང་།
+database.creationDate=བཟོ་བའི་དུས་ཚོད།
+database.fileSize=ཡིག་ཆའི་ཆེ་ཆུང་།
+database.deleteBackupFile=གྲབས་ཉར་ཡིག་ཆ་སུབ་པ།
+database.importBackupFile=གྲབས་ཉར་ཡིག་ཆ་ནང་འདྲེན།
+database.createBackupFile=གྲབས་ཉར་ཡིག་ཆ་བཟོ་བ།
+database.downloadBackupFile=གྲབས་ཉར་ཡིག་ཆ་ཕབ་ལེན།
+database.info_1=གཞི་གྲངས་ནང་འདྲེན་སྐབས་བཀོད་པ་ཏག་ཏག་ཡིན་པ་ངེས་པར་དུ་བྱེད་དགོས། གལ་སྲིད་ཁྱེད་རང་གང་བྱེད་བཞིན་པ་མི་ཤེས་ན། ཆེད་ལས་པ་ཞིག་ལས་ལམ་སྟོན་དང་རྒྱབ་སྐྱོར་ཞུ་རོགས། བཀོད་པའི་ནང་ནོར་འཁྲུལ་ཡོད་ན་མཉེན་ཆས་ལ་སྐྱོན་ཤོར་སྲིད་པ་དང་། ཐ་ན་མཉེན་ཆས་གཏན་ནས་འཁོར་སྐྱོད་བྱེད་མི་ཐུབ་པའང་ཡོང་སྲིད།
+database.info_2=ཡིག་ཆ་ཡར་འཇུག་སྐབས་ཡིག་ཆའི་མིང་ལ་ཁྱད་པར་མེད། དེའི་རྗེས་སུ་ backup_user_yyyyMMddHHmm.sql ཞེས་པའི་རྣམ་པར་མིང་བསྐྱར་འདོགས་བྱ་རྒྱུ་ཡིན་པས། མིང་འདོགས་སྟངས་གཅིག་མཚུངས་ཡིན་པ་ངེས་པར་བྱེད་ཐུབ།
+database.submit=གྲབས་ཉར་ནང་འདྲེན།
+database.importIntoDatabaseSuccessed=གཞི་གྲངས་མཛོད་དུ་ནང་འདྲེན་ལེགས་གྲུབ།
+database.backupCreated=གཞི་གྲངས་མཛོད་གྲབས་ཉར་ལེགས་གྲུབ།
+database.fileNotFound=ཡིག་ཆ་རྙེད་མ་བྱུང་།
+database.fileNullOrEmpty=ཡིག་ཆ་སྟོང་པའམ་མེད་པ་ཡིན་མི་ཆོག
+database.failedImportFile=ཡིག་ཆ་ནང་འདྲེན་ཕམ་པ།
+database.notSupported=སྡུད་གཞི་རྒྱབ་སྐྱོར་མི་བྱེད།
 
-session.expired=Your session has expired. Please refresh the page and try again.
-session.refreshPage=Refresh Page
+session.expired=ཁྱེད་ཀྱི་གླེང་མོལ་དུས་ཡོལ་ཟིན། ཤོག་ངོས་གསར་སྒྱུར་བྱས་ནས་ཡང་བསྐྱར་ཚོད་ལྟ་བྱེད་རོགས།
+session.refreshPage=ཤོག་ངོས་གསར་སྒྱུར།
 
 #############
 # HOME-PAGE #
 #############
-home.desc=Your locally hosted one-stop-shop for all your PDF needs.
-home.searchBar=Search for features...
+home.desc=ཁྱེད་ཀྱི་ PDF དགོས་མཁོ་ཚང་མའི་ཆེད་དུ་ས་གནས་རང་དུ་བཞག་པའི་ཞབས་ཞུ་ཁང་།
+home.searchBar=ནུས་པ་འཚོལ་བཤེར།
 
 
 home.viewPdf.title=View/Edit PDF
-home.viewPdf.desc=View, annotate, draw, add text or images
-viewPdf.tags=view,read,annotate,text,image,highlight,edit
+home.viewPdf.desc=ལྟ་བ། མཆན་འགྲེལ། ཡི་གེ་དང་པར་རིས་སྣོན་པ།
+viewPdf.tags=ལྟ་བ།,ཀློག་པ།,མཆན་འགྲེལ།,ཡི་གེ,པར་རིས།
 
 home.setFavorites=Set Favourites
 home.hideFavorites=Hide Favourites
@@ -490,189 +490,189 @@ home.alphabetical=Alphabetical
 home.globalPopularity=Global Popularity
 home.sortBy=Sort by:
 
-home.multiTool.title=PDF Multi Tool
-home.multiTool.desc=Merge, Rotate, Rearrange, Split, and Remove pages
-multiTool.tags=Multi Tool,Multi operation,UI,click drag,front end,client side,interactive,intractable,move,delete,migrate,divide
+home.multiTool.title=PDF ལག་ཆ་མང་པོ།
+home.multiTool.desc=སྡེབ་སྦྱོར། འཁོར་སྐྱོད། བསྐྱར་སྒྲིག ཁ་གྱེས། དང་ཤོག་ངོས་སུབ་པ།
+multiTool.tags=ལག་ཆ་མང་པོ།,བཀོལ་སྤྱོད་མང་པོ།,UI,མཐེབ་གནོན་འཐེན་པ།,མདུན་ངོས།,མཁོ་མཁན་ཕྱོགས།,སྤྱོད་སྒོ།,འགུལ་སྐྱོད།,སུབ་པ།,གནས་སྤོ།,བགོ་བ།
 
-home.merge.title=Merge
-home.merge.desc=Easily merge multiple PDFs into one.
-merge.tags=merge,Page operations,Back end,server side
+home.merge.title=སྡེབ་སྦྱོར།
+home.merge.desc=PDF མང་པོ་གཅིག་ཏུ་སྡེབ་སྦྱོར་བྱེད་པ།
+merge.tags=སྡེབ་སྦྱོར།,ཤོག་ངོས་བཀོལ་སྤྱོད།,རྒྱབ་ངོས།,ཞབས་ཞུ་ཕྱོགས།
 
-home.split.title=Split
-home.split.desc=Split PDFs into multiple documents
-split.tags=Page operations,divide,Multi Page,cut,server side
+home.split.title=ཁ་གྱེས།
+home.split.desc=PDF ཡིག་ཆ་མང་པོར་བགོ་བ།
+split.tags=ཤོག་ངོས་བཀོལ་སྤྱོད།,བགོ་བ།,ཤོག་ངོས་མང་པོ།,གཅོད་པ།,ཞབས་ཞུ་ཕྱོགས།
 
-home.rotate.title=Rotate
-home.rotate.desc=Easily rotate your PDFs.
-rotate.tags=server side
-
-
-home.imageToPdf.title=Image to PDF
-home.imageToPdf.desc=Convert a image (PNG, JPEG, GIF) to PDF.
-imageToPdf.tags=conversion,img,jpg,picture,photo
-
-home.pdfToImage.title=PDF to Image
-home.pdfToImage.desc=Convert a PDF to a image. (PNG, JPEG, GIF)
-pdfToImage.tags=conversion,img,jpg,picture,photo
-
-home.pdfOrganiser.title=Organise
-home.pdfOrganiser.desc=Remove/Rearrange pages in any order
-pdfOrganiser.tags=duplex,even,odd,sort,move
+home.rotate.title=འཁོར་སྐྱོད།
+home.rotate.desc=PDF ལས་སླ་པོའི་ངང་འཁོར་སྐྱོད་བྱེད་པ།
+rotate.tags=ཞབས་ཞུ་ཕྱོགས།
 
 
-home.addImage.title=Add image
-home.addImage.desc=Adds a image onto a set location on the PDF
-addImage.tags=img,jpg,picture,photo
+home.imageToPdf.title=པར་རིས་ནས་ PDF ལ།
+home.imageToPdf.desc=པར་རིས་ (PNG, JPEG, GIF) ནས་ PDF ལ་བསྒྱུར་བ།
+imageToPdf.tags=བསྒྱུར་བ།,པར་རིས།,jpg,པར།,འདྲ་པར།
 
-home.watermark.title=Add Watermark
-home.watermark.desc=Add a custom watermark to your PDF document.
-watermark.tags=Text,repeating,label,own,copyright,trademark,img,jpg,picture,photo
+home.pdfToImage.title=PDF ནས་པར་རིས་ལ།
+home.pdfToImage.desc=PDF ནས་པར་རིས་ (PNG, JPEG, GIF) ལ་བསྒྱུར་བ།
+pdfToImage.tags=བསྒྱུར་བ།,པར་རིས།,jpg,པར།,འདྲ་པར།
 
-home.permissions.title=Change Permissions
-home.permissions.desc=Change the permissions of your PDF document
-permissions.tags=read,write,edit,print
+home.pdfOrganiser.title=གོ་སྒྲིག
+home.pdfOrganiser.desc=ཤོག་ངོས་རྣམས་གོ་རིམ་གང་རུང་དུ་སུབ་པའམ་བསྐྱར་སྒྲིག་བྱེད་པ།
+pdfOrganiser.tags=ཤོག་ངོས་གཉིས་མ།,ཨང་གྲངས་ཟུང་ལྡན།,ཨང་གྲངས་ཡ་གྲངས།,གོ་རིམ་སྒྲིག་པ།,སྤོ་བ།
 
 
-home.removePages.title=Remove
-home.removePages.desc=Delete unwanted pages from your PDF document.
-removePages.tags=Remove pages,delete pages
+home.addImage.title=པར་རིས་སྣོན་པ།
+home.addImage.desc=PDF ནང་གནས་ས་ངེས་ཅན་ཞིག་ཏུ་པར་རིས་སྣོན་པ།
+addImage.tags=པར་རིས།,jpg,པར།,འདྲ་པར།
 
-home.addPassword.title=Add Password
-home.addPassword.desc=Encrypt your PDF document with a password.
-addPassword.tags=secure,security
+home.watermark.title=ཆུ་རྟགས་སྣོན་པ།
+home.watermark.desc=PDF ཡིག་ཆར་རང་སྒྲིག་གི་ཆུ་རྟགས་སྣོན་པ།
+watermark.tags=ཡི་གེ,བསྐྱར་ཟློས།,ཁ་ཡིག,རང་དབང་།,པར་དབང་།,ཚོང་རྟགས།,པར་རིས།,jpg,པར།,འདྲ་པར།
 
-home.removePassword.title=Remove Password
-home.removePassword.desc=Remove password protection from your PDF document.
-removePassword.tags=secure,Decrypt,security,unpassword,delete password
+home.permissions.title=ཆོག་མཆན་བསྒྱུར་བ།
+home.permissions.desc=PDF ཡིག་ཆའི་ཆོག་མཆན་བསྒྱུར་བ།
+permissions.tags=ཀློག་པ།,འབྲི་བ།,རྩོམ་སྒྲིག,པར་འདེབས།
 
-home.compressPdfs.title=Compress
-home.compressPdfs.desc=Compress PDFs to reduce their file size.
-compressPdfs.tags=squish,small,tiny
+
+home.removePages.title=སུབ་པ།
+home.removePages.desc=PDF ཡིག་ཆ་ནས་མི་དགོས་པའི་ཤོག་ངོས་རྣམས་སུབ་པ།
+removePages.tags=ཤོག་ངོས་སུབ་པ།,ཤོག་ངོས་གསུབ་པ།
+
+home.addPassword.title=གསང་ཚིག་སྣོན་པ།
+home.addPassword.desc=PDF ཡིག་ཆར་གསང་ཚིག་གིས་གསང་སྡོམ་བྱེད་པ།
+addPassword.tags=བདེ་འཇགས།,ཉེན་སྲུང་།
+
+home.removePassword.title=གསང་ཚིག་སུབ་པ།
+home.removePassword.desc=PDF ཡིག་ཆ་ནས་གསང་ཚིག་སྲུང་སྐྱོབ་སུབ་པ།
+removePassword.tags=བདེ་འཇགས།,གསང་སྡོམ་གྲོལ་བ།,ཉེན་སྲུང་།,གསང་ཚིག་མེད་པ།,གསང་ཚིག་སུབ་པ།
+
+home.compressPdfs.title=སྡུད་སྒྲིལ།
+home.compressPdfs.desc=ཡིག་ཆའི་ཆེ་ཆུང་ཆུང་དུ་གཏོང་ཆེད་ PDF སྡུད་སྒྲིལ་བྱེད་པ།
+compressPdfs.tags=བསྡུས་པ།,ཆུང་ཆུང་།,ཆུང་ཆུང་།
 
 home.unlockPDFForms.title=Unlock PDF Forms
 home.unlockPDFForms.desc=Remove read-only property of form fields in a PDF document.
 unlockPDFForms.tags=remove,delete,form,field,readonly
 
-home.changeMetadata.title=Change Metadata
-home.changeMetadata.desc=Change/Remove/Add metadata from a PDF document
-changeMetadata.tags=Title,author,date,creation,time,publisher,producer,stats
+home.changeMetadata.title=གནས་ཆ་སྒྱུར་བཅོས།
+home.changeMetadata.desc=PDF ཡིག་ཆ་ནས་གནས་ཆ་བསྒྱུར་བའམ་སུབ་པ།སྣོན་པ།
+changeMetadata.tags=ཁ་བྱང་།,རྩོམ་པ་པོ།,ཚེས་གྲངས།,བཟོ་བ།,དུས་ཚོད།,པར་སྐྲུན་པ།,ཐོན་སྐྱེད་པ།,སྡོམ་རྩིས།
 
-home.fileToPDF.title=Convert file to PDF
-home.fileToPDF.desc=Convert nearly any file to PDF (DOCX, PNG, XLS, PPT, TXT and more)
-fileToPDF.tags=transformation,format,document,picture,slide,text,conversion,office,docs,word,excel,powerpoint
+home.fileToPDF.title=ཡིག་ཆ་ནས་ PDF ལ་བསྒྱུར་བ།
+home.fileToPDF.desc=ཡིག་ཆ་ཕལ་ཆེ་བ་ PDF ལ་བསྒྱུར་ཐུབ། (DOCX, PNG, XLS, PPT, TXT སོགས།)
+fileToPDF.tags=བསྒྱུར་བཅོས།,རྣམ་གཞག,ཡིག་ཆ།,པར།,སྟོན་བྱེད།,ཡི་གེ,བསྒྱུར་བ།,ཡིག་ཚང་།,docs,word,excel,powerpoint
 
-home.ocr.title=OCR / Cleanup scans
-home.ocr.desc=Cleanup scans and detects text from images within a PDF and re-adds it as text.
-ocr.tags=recognition,text,image,scan,read,identify,detection,editable
+home.ocr.title=OCR / བཤེར་འབེབས་གཙང་སེལ།
+home.ocr.desc=བཤེར་འབེབས་གཙང་སེལ་དང་ PDF ནང་གི་པར་རིས་ནས་ཡི་གེ་ངོས་འཛིན་བྱས་ཏེ་ཡི་གེའི་རྣམ་པར་བསྐྱར་སྣོན་བྱེད་པ།
+ocr.tags=ངོས་འཛིན།,ཡི་གེ,པར་རིས།,བཤེར་འབེབས།,ཀློག་པ།,ངོས་འཛིན།,འཚོལ་ཞིབ།,རྩོམ་སྒྲིག་རུང་བ།
 
-home.extractImages.title=Extract Images
-home.extractImages.desc=Extracts all images from a PDF and saves them to zip
-extractImages.tags=picture,photo,save,archive,zip,capture,grab
+home.extractImages.title=པར་རིས་ཕྱིར་འདོན།
+home.extractImages.desc=PDF ནས་པར་རིས་ཚང་མ་ཕྱིར་བཏོན་ནས་ zip ནང་ཉར་ཚགས་བྱེད་པ།
+extractImages.tags=པར།,འདྲ་པར།,ཉར་ཚགས།,ཡིག་མཛོད།,zip,འཛིན་པ།,ལེན་པ།
 
-home.pdfToPDFA.title=PDF to PDF/A
-home.pdfToPDFA.desc=Convert PDF to PDF/A for long-term storage
-pdfToPDFA.tags=archive,long-term,standard,conversion,storage,preservation
+home.pdfToPDFA.title=PDF ནས་ PDF/A ལ།
+home.pdfToPDFA.desc=PDF ནས་དུས་ཡུན་རིང་པོའི་ཉར་ཚགས་ཆེད་ PDF/A ལ་བསྒྱུར་བ།
+pdfToPDFA.tags=ཡིག་མཛོད།,དུས་ཡུན་རིང་པོ།,ཚད་ལྡན།,བསྒྱུར་བ།,ཉར་ཚགས།,སྲུང་སྐྱོབ།
 
-home.PDFToWord.title=PDF to Word
-home.PDFToWord.desc=Convert PDF to Word formats (DOC, DOCX and ODT)
-PDFToWord.tags=doc,docx,odt,word,transformation,format,conversion,office,microsoft,docfile
+home.PDFToWord.title=PDF ནས་ Word ལ།
+home.PDFToWord.desc=PDF ནས་ Word རྣམ་གཞག་ (DOC, DOCX དང་ ODT) ལ་བསྒྱུར་བ།
+PDFToWord.tags=doc,docx,odt,word,བསྒྱུར་བཅོས།,རྣམ་གཞག,བསྒྱུར་བ།,ཡིག་ཚང་།,microsoft,docfile
 
-home.PDFToPresentation.title=PDF to Presentation
-home.PDFToPresentation.desc=Convert PDF to Presentation formats (PPT, PPTX and ODP)
-PDFToPresentation.tags=slides,show,office,microsoft
+home.PDFToPresentation.title=PDF ནས་སྟོན་བྱེད་ལ།
+home.PDFToPresentation.desc=PDF ནས་སྟོན་བྱེད་རྣམ་གཞག་ (PPT, PPTX དང་ ODP) ལ་བསྒྱུར་བ།
+PDFToPresentation.tags=སྟོན་བྱེད།,འཁྲབ་སྟོན།,ཡིག་ཚང་།,microsoft
 
-home.PDFToText.title=PDF to RTF (Text)
-home.PDFToText.desc=Convert PDF to Text or RTF format
+home.PDFToText.title=PDF ནས་ RTF (ཡི་གེ) ལ།
+home.PDFToText.desc=PDF ནས་ཡི་གེའམ་ RTF རྣམ་གཞག་ལ་བསྒྱུར་བ།
 PDFToText.tags=richformat,richtextformat,rich text format
 
-home.PDFToHTML.title=PDF to HTML
-home.PDFToHTML.desc=Convert PDF to HTML format
-PDFToHTML.tags=web content,browser friendly
+home.PDFToHTML.title=PDF ནས་ HTML ལ།
+home.PDFToHTML.desc=PDF ནས་ HTML རྣམ་གཞག་ལ་བསྒྱུར་བ།
+PDFToHTML.tags=དྲ་ངོས་ནང་དོན།,བཤར་ཆས་འཆམ་མཐུན།
 
 
-home.PDFToXML.title=PDF to XML
-home.PDFToXML.desc=Convert PDF to XML format
-PDFToXML.tags=data-extraction,structured-content,interop,transformation,convert
+home.PDFToXML.title=PDF ནས་ XML ལ།
+home.PDFToXML.desc=PDF ནས་ XML རྣམ་གཞག་ལ་བསྒྱུར་བ།
+PDFToXML.tags=གཞི་གྲངས་ཕྱིར་འདོན།,སྒྲོམ་གཞི་ཅན་གྱི་ནང་དོན།,མཉམ་འབྲེལ།,བསྒྱུར་བཅོས།,བསྒྱུར་བ།
 
-home.ScannerImageSplit.title=Detect/Split Scanned photos
-home.ScannerImageSplit.desc=Splits multiple photos from within a photo/PDF
-ScannerImageSplit.tags=separate,auto-detect,scans,multi-photo,organize
+home.ScannerImageSplit.title=བཤེར་པར་ངོས་འཛིན་/ཁ་གྱེས།
+home.ScannerImageSplit.desc=པར་རིས་/PDF ནང་གི་པར་མང་པོ་ཁ་གྱེས་བྱེད་པ།
+ScannerImageSplit.tags=ཁ་གྱེས།,རང་འགུལ་ངོས་འཛིན།,བཤེར་འབེབས།,པར་མང་པོ།,གོ་སྒྲིག
 
-home.sign.title=Sign
-home.sign.desc=Adds signature to PDF by drawing, text or image
-sign.tags=authorize,initials,drawn-signature,text-sign,image-signature
+home.sign.title=མིང་རྟགས།
+home.sign.desc=རི་མོ། ཡི་གེ། པར་རིས་བཅས་ཀྱི་སྒོ་ནས་ PDF ལ་མིང་རྟགས་སྣོན་པ།
+sign.tags=དབང་སྤྲོད།,མིང་རྟགས་ཐུང་ངུ་།,བྲིས་པའི་མིང་རྟགས།,ཡི་གེའི་མིང་རྟགས།,པར་རིས་མིང་རྟགས།
 
-home.flatten.title=Flatten
-home.flatten.desc=Remove all interactive elements and forms from a PDF
-flatten.tags=static,deactivate,non-interactive,streamline
+home.flatten.title=སྙོམས་པ།
+home.flatten.desc=PDF ནས་སྤྱོད་སྒོ་ཅན་གྱི་ཆ་ཤས་དང་འགེངས་ཤོག་ཚང་མ་སུབ་པ།
+flatten.tags=སྙོམས་པ།,འགེངས་ཤོག,སྤྱོད་སྒོ།,ཆ་ཤས།,སུབ་པ།
 
-home.repair.title=Repair
-home.repair.desc=Tries to repair a corrupt/broken PDF
-repair.tags=fix,restore,correction,recover
+home.repair.title=བཟོ་བཅོས།
+home.repair.desc=སྐྱོན་ཤོར་བའམ་གཏོར་བཤིག་ཐེབས་པའི་ PDF བཟོ་བཅོས་བྱེད་ཐབས་བྱེད་པ།
+repair.tags=སྐྱོན་སེལ།,བཟོ་བཅོས།,གསོ་བ།,ལེགས་བཅོས།
 
-home.removeBlanks.title=Remove Blank pages
-home.removeBlanks.desc=Detects and removes blank pages from a document
-removeBlanks.tags=cleanup,streamline,non-content,organize
+home.removeBlanks.title=སྟོང་ཤོག་སུབ་པ།
+home.removeBlanks.desc=PDF ནང་གི་སྟོང་ཤོག་རང་འགུལ་ངོས་འཛིན་དང་སུབ་པ།
+removeBlanks.tags=སྟོང་ཤོག་སུབ་པ། སྟོང་པ་སུབ་པ། དཀར་ཤོག་སུབ་པ། PDF སྟོང་ཤོག་སུབ་པ།
 
-home.removeAnnotations.title=Remove Annotations
-home.removeAnnotations.desc=Removes all comments/annotations from a PDF
-removeAnnotations.tags=comments,highlight,notes,markup,remove
+home.removeAnnotations.title=མཆན་འགྲེལ་སུབ་པ།
+home.removeAnnotations.desc=PDF ནང་གི་མཆན་འགྲེལ་ཚང་མ་སུབ་པ།
+removeAnnotations.tags=མཆན་འགྲེལ་སུབ་པ། དཔྱད་བརྗོད་སུབ་པ། མཆན་བུ་སུབ་པ། PDF མཆན་འགྲེལ་སུབ་པ།
 
-home.compare.title=Compare
-home.compare.desc=Compares and shows the differences between 2 PDF Documents
-compare.tags=differentiate,contrast,changes,analysis
+home.compare.title=PDF བསྡུར་བ།
+home.compare.desc=PDF ཡིག་ཆ་གཉིས་ཀྱི་ཁྱད་པར་བསྡུར་བ།
+compare.tags=བསྡུར་བ། ཁྱད་པར། ཞིབ་བསྡུར། གཤིབ་བསྡུར། PDF བསྡུར་བ།
 
-home.certSign.title=Sign with Certificate
-home.certSign.desc=Signs a PDF with a Certificate/Key (PEM/P12)
-certSign.tags=authenticate,PEM,P12,official,encrypt
+home.certSign.title=ལག་ཁྱེར་མིང་རྟགས།
+home.certSign.desc=ལག་ཁྱེར་/ལྡེ་མིག་ (PEM/P12) གྱིས་ PDF ལ་མིང་རྟགས་རྒྱག་པ།
+certSign.tags=ར་སྤྲོད།,PEM,P12,གཞུང་འབྲེལ།,གསང་སྡོམ།
 
-home.removeCertSign.title=Remove Certificate Sign
-home.removeCertSign.desc=Remove certificate signature from PDF
-removeCertSign.tags=authenticate,PEM,P12,official,decrypt
+home.removeCertSign.title=ལག་ཁྱེར་མིང་རྟགས་སུབ་པ།
+home.removeCertSign.desc=PDF ནས་ལག་ཁྱེར་མིང་རྟགས་སུབ་པ།
+removeCertSign.tags=ར་སྤྲོད།,PEM,P12,གཞུང་འབྲེལ།,གསང་སྡོམ་གྲོལ་བ།
 
-home.pageLayout.title=Multi-Page Layout
-home.pageLayout.desc=Merge multiple pages of a PDF document into a single page
-pageLayout.tags=merge,composite,single-view,organize
+home.pageLayout.title=ཤོག་ངོས་མང་པོའི་བཀོད་པ།
+home.pageLayout.desc=PDF ཡིག་ཆའི་ཤོག་ངོས་མང་པོ་ཤོག་ངོས་གཅིག་ཏུ་སྡེབ་སྦྱོར་བྱེད་པ།
+pageLayout.tags=སྡེབ་སྦྱོར།,བསྡུས་པ།,ལྟ་ཚུལ་གཅིག,གོ་སྒྲིག
 
-home.scalePages.title=Adjust page size/scale
-home.scalePages.desc=Change the size/scale of a page and/or its contents.
-scalePages.tags=resize,modify,dimension,adapt
+home.scalePages.title=ཤོག་ངོས་ཆེ་ཆུང་/ཚད་སྒྲིག་པ།
+home.scalePages.desc=ཤོག་ངོས་དང་/ཡང་ན་དེའི་ནང་དོན་གྱི་ཆེ་ཆུང་/ཚད་བསྒྱུར་བ།
+scalePages.tags=ཆེ་ཆུང་བསྐྱར་སྒྲིག,བཟོ་བཅོས།,ཚད་གཞི།,བསྟུན་འགྱུར།
 
-home.pipeline.title=Pipeline
-home.pipeline.desc=Run multiple actions on PDFs by defining pipeline scripts
-pipeline.tags=automate,sequence,scripted,batch-process
+home.pipeline.title=བརྒྱུད་རིམ།
+home.pipeline.desc=བརྒྱུད་རིམ་འཁྲབ་གཞུང་བཟོས་ནས་ PDF ལ་བྱ་བ་མང་པོ་འཁོར་སྐྱོད་བྱེད་པ།
+pipeline.tags=རང་འགུལ།,རིམ་པ།,འཁྲབ་གཞུང་།,ཆ་ཚང་བཀོལ་སྤྱོད།
 
-home.add-page-numbers.title=Add Page Numbers
-home.add-page-numbers.desc=Add Page numbers throughout a document in a set location
-add-page-numbers.tags=paginate,label,organize,index
+home.add-page-numbers.title=ཤོག་གྲངས་སྣོན་པ།
+home.add-page-numbers.desc=ཡིག་ཆའི་ནང་གནས་ས་ངེས་ཅན་དུ་ཤོག་གྲངས་སྣོན་པ།
+add-page-numbers.tags=ཤོག་གྲངས་རྒྱག་པ།,མིང་རྟགས།,གོ་སྒྲིག,དཀར་ཆག
 
-home.auto-rename.title=Auto Rename PDF File
-home.auto-rename.desc=Auto renames a PDF file based on its detected header
-auto-rename.tags=auto-detect,header-based,organize,relabel
+home.auto-rename.title=PDF ཡིག་ཆའི་མིང་རང་འགུལ་བསྐྱར་འདོགས།
+home.auto-rename.desc=ངོས་འཛིན་བྱས་པའི་འགོ་བརྗོད་ལ་གཞིགས་ནས་ PDF ཡིག་ཆའི་མིང་རང་འགུལ་བསྐྱར་འདོགས་བྱེད་པ།
+auto-rename.tags=རང་འགུལ་ངོས་འཛིན།,འགོ་བརྗོད་གཞིར་བཟུང་།,གོ་སྒྲིག,མིང་བསྐྱར་འདོགས།
 
-home.adjust-contrast.title=Adjust Colours/Contrast
-home.adjust-contrast.desc=Adjust Contrast, Saturation and Brightness of a PDF
-adjust-contrast.tags=color-correction,tune,modify,enhance,colour-correction
+home.adjust-contrast.title=ཚོས་གཞི་/འོད་ཁྱད་སྙོམ་སྒྲིག
+home.adjust-contrast.desc=PDF ཡི་འོད་ཁྱད། ཚོས་ཟིལ། དང་གསལ་ཚད་སྙོམ་སྒྲིག་བྱེད་པ།
+adjust-contrast.tags=ཚོས་གཞི་ལེགས་སྒྲིག,སྙོམ་སྒྲིག,བཟོ་བཅོས།,ཡར་རྒྱས།,ཚོས་མདངས་ལེགས་སྒྲིག
 
-home.crop.title=Crop PDF
-home.crop.desc=Crop a PDF to reduce its size (maintains text!)
-crop.tags=trim,shrink,edit,shape
+home.crop.title=PDF གཏུབ་གཅོད།
+home.crop.desc=ཆེ་ཆུང་ཆུང་དུ་གཏོང་ཆེད་ PDF གཏུབ་གཅོད་བྱེད་པ། (ཡི་གེ་རྣམས་སྲུང་སྐྱོབ་བྱེད་ཐུབ།)
+crop.tags=གཏུབ་པ།,ཆུང་དུ་གཏོང་བ།,རྩོམ་སྒྲིག,དབྱིབས།
 
-home.autoSplitPDF.title=Auto Split Pages
-home.autoSplitPDF.desc=Auto Split Scanned PDF with physical scanned page splitter QR Code
-autoSplitPDF.tags=QR-based,separate,scan-segment,organize
+home.autoSplitPDF.title=ཤོག་ངོས་རང་འགུལ་ཁ་གྱེས།
+home.autoSplitPDF.desc=བཤེར་འབེབས་བྱས་པའི་ PDF ནང་གི་དངོས་ཡོད་བཤེར་འབེབས་ཤོག་ངོས་ཁ་གྱེས་ QR Code བེད་སྤྱོད་བྱས་ནས་རང་འགུལ་ཁ་གྱེས་བྱེད་པ།
+autoSplitPDF.tags=QR གཞིར་བཟུང་།,ཁ་གྱེས།,བཤེར་དུམ།,གོ་སྒྲིག
 
-home.sanitizePdf.title=Sanitize
-home.sanitizePdf.desc=Remove scripts and other elements from PDF files
-sanitizePdf.tags=clean,secure,safe,remove-threats
+home.sanitizePdf.title=གཙང་སེལ།
+home.sanitizePdf.desc=PDF ཡིག་ཆ་ནས་འཁྲབ་གཞུང་དང་ཆ་ཤས་གཞན་དག་སུབ་པ།
+sanitizePdf.tags=གཙང་སེལ།,བདེ་འཇགས།,ཉེན་མེད།,ཉེན་ཁ་སེལ་བ།
 
-home.URLToPDF.title=URL/Website To PDF
-home.URLToPDF.desc=Converts any http(s)URL to PDF
-URLToPDF.tags=web-capture,save-page,web-to-doc,archive
+home.URLToPDF.title=དྲ��ཚིགས་ནས་ PDF ལ།
+home.URLToPDF.desc=http(s) དྲ་ཚིགས་གང་རུང་ PDF ལ་བསྒྱུར་བ།
+URLToPDF.tags=དྲ་ངོས་ལེན་པ།,ཤོག་ངོས་ཉར་ཚགས།,དྲ་ཚིགས་ཡིག་ཆ།,ཡིག་མཛོད།
 
-home.HTMLToPDF.title=HTML to PDF
-home.HTMLToPDF.desc=Converts any HTML file or zip to PDF
-HTMLToPDF.tags=markup,web-content,transformation,convert
+home.HTMLToPDF.title=HTML ནས་ PDF ལ།
+home.HTMLToPDF.desc=HTML ཡིག་ཆའམ་ zip ཡིག་ཆ་གང་རུང་ PDF ལ་བསྒྱུར་བ།
+HTMLToPDF.tags=རྟགས་རྒྱག,དྲ་ངོས་ནང་དོན།,བསྒྱུར་བཅོས།,བསྒྱུར་བ།
 
 #eml-to-pdf
 home.EMLToPDF.title=Email to PDF
@@ -691,95 +691,95 @@ EMLToPDF.troubleshootingTip1=Email to HTML is a more reliable process, so with b
 EMLToPDF.troubleshootingTip2=With a small number of Emails, if the PDF is malformed, you can download HTML and override some of the problematic HTML/CSS code.
 EMLToPDF.troubleshootingTip3=Embeddings, however, do not work with HTMLs
 
-home.MarkdownToPDF.title=Markdown to PDF
-home.MarkdownToPDF.desc=Converts any Markdown file to PDF
-MarkdownToPDF.tags=markup,web-content,transformation,convert,md
+home.MarkdownToPDF.title=Markdown ནས་ PDF ལ།
+home.MarkdownToPDF.desc=Markdown ཡིག་ཆ་གང་རུང་ PDF ལ་བསྒྱུར་བ།
+MarkdownToPDF.tags=རྟགས་རྒྱག,དྲ་ངོས་ནང་དོན།,བསྒྱུར་བཅོས།,བསྒྱུར་བ།
 
 home.PDFToMarkdown.title=PDF to Markdown
 home.PDFToMarkdown.desc=Converts any PDF to Markdown
 PDFToMarkdown.tags=markup,web-content,transformation,convert,md
 
-home.getPdfInfo.title=Get ALL Info on PDF
-home.getPdfInfo.desc=Grabs any and all information possible on PDFs
-getPdfInfo.tags=infomation,data,stats,statistics
+home.getPdfInfo.title=PDF ཡི་གནས་ཚུལ་ཆ་ཚང་ལེན་པ།
+home.getPdfInfo.desc=PDF ཡི་གནས་ཚུལ་ཡོད་ཚད་ལེན་པ།
+getPdfInfo.tags=གནས་ཚུལ།,གཞི་གྲངས།,སྡོམ་རྩིས།,གྲངས་ཐོ།
 
 
-home.extractPage.title=Extract page(s)
-home.extractPage.desc=Extracts select pages from PDF
-extractPage.tags=extract
+home.extractPage.title=ཤོག་ངོས་ཕྱིར་འདོན།
+home.extractPage.desc=PDF ནས་འདེམས་སྒྲུག་བྱས་པའི་ཤོག་ངོས་རྣམས་ཕྱིར་འདོན་པ།
+extractPage.tags=ཕྱིར་འདོན།
 
 
-home.PdfToSinglePage.title=PDF to Single Large Page
-home.PdfToSinglePage.desc=Merges all PDF pages into one large single page
-PdfToSinglePage.tags=single page
+home.PdfToSinglePage.title=PDF ནས་ཤོག་ངོས་ཆེན་པོ་གཅིག་ལ།
+home.PdfToSinglePage.desc=PDF ཡི་ཤོག་ངོས་ཚང་མ་ཤོག་ངོས་ཆེན་པོ་གཅིག་ཏུ་སྡེབ་སྦྱོར་བྱེད་པ།
+PdfToSinglePage.tags=ཤོག་ངོས་གཅིག
 
 
-home.showJS.title=Show Javascript
-home.showJS.desc=Searches and displays any JS injected into a PDF
+home.showJS.title=Javascript སྟོན་པ།
+home.showJS.desc=PDF ནང་དུ་བཅུག་པའི་ JS གང་ཡོད་འཚོལ་ཞིབ་དང་མངོན་སྟོན་བྱེད་པ།
 showJS.tags=JS
 
-home.autoRedact.title=Auto Redact
-home.autoRedact.desc=Auto Redacts(Blacks out) text in a PDF based on input text
-autoRedact.tags=Redact,Hide,black out,black,marker,hidden
+home.autoRedact.title=རང་འགུལ་སྒྲིབ་སྲུང་།
+home.autoRedact.desc=འཇུག་པའི་ཡི་གེ་གཞིར་བཟུང་ནས་ PDF ནང་གི་ཡི་གེ་རྣམས་རང་འགུལ་གྱིས་སྒྲིབ་པ།
+autoRedact.tags=སྒྲིབ་སྲུང་།,སྦས་པ།,ནག་པོས་སྒྲིབ་པ།,ནག་པོ།,རྟགས་རྒྱག,སྦས་པ།
 
-home.redact.title=Manual Redaction
-home.redact.desc=Redacts a PDF based on selected text, drawn shapes and/or selected page(s)
-redact.tags=Redact,Hide,black out,black,marker,hidden,manual
+home.redact.title=ལག་བཟོས་སྒྲིབ་སྲུང་།
+home.redact.desc=འདེམས་སྒྲུག་བྱས་པའི་ཡི་གེ། བྲིས་པའི་དབྱིབས། དང་/ཡང་ན་འདེམས་སྒྲུག་བྱས་པའི་ཤོག་ངོས་གཞིར་བཟུང་ནས་ PDF སྒྲིབ་སྲུང་བྱེད་པ།
+redact.tags=སྒྲིབ་སྲུང་།,སྦས་པ།,ནག་པོས་སྒྲིབ་པ།,ནག་པོ།,རྟགས་རྒྱག,སྦས་པ།,ལག་བཟོས།
 
-home.tableExtraxt.title=PDF to CSV
-home.tableExtraxt.desc=Extracts Tables from a PDF converting it to CSV
-tableExtraxt.tags=CSV,Table Extraction,extract,convert
-
-
-home.autoSizeSplitPDF.title=Auto Split by Size/Count
-home.autoSizeSplitPDF.desc=Split a single PDF into multiple documents based on size, page count, or document count
-autoSizeSplitPDF.tags=pdf,split,document,organization
+home.tableExtraxt.title=PDF ནས་ CSV ལ།
+home.tableExtraxt.desc=PDF ནས་རེའུ་མིག་རྣམས་ CSV ལ་ཕྱིར་འདོན་པ།
+tableExtraxt.tags=CSV,རེའུ་མིག་ཕྱིར་འདོན།,ཕྱིར་འདོན།,བསྒྱུར་བ།
 
 
-home.overlay-pdfs.title=Overlay PDFs
-home.overlay-pdfs.desc=Overlays PDFs on-top of another PDF
-overlay-pdfs.tags=Overlay
-
-home.split-by-sections.title=Split PDF by Sections
-home.split-by-sections.desc=Divide each page of a PDF into smaller horizontal and vertical sections
-split-by-sections.tags=Section Split, Divide, Customize,Customise
-
-home.AddStampRequest.title=Add Stamp to PDF
-home.AddStampRequest.desc=Add text or add image stamps at set locations
-AddStampRequest.tags=Stamp, Add image, center image, Watermark, PDF, Embed, Customize,Customise
+home.autoSizeSplitPDF.title=ཆེ་ཆུང་/གྲངས་ཀ་ལྟར་རང་འགུལ་ཁ་གྱེས།
+home.autoSizeSplitPDF.desc=PDF གཅིག་ནས་ཡིག་ཆ་མང་པོར་ཆེ་ཆུང་། ཤོག་གྲངས། ཡང་ན་ཡིག་ཆའི་གྲངས་ཀ་གཞིར་བཟུང་ནས་ཁ་གྱེས་བྱེད་པ།
+autoSizeSplitPDF.tags=pdf,ཁ་གྱེས།,ཡིག་ཆ།,གོ་སྒྲིག
 
 
-home.removeImagePdf.title=Remove image
-home.removeImagePdf.desc=Remove image from PDF to reduce file size
-removeImagePdf.tags=Remove Image,Page operations,Back end,server side
+home.overlay-pdfs.title=PDF སྟེང་བརྩེགས།
+home.overlay-pdfs.desc=PDF གཞན་ཞིག་གི་སྟེང་དུ་ PDF བརྩེགས་པ།
+overlay-pdfs.tags=སྟེང་བརྩེགས།
+
+home.split-by-sections.title=དུམ་བུ་ལྟར་ PDF ཁ་གྱེས།
+home.split-by-sections.desc=PDF ཡི་ཤོག་ངོས་རེ་རེ་གཞུང་དང་འཕྲེད་ཀྱི་དུམ་བུ་ཆུང་ཆུང་དུ་བགོ་བ།
+split-by-sections.tags=དུམ་བུ་ཁ་གྱེས།,བགོ་བ།,རང་སྒྲིག,སྒྲིག་སྦྱོར།
+
+home.AddStampRequest.title=PDF ལ་ཐེལ་ཙེ་སྣོན་པ།
+home.AddStampRequest.desc=གནས་ས་ངེས་ཅན་དུ་ཡི་གེའམ་པར་རིས་ཀྱི་ཐེལ་ཙེ་སྣོན་པ།
+AddStampRequest.tags=ཐེལ་ཙེ།,པར་རིས་སྣོན་པ།,དཀྱིལ་སྒྲིག་པར་རིས།,ཆུ་རྟགས།,PDF,ནང་འཇུག,རང་སྒྲིག,སྒྲིག་སྦྱོར།
 
 
-home.splitPdfByChapters.title=Split PDF by Chapters
-home.splitPdfByChapters.desc=Split a PDF into multiple files based on its chapter structure.
-splitPdfByChapters.tags=split,chapters,bookmarks,organize
+home.removeImagePdf.title=པར་རིས་སུབ་པ།
+home.removeImagePdf.desc=ཡིག་ཆའི་ཆེ་ཆུང་ཆུང་དུ་གཏོང་ཆེད་ PDF ནས་པར་རིས་སུབ་པ།
+removeImagePdf.tags=པར་རིས་སུབ་པ།,ཤོག་ངོས་བཀོལ་སྤྱོད།,རྒྱབ་ངོས།,ཞབས་ཞུ་ཕྱོགས།
 
-home.validateSignature.title=Validate PDF Signature
-home.validateSignature.desc=Verify digital signatures and certificates in PDF documents
-validateSignature.tags=signature,verify,validate,pdf,certificate,digital signature,Validate Signature,Validate certificate
+
+home.splitPdfByChapters.title=ལེའུ་ལྟར་ PDF ཁ་གྱེས།
+home.splitPdfByChapters.desc=PDF ཡི་ལེའུའི་སྒྲོམ་གཞི་གཞིར་བཟུང་ནས་ཡིག་ཆ་མང་པོར་ཁ་གྱེས་བྱེད་པ།
+splitPdfByChapters.tags=ཁ་གྱེས།,ལེའུ།,དཔེ་རྟགས།,གོ་སྒྲིག
+
+home.validateSignature.title=PDF མིང་རྟགས་ར་སྤྲོད།
+home.validateSignature.desc=PDF ཡིག་ཆའི་ནང་གི་ཨང་ཀིའི་མིང་རྟགས་དང་ལག་ཁྱེར་ར་སྤྲོད་བྱེད་པ།
+validateSignature.tags=མིང་རྟགས།,ར་སྤྲོད།,ཆ་འཇོག,pdf,ལག་ཁྱེར།,ཨང་ཀིའི་མིང་རྟགས།,མིང་རྟགས་ར་སྤྲོད།,ལག་ཁྱེར་ར་སྤྲོད།
 
 #replace-invert-color
-replace-color.title=Advanced Colour options
-replace-color.header=Replace-Invert Colour PDF
-home.replaceColorPdf.title=Advanced Colour options
-home.replaceColorPdf.desc=Replace colour for text and background in PDF and invert full colour of pdf to reduce file size
-replaceColorPdf.tags=Replace Colour,Page operations,Back end,server side
-replace-color.selectText.1=Replace or Invert colour Options
-replace-color.selectText.2=Default(Default high contrast colours)
-replace-color.selectText.3=Custom(Customised colours)
-replace-color.selectText.4=Full-Invert(Invert all colours)
-replace-color.selectText.5=High contrast colour options
-replace-color.selectText.6=white text on black background
-replace-color.selectText.7=Black text on white background
-replace-color.selectText.8=Yellow text on black background
-replace-color.selectText.9=Green text on black background
-replace-color.selectText.10=Choose text Colour
-replace-color.selectText.11=Choose background Colour
-replace-color.submit=Replace
+replace-color.title=ཚོས་གཞིའི་གདམ་ག་མཐོ་རིམ།
+replace-color.header=ཚོས་གཞི་བརྗེ་སྒྱུར་-ལྡོག་སྒྱུར་ PDF
+home.replaceColorPdf.title=ཚོས་གཞིའི་གདམ་ག་མཐོ་རིམ།
+home.replaceColorPdf.desc=PDF ནང་གི་ཡི་གེ་དང་རྒྱབ་ལྗོངས་ཀྱི་ཚོས་གཞི་བརྗེ་སྒྱུར་བྱེད་པ་དང་ཡིག་ཆའི་ཆེ་ཆུང་ཆུང་དུ་གཏོང་ཆེད་ཚོས་གཞི་ཡོངས་རྫོགས་ལྡོག་སྒྱུར་བྱེད་པ།
+replaceColorPdf.tags=ཚོས་གཞི་བརྗེ་སྒྱུར།,ཤོག་ངོས་བཀོལ་སྤྱོད���,རྒྱབ་ངོས།,ཞབས་ཞུ་ཕྱོགས།
+replace-color.selectText.1=ཚོས་གཞི་བརྗེ་སྒྱུར་རམ་ལྡོག་སྒྱུར་གྱི་གདམ་ག
+replace-color.selectText.2=སྔོན་སྒྲིག (སྔོན་སྒྲིག་གི་འོད་ཁྱད་མཐོ་བའི་ཚོས་གཞི།)
+replace-color.selectText.3=རང་སྒྲིག (རང་སྒྲིག་གི་ཚོས་གཞི།)
+replace-color.selectText.4=ཡོངས་རྫོགས་ལྡོག་སྒྱུར། (ཚོས་གཞི་ཚང་མ་ལྡོག་སྒྱུར།)
+replace-color.selectText.5=འོད་ཁྱད་མཐོ་བའི་ཚོས་གཞིའི་གདམ་ག
+replace-color.selectText.6=རྒྱབ་ལྗོངས་ནག་པོའི་སྟེང་གི་ཡི་གེ་དཀར་པོ།
+replace-color.selectText.7=རྒྱབ་ལྗོངས་དཀར་པོའི་སྟེང་གི་ཡི་གེ་ནག་པོ།
+replace-color.selectText.8=རྒྱབ་ལྗོངས་ནག་པོའི་སྟེང་གི་ཡི་གེ་སེར་པོ།
+replace-color.selectText.9=རྒྱབ་ལྗོངས་ནག་པོའི་སྟེང་གི་ཡི་གེ་ལྗང་ཁུ།
+replace-color.selectText.10=ཡི་གེའི་ཚོས་གཞི་འདེམས་པ།
+replace-color.selectText.11=རྒྱབ་ལྗོངས་ཀྱི་ཚོས་གཞི་འདེམས་པ།
+replace-color.submit=བརྗེ་སྒྱུར།
 
 
 
@@ -789,93 +789,93 @@ replace-color.submit=Replace
 #                         #
 ###########################
 #login
-login.title=Sign in
-login.header=Sign in
-login.signin=Sign in
-login.rememberme=Remember me
-login.invalid=Invalid username or password.
-login.locked=Your account has been locked.
-login.signinTitle=Please sign in
-login.ssoSignIn=Login via Single Sign-on
-login.oAuth2AutoCreateDisabled=OAUTH2 Auto-Create User Disabled
-login.oAuth2AdminBlockedUser=Registration or logging in of non-registered users is currently blocked. Please contact the administrator.
-login.oauth2RequestNotFound=Authorization request not found
-login.oauth2InvalidUserInfoResponse=Invalid User Info Response
-login.oauth2invalidRequest=Invalid Request
-login.oauth2AccessDenied=Access Denied
-login.oauth2InvalidTokenResponse=Invalid Token Response
-login.oauth2InvalidIdToken=Invalid Id Token
-login.relyingPartyRegistrationNotFound=No relying party registration found
-login.userIsDisabled=User is deactivated, login is currently blocked with this username. Please contact the administrator.
-login.alreadyLoggedIn=You are already logged in to
-login.alreadyLoggedIn2=devices. Please log out of the devices and try again.
-login.toManySessions=You have too many active sessions
+login.title=�ང་འཛུལ།
+login.header=ནང་འཛུལ།
+login.signin=ནང་འཛུལ།
+login.rememberme=ང་དྲན་པར་བྱེད།
+login.invalid=སྤྱོད་མིང་ངམ་གསང་ཚིག་ནོར་འདུག
+login.locked=ཁྱེད་ཀྱི་ཐོ་མཛོད་ཟྭ་རྒྱག་བརྒྱབ་ཟིན།
+login.signinTitle=ནང་འཛུལ་གནང་རོགས།
+login.ssoSignIn=གཅིག་གྱུར་ནང་འཛུལ་བརྒྱུད་ནས་ནང་འཛུལ།
+login.oAuth2AutoCreateDisabled=OAUTH2 རང་འགུལ་སྤྱོད་མཁན་གསར་བཟོ་བཀག་སྡོམ་བྱས་ཟིན།
+login.oAuth2AdminBlockedUser=ད་ལྟ་ཐོ་འགོད་མ་བྱས་པའི་སྤྱོད་མཁན་གྱི་ཐོ་འགོད་དང་ནང་འཛུལ་བཀག་སྡོམ་བྱས་ཡོད། དོ་དམ་པར་འབྲེལ་བ་གནང་རོགས།
+login.oauth2RequestNotFound=དབང་སྤྲོད་རེ་ཞུ་རྙེད་མ་བྱུང་།
+login.oauth2InvalidUserInfoResponse=སྤྱོད་མཁན་གྱི་གནས་ཚུལ་ལན་འདེབས་ནོར་འཁྲུལ།
+login.oauth2invalidRequest=རེ་ཞུ་ནོར་འཁྲུལ།
+login.oauth2AccessDenied=འཛུལ་སྤྱོད་བཀག་འགོག
+login.oauth2InvalidTokenResponse=བརྡ་རྟགས་ལན་འདེབས་ནོར་འཁྲུལ།
+login.oauth2InvalidIdToken=ངོ་རྟགས་བརྡ་རྟགས་ནོར་འཁྲུལ།
+login.relyingPartyRegistrationNotFound=བརྟེན་སའི་ཚོགས་པའི་ཐོ་འགོད་རྙེད་མ་བྱུང་།
+login.userIsDisabled=སྤྱོད་མཁན་བཀག་སྡོམ་བྱས་ཟིན། སྤྱོད་མིང་འདི་བརྒྱུད་ནས་ནང་འཛུལ་བྱེད་མི་ཆོག དོ་དམ་པར་འབྲེལ་བ་གནང་རོགས།
+login.alreadyLoggedIn=ཁྱེད་རང་
+login.alreadyLoggedIn2=སྒྲིག་ཆས་ནང་ནང་འཛུལ་བྱས་ཟིན། སྒྲིག་ཆས་ནས་ཕྱིར་འཐེན་བྱས་ནས་ཡང་བསྐྱར་ཚོད་ལྟ་བྱེད་རོགས།
+login.toManySessions=ཁྱེད་ལ་འཛུལ་ཞུགས་བྱས་པའི་གནས་སྐབས་མང་དྲགས་འདུག
 login.logoutMessage=You have been logged out.
 
 #auto-redact
-autoRedact.title=Auto Redact
-autoRedact.header=Auto Redact
-autoRedact.colorLabel=Colour
-autoRedact.textsToRedactLabel=Text to Redact (line-separated)
-autoRedact.textsToRedactPlaceholder=e.g. \nConfidential \nTop-Secret
-autoRedact.useRegexLabel=Use Regex
-autoRedact.wholeWordSearchLabel=Whole Word Search
-autoRedact.customPaddingLabel=Custom Extra Padding
-autoRedact.convertPDFToImageLabel=Convert PDF to PDF-Image (Used to remove text behind the box)
-autoRedact.submitButton=Submit
+autoRedact.title=རང་འགུལ་སྒྲིབ་སྲུང་།
+autoRedact.header=རང་འགུལ་སྒྲིབ་སྲུང་།
+autoRedact.colorLabel=ཚོས་གཞི།
+autoRedact.textsToRedactLabel=སྒྲིབ་རྒྱུའི་ཡི་གེ། (ཐིག་ཕྲེང་སོ་སོར།)
+autoRedact.textsToRedactPlaceholder=དཔེར་ན། \nགསང་བ། \nགསང་ཆེ།
+autoRedact.useRegexLabel=Regex བེད་སྤྱོད།
+autoRedact.wholeWordSearchLabel=ཚིག་ཆ་ཚང་འཚོལ་བ།
+autoRedact.customPaddingLabel=མཐའ་མཚམས་སྟོང་ཆ་སྣོན་པ།
+autoRedact.convertPDFToImageLabel=PDF ནས་ PDF-པར་རིས་ལ་བསྒྱུར་བ། (སྒྲོམ་གྱི་རྒྱབ་ཀྱི་ཡི་གེ་སུབ་པར་བེད་སྤྱོད།)
+autoRedact.submitButton=ཕུལ་བ།
 
 #redact
-redact.title=Manual Redaction
-redact.header=Manual Redaction
-redact.submit=Redact
-redact.textBasedRedaction=Text based Redaction
-redact.pageBasedRedaction=Page-based Redaction
-redact.convertPDFToImageLabel=Convert PDF to PDF-Image (Used to remove text behind the box)
-redact.pageRedactionNumbers.title=Pages
-redact.pageRedactionNumbers.placeholder=(e.g. 1,2,8 or 4,7,12-16 or 2n-1)
-redact.redactionColor.title=Redaction Color
-redact.export=Export
-redact.upload=Upload
-redact.boxRedaction=Box draw redaction
-redact.zoom=Zoom
-redact.zoomIn=Zoom in
-redact.zoomOut=Zoom out
-redact.nextPage=Next Page
-redact.previousPage=Previous Page
-redact.toggleSidebar=Toggle Sidebar
-redact.showThumbnails=Show Thumbnails
-redact.showDocumentOutline=Show Document Outline (double-click to expand/collapse all items)
-redact.showAttatchments=Show Attachments
-redact.showLayers=Show Layers (double-click to reset all layers to the default state)
-redact.colourPicker=Colour Picker
-redact.findCurrentOutlineItem=Find current outline item
+redact.title=ལག་བཟོས་སྒྲིབ་སྲུང་།
+redact.header=ལག་བཟོས་སྒྲིབ་སྲུང་།
+redact.submit=སྒྲིབ་སྲུང་།
+redact.textBasedRedaction=ཡི་གེ་གཞིར་བཟུང་བའི་སྒྲིབ་སྲུང་།
+redact.pageBasedRedaction=ཤོག་ངོས་གཞིར་བཟུང་བའི་སྒྲིབ་སྲུང་།
+redact.convertPDFToImageLabel=PDF ནས་ PDF-པར་རིས་ལ་བསྒྱུར་བ། (སྒྲོམ་གྱི་རྒྱབ་ཀྱི་ཡི་གེ་སུབ་པར་བེད་སྤྱོད།)
+redact.pageRedactionNumbers.title=ཤོག་ངོས།
+redact.pageRedactionNumbers.placeholder=(དཔེར་ན། 1,2,8 ཡང་ན་ 4,7,12-16 ཡང་ན་ 2n-1)
+redact.redactionColor.title=སྒྲིབ་སྲུང་གི་ཚོས་གཞི།
+redact.export=ཕྱིར་འདྲེན།
+redact.upload=ཡར་འཇུག
+redact.boxRedaction=སྒྲོམ་བྲིས་སྒྲིབ་སྲུང་།
+redact.zoom=ཆེ་ཆུང་།
+redact.zoomIn=ཆེ་རུ་གཏོང་བ།
+redact.zoomOut=ཆུང་དུ་གཏོང་བ།
+redact.nextPage=ཤོག་ངོས་རྗེས་མ།
+redact.previousPage=ཤོག་ངོས་སྔོན་མ།
+redact.toggleSidebar=ཟུར་སྣེའི་སྡེ་ཚན་སྟོན་སྦས།
+redact.showThumbnails=བསྡུས་པར་སྟོན།
+redact.showDocumentOutline=ཡིག་ཆའི་སྒྲོམ་གཞི་སྟོན། (ནང་གསེས་ཚང་མ་རྒྱ་སྐྱེད་/བསྡུ་བར་ཉིས་རྡེབ།)
+redact.showAttatchments=ཟུར་སྦྱར་སྟོན།
+redact.showLayers=རིམ་པ་སྟོན། (རིམ་པ་ཚང་མ་སྔོན་སྒྲིག་གནས་བབ་ལ་བསྐྱར་སྒྲིག་བྱེད་པར་ཉིས་རྡེབ།)
+redact.colourPicker=ཚོས་གཞི་འདེམས་བྱེད���
+redact.findCurrentOutlineItem=ད་ལྟའི་སྒྲོམ་གཞིའི་ནང་དོན་འཚོལ་བ།
 redact.applyChanges=Apply Changes
 
 #showJS
-showJS.title=Show Javascript
-showJS.header=Show Javascript
-showJS.downloadJS=Download Javascript
-showJS.submit=Show
+showJS.title=Javascript ས�ོན་པ།
+showJS.header=Javascript སྟོན་པ།
+showJS.downloadJS=Javascript ཕབ་ལེན།
+showJS.submit=སྟོན་པ།
 
 
 #pdfToSinglePage
-pdfToSinglePage.title=PDF To Single Page
-pdfToSinglePage.header=PDF To Single Page
-pdfToSinglePage.submit=Convert To Single Page
+pdfToSinglePage.title=PDF ནས་ཤོག་ངོས་གཅིག་ལ།
+pdfToSinglePage.header=PDF ནས་ཤོག་ངོས་གཅིག་ལ།
+pdfToSinglePage.submit=ཤོག་ངོས་གཅིག་ལ་བསྒྱུར་བ།
 
 
 #pageExtracter
-pageExtracter.title=Extract Pages
-pageExtracter.header=Extract Pages
-pageExtracter.submit=Extract
-pageExtracter.placeholder=(e.g. 1,2,8 or 4,7,12-16 or 2n-1)
+pageExtracter.title=ཤོག་ངོས་ཕྱིར་འདོན།
+pageExtracter.header=ཤོག་ངོས་ཕྱིར་འདོན།
+pageExtracter.submit=ཕྱིར་འདོན།
+pageExtracter.placeholder=(དཔེར་ན། 1,2,8 ཡང་ན་ 4,7,12-16 ཡང་ན་ 2n-1)
 
 
 #getPdfInfo
-getPdfInfo.title=Get Info on PDF
-getPdfInfo.header=Get Info on PDF
-getPdfInfo.submit=Get Info
-getPdfInfo.downloadJson=Download JSON
+getPdfInfo.title=PDF ཡི་གནས་ཚུལ་ལེན་པ།
+getPdfInfo.header=PDF ཡི་གནས་ཚུལ་ལེན་པ།
+getPdfInfo.submit=གནས་ཚུལ་ལེན་པ།
+getPdfInfo.downloadJson=JSON ཕབ་ལེན།
 getPdfInfo.summary=PDF Summary
 getPdfInfo.summary.encrypted=This PDF is encrypted so may face issues with some applications
 getPdfInfo.summary.permissions=This PDF has {0} restricted permissions which may limit what you can do with it
@@ -901,11 +901,11 @@ getPdfInfo.section.PerPageInfo=Detailed information about each page in the docum
 
 
 #markdown-to-pdf
-MarkdownToPDF.title=Markdown To PDF
-MarkdownToPDF.header=Markdown To PDF
-MarkdownToPDF.submit=Convert
-MarkdownToPDF.help=Work in progress
-MarkdownToPDF.credit=Uses WeasyPrint
+MarkdownToPDF.title=Markdown ནས་ PDF ལ།
+MarkdownToPDF.header=Markdown ནས་ PDF ལ།
+MarkdownToPDF.submit=བསྒྱུར་བ།
+MarkdownToPDF.help=ལས་ཀ་བྱེད་བཞིན་པ།
+MarkdownToPDF.credit=WeasyPrint བེད་སྤྱོད་བྱེད་པ།
 
 
 #pdf-to-markdown
@@ -915,510 +915,510 @@ PDFToMarkdown.submit=Convert
 
 
 #url-to-pdf
-URLToPDF.title=URL To PDF
-URLToPDF.header=URL To PDF
-URLToPDF.submit=Convert
-URLToPDF.credit=Uses WeasyPrint
+URLToPDF.title=URL ནས་ PDF ལ།
+URLToPDF.header=URL ནས་ PDF ལ།
+URLToPDF.submit=བསྒྱུར་བ།
+URLToPDF.credit=WeasyPrint བེད་སྤྱོད་བྱེད་པ།
 
 
 #html-to-pdf
-HTMLToPDF.title=HTML To PDF
-HTMLToPDF.header=HTML To PDF
-HTMLToPDF.help=Accepts HTML files and ZIPs containing html/css/images etc required
-HTMLToPDF.submit=Convert
-HTMLToPDF.credit=Uses WeasyPrint
-HTMLToPDF.zoom=Zoom level for displaying the website.
-HTMLToPDF.pageWidth=Width of the page in centimeters. (Blank to default)
-HTMLToPDF.pageHeight=Height of the page in centimeters. (Blank to default)
-HTMLToPDF.marginTop=Top margin of the page in millimeters. (Blank to default)
-HTMLToPDF.marginBottom=Bottom margin of the page in millimeters. (Blank to default)
-HTMLToPDF.marginLeft=Left margin of the page in millimeters. (Blank to default)
-HTMLToPDF.marginRight=Right margin of the page in millimeters. (Blank to default)
-HTMLToPDF.printBackground=Render the background of websites.
-HTMLToPDF.defaultHeader=Enable Default Header (Name and page number)
-HTMLToPDF.cssMediaType=Change the CSS media type of the page.
-HTMLToPDF.none=None
-HTMLToPDF.print=Print
-HTMLToPDF.screen=Screen
+HTMLToPDF.title=HTML ནས་ PDF ལ།
+HTMLToPDF.header=HTML ནས་ PDF ལ།
+HTMLToPDF.help=HTML ཡིག་ཆ་དང་དགོས་མཁོའི་ html/css/པར་རིས་སོགས་འདུས་པའི་ ZIP ཡིག་ཆ་ངོས་ལེན་བྱེད་པ།
+HTMLToPDF.submit=བསྒྱུར་བ།
+HTMLToPDF.credit=WeasyPrint བེད་སྤྱོད་བྱེད་པ།
+HTMLToPDF.zoom=དྲ་ཚིགས་སྟོན་པའི་ཆེ་ཆུང་ཚད།
+HTMLToPDF.pageWidth=ཤོག་ངོས་ཀྱི་ཞེང་ཚད་སེན་ཊི་མི་ཊར་ནང་། (སྟོང་པར་བཞག་ན་སྔོན་སྒྲིག)
+HTMLToPDF.pageHeight=ཤོག་ངོས་ཀྱི་དཔངས་ཚད་སེན་ཊི་མི་ཊར་ནང་། (སྟོང་པར་བཞག་ན་སྔོན་སྒྲིག)
+HTMLToPDF.marginTop=ཤོག་ངོས་ཀྱི་སྟེང་མཐའི་བར་ཐག་མི་ལི་མི་ཊར་ནང་། (སྟོང་པར་བཞག་ན་སྔོན་སྒྲིག)
+HTMLToPDF.marginBottom=ཤོག་ངོས་ཀྱི་འོག་མཐའི་བར་ཐག་མི་ལི་མི་ཊར་ནང་། (སྟོང་པར་བཞག་ན་སྔོན་སྒྲིག)
+HTMLToPDF.marginLeft=ཤོག་ངོས་ཀྱི་གཡོན་མཐའི་བར་ཐག་མི་ལི་མི་ཊར་ནང་། (སྟོང་པར་བཞག་ན་སྔོན་སྒྲིག)
+HTMLToPDF.marginRight=ཤོག་ངོས་ཀྱི་གཡས་མཐའི་བར་ཐག་མི་ལི་མི་ཊར་ནང་། (སྟོང་པར་བཞག་ན་སྔོན་སྒྲིག)
+HTMLToPDF.printBackground=དྲ་ཚིགས་ཀྱི་རྒྱབ་ལྗོངས་མངོན་པ།
+HTMLToPDF.defaultHeader=སྔོན་སྒྲིག་མགོ་བྱང་སྤྱོད་པ། (མིང་དང་ཤོག་གྲངས།)
+HTMLToPDF.cssMediaType=ཤོག་ངོས་ཀྱི་ CSS བརྒྱུད་ལམ་རིགས་བསྒྱུར་བ།
+HTMLToPDF.none=མེད།
+HTMLToPDF.print=པར་འདེབས།
+HTMLToPDF.screen=བརྙན་ཡོལ།
 
 
 #AddStampRequest
-AddStampRequest.header=Stamp PDF
-AddStampRequest.title=Stamp PDF
-AddStampRequest.stampType=Stamp Type
-AddStampRequest.stampText=Stamp Text
-AddStampRequest.stampImage=Stamp Image
-AddStampRequest.alphabet=Alphabet
-AddStampRequest.fontSize=Font/Image Size
-AddStampRequest.rotation=Rotation
-AddStampRequest.opacity=Opacity
-AddStampRequest.position=Position
-AddStampRequest.overrideX=Override X Coordinate
-AddStampRequest.overrideY=Override Y Coordinate
-AddStampRequest.customMargin=Custom Margin
-AddStampRequest.customColor=Custom Text Colour
-AddStampRequest.submit=Submit
+AddStampRequest.header=PDF ལ་ཐེལ་ཙེ་རྒྱག་པ།
+AddStampRequest.title=PDF ལ་ཐེལ་ཙེ་རྒྱག་པ།
+AddStampRequest.stampType=ཐེལ་ཙེའི་རིགས།
+AddStampRequest.stampText=ཐེལ་ཙེའི་ཡི་གེ
+AddStampRequest.stampImage=ཐེལ་ཙེའི་པར་རིས།
+AddStampRequest.alphabet=ཡི་གེའི་གཟུགས།
+AddStampRequest.fontSize=ཡི་གེ/པར་རིས་ཀྱི་ཆེ་ཆུང་།
+AddStampRequest.rotation=འཁོར་སྐྱོད།
+AddStampRequest.opacity=གསལ་ཚད།
+AddStampRequest.position=གནས་ས།
+AddStampRequest.overrideX=X གནས་ཚད་བརྗེ་བསྒྱུར།
+AddStampRequest.overrideY=Y གནས་ཚད་བརྗེ་བསྒྱུར།
+AddStampRequest.customMargin=མཐའ་མཚམས་རང་སྒྲིག
+AddStampRequest.customColor=ཡི་གེའི་ཚོས་མདོག་རང་སྒྲིག
+AddStampRequest.submit=ཕུལ་བ།
 
 
 #sanitizePDF
-sanitizePDF.title=Sanitize PDF
-sanitizePDF.header=Sanitize a PDF file
-sanitizePDF.selectText.1=Remove JavaScript actions
-sanitizePDF.selectText.2=Remove embedded files
+sanitizePDF.title=PDF གཙང་སེལ།
+sanitizePDF.header=PDF ཡིག་ཆ་གཙང་སེལ།
+sanitizePDF.selectText.1=Javascript བྱ་འགུལ་སུབ་པ།
+sanitizePDF.selectText.2=ནང་འཇུག་ཡིག་ཆ་སུབ་པ།
 sanitizePDF.selectText.3=Remove XMP metadata
-sanitizePDF.selectText.4=Remove links
-sanitizePDF.selectText.5=Remove fonts
+sanitizePDF.selectText.4=འབྲེལ་ཐག་སུབ་པ།
+sanitizePDF.selectText.5=ཡིག་གཟུགས་སུབ་པ།
 sanitizePDF.selectText.6=Remove Document Info Metadata
-sanitizePDF.submit=Sanitize PDF
+sanitizePDF.submit=PDF གཙང་སེལ།
 
 
 #addPageNumbers
-addPageNumbers.title=Add Page Numbers
-addPageNumbers.header=Add Page Numbers
-addPageNumbers.selectText.1=Select PDF file:
-addPageNumbers.selectText.2=Margin Size
-addPageNumbers.selectText.3=Position
-addPageNumbers.selectText.4=Starting Number
-addPageNumbers.selectText.5=Pages to Number
-addPageNumbers.selectText.6=Custom Text
-addPageNumbers.customTextDesc=Custom Text
-addPageNumbers.numberPagesDesc=Which pages to number, default 'all', also accepts 1-5 or 2,5,9 etc
-addPageNumbers.customNumberDesc=Defaults to {n}, also accepts 'Page {n} of {total}', 'Text-{n}', '{filename}-{n}
-addPageNumbers.submit=Add Page Numbers
+addPageNumbers.title=ཤོག་གྲངས་སྣོན་པ།
+addPageNumbers.header=ཤོག་གྲངས་སྣོན་པ།
+addPageNumbers.selectText.1=PDF ཡིག་ཆ་འདེམས་པ།
+addPageNumbers.selectText.2=མཐའ་མཚམས་ཀྱི་ཆེ་ཆུང་།
+addPageNumbers.selectText.3=གནས་ས།
+addPageNumbers.selectText.4=འགོ་འཛུགས་ཨང་གྲངས།
+addPageNumbers.selectText.5=ཨང་གྲངས་རྒྱག་རྒྱུའི་ཤོག་ངོས།
+addPageNumbers.selectText.6=རང་སྒྲིག་ཡི་གེ
+addPageNumbers.customTextDesc=རང་སྒྲིག་ཡི་གེ
+addPageNumbers.numberPagesDesc=ཨང་གྲངས་རྒྱག་རྒྱུའི་ཤོག་ངོས། སྔོན་སྒྲིག་ནི་'ཚང་མ་'ཡིན། 1-5 ཡང་ན་ 2,5,9 སོགས་ཀྱང་ངོས་ལེན་བྱེད།
+addPageNumbers.customNumberDesc=སྔོན་སྒྲིག་ནི་ {n} ཡིན། 'ཤོག་ངོས་ {n} / {total}', 'ཡི་གེ-{n}', '{filename}-{n}' སོགས་ཀྱང་ངོས་ལེན་བྱེད།
+addPageNumbers.submit=ཤོག་གྲངས་སྣོན་པ།
 
 
 #auto-rename
-auto-rename.title=Auto Rename
-auto-rename.header=Auto Rename PDF
-auto-rename.submit=Auto Rename
+auto-rename.title=རང་འགུལ་མིང་བསྐྱར་འདོགས།
+auto-rename.header=PDF རང་འགུལ་མིང་བསྐྱར་འདོགས།
+auto-rename.submit=རང་འགུལ་མིང་བསྐྱར་འདོགས།
 
 
 #adjustContrast
-adjustContrast.title=Adjust Contrast
-adjustContrast.header=Adjust Contrast
-adjustContrast.contrast=Contrast:
-adjustContrast.brightness=Brightness:
-adjustContrast.saturation=Saturation:
-adjustContrast.download=Download
+adjustContrast.title=འོད་ཁྱད་སྙོམ་སྒྲིག
+adjustContrast.header=འོད་ཁྱད་སྙོམ་སྒྲིག
+adjustContrast.contrast=འོད་ཁྱད།
+adjustContrast.brightness=གསལ་ཚད།
+adjustContrast.saturation=མདོག་ཚད།
+adjustContrast.download=ཕབ་ལེན།
 
 
 #crop
-crop.title=Crop
-crop.header=Crop PDF
-crop.submit=Submit
+crop.title=གཏུབ་གཅོད།
+crop.header=PDF གཏུབ་གཅོད།
+crop.submit=ཕུལ་བ།
 
 
 #autoSplitPDF
-autoSplitPDF.title=Auto Split PDF
-autoSplitPDF.header=Auto Split PDF
-autoSplitPDF.description=Print, Insert, Scan, upload, and let us auto-separate your documents. No manual work sorting needed.
-autoSplitPDF.selectText.1=Print out some divider sheets from below (Black and white is fine).
-autoSplitPDF.selectText.2=Scan all your documents at once by inserting the divider sheet between them.
-autoSplitPDF.selectText.3=Upload the single large scanned PDF file and let Stirling PDF handle the rest.
-autoSplitPDF.selectText.4=Divider pages are automatically detected and removed, guaranteeing a neat final document.
-autoSplitPDF.formPrompt=Submit PDF containing Stirling-PDF Page dividers:
-autoSplitPDF.duplexMode=Duplex Mode (Front and back scanning)
-autoSplitPDF.dividerDownload2=Download 'Auto Splitter Divider (with instructions).pdf'
-autoSplitPDF.submit=Submit
+autoSplitPDF.title=PDF རང་འགུལ་ཁ་གྱེས།
+autoSplitPDF.header=PDF རང་འགུལ་ཁ་གྱེས།
+autoSplitPDF.description=པར་འདེབས། ནང་འཇུག བཤེར་འབེབས། ཡར་འཇོག་བྱས་ནས་ང་ཚོས་ཡིག་ཆ་རྣམས་རང་འགུལ་གྱིས་ཁ་གྱེས་བྱེད་དུ་འཇུག ལག་བཟོས་གོ་རིམ་སྒྲིག་དགོས་མེད།
+autoSplitPDF.selectText.1=གཤམ་ནས་བར་མཚམས་ཤོག་བུ་འགའ་པར་འདེབས་བྱེད། (ནག་དཀར་ཡིན་ནའང་འགྲིག)
+autoSplitPDF.selectText.2=ཡིག་ཆ་ཚང་མའི་བར་དུ་བར་མཚམས་ཤོག་བུ་བཅུག་ནས་ཐེངས་གཅིག་ལ་བཤེར་འབེབས་བྱེད།
+autoSplitPDF.selectText.3=བཤེར་འབེབས་བྱས་པའི་ PDF ཡིག་ཆ་ཆེན་པོ་གཅིག་ཡར་འཇོག་བྱས་ནས་ Stirling PDF ལ་ལྷག་མ་བྱེད་དུ་འཇུག
+autoSplitPDF.selectText.4=བར་མཚམས་ཤོག་ངོས་རྣམས་རང་འགུལ་གྱིས་ངོས་འཛིན་དང་སུབ་པ་བྱས་ནས་མཐའ་མའི་ཡིག་ཆ་གཙང་མ་ཞིག་ངེས་པར་དུ་ཐོབ་ཐུབ།
+autoSplitPDF.formPrompt=Stirling-PDF ཤོག་ངོས་བར་མཚམས་ཡོད་པའི་ PDF ཕུལ་བ།
+autoSplitPDF.duplexMode=ཕྱོགས་གཉིས་ཀྱི་རྣམ་པ། (མདུན་རྒྱབ་བཤེར་འབེབས།)
+autoSplitPDF.dividerDownload2='རང་འགུལ་ཁ་གྱེས་བར་མཚམས། (བཀོལ་སྤྱོད་ལམ་སྟོན་དང་བཅས་པ།).pdf' ཕབ་ལེན།
+autoSplitPDF.submit=ཕུལ་བ།
 
 
 #pipeline
-pipeline.title=Pipeline
+pipeline.title=རྒ��ུ་ལམ།
 
 
 #pageLayout
-pageLayout.title=Multi Page Layout
-pageLayout.header=Multi Page Layout
-pageLayout.pagesPerSheet=Pages per sheet:
-pageLayout.addBorder=Add Borders
-pageLayout.submit=Submit
+pageLayout.title=ཤོག་ངོས་མང་པོའི་བཀོད་པ།
+pageLayout.header=ཤོག་ངོས་མང་པོའི་བཀོད་པ།
+pageLayout.pagesPerSheet=ཤོག་ལྷེ་རེར་ཤོག་ངོས་གྲངས།
+pageLayout.addBorder=མཐའ་མཚམས་སྣོན་པ།
+pageLayout.submit=ཕུལ་བ།
 
 
 #scalePages
-scalePages.title=Adjust page-scale
-scalePages.header=Adjust page-scale
-scalePages.pageSize=Size of a page of the document.
-scalePages.keepPageSize=Original Size
-scalePages.scaleFactor=Zoom level (crop) of a page.
-scalePages.submit=Submit
+scalePages.title=ཤོག་ངོས་ཆེ་ཆུང་སྙོམ་སྒྲིག
+scalePages.header=ཤོག་ངོས་ཆེ་ཆུང་སྙོམ་སྒྲིག
+scalePages.pageSize=ཡིག་ཆའི་ཤོག་ངོས་ཀྱི་ཆེ་ཆུང་།
+scalePages.keepPageSize=ཐོག་མའི་ཆེ་ཆུང་།
+scalePages.scaleFactor=ཤོག་ངོས་ཀྱི་ཆེ་ཆུང་ཚད། (གཏུབ་གཅོད།)
+scalePages.submit=ཕུལ་བ།
 
 
 #certSign
-certSign.title=Certificate Signing
-certSign.header=Sign a PDF with your certificate (Work in progress)
-certSign.selectPDF=Select a PDF File for Signing:
-certSign.jksNote=Note: If your certificate type is not listed below, please convert it to a Java Keystore (.jks) file using the keytool command line tool. Then, choose the .jks file option below.
-certSign.selectKey=Select Your Private Key File (PKCS#8 format, could be .pem or .der):
-certSign.selectCert=Select Your Certificate File (X.509 format, could be .pem or .der):
-certSign.selectP12=Select Your PKCS#12 Keystore File (.p12 or .pfx) (Optional, If provided, it should contain your private key and certificate):
-certSign.selectJKS=Select Your Java Keystore File (.jks or .keystore):
-certSign.certType=Certificate Type
-certSign.password=Enter Your Keystore or Private Key Password (If Any):
-certSign.showSig=Show Signature
-certSign.reason=Reason
-certSign.location=Location
-certSign.name=Name
-certSign.showLogo=Show Logo
-certSign.submit=Sign PDF
+certSign.title=ལག་ཁྱེར་མིང་རྟགས།
+certSign.header=ཁྱེད་ཀྱི་ལག་ཁྱེར་གྱིས་ PDF ལ་མིང་རྟགས་རྒྱག་པ། (ལས་ཀ་བྱེད་བཞིན་པ།)
+certSign.selectPDF=མིང་རྟགས་རྒྱག་རྒྱུའི་ PDF ཡིག་ཆ་འདེམས་པ།
+certSign.jksNote=དྲན་གསོ། གལ་སྲིད་ཁྱེད་ཀྱི་ལག་ཁྱེར་གྱི་རིགས་གཤམ་དུ་མེད་ན། keytool བཀའ་བརྡ་ཐིག་བེད་སྤྱོད་བྱས་ནས་ Java Keystore (.jks) ཡིག་ཆ་ལ་བསྒྱུར་རོགས། དེ་ནས་གཤམ་དུ་ .jks ཡིག་ཆ་འདེམས་རོགས།
+certSign.selectKey=སྒེར་གྱི་ལྡེ་མིག་ཡིག་ཆ་འདེམས་པ། (PKCS#8 རྣམ་གཞག .pem ཡང་ན་ .der ཡིན་སྲིད།)
+certSign.selectCert=ལག་ཁྱེར་ཡིག་ཆ་འདེམས་པ། (X.509 རྣམ་གཞག .pem ཡང་ན་ .der ཡིན་སྲིད།)
+certSign.selectP12=PKCS#12 ལྡེ་མིག་མཛོད་ཡིག་ཆ་འདེམས་པ། (.p12 ཡང་ན་ .pfx) (འདེམས་རུང་། གལ་སྲིད་མཁོ་སྤྲོད་བྱས་ན། དེའི་ནང་དུ་ཁྱེད་ཀྱི་སྒེར་གྱི་ལྡེ་མིག་དང་ལག་ཁྱེར་འདུས་ཡོད་དགོས།)
+certSign.selectJKS=Java ལྡེ་མིག་མཛོད་ཡིག་ཆ་འདེམས་པ། (.jks ཡང་ན་ .keystore)
+certSign.certType=ལག་ཁྱེར་གྱི་རིགས།
+certSign.password=ཁྱེད་ཀྱི་ལྡེ་མིག་མཛོད་དམ་སྒེར་གྱི་ལྡེ་མིག་གི་གསང་ཚིག་འཇུག་པ། (གལ་སྲིད་ཡོད་ན།)
+certSign.showSig=མིང་རྟགས་སྟོན།
+certSign.reason=རྒྱུ་མཚན།
+certSign.location=ས་གནས།
+certSign.name=མིང་།
+certSign.showLogo=མཚོན་རྟགས་སྟོན།
+certSign.submit=PDF ལ་མིང་རྟགས་རྒྱག་པ།
 
 
 #removeCertSign
-removeCertSign.title=Remove Certificate Signature
-removeCertSign.header=Remove the digital certificate from the PDF
-removeCertSign.selectPDF=Select a PDF file:
-removeCertSign.submit=Remove Signature
+removeCertSign.title=ལག་ཁྱེར་མིང་རྟགས་སུབ་པ།
+removeCertSign.header=PDF ནས་ཨང་ཀིའི་ལག་ཁྱེར་སུབ་པ།
+removeCertSign.selectPDF=PDF ཡིག་ཆ་འདེམས་པ།
+removeCertSign.submit=མིང་རྟགས་སུབ་པ།
 
 
 #removeBlanks
-removeBlanks.title=Remove Blanks
-removeBlanks.header=Remove Blank Pages
-removeBlanks.threshold=Pixel Whiteness Threshold:
-removeBlanks.thresholdDesc=Threshold for determining how white a white pixel must be to be classed as 'White'. 0 = Black, 255 pure white.
-removeBlanks.whitePercent=White Percent (%):
-removeBlanks.whitePercentDesc=Percent of page that must be 'white' pixels to be removed
-removeBlanks.submit=Remove Blanks
+removeBlanks.title=སྟོང་ཤོག་སུབ་པ།
+removeBlanks.header=སྟོང་པའི་ཤོག་ངོས་སུབ་པ།
+removeBlanks.threshold=པིག་ཟེལ་དཀར་པོའི་མཚམས་ཚད།
+removeBlanks.thresholdDesc=པིག་ཟེལ་དཀར་པོ་ཞིག་'དཀར་པོ་'རུ་རྩི་བའི་དཀར་ཚད་ཀྱི་མཚམས། 0 = ནག་པོ། 255 དཀར་པོ་གཙང་མ།
+removeBlanks.whitePercent=དཀར་པོའི་བརྒྱ་ཆ། (%)
+removeBlanks.whitePercentDesc=སུབ་རྒྱུའི་ཤོག་ངོས་ཤིག་གི་'དཀར་པོའི་'པིག་ཟེལ་གྱི་བརྒྱ་ཆ།
+removeBlanks.submit=སྟོང་ཤོག་སུབ་པ།
 
 
 #removeAnnotations
-removeAnnotations.title=Remove Annotations
-removeAnnotations.header=Remove Annotations
-removeAnnotations.submit=Remove
+removeAnnotations.title=མཆན་འགྲེལ་སུབ་པ།
+removeAnnotations.header=མཆན་འགྲེལ་སུབ་པ།
+removeAnnotations.submit=སུབ་པ།
 
 
 #compare
-compare.title=Compare
-compare.header=Compare PDFs
-compare.highlightColor.1=Highlight Colour 1:
-compare.highlightColor.2=Highlight Colour 2:
-compare.document.1=Document 1
-compare.document.2=Document 2
-compare.submit=Compare
-compare.complex.message=One or both of the provided documents are large files, accuracy of comparison may be reduced
-compare.large.file.message=One or Both of the provided documents are too large to process
-compare.no.text.message=One or both of the selected PDFs have no text content. Please choose PDFs with text for comparison.
+compare.title=བས�ུར་བ།
+compare.header=PDF བསྡུར་བ།
+compare.highlightColor.1=མདངས་འདོན་ཚོས་གཞི་ ༡།
+compare.highlightColor.2=མདངས་འདོན་ཚོས་གཞི་ ༢།
+compare.document.1=ཡིག་ཆ་ ༡
+compare.document.2=ཡིག་ཆ་ ༢
+compare.submit=བསྡུར་བ།
+compare.complex.message=མཁོ་སྤྲོད་བྱས་པའི་ཡིག་ཆ་གཅིག་གམ་གཉིས་ཀ་ཡིག་ཆ་ཆེན་པོ་ཡིན་པས། བསྡུར་བའི་ཏག་ཏག་ཚད་ཉུང་དུ་འགྲོ་སྲིད།
+compare.large.file.message=མཁོ་སྤྲོད་བྱས་པའི་ཡིག་ཆ་གཅིག་གམ་གཉིས་ཀ་བཀོལ་སྤྱོད་བྱེད་མི་ཐུབ་པའི་ཆེ་ཚད་ཡིན།
+compare.no.text.message=འདེམས་པའི་ PDF གཅིག་གམ་གཉིས་ཀར་ཡི་གེའི་ནང་དོན་མི་འདུག བསྡུར་བའི་ཆེད་དུ་ཡི་གེ་ཡོད་པའི་ PDF འདེམས་རོགས།
 
 #sign
-sign.title=Sign
-sign.header=Sign PDFs
-sign.upload=Upload Image
-sign.draw=Draw Signature
-sign.text=Text Input
-sign.clear=Clear
-sign.add=Add
-sign.saved=Saved Signatures
-sign.save=Save Signature
-sign.personalSigs=Personal Signatures
-sign.sharedSigs=Shared Signatures
-sign.noSavedSigs=No saved signatures found
-sign.addToAll=Add to all pages
-sign.delete=Delete
-sign.first=First page
-sign.last=Last page
-sign.next=Next page
-sign.previous=Previous page
-sign.maintainRatio=Toggle maintain aspect ratio
+sign.title=མིང་རྟགས།
+sign.header=PDF ལ་མིང་རྟགས་རྒྱག་པ།
+sign.upload=པར་རིས་ཡར་འཇོག
+sign.draw=མིང་རྟགས་འབྲི་བ།
+sign.text=ཡི་གེ་འཇུག་པ།
+sign.clear=གཙང་སེལ།
+sign.add=སྣོན་པ།
+sign.saved=ཉར་ཚགས་བྱས་པའི་མིང་རྟགས།
+sign.save=མིང་རྟགས་ཉར་ཚགས།
+sign.personalSigs=སྒེར་གྱི་མིང་རྟགས།
+sign.sharedSigs=མཉམ་སྤྱོད་མིང་རྟགས།
+sign.noSavedSigs=ཉར་ཚགས་བྱས་པའི་མིང་རྟགས་མ་རྙེད།
+sign.addToAll=ཤོག་ངོས་ཚང་མར་སྣོན་པ།
+sign.delete=སུབ་པ།
+sign.first=ཤོག་ངོས་དང་པོ།
+sign.last=ཤོག་ངོས་མཐའ་མ།
+sign.next=ཤོག་ངོས་རྗེས་མ།
+sign.previous=ཤོག་ངོས་སྔོན་མ།
+sign.maintainRatio=བསྡུར་ཚད་རྒྱུན་འཁྱོངས་སྒོ་རྒྱག་པ།
 sign.undo=Undo
 sign.redo=Redo
 
 #repair
-repair.title=Repair
-repair.header=Repair PDFs
-repair.submit=Repair
+repair.title=བཟོ་བཅོས།
+repair.header=PDF བཟོ་བཅོས།
+repair.submit=བཟོ་བཅོས།
 
 
 #flatten
-flatten.title=Flatten
-flatten.header=Flatten PDF
-flatten.flattenOnlyForms=Flatten only forms
-flatten.submit=Flatten
+flatten.title=སྙ�མས་པ།
+flatten.header=PDF སྙོམས་པ།
+flatten.flattenOnlyForms=འགེངས་ཤོག་ཁོ་ན་སྙོམས་པ།
+flatten.submit=སྙོམས་པ།
 
 
 #ScannerImageSplit
-ScannerImageSplit.selectText.1=Angle Threshold:
-ScannerImageSplit.selectText.2=Sets the minimum absolute angle required for the image to be rotated (default: 10).
-ScannerImageSplit.selectText.3=Tolerance:
-ScannerImageSplit.selectText.4=Determines the range of colour variation around the estimated background colour (default: 30).
-ScannerImageSplit.selectText.5=Minimum Area:
-ScannerImageSplit.selectText.6=Sets the minimum area threshold for a photo (default: 10000).
-ScannerImageSplit.selectText.7=Minimum Contour Area:
-ScannerImageSplit.selectText.8=Sets the minimum contour area threshold for a photo
-ScannerImageSplit.selectText.9=Border Size:
-ScannerImageSplit.selectText.10=Sets the size of the border added and removed to prevent white borders in the output (default: 1).
-ScannerImageSplit.info=Python is not installed. It is required to run.
+ScannerImageSplit.selectText.1=�ུར་ཚད་མཚམས།
+ScannerImageSplit.selectText.2=པར་རིས་འཁོར་སྐྱོད་བྱེད་དགོས་པའི་ཉུང་མཐའི་ཟུར་ཚད་སྒྲིག་འགོད་བྱེད་པ། (སྔོན་སྒྲིག 10)
+ScannerImageSplit.selectText.3=བཟོད་སྲན་ཚད།
+ScannerImageSplit.selectText.4=ཚོད་དཔག་བྱས་པའི་རྒྱབ་ལྗོངས་ཚོས་གཞིའི་མཐའ་འཁོར་གྱི་ཚོས་མདོག་འགྱུར་བའི་ཁྱབ་ཚད་ཐག་གཅོད་བྱེད་པ། (སྔོན་སྒྲིག 30)
+ScannerImageSplit.selectText.5=ཉུང་མཐའི་རྒྱ་ཁྱོན།
+ScannerImageSplit.selectText.6=པར་རིས་ཤིག་གི་ཉུང་མཐའི་རྒྱ་ཁྱོན་མཚམས་སྒྲིག་འགོད་བྱེད་པ། (སྔོན་སྒྲིག 10000)
+ScannerImageSplit.selectText.7=ཉུང་མཐའི་མཐའ་འཁོར་རྒྱ་ཁྱོན།
+ScannerImageSplit.selectText.8=པར་རིས་ཤིག་གི་ཉུང་མཐའི་མཐའ་འཁོར་རྒྱ་ཁྱོན་མཚམས་སྒྲིག་འགོད་བྱེད་པ།
+ScannerImageSplit.selectText.9=མཐའ་མཚམས་ཆེ་ཆུང་།
+ScannerImageSplit.selectText.10=ཕྱིར་འདོན་པའི་ནང་དཀར་མཐའ་འགོག་པའི་ཆེད་དུ་སྣོན་པ་དང་སུབ་པ་བྱེད་པ�� (སྔོན་སྒྲིག 1)
+ScannerImageSplit.info=Python སྒྲིག་འཇུག་བྱས་མི་འདུག འདི་བཀོལ་སྤྱོད་བྱེད་པར་དགོས་མཁོ་ཡིན།
 
 
 #OCR
-ocr.title=OCR / Scan Cleanup
-ocr.header=Cleanup Scans / OCR (Optical Character Recognition)
-ocr.selectText.1=Select languages that are to be detected within the PDF (Ones listed are the ones currently detected):
-ocr.selectText.2=Produce text file containing OCR text alongside the OCR'ed PDF
-ocr.selectText.3=Correct pages were scanned at a skewed angle by rotating them back into place
-ocr.selectText.4=Clean page so its less likely that OCR will find text in background noise. (No output change)
-ocr.selectText.5=Clean page so its less likely that OCR will find text in background noise, maintains cleanup in output.
-ocr.selectText.6=Ignores pages that have interactive text on them, only OCRs pages that are images
-ocr.selectText.7=Force OCR, will OCR Every page removing all original text elements
-ocr.selectText.8=Normal (Will error if PDF contains text)
-ocr.selectText.9=Additional Settings
-ocr.selectText.10=OCR Mode
-ocr.selectText.11=Remove images after OCR (Removes ALL images, only useful if part of conversion step)
-ocr.selectText.12=Render Type (Advanced)
-ocr.help=Please read this documentation on how to use this for other languages and/or use not in docker
-ocr.credit=This service uses qpdf and Tesseract for OCR.
-ocr.submit=Process PDF with OCR
+ocr.title=OCR / བ�ེར་འབེབས་གཙང་སེལ།
+ocr.header=བཤེར་འབེབས་གཙང་སེལ། / OCR (འོད་ཀྱི་ཡིག་འབྲུ་ངོས་འཛིན།)
+ocr.selectText.1=PDF ནང་དུ་ངོས་འཛིན་བྱ་རྒྱུའི་སྐད་ཡིག་འདེམས་པ། (བཀོད་པ་རྣམས་ནི་ད་ལྟ་ངོས་འཛིན་བྱས་ཟིན་པ་ཡིན།)
+ocr.selectText.2=OCR བྱས་པའི་ཡི་གེ་དང་མཉམ་དུ་ OCR བྱས་པའི་ PDF ཡི་ཡི་གེའི་ཡིག་ཆ་བཟོ་བ།
+ocr.selectText.3=ཡོ་འཁྱོག་ཏུ་བཤེར་འབེབས་བྱས་པའི་ཤོག་ངོས་རྣམས་ཡང་བསྐྱར་འཁོར་སྐྱོད་བྱས་ནས་གནས་སུ་འཇོག་པ།
+ocr.selectText.4=OCR གྱིས་རྒྱབ་ལྗོངས་ཀྱི་སྒྲ་གདངས་ནང་དུ་ཡི་གེ་རྙེད་མི་སྲིད་པའི་ཆེད་དུ་ཤོག་ངོས་གཙང་སེལ་བྱེད་པ། (ཕྱིར་འདོན་ལ་འགྱུར་བ་མེད།)
+ocr.selectText.5=OCR གྱིས་རྒྱབ་ལྗོངས་ཀྱི་སྒྲ་གདངས་ནང་དུ་ཡི་གེ་རྙེད་མི་སྲིད་པའི་ཆེད་དུ་ཤོག་ངོས་གཙང་སེལ་བྱེད་པ། ཕྱིར་འདོན་ནང་དུ་གཙང་སེལ་རྒྱུན་འཁྱོངས་བྱེད་པ།
+ocr.selectText.6=སྤྱོད་སྒོ་ཡོད་པའི་ཡི་གེ་ཡོད་པའི་ཤོག་ངོས་རྣམས་སྣང་མེད་དུ་འཇོག་པ། པར་རིས་ཡིན་པའི་ཤོག་ངོས་ཁོ་ནར་ OCR བྱེད་པ།
+ocr.selectText.7=OCR བཙན་སྐུལ་བྱེད་པ། ཤོག་ངོས་ཚང་མར་ OCR བྱས་ནས་ཐོག་མའི་ཡི་གེའི་གཞི་རྐྱེན་ཚང་མ་སུབ་པ།
+ocr.selectText.8=རྒྱུན་ལྡན། (PDF ནང་དུ་ཡི་གེ་ཡོད་ན་ནོར་འཁྲུལ་འབྱུང་།)
+ocr.selectText.9=ཟུར་སྣོན་སྒྲིག་འགོད།
+ocr.selectText.10=OCR རྣམ་པ།
+ocr.selectText.11=པར་རིས་ཕྱིར་འདོན།
+ocr.selectText.12=པར་རིས་ཕྱིར་འདོན།
+ocr.help=སྐད་ཡིག་གཞན་དག་གི་ཆེད་དུ་བེད་སྤྱོད་བྱེད་སྟངས་དང་/ཡང་ན་ docker མིན་པའི་བེད་སྤྱོད་ཀྱི་ཆེད་དུ་ཡིག་ཆ་འདི་ཀློག་རོགས།
+ocr.credit=ཞབས་ཞུ་འདིས་ OCR གྱི་ཆེད་དུ་ qpdf དང་ Tesseract བེད་སྤྱོད་བྱེད་པ།
+ocr.submit=OCR བརྒྱུད་ནས་ PDF བཀོལ་སྤྱོད།
 
 
 #extractImages
 extractImages.title=Extract Images
 extractImages.header=Extract Images
-extractImages.selectText=Select image format to convert extracted images to
-extractImages.allowDuplicates=Save duplicate images
-extractImages.submit=Extract
+extractImages.selectText=ཕྱིར་བཏོན་པའི་པར་རིས་རྣམས་བསྒྱུར་རྒྱུའི་པར་རིས་རྣམ་གཞག་འདེམས་པ།
+extractImages.allowDuplicates=བསྐྱར་ཟློས་པར་རིས་ཉར་ཚགས།
+extractImages.submit=ཕྱིར་འདོན།
 
 
 #File to PDF
-fileToPDF.title=File to PDF
-fileToPDF.header=Convert any file to PDF
-fileToPDF.credit=This service uses LibreOffice and Unoconv for file conversion.
-fileToPDF.supportedFileTypesInfo=Supported File types
-fileToPDF.supportedFileTypes=Supported file types should include the below however for a full updated list of supported formats, please refer to the LibreOffice documentation
-fileToPDF.submit=Convert to PDF
+fileToPDF.title=ཡིག་ཆ་ནས་ PDF ལ།
+fileToPDF.header=ཡིག་ཆ་གང་རུང་ PDF ལ་བསྒྱུར་བ།
+fileToPDF.credit=ཞབས་ཞུ་འདིས་ཡིག་ཆ་བསྒྱུར་བའི་ཆེད་དུ་ LibreOffice དང་ Unoconv བེད་སྤྱོད་བྱེད་པ།
+fileToPDF.supportedFileTypesInfo=རྒྱབ་སྐྱོར་བྱེད་པའི་ཡིག་ཆའི་རིགས།
+fileToPDF.supportedFileTypes=རྒྱབ་སྐྱོར་བྱེད་པའི་ཡིག་ཆའི་རིགས་ནང་དུ་གཤམ་གྱི་རྣམས་འདུས་ཡོད་ཀྱང་། རྒྱབ་སྐྱོར་བྱེད་པའི་རྣམ་གཞག་གི་ཆ་ཚང་བའི་ཐོ་གཞུང་གསར་ཤོས་ཀྱི་ཆེད་དུ། LibreOffice ཡི་ཡིག་ཆར་གཟིགས་རོགས།
+fileToPDF.submit=PDF ལ་བསྒྱུར་བ།
 
 
 #compress
-compress.title=Compress
-compress.header=Compress PDF
-compress.credit=This service uses qpdf for PDF Compress/Optimisation.
-compress.grayscale.label=Apply Grayscale for Compression
+compress.title=སྡུད་སྒྲིལ།
+compress.header=PDF སྡུད་སྒྲིལ།
+compress.credit=ཞབས་ཞུ་འདིས་ PDF སྡུད་སྒྲིལ་/ཡར་རྒྱས་གཏོང་བའི་ཆེད་དུ་ qpdf བེད་སྤྱོད་བྱེད་པ།
+compress.grayscale.label=应用灰度进行压缩
 compress.selectText.1=Compression Settings
 compress.selectText.1.1=1-3 PDF compression,</br> 4-6 lite image compression,</br> 7-9 intense image compression Will dramatically reduce image quality
 compress.selectText.2=Optimisation level:
-compress.selectText.4=Auto mode - Auto adjusts quality to get PDF to exact size
-compress.selectText.5=Expected PDF Size (e.g. 25MB, 10.8MB, 25KB)
-compress.submit=Compress
+compress.selectText.4=རང་འགུལ་རྣམ་པ། - PDF ཏག་ཏག་ཆེ་ཆུང་ཚད་ལ་འཁྲིད་པའི་ཆེད་དུ་སྤུས་ཚད་རང་འགུལ་གྱིས་སྙོམ་སྒྲིག་བྱེད་པ།
+compress.selectText.5=རེ་བའི་ PDF ཆེ་ཆུང་། (དཔེར་ན། 25MB, 10.8MB, 25KB)
+compress.submit=སྡུད་སྒྲིལ།
 
 
 #Add image
-addImage.title=Add Image
-addImage.header=Add image to PDF
-addImage.everyPage=Every Page?
-addImage.upload=Add image
-addImage.submit=Add image
+addImage.title=པར་རིས་སྣོན་པ།
+addImage.header=PDF ལ་པར་རིས་སྣོན་པ།
+addImage.everyPage=ཤོག་ངོས་ཚང་མར་ཡིན་ནམ།
+addImage.upload=པར་རིས་སྣོན་པ།
+addImage.submit=པར་རིས་སྣོན་པ།
 
 
 #merge
-merge.title=Merge
+merge.title=སྡེབ་སྦྱོར།
 merge.header=Merge multiple PDFs (2+)
 merge.sortByName=Sort by name
-merge.sortByDate=Sort by date
-merge.removeCertSign=Remove digital signature in the merged file?
+merge.sortByDate=དུས་ཚོད་ལྟར་གོ་རིམ་སྒྲིག་པ།
+merge.removeCertSign=སྡེབ་སྦྱོར་བྱས་པའི་ཡིག་ཆའི་ནང་གི་ཨང་ཀིའི་མིང་རྟགས་སུབ་བམ།
 merge.generateToc=Generate table of contents in the merged file?
-merge.submit=Merge
+merge.submit=སྡེབ་སྦྱོར།
 
 
 #pdfOrganiser
-pdfOrganiser.title=Page Organiser
-pdfOrganiser.header=PDF Page Organiser
-pdfOrganiser.submit=Rearrange Pages
-pdfOrganiser.mode=Mode
-pdfOrganiser.mode.1=Custom Page Order
-pdfOrganiser.mode.2=Reverse Order
-pdfOrganiser.mode.3=Duplex Sort
-pdfOrganiser.mode.4=Booklet Sort
-pdfOrganiser.mode.5=Side Stitch Booklet Sort
-pdfOrganiser.mode.6=Odd-Even Split
+pdfOrganiser.title=ཤོག་ངོས་གོ་སྒྲིག་བྱེད་མཁན།
+pdfOrganiser.header=PDF ཤོག་ངོས་གོ་སྒྲིག་བྱེད་མཁན།
+pdfOrganiser.submit=ཤོག་ངོས་བསྐྱར་སྒྲིག
+pdfOrganiser.mode=རྣམ་པ།
+pdfOrganiser.mode.1=རང་སྒྲིག་ཤོག་ངོས་གོ་རིམ།
+pdfOrganiser.mode.2=ལྡོག་ཕྱོགས་གོ་རིམ།
+pdfOrganiser.mode.3=ཕྱོགས་གཉིས་གོ་རིམ།
+pdfOrganiser.mode.4=དེབ་ཆུང་གོ་རིམ།
+pdfOrganiser.mode.5=ཟུར་འདྲུད་དེབ་ཆུང་གོ་རིམ།
+pdfOrganiser.mode.6=ཡ་ཟུང་དབྱེ་བ།
 pdfOrganiser.mode.7=Remove First
 pdfOrganiser.mode.8=Remove Last
-pdfOrganiser.mode.9=Remove First and Last
-pdfOrganiser.mode.10=Odd-Even Merge
+pdfOrganiser.mode.9=དང་པོ་དང་མཐའ་མ་སུབ་པ།
+pdfOrganiser.mode.10=ཡ་ཟུང་སྡེབ་སྦྱོར།
 pdfOrganiser.mode.11=Duplicate all pages
-pdfOrganiser.placeholder=(e.g. 1,3,2 or 4-8,2,10-12 or 2n-1)
+pdfOrganiser.placeholder=(དཔེར་ན། 1,3,2 ཡང་ན་ 4-8,2,10-12 ཡང་ན་ 2n-1)
 
 
 #multiTool
-multiTool.title=PDF Multi Tool
-multiTool.header=PDF Multi Tool
-multiTool.uploadPrompts=File Name
-multiTool.selectAll=Select All
-multiTool.deselectAll=Deselect All
-multiTool.selectPages=Page Select
-multiTool.selectedPages=Selected Pages
-multiTool.page=Page
-multiTool.deleteSelected=Delete Selected
-multiTool.downloadAll=Export
-multiTool.downloadSelected=Export Selected
+multiTool.title=PDF ལག་ཆ་མང་པོ།
+multiTool.header=PDF ལག་ཆ་མང་པོ།
+multiTool.uploadPrompts=ཡིག་ཆའི་མིང་།
+multiTool.selectAll=ཚང་མ་འདེམས་པ།
+multiTool.deselectAll=འདེམས་པ་ཚང་མ་འདོར་བ།
+multiTool.selectPages=ཤོག་ངོས་འདེམས་པ།
+multiTool.selectedPages=འདེམས་པའི་ཤོག་ངོས།
+multiTool.page=ཤོག་ངོས།
+multiTool.deleteSelected=འདེམས་པ་སུབ་པ།
+multiTool.downloadAll=ཕྱིར་འདྲེན།
+multiTool.downloadSelected=འདེམས་པ་ཕྱིར་འདྲེན།
 
-multiTool.insertPageBreak=Insert Page Break
-multiTool.addFile=Add File
-multiTool.rotateLeft=Rotate Left
-multiTool.rotateRight=Rotate Right
-multiTool.split=Split
+multiTool.insertPageBreak=ཤོག་ངོས་བར་མཚམས་འཇུག་པ།
+multiTool.addFile=ཡིག་ཆ་སྣོན་པ།
+multiTool.rotateLeft=གཡོན་དུ་འཁོར་བ།
+multiTool.rotateRight=གཡས་སུ་འཁོར་བ།
+multiTool.split=དབྱེ་བ།
 multiTool.moveLeft=Move Left
 multiTool.moveRight=Move Right
-multiTool.delete=Delete
-multiTool.dragDropMessage=Page(s) Selected
-multiTool.undo=Undo (CTRL + Z)
-multiTool.redo=Redo (CTRL + Y)
+multiTool.delete=སུབ་པ།
+multiTool.dragDropMessage=ཤིག་ཆ་འདྲུད་འཐེན་བྱས་ནས་གོ་རིམ་བསྒྱུར་བཅོས་བྱེད་ཆོག
+multiTool.undo=ཕྱིར་འཐེན།
+multiTool.redo=བསྐྱར་བཟོ།
 
 #decrypt
-decrypt.passwordPrompt=This file is password-protected. Please enter the password:
-decrypt.cancelled=Operation cancelled for PDF: {0}
-decrypt.noPassword=No password provided for encrypted PDF: {0}
-decrypt.invalidPassword=Please try again with the correct password.
-decrypt.invalidPasswordHeader=Incorrect password or unsupported encryption for PDF: {0}
+decrypt.passwordPrompt=ཡིག་ཆ་འདི་གསང་ཚིག་གིས་སྲུང་སྐྱོབ་བྱས་ཡོད། གསང་ཚིག་འཇུག་རོགས།
+decrypt.cancelled=PDF ཡི་བྱ་བ་མཚམས་འཇོག་བྱས་ཟིན། {0}
+decrypt.noPassword=གསང་སྡོམ་གྲོལ་ཟིན། {0}
+decrypt.invalidPassword=གསང་ཚིག་ཏག་ཏག་དང་མཉམ་དུ་ཡང་བསྐྱར་ཚོད་ལྟ་བྱེད་རོགས།
+decrypt.invalidPasswordHeader=གསང་ཚིག་ནོར་བའམ་རྒྱབ་སྐྱོར་མི་བྱེད་པའི་གསང་སྡོམ་ PDF ཡིན་པ། {0}
 decrypt.unexpectedError=There was an error processing the file. Please try again.
 decrypt.serverError=Server error while decrypting: {0}
-decrypt.success=File decrypted successfully.
+decrypt.success=ཡིག་ཆའི་གསང་སྡོམ་གྲོལ་ཟིན།
 
 #multiTool-advert
 multiTool-advert.message=This feature is also available in our <a href="{0}">multi-tool page</a>. Check it out for enhanced page-by-page UI and additional features!
 
 #view pdf
 viewPdf.title=View/Edit PDF
-viewPdf.header=View PDF
+viewPdf.header=PDF ལྟ་བ།
 
 #pageRemover
 pageRemover.title=Page Remover
 pageRemover.header=PDF Page remover
-pageRemover.pagesToDelete=Pages to delete (Enter a comma-separated list of page numbers) :
-pageRemover.submit=Delete Pages
-pageRemover.placeholder=(e.g. 1,2,6 or 1-10,15-30)
+pageRemover.pagesToDelete=སུབ་རྒྱུའི་ཤོག་ངོས། (ཤོག་གྲངས་ཀྱི་ཐོ་གཞུང་ཚག་ཤད་ཀྱིས་བཅད་ནས་འཇུག་པ།)
+pageRemover.submit=ཤོག་ངོས་སུབ་པ།
+pageRemover.placeholder=(དཔེར་ན། 1,2,6 ཡང་ན་ 1-10,15-30)
 
 
 #rotate
 rotate.title=Rotate PDF
-rotate.header=Rotate PDF
-rotate.selectAngle=Select rotation angle (in multiples of 90 degrees):
-rotate.submit=Rotate
+rotate.header=PDF འཁོར་སྐྱོད།
+rotate.selectAngle=འཁོར་སྐྱོད་ཀྱི་ཟུར་ཚད་འདེམས་པ། (ཟུར་ཚད་ 90 ཡི་སྒྱུར་ཐོབ་ནང་དུ།)
+rotate.submit=འཁོར་སྐྱོད།
 
 
 #split-pdfs
-split.title=Split PDF
-split.header=Split PDF
-split.desc.1=The numbers you select are the page number you wish to do a split on
-split.desc.2=As such selecting 1,3,7-9 would split a 10 page document into 6 separate PDFS with:
-split.desc.3=Document #1: Page 1
-split.desc.4=Document #2: Page 2 and 3
-split.desc.5=Document #3: Page 4, 5, 6 and 7
+split.title=PDF ཁ་གྱེས།
+split.header=PDF ཁ་གྱེས།
+split.desc.1=ཁྱེད་ཀྱིས་འདེམས་པའི་ཨང་གྲངས་རྣམས་ནི་ཁ་གྱེས་བྱ་རྒྱུའི་ཤོག་ངོས་ཨང་གྲངས་ཡིན།
+split.desc.2=དེ་ལྟར་ཤོག་ངོས་ 10 ཡོད་པའི་ཡིག་ཆ་ཞིག་ལ་ 1,3,7-9 འདེམས་ན་ PDF ཡིག་ཆ་ 6 ལ་ཁ་གྱེས་ཏེ།
+split.desc.3=ཡིག་ཆ་ #1: ཤོག་ངོས་ 1
+split.desc.4=ཡིག་ཆ་ #2: ཤོག་ངོས་ 2 དང་ 3
+split.desc.5=ཡིག་ཆ་ #3: ཤོག་ངོས་ 4, 5, 6 དང་ 7
 split.desc.6=Document #4: Page 8
 split.desc.7=Document #5: Page 9
-split.desc.8=Document #6: Page 10
-split.splitPages=Enter pages to split on:
-split.submit=Split
+split.desc.8=ཡིག་ཆ་ #6: ཤོག་ངོས་ 10
+split.splitPages=ཁ་གྱེས་བྱ་རྒྱུའི་ཤོག་ངོས་འཇུག་པ།
+split.submit=ཁ་གྱེས།
 
 
 #merge
-imageToPDF.title=Image to PDF
-imageToPDF.header=Image to PDF
-imageToPDF.submit=Convert
-imageToPDF.selectLabel=Image Fit Options
-imageToPDF.fillPage=Fill Page
-imageToPDF.fitDocumentToImage=Fit Page to Image
-imageToPDF.maintainAspectRatio=Maintain Aspect Ratios
-imageToPDF.selectText.2=Auto rotate PDF
-imageToPDF.selectText.3=Multi file logic (Only enabled if working with multiple images)
-imageToPDF.selectText.4=Merge into single PDF
-imageToPDF.selectText.5=Convert to separate PDFs
+imageToPDF.title=པར་རིས་ནས་ PDF ལ།
+imageToPDF.header=པར་རིས་ནས་ PDF ལ།
+imageToPDF.submit=བསྒྱུར་བ།
+imageToPDF.selectLabel=པར་རིས་འཚམ་སྒྲིག་གདམ་ག
+imageToPDF.fillPage=ཤོག་ངོས་བཀང་བ།
+imageToPDF.fitDocumentToImage=ཤོག་ངོས་པར་རིས་དང་འཚམ་པར་བཟོ་བ།
+imageToPDF.maintainAspectRatio=བསྡུར་ཚད་རྒྱུན་འཁྱོངས།
+imageToPDF.selectText.2=PDF འཁོར་སྐྱོད་བྱ་རྒྱུའི།
+imageToPDF.selectText.3=ཡིག་ཆ་མང་པོའི་གཏན་ཚིགས། (པར་རིས་མང་པོ་དང་མཉམ་དུ་ལས་ཀ་བྱེད་སྐབས་ཁོ་ནར་སྤྱོད་ཆོག)
+imageToPDF.selectText.4=PDF གཅིག་ཏུ་སྡེབ་སྦྱོར།
+imageToPDF.selectText.5=PDF སོ་སོར་བསྒྱུར་བ།
 
 
 #pdfToImage
-pdfToImage.title=PDF to Image
-pdfToImage.header=PDF to Image
-pdfToImage.selectText=Image Format
-pdfToImage.singleOrMultiple=Page to Image result type
-pdfToImage.single=Single Big Image Combing all pages
-pdfToImage.multi=Multiple Images, one image per page
-pdfToImage.colorType=Colour type
-pdfToImage.color=Colour
-pdfToImage.grey=Greyscale
-pdfToImage.blackwhite=Black and White (May lose data!)
-pdfToImage.submit=Convert
-pdfToImage.info=Python is not installed. Required for WebP conversion.
-pdfToImage.placeholder=(e.g. 1,2,8 or 4,7,12-16 or 2n-1)
+pdfToImage.title=PDF ནས་པར་རིས་ལ།
+pdfToImage.header=PDF ནས་པར་རིས་ལ།
+pdfToImage.selectText=པར་རིས་རྣམ་གཞག
+pdfToImage.singleOrMultiple=ཤོག་ངོས་ནས་པར་རིས་ཀྱི་འབྲས་བུའི་རིགས།
+pdfToImage.single=ཤོག་ངོས་ཚང་མ་མཉམ་དུ་སྦྱར་བའི་པར་རིས་ཆེན་པོ་གཅིག
+pdfToImage.multi=པར་རིས་མང་པོ། ཤོག་ངོས་རེར་པར་རིས་རེ།
+pdfToImage.colorType=ཚོས་མདོག་གི་རིགས།
+pdfToImage.color=ཚོས་མདོག
+pdfToImage.grey=སྐྱ་མདོག
+pdfToImage.blackwhite=དཀར་ནག (གནས་ཚུལ་བརླག་སྲིད།)
+pdfToImage.submit=བསྒྱུར་བ།
+pdfToImage.info=Python སྒྲིག་འཇུག་བྱས་མི་འདུག WebP བསྒྱུར་བར་དགོས་མཁོ་ཡིན།
+pdfToImage.placeholder=(དཔེར་ན། 1,2,8 ཡང་ན་ 4,7,12-16 ཡང་ན་ 2n-1)
 
 
 #addPassword
-addPassword.title=Add Password
-addPassword.header=Add password (Encrypt)
-addPassword.selectText.1=Select PDF to encrypt
-addPassword.selectText.2=User Password
-addPassword.selectText.3=Encryption Key Length
-addPassword.selectText.4=Higher values are stronger, but lower values have better compatibility.
-addPassword.selectText.5=Permissions to set (Recommended to be used along with Owner password)
-addPassword.selectText.6=Prevent assembly of document
-addPassword.selectText.7=Prevent content extraction
-addPassword.selectText.8=Prevent extraction for accessibility
-addPassword.selectText.9=Prevent filling in form
-addPassword.selectText.10=Prevent modification
-addPassword.selectText.11=Prevent annotation modification
-addPassword.selectText.12=Prevent printing
+addPassword.title=གསང་ཚིག་སྣོན་པ།
+addPassword.header=གསང་ཚིག་སྣོན་པ། (གསང་སྡོམ།)
+addPassword.selectText.1=གསང་སྡོམ་བྱ་རྒྱུའི་ PDF འདེམས་པ།
+addPassword.selectText.2=སྤྱོད་མཁན་གྱི་གསང་ཚིག
+addPassword.selectText.3=གསང་སྡོམ་ལྡེ་མིག་གི་རིང་ཚད།
+addPassword.selectText.4=ཚད་མཐོ་བ་རྣམས་སྲ་བརྟན་ཆེ་བ་ཡོད། འོན་ཀྱང་ཚད་དམའ་བ་རྣམས་འཆམ་མཐུན་རང་བཞིན་བཟང་བ་ཡོད།
+addPassword.selectText.5=ཆོག་མཆན་སྒྲིག་འགོད། (བདག་པོའི་གསང་ཚིག་དང་མཉམ་དུ་བེད་སྤྱོད་བྱེད་པར་འོས་སྦྱོར་བྱེད།)
+addPassword.selectText.6=ཡིག་ཆ་སྒྲིག་སྦྱོར་འགོག་པ།
+addPassword.selectText.7=ནང་དོན་ཕྱིར་འདོན་འགོག་པ།
+addPassword.selectText.8=མཐུན་རྐྱེན་གྱི་ཆེད་དུ་ཕྱིར་འདོན་འགོག་པ།
+addPassword.selectText.9=འགེངས་ཤོག་བཀང་བ་འགོག་པ།
+addPassword.selectText.10=བཟོ་བཅོས་འགོག་པ།
+addPassword.selectText.11=མཆན་འགྲེལ་བཟོ་བཅོས་འགོག་པ།
+addPassword.selectText.12=Prevent printin
 addPassword.selectText.13=Prevent printing different formats
-addPassword.selectText.14=Owner Password
-addPassword.selectText.15=Restricts what can be done with the document once it is opened (Not supported by all readers)
-addPassword.selectText.16=Restricts the opening of the document itself
-addPassword.submit=Encrypt
+addPassword.selectText.14=སྤྱོད་མཁན་གྱི་གསང་གྲངས།
+addPassword.selectText.15=ཡིག་ཚགས་རང་སྟེང་ཁ་ཕྱེས་རྒྱུར་བཀག་སྡོམ་བྱེད། འདི་ལྟར་བྱས་ན་ཀློག་ཆས་ཀྱིས་ནུས་པ་ཐོན་པ་པའི་ངེས་པ་མེད།
+addPassword.selectText.16=ཡིག་ཚགས་རང་སྟེང་ཁ་ཕྱེས་རྒྱུར་བཀག་སྡོམ་བྱེད།
+addPassword.submit=གསང་བསྒྱུར།
 
 
 #watermark
-watermark.title=Add Watermark
-watermark.header=Add Watermark
-watermark.customColor=Custom Text Colour
-watermark.selectText.1=Select PDF to add watermark to:
-watermark.selectText.2=Watermark Text:
-watermark.selectText.3=Font Size:
-watermark.selectText.4=Rotation (0-360):
-watermark.selectText.5=Width Spacer (Space between each watermark horizontally):
-watermark.selectText.6=Height Spacer (Space between each watermark vertically):
-watermark.selectText.7=Opacity (0% - 100%):
-watermark.selectText.8=Watermark Type:
-watermark.selectText.9=Watermark Image:
-watermark.selectText.10=Convert PDF to PDF-Image
-watermark.submit=Add Watermark
-watermark.type.1=Text
-watermark.type.2=Image
+watermark.title=རྟ�ས་ཐེལ་སྣོན་པ།
+watermark.header=རྟགས་ཐེལ་སྣོན་པ།
+watermark.customColor=ཡི་གེའི་ཚོས་མདོག་རང་སྒྲིག
+watermark.selectText.1=རྟགས་ཐེལ་སྣོན་རྒྱུའི་ PDF འདེམས་པ།
+watermark.selectText.2=རྟགས་ཐེལ་གྱི་ཡི་གེ།
+watermark.selectText.3=ཡིག་གཟུགས་ཆེ་ཆུང་།
+watermark.selectText.4=འཁོར་སྐྱོད། (0-360)
+watermark.selectText.5=ཞེང་ཚད་བར་སྟོང་། (རྟགས་ཐེལ་རེ་རེའི་བར་གྱི་གཞུང་ཕྱོགས་བར་ཐག)
+watermark.selectText.6=མཐོ་ཚད་བར་སྟོང་། (རྟགས་ཐེལ་རེ་རེའི་བར་གྱི་གྱེན་ཕྱོགས་བར་ཐག)
+watermark.selectText.7=གསལ་ཚད། (0% - 100%)
+watermark.selectText.8=རྟགས་ཐེལ་གྱི་རིགས།
+watermark.selectText.9=རྟགས་ཐེལ་གྱི་པར་རིས།
+watermark.selectText.10=PDF ནས་ PDF-པར་རིས་ལ་བསྒྱུར་བ།
+watermark.submit=རྟགས་ཐེལ་སྣོན་པ།
+watermark.type.1=ཡི་གེ
+watermark.type.2=པར་རིས།
 
 
 #Change permissions
-permissions.title=Change Permissions
-permissions.header=Change Permissions
-permissions.warning=Warning to have these permissions be unchangeable it is recommended to set them with a password via the add-password page
-permissions.selectText.1=Select PDF to change permissions
-permissions.selectText.2=Permissions to set
-permissions.selectText.3=Prevent assembly of document
-permissions.selectText.4=Prevent content extraction
-permissions.selectText.5=Prevent extraction for accessibility
-permissions.selectText.6=Prevent filling in form
-permissions.selectText.7=Prevent modification
-permissions.selectText.8=Prevent annotation modification
-permissions.selectText.9=Prevent printing
-permissions.selectText.10=Prevent printing different formats
-permissions.submit=Change
+permissions.title=ཆོག་མཆན་བསྒྱུར་བ།
+permissions.header=ཆོག་མཆན་བསྒྱུར་བ།
+permissions.warning=ཉེན་བརྡ། ཆོག་མཆན་འདི་དག་བསྒྱུར་མི་ཐུབ་པ་བཟོ་དགོས་ན། གསང་ཚིག་སྣོན་པའི་ཤོག་ངོས་བརྒྱུད་ནས་གསང་ཚིག་དང་མཉམ་དུ་སྒྲིག་འགོད་བྱེད་པའི་འོས་སྦྱོར་ཡོད།
+permissions.selectText.1=ཆོག་མཆན་བསྒྱུར་རྒྱུའི་ PDF འདེམས་པ།
+permissions.selectText.2=སྒྲིག་འགོད་བྱ་རྒྱུའི་ཆོག་མཆན།
+permissions.selectText.3=ཡིག་ཆ་སྡེབ་སྒྲིག་འགོག་པ།
+permissions.selectText.4=ནང་དོན་ཕྱིར་འདོན་འགོག་པ།
+permissions.selectText.5=མཐུན་རྐྱེན་གྱི་ཆེད་དུ་ཕྱིར་འདོན་འགོག་པ།
+permissions.selectText.6=འགེངས་ཤོག་བཀང་བ་འགོག་པ།
+permissions.selectText.7=བཟོ་བཅོས་འགོག་པ།
+permissions.selectText.8=མཆན་འགྲེལ་བཟོ་བཅོས་འགོག་པ།
+permissions.selectText.9=པར་འདེབས་འགོག་པ།
+permissions.selectText.10=པར་འདེབས་རྣམ་པ་མི་འདྲ་བ་འགོག་པ།
+permissions.submit=བསྒྱུར་བ།
 
 
 #remove password
-removePassword.title=Remove password
-removePassword.header=Remove password (Decrypt)
-removePassword.selectText.1=Select PDF to Decrypt
-removePassword.selectText.2=Password
-removePassword.submit=Remove
+removePassword.title=གསང་ཚིག་སུབ་པ།
+removePassword.header=གསང་ཚིག་སུབ་པ། (གསང་སྡོམ་གྲོལ་བ།)
+removePassword.selectText.1=གསང་སྡོམ་གྲོལ་རྒྱུའི་ PDF འདེམས་པ།
+removePassword.selectText.2=གསང་ཚིག
+removePassword.submit=སུབ་པ།
 
 
 #changeMetadata
-changeMetadata.title=Change Metadata
-changeMetadata.header=Change Metadata
-changeMetadata.selectText.1=Please edit the variables you wish to change
-changeMetadata.selectText.2=Delete all metadata
-changeMetadata.selectText.3=Show Custom Metadata:
-changeMetadata.author=Author:
-changeMetadata.creationDate=Creation Date (yyyy/MM/dd HH:mm:ss):
-changeMetadata.creator=Creator:
-changeMetadata.keywords=Keywords:
-changeMetadata.modDate=Modification Date (yyyy/MM/dd HH:mm:ss):
-changeMetadata.producer=Producer:
-changeMetadata.subject=Subject:
-changeMetadata.trapped=Trapped:
-changeMetadata.selectText.4=Other Metadata:
-changeMetadata.selectText.5=Add Custom Metadata Entry
-changeMetadata.submit=Change
+changeMetadata.title=གནས་ཚུལ་ཞིབ་ཕྲ་བསྒྱུར་བ།
+changeMetadata.header=གནས་ཚུལ་ཞིབ་ཕྲ་བསྒྱུར་བ།
+changeMetadata.selectText.1=བསྒྱུར་འདོད་པའི་འགྱུར་ཚད་རྣམས་རྩོམ་སྒྲིག་བྱེད་རོགས།
+changeMetadata.selectText.2=གནས་ཚུལ་ཞིབ་ཕྲ་ཚང་མ་སུབ་པ།
+changeMetadata.selectText.3=རང་སྒྲིག་གནས་ཚུལ་ཞིབ་ཕྲ་སྟོན།
+changeMetadata.author=རྩོམ་པ་པོ།
+changeMetadata.creationDate=བཟོ་བའི་དུས་ཚོད། (yyyy/MM/dd HH:mm:ss)
+changeMetadata.creator=བཟོ་མཁན།
+changeMetadata.keywords=གནད་ཚིག
+changeMetadata.modDate=བཟོ་བཅོས་དུས་ཚོད། (yyyy/MM/dd HH:mm:ss)
+changeMetadata.producer=སྐྲུན་མཁན།
+changeMetadata.subject=བརྗོད་གཞི།
+changeMetadata.trapped=བཟུང་བ།
+changeMetadata.selectText.4=གནས་ཚུལ་ཞིབ་ཕྲ་གཞན།
+changeMetadata.selectText.5=རང་སྒྲིག་གནས་ཚུལ་ཞིབ་ཕྲ་གསར་སྣོན།
+changeMetadata.submit=བསྒྱུར་བ།
 
 #unlockPDFForms
 unlockPDFForms.title=Remove Read-Only from Form Fields
@@ -1426,123 +1426,123 @@ unlockPDFForms.header=Unlock PDF Forms
 unlockPDFForms.submit=Remove
 
 #pdfToPDFA
-pdfToPDFA.title=PDF To PDF/A
-pdfToPDFA.header=PDF To PDF/A
-pdfToPDFA.credit=This service uses libreoffice for PDF/A conversion
-pdfToPDFA.submit=Convert
-pdfToPDFA.tip=Currently does not work for multiple inputs at once
-pdfToPDFA.outputFormat=Output format
-pdfToPDFA.pdfWithDigitalSignature=The PDF contains a digital signature. This will be removed in the next step.
+pdfToPDFA.title=PDF ནས་ PDF/A ལ།
+pdfToPDFA.header=PDF ནས་ PDF/A ལ།
+pdfToPDFA.credit=ཞབས་ཞུ་འདིས་ PDF/A བསྒྱུར་བའི་ཆེད་དུ་ libreoffice བེད་སྤྱོད་བྱེད་པ།
+pdfToPDFA.submit=བསྒྱུར་བ།
+pdfToPDFA.tip=ད་ལྟ་ཡིག་ཆ་མང་པོ་དུས་གཅིག་ལ་བསྒྱུར་མི་ཐུབ།
+pdfToPDFA.outputFormat=ཕྱིར་འདོན་རྣམ་གཞག
+pdfToPDFA.pdfWithDigitalSignature=PDF འདིར་ཨང་ཀིའི་མིང་རྟགས་ཡོད། འདི་རྗེས་མའི་རིམ་པར་སུབ་ངེས་ཡིན།
 
 
 #PDFToWord
-PDFToWord.title=PDF to Word
-PDFToWord.header=PDF to Word
-PDFToWord.selectText.1=Output file format
-PDFToWord.credit=This service uses LibreOffice for file conversion.
-PDFToWord.submit=Convert
+PDFToWord.title=PDF ནས་ Word ལ།
+PDFToWord.header=PDF ནས་ Word ལ།
+PDFToWord.selectText.1=ཕྱིར་འདོན་ཡིག་ཆའི་རྣམ་གཞག
+PDFToWord.credit=ཞབས་ཞུ་འདིས་ཡིག་ཆ་བསྒྱུར་བའི་ཆེད་དུ་ LibreOffice བེད་སྤྱོད་བྱེད་པ།
+PDFToWord.submit=བསྒྱུར་བ།
 
 
 #PDFToPresentation
-PDFToPresentation.title=PDF to Presentation
-PDFToPresentation.header=PDF to Presentation
-PDFToPresentation.selectText.1=Output file format
+PDFToPresentation.title=PDF ནས་སྤྱན་འབུལ་ལ།
+PDFToPresentation.header=PDF ནས་སྤྱན་འབུལ་ལ།
+PDFToPresentation.selectText.1=ཕྱིར་འདོན་ཡིག་ཆའི་རྣམ་གཞག
 PDFToPresentation.credit=This service uses LibreOffice for file conversion.
 PDFToPresentation.submit=Convert
 
 
 #PDFToText
-PDFToText.title=PDF to RTF (Text)
-PDFToText.header=PDF to RTF (Text)
-PDFToText.selectText.1=Output file format
+PDFToText.title=PDF ནས་ RTF ལ། (ཡི་གེ)
+PDFToText.header=PDF ནས་ RTF ལ། (ཡི་གེ)
+PDFToText.selectText.1=ཕྱིར་འདོན་ཡིག་ཆའི་རྣམ་གཞག
 PDFToText.credit=This service uses LibreOffice for file conversion.
 PDFToText.submit=Convert
 
 
 #PDFToHTML
-PDFToHTML.title=PDF to HTML
-PDFToHTML.header=PDF to HTML
+PDFToHTML.title=PDF ནས་ HTML ལ།
+PDFToHTML.header=PDF ནས་ HTML ལ།
 PDFToHTML.credit=This service uses pdftohtml for file conversion.
 PDFToHTML.submit=Convert
 
 
 #PDFToXML
-PDFToXML.title=PDF to XML
-PDFToXML.header=PDF to XML
+PDFToXML.title=PDF ནས་ XML ལ།
+PDFToXML.header=PDF ནས་ XML ལ།
 PDFToXML.credit=This service uses LibreOffice for file conversion.
 PDFToXML.submit=Convert
 
 #PDFToCSV
-PDFToCSV.title=PDF to CSV
-PDFToCSV.header=PDF to CSV
+PDFToCSV.title=PDF ནས་ CSV ལ།
+PDFToCSV.header=PDF ནས་ CSV ལ།
 PDFToCSV.prompt=Choose page to extract table
 PDFToCSV.submit=Extract
 
 #split-by-size-or-count
-split-by-size-or-count.title=Split PDF by Size or Count
-split-by-size-or-count.header=Split PDF by Size or Count
-split-by-size-or-count.type.label=Select Split Type
-split-by-size-or-count.type.size=By Size
-split-by-size-or-count.type.pageCount=By Page Count
-split-by-size-or-count.type.docCount=By Document Count
-split-by-size-or-count.value.label=Enter Value
-split-by-size-or-count.value.placeholder=Enter size (e.g., 2MB or 3KB) or count (e.g., 5)
-split-by-size-or-count.submit=Submit
+split-by-size-or-count.title=�ེ་ཆུང་ངམ་གྲངས་ཀ་ལྟར་ PDF ཁ་གྱེས།
+split-by-size-or-count.header=ཆེ་ཆུང་ངམ་གྲངས་ཀ་ལྟར་ PDF ཁ་གྱེས།
+split-by-size-or-count.type.label=ཁ་གྱེས་རིགས་འདེམས་པ།
+split-by-size-or-count.type.size=ཆེ་ཆུང་ལྟར།
+split-by-size-or-count.type.pageCount=ཤོག་གྲངས་ལྟར།
+split-by-size-or-count.type.docCount=ཡིག་ཆའི་གྲངས་ཀ་ལྟར།
+split-by-size-or-count.value.label=གྲངས་ཐང་འཇུག་པ།
+split-by-size-or-count.value.placeholder=ཆེ་ཆུང་ (དཔེར་ན། 2MB ཡང་ན་ 3KB) ཡང་ན་གྲངས་ཀ་ (དཔེར་ན། 5) འཇུག་པ།
+split-by-size-or-count.submit=ཕུལ་བ།
 
 
 #overlay-pdfs
-overlay-pdfs.header=Overlay PDF Files
-overlay-pdfs.baseFile.label=Select Base PDF File
-overlay-pdfs.overlayFiles.label=Select Overlay PDF Files
-overlay-pdfs.mode.label=Select Overlay Mode
-overlay-pdfs.mode.sequential=Sequential Overlay
-overlay-pdfs.mode.interleaved=Interleaved Overlay
-overlay-pdfs.mode.fixedRepeat=Fixed Repeat Overlay
-overlay-pdfs.counts.label=Overlay Counts (for Fixed Repeat Mode)
-overlay-pdfs.counts.placeholder=Enter comma-separated counts (e.g., 2,3,1)
-overlay-pdfs.position.label=Select Overlay Position
-overlay-pdfs.position.foreground=Foreground
-overlay-pdfs.position.background=Background
-overlay-pdfs.submit=Submit
+overlay-pdfs.header=PDF ཡིག་ཆ་བརྩེགས་པ།
+overlay-pdfs.baseFile.label=གཞི་རྩའི་ PDF ཡིག་ཆ་འདེམས་པ།
+overlay-pdfs.overlayFiles.label=བརྩེགས་རྒྱུའི་ PDF ཡིག་ཆ་འདེམས་པ།
+overlay-pdfs.mode.label=བརྩེགས་སྟངས་འདེམས་པ།
+overlay-pdfs.mode.sequential=རིམ་བཞིན་བརྩེགས་པ།
+overlay-pdfs.mode.interleaved=སྤེལ་མར་བརྩེགས་པ།
+overlay-pdfs.mode.fixedRepeat=བསྐྱར་ཟློས་གཏན་འཇགས་བརྩེགས་པ།
+overlay-pdfs.counts.label=བརྩེགས་གྲངས། (བསྐྱར་ཟློས་གཏན་འཇགས་རྣམ་པའི་ཆེད།)
+overlay-pdfs.counts.placeholder=ཚེག་ཁྱིམ་གྱིས་བཅད་པའི་གྲངས་ཀ་འཇུག་པ། (དཔེར་ན། 2,3,1)
+overlay-pdfs.position.label=བརྩེགས་སའི་གནས་ས་འདེམས་པ།
+overlay-pdfs.position.foreground=མདུན་ངོས།
+overlay-pdfs.position.background=རྒྱབ་ལྗོངས།
+overlay-pdfs.submit=ཕུལ་བ།
 
 
 #split-by-sections
-split-by-sections.title=Split PDF by Sections
-split-by-sections.header=Split PDF into Sections
-split-by-sections.horizontal.label=Horizontal Divisions
-split-by-sections.vertical.label=Vertical Divisions
-split-by-sections.horizontal.placeholder=Enter number of horizontal divisions
-split-by-sections.vertical.placeholder=Enter number of vertical divisions
-split-by-sections.submit=Split PDF
-split-by-sections.merge=Merge Into One PDF
+split-by-sections.title=�་ཤས་ལྟར་ PDF ཁ་གྱེས།
+split-by-sections.header=PDF ཆ་ཤས་སུ་ཁ་གྱེས།
+split-by-sections.horizontal.label=གཞུང་ཕྱོགས་བགོ་བཤའ།
+split-by-sections.vertical.label=གྱེན་ཕྱོགས་བགོ་བཤའ།
+split-by-sections.horizontal.placeholder=གཞུང་ཕྱོགས་བགོ་བཤའི་གྲངས་ཀ་འཇུག་པ།
+split-by-sections.vertical.placeholder=གྱེན་ཕྱོགས་བགོ་བཤའི་གྲངས་ཀ་འཇུག་པ།
+split-by-sections.submit=PDF ཁ་གྱེས།
+split-by-sections.merge=PDF གཅིག་ཏུ་སྡེབ་སྦྱོར།
 
 
 #printFile
-printFile.title=Print File
-printFile.header=Print File to Printer
-printFile.selectText.1=Select File to Print
-printFile.selectText.2=Enter Printer Name
-printFile.submit=Print
+printFile.title=ཡིག་ཆ་པར་འདེབས།
+printFile.header=ཡིག་ཆ་པར་འདེབས་འཕྲུལ་འཁོར་ལ་པར་འདེབས།
+printFile.selectText.1=པར་འདེབས་བྱ་རྒྱུའི་ཡིག་ཆ་འདེམས་པ།
+printFile.selectText.2=པར་འདེབས་འཕྲུལ་འཁོར་གྱི་མིང་འཇུག་པ།
+printFile.submit=པར་འདེབས།
 
 
 #licenses
-licenses.nav=Licences
-licenses.title=3rd Party Licences
-licenses.header=3rd Party Licences
-licenses.module=Module
-licenses.version=Version
-licenses.license=Licence
+licenses.nav=ཆོག་མཆན།
+licenses.title=ཕྱི་ཡི་ཆོག་མཆན།
+licenses.header=ཕྱི་ཡི་ཆོག་མཆན།
+licenses.module=སྡེ་ཚན།
+licenses.version=པར་གཞི།
+licenses.license=ཆོག་མཆན།
 
 #survey
-survey.nav=Survey
-survey.title=Stirling-PDF Survey
-survey.description=Stirling-PDF has no tracking so we want to hear from our users to improve Stirling-PDF!
-survey.changes=Stirling-PDF has changed since the last survey! To find out more please check our blog post here:
-survey.changes2=With these changes we are getting paid business support and funding
-survey.please=Please consider taking our survey to have input on the future of Stirling-PDF!
-survey.disabled=(Survey popup will be disabled in following updates but available at foot of page)
-survey.button=Take Survey
-survey.dontShowAgain=Don't show again
+survey.nav=བསམ་ཞིབ།
+survey.title=Stirling-PDF བསམ་ཞིབ།
+survey.description=Stirling-PDF ལ་རྗེས་འདེད་མེད་པས། ང་ཚོས་ Stirling-PDF ཡར་རྒྱས་གཏོང་བའི་ཆེད་དུ་སྤྱོད་མཁན་ཚོའི་བསམ་འཆར་ཉན་འདོད་ཡོད།
+survey.changes=བསམ་ཞིབ་སྔ་མ་ནས་བཟུང་ Stirling-PDF ལ་འགྱུར་བ་བྱུང་ཡོད། དེའི་སྐོར་ལ་གནས་ཚུལ་མང་བ་ཤེས་འདོད་ན་ང་ཚོའི་རྩོམ་ཡིག་འདིར་གཟིགས་རོགས།
+survey.changes2=འགྱུར་བ་འདི་དག་དང་མཉམ་དུ་ང་ཚོར་ཚོང་དོན་རྒྱབ་སྐྱོར་དང་མ་དངུལ་ཐོབ་བཞིན་ཡོད།
+survey.please=Stirling-PDF ཡི་མ་འོངས་པའི་ཐད་ལ་ནུས་པ་ཐོན་པའི་ཆེད་དུ་ང་ཚོའི་བསམ་ཞིབ་ནང་མཉམ་ཞུགས་གནང་རོགས།
+survey.disabled=(བསམ་ཞིབ་སྒེའུ་ཁུང་རྗེས་མའི་གསར་སྒྱུར་ནང་སྒོ་རྒྱག་རྒྱུ་ཡིན་ཡང་ཤོག་ངོས་མཇུག་ཏུ་ཡོད་རྒྱུ་ཡིན།)
+survey.button=བསམ་ཞིབ་བྱེད་པ།
+survey.dontShowAgain=ཡང་བསྐྱར་མ་སྟོན།
 survey.meeting.1=If you're using Stirling PDF at work, we'd love to speak to you. We're offering technical support sessions in exchange for a 15 minute user discovery session.
 survey.meeting.2=This is a chance to:
 survey.meeting.3=Get help with deployment, integrations, or troubleshooting
@@ -1554,87 +1554,87 @@ survey.meeting.notInterested=Not a business and/or interested in a meeting?
 survey.meeting.button=Book meeting
 
 #error
-error.sorry=Sorry for the issue!
-error.needHelp=Need help / Found an issue?
-error.contactTip=If you're still having trouble, don't hesitate to reach out to us for help. You can submit a ticket on our GitHub page or contact us through Discord:
-error.404.head=404 - Page Not Found | Oops, we tripped in the code!
-error.404.1=We can't seem to find the page you're looking for.
-error.404.2=Something went wrong
-error.github=Submit a ticket on GitHub
-error.showStack=Show Stack Trace
-error.copyStack=Copy Stack Trace
-error.githubSubmit=GitHub - Submit a ticket
-error.discordSubmit=Discord - Submit Support post
+error.sorry=དཀའ་ངལ་ལ་དགོངས་དག
+error.needHelp=རོགས་རམ་དགོས་སམ། / དཀའ་ངལ་ཞིག་རྙེད་སོང་ངམ།
+error.contactTip=གལ་སྲིད་ད་དུང་དཀའ་ངལ་འཕྲད་བཞིན་ཡོད་ན། རོགས་རམ་ཞུ་བར་ང་ཚོར་འབྲེལ་གཏུག་བྱེད་རོགས། ཁྱེད་ཀྱིས་ང་ཚོའི་ GitHub ཤོག་ངོས་སུ་སྙན་ཞུ་འབུལ་བའམ་ Discord བརྒྱུད་ནས་འབྲེལ་བ་གནང་ཆོག
+error.404.head=404 - ཤོག་ངོས་མ་རྙེད། | དགོངས་པ་མ་ཚོམ། ང་ཚོ་ཚབས་ཆེའི་ནོར་འཁྲུལ་ཞིག་བྱུང་སོང་།
+error.404.1=ཁྱེད་ཀྱིས་འཚོལ་བཞིན་པའི་ཤོག་ངོས་དེ་རྙེད་ཐུབ་ཀྱི་མི་འདུག
+error.404.2=ནོར་འཁྲུལ་ཞིག་བྱུང་སོང་།
+error.github=GitHub སྟེང་དུ་སྙན་ཞུ་འབུལ་བ།
+error.showStack=Stack Trace སྟོན།
+error.copyStack=Stack Trace པར་སློག
+error.githubSubmit=GitHub - སྙན་ཞུ་འབུལ་བ།
+error.discordSubmit=Discord - རྒྱབ་སྐྱོར་སྙན་ཞུ་འབུལ་བ།
 
 
 #remove-image
-removeImage.title=Remove image
-removeImage.header=Remove image
-removeImage.removeImage=Remove image
-removeImage.submit=Remove image
+removeImage.title=པ�་རིས་སུབ་པ།
+removeImage.header=པར་རིས་སུབ་པ།
+removeImage.removeImage=པར་རིས་སུབ་པ།
+removeImage.submit=པར་རིས་སུབ་པ།
 
 
-splitByChapters.title=Split PDF by Chapters
-splitByChapters.header=Split PDF by Chapters
-splitByChapters.bookmarkLevel=Bookmark Level
-splitByChapters.includeMetadata=Include Metadata
-splitByChapters.allowDuplicates=Allow Duplicates
+splitByChapters.title=ལེའ�་ལྟར་ PDF ཁ་གྱེས།
+splitByChapters.header=ལེའུ་ལྟར་ PDF ཁ་གྱེས།
+splitByChapters.bookmarkLevel=དཔེ་རྟགས་རིམ་པ།
+splitByChapters.includeMetadata=གནས་ཚུལ་ཞིབ་ཕྲ་ཚུད་པ།
+splitByChapters.allowDuplicates=བསྐྱར་ཟློས་ཆོག་པ།
 splitByChapters.desc.1=This tool splits a PDF file into multiple PDFs based on its chapter structure.
 splitByChapters.desc.2=Bookmark Level: Choose the level of bookmarks to use for splitting (0 for top-level, 1 for second-level, etc.).
-splitByChapters.desc.3=Include Metadata: If checked, the original PDF's metadata will be included in each split PDF.
+splitByChapters.desc.3=Include Metadata: If checked, the original PDF metadata will be included in each split PDF.
 splitByChapters.desc.4=Allow Duplicates: If checked, allows multiple bookmarks on the same page to create separate PDFs.
 splitByChapters.submit=Split PDF
 
 #File Chooser
-fileChooser.click=Click
-fileChooser.or=or
-fileChooser.dragAndDrop=Drag & Drop
-fileChooser.dragAndDropPDF=Drag & Drop PDF file
-fileChooser.dragAndDropImage=Drag & Drop Image file
-fileChooser.hoveredDragAndDrop=Drag & Drop file(s) here
-fileChooser.extractPDF=Extracting...
+fileChooser.click=སྤྱོད།
+fileChooser.or=ཡང་ན།
+fileChooser.dragAndDrop=འཐེན་ནས་འཇོག་པ།
+fileChooser.dragAndDropPDF=PDF ཡིག་ཆ་འཐེན་ནས་འཇོག་པ།
+fileChooser.dragAndDropImage=པར་རིས་ཡིག་ཆ་འཐེན་ནས་འཇོག་པ།
+fileChooser.hoveredDragAndDrop=ཡིག་ཆ་འདིར་འཐེན་ནས་འཇོག་པ།
+fileChooser.extractPDF=འདོན་རིས་འགྱུར་བའི་སྒྲིག་བཏང་བ།
 
 #release notes
-releases.footer=Releases
-releases.title=Release Notes
-releases.header=Release Notes
-releases.current.version=Current Release
-releases.note=Release notes are only available in English
+releases.footer=པར་གཞི།
+releases.title=པར་གཞི་གསར་པའི་གསལ་བསྒྲགས།
+releases.header=པར་གཞི་གསར་པའི་གསལ་བསྒྲགས།
+releases.current.version=མིག་སྔའི་པར་གཞི།
+releases.note=པར་གཞི་གསར་པའི་གསལ་བསྒྲགས་དབྱིན་ཡིག་ཁོ་ནར་ཡོད།
 
 #Validate Signature
-validateSignature.title=Validate PDF Signatures
-validateSignature.header=Validate Digital Signatures
-validateSignature.selectPDF=Select signed PDF file
-validateSignature.submit=Validate Signatures
-validateSignature.results=Validation Results
-validateSignature.status=Status
-validateSignature.signer=Signer
-validateSignature.date=Date
-validateSignature.reason=Reason
-validateSignature.location=Location
-validateSignature.noSignatures=No digital signatures found in this document
-validateSignature.status.valid=Valid
-validateSignature.status.invalid=Invalid
-validateSignature.chain.invalid=Certificate chain validation failed - cannot verify signer's identity
-validateSignature.trust.invalid=Certificate not in trust store - source cannot be verified
-validateSignature.cert.expired=Certificate has expired
-validateSignature.cert.revoked=Certificate has been revoked
-validateSignature.signature.info=Signature Information
-validateSignature.signature=Signature
-validateSignature.signature.mathValid=Signature is mathematically valid BUT:
-validateSignature.selectCustomCert=Custom Certificate File X.509 (Optional)
-validateSignature.cert.info=Certificate Details
-validateSignature.cert.issuer=Issuer
-validateSignature.cert.subject=Subject
-validateSignature.cert.serialNumber=Serial Number
-validateSignature.cert.validFrom=Valid From
-validateSignature.cert.validUntil=Valid Until
-validateSignature.cert.algorithm=Algorithm
-validateSignature.cert.keySize=Key Size
-validateSignature.cert.version=Version
-validateSignature.cert.keyUsage=Key Usage
-validateSignature.cert.selfSigned=Self-Signed
-validateSignature.cert.bits=bits
+validateSignature.title=PDF མིང་རྟགས་ར་སྤྲོད།
+validateSignature.header=ཨང་ཀིའི་མིང་རྟགས་ར་སྤྲོད།
+validateSignature.selectPDF=མིང་རྟགས་བཀོད་པའི་ PDF ཡིག་ཆ་འདེམས་པ།
+validateSignature.submit=མིང་རྟགས་ར་སྤྲོད།
+validateSignature.results=ར་སྤྲོད་འབྲས་བུ།
+validateSignature.status=གནས་སྟངས།
+validateSignature.signer=མིང་རྟགས་འགོད་མཁན།
+validateSignature.date=དུས་ཚོད།
+validateSignature.reason=རྒྱུ་མཚན།
+validateSignature.location=ས་གནས།
+validateSignature.noSignatures=ཡིག་ཆ་འདིའི་ནང་དུ་ཨང་ཀིའི་མིང་རྟགས་མ་རྙེད།
+validateSignature.status.valid=ནུས་ལྡན།
+validateSignature.status.invalid=ནུས་མེད།
+validateSignature.chain.invalid=ལག་ཁྱེར་བརྒྱུད་རིམ་ར་སྤྲོད་མ་འགྲུབ་པ། - མིང་རྟགས་འགོད་མཁན་གྱི་ངོ་སྤྲོད་ར་སྤྲོད་བྱེད་མི་ཐུབ།
+validateSignature.trust.invalid=ལག་ཁྱེར་ཡིད་ཆེས་མཛོད་ཁང་ནང་མེད་པ། - འབྱུང་ཁུངས་ར་སྤྲོད་བྱེད་མི་ཐུབ།
+validateSignature.cert.expired=ལག་ཁྱེར་དུས་ཡོལ་ཟིན།
+validateSignature.cert.revoked=ལག་ཁྱེར་ཕྱིར་འཐེན་བྱས་ཟིན།
+validateSignature.signature.info=མིང་རྟགས་ཀྱི་གནས་ཚུལ།
+validateSignature.signature=མིང་རྟགས།
+validateSignature.signature.mathValid=མིང་རྟགས་ཨང་རྩིས་ཐོག་ནས་ནུས་ལྡན་ཡིན་ཡང་།
+validateSignature.selectCustomCert=རང་སྒྲིག་ལག་ཁྱེར་ཡིག་ཆ་ X.509 (འདམ་ག)
+validateSignature.cert.info=ལག་ཁྱེར་ཞིབ་ཕྲ།
+validateSignature.cert.issuer=སྤྲོད་མཁན།
+validateSignature.cert.subject=བརྗོད་གཞི།
+validateSignature.cert.serialNumber=ཨང་གྲངས་གོ་རིམ།
+validateSignature.cert.validFrom=ནུས་ལྡན་འགོ་འཛུགས།
+validateSignature.cert.validUntil=ནུས་ལྡན་མཇུག་སྒྲིལ།
+validateSignature.cert.algorithm=བྱེད་ཐབས།
+validateSignature.cert.keySize=ལྡེ་མིག་ཆེ་ཆུང་།
+validateSignature.cert.version=པར་གཞི།
+validateSignature.cert.keyUsage=ལྡེ་མིག་བེད་སྤྱོད།
+validateSignature.cert.selfSigned=རང་མིང་རྟགས།
+validateSignature.cert.bits=གནས།
 
 ####################
 #  Cookie banner   #


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- Reverts the file `messages_bo_CN.properties` to its original (pre-PR #3614) Tibetan content.
- This change is necessary because unintentionally replaced all Tibetan translation keys with English , potentially impacting the UI consistency for users relying on this translation file.
- The original file contents were fully restored based on backup.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
