### PR TITLE
Update Hungarian labels for the team feature

### DIFF
--- a/stirling-pdf/src/main/resources/messages_hu_HU.properties
+++ b/stirling-pdf/src/main/resources/messages_hu_HU.properties
@@ -220,12 +220,12 @@ addToDoc=Hozzáadás a dokumentumhoz
 reset=Visszaállítás
 apply=Alkalmaz
 noFileSelected=Nincs fájl kiválasztva. Kérjük, töltsön fel egyet.
-view=View
-cancel=Cancel
+view=Megtekintés
+cancel=Mégse
 
-back.toSettings=Back to Settings
-back.toHome=Back to Home
-back.toAdmin=Back to Admin
+back.toSettings=Vissza a Beállításokhoz
+back.toHome=Vissza a Kezdőlapra
+back.toAdmin=Vissza a Rendszergazdai beállításokhoz
 
 legal.privacy=Adatvédelmi irányelvek
 legal.terms=Felhasználási feltételek
@@ -393,13 +393,13 @@ adminUserSettings.teamHidden=Hidden
 adminUserSettings.totalMembers=Összes tag
 adminUserSettings.confirmDeleteTeam=Biztosan törli ezt a csapatot?
 
-teamCreated=Team created successfully
-teamExists=A team with that name already exists
-teamNameExists=Another team with that name already exists
-teamNotFound=Team not found
-teamDeleted=Team deleted
-teamHasUsers=Cannot delete a team with users assigned
-teamRenamed=Team renamed successfully
+teamCreated=Csapat sikeresen létrehozva
+teamExists=A csapat már létezik
+teamNameExists=A csapat neve már létezik
+teamNotFound=Csapat nem található
+teamDeleted=Csapat törölve
+teamHasUsers=Nem lehet törölni egy olyan csapatot, amelyhez felhasználók vannak rendelve
+teamRenamed=Csapat sikeresen átnevezve
 
 # Team user management
 team.addUser=Felhasználó hozzáadása a csapathoz
@@ -411,16 +411,16 @@ team.back=Vissza a csapatokhoz
 team.internal=Belső csapat
 team.internalTeamNotAccessible=A belső csapat egy rendszer csapat, és nem érhető el
 team.cannotMoveInternalUsers=A belső csapatban lévő felhasználók nem mozgathatók más csapatokba.
-team.hidden=Hidden
-team.name=Team Name
-team.totalMembers=Total Members
-team.members=Members
-team.username=Username
-team.role=Role
-team.status=Status
-team.enabled=Enabled
-team.disabled=Disabled
-team.noMembers=This team has no members yet.
+team.hidden=Rejtett csapat
+team.name=Csapat neve
+team.totalMembers=Összes tag
+team.members=Tagok
+team.username=Felhasználónév
+team.role=Szerepkör
+team.status=Állapot
+team.enabled=Engedélyezve
+team.disabled=Letiltva
+team.noMembers=Ez a csapat még nem rendelkezik tagokkal.
 
 
 


### PR DESCRIPTION
# Description of Changes
This pull request updates the Hungarian (`hu_HU`) localization file for the `stirling-pdf` project, translating previously untranslated English strings into Hungarian. The changes enhance the user experience for Hungarian-speaking users by providing a fully localized interface.

### Localization Updates:

* Updated navigation-related strings such as `view`, `cancel`, and `back.toSettings` to their Hungarian equivalents (`Megtekintés`, `Mégse`, `Vissza a Beállításokhoz`, etc.).
* Translated team management messages like `teamCreated`, `teamDeleted`, and `teamHasUsers` into Hungarian (`Csapat sikeresen létrehozva`, `Csapat törölve`, etc.).
* Localized team-related labels such as `team.hidden`, `team.name`, and `team.noMembers` to Hungarian (`Rejtett csapat`, `Csapat neve`, `Ez a csapat még nem rendelkezik tagokkal.`, etc.).
---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
