### PR TITLE
Restore zh_TW locale to state before incorrect commit

### DIFF
--- a/stirling-pdf/src/main/resources/messages_zh_TW.properties
+++ b/stirling-pdf/src/main/resources/messages_zh_TW.properties
@@ -3,138 +3,6 @@
 ###########
 # the direction that the language is written (ltr = left to right, rtl = right to left)
 language.direction=ltr
-
-# Language names for reuse throughout the application
-lang.afr=Afrikaans
-lang.amh=Amharic
-lang.ara=Arabic
-lang.asm=Assamese
-lang.aze=Azerbaijani
-lang.aze_cyrl=Azerbaijani (Cyrillic)
-lang.bel=Belarusian
-lang.ben=Bengali
-lang.bod=Tibetan
-lang.bos=Bosnian
-lang.bre=Breton
-lang.bul=Bulgarian
-lang.cat=Catalan
-lang.ceb=Cebuano
-lang.ces=Czech
-lang.chi_sim=Chinese (Simplified)
-lang.chi_sim_vert=Chinese (Simplified, Vertical)
-lang.chi_tra=Chinese (Traditional)
-lang.chi_tra_vert=Chinese (Traditional, Vertical)
-lang.chr=Cherokee
-lang.cos=Corsican
-lang.cym=Welsh
-lang.dan=Danish
-lang.dan_frak=Danish (Fraktur)
-lang.deu=German
-lang.deu_frak=German (Fraktur)
-lang.div=Divehi
-lang.dzo=Dzongkha
-lang.ell=Greek
-lang.eng=English
-lang.enm=English, Middle (1100-1500)
-lang.epo=Esperanto
-lang.equ=Math / equation detection module
-lang.est=Estonian
-lang.eus=Basque
-lang.fao=Faroese
-lang.fas=Persian
-lang.fil=Filipino
-lang.fin=Finnish
-lang.fra=French
-lang.frk=Frankish
-lang.frm=French, Middle (ca.1400-1600)
-lang.fry=Western Frisian
-lang.gla=Scottish Gaelic
-lang.gle=Irish
-lang.glg=Galician
-lang.grc=Ancient Greek
-lang.guj=Gujarati
-lang.hat=Haitian, Haitian Creole
-lang.heb=Hebrew
-lang.hin=Hindi
-lang.hrv=Croatian
-lang.hun=Hungarian
-lang.hye=Armenian
-lang.iku=Inuktitut
-lang.ind=Indonesian
-lang.isl=Icelandic
-lang.ita=Italian
-lang.ita_old=Italian (Old)
-lang.jav=Javanese
-lang.jpn=Japanese
-lang.jpn_vert=Japanese (Vertical)
-lang.kan=Kannada
-lang.kat=Georgian
-lang.kat_old=Georgian (Old)
-lang.kaz=Kazakh
-lang.khm=Central Khmer
-lang.kir=Kirghiz, Kyrgyz
-lang.kmr=Northern Kurdish
-lang.kor=Korean
-lang.kor_vert=Korean (Vertical)
-lang.lao=Lao
-lang.lat=Latin
-lang.lav=Latvian
-lang.lit=Lithuanian
-lang.ltz=Luxembourgish
-lang.mal=Malayalam
-lang.mar=Marathi
-lang.mkd=Macedonian
-lang.mlt=Maltese
-lang.mon=Mongolian
-lang.mri=Maori
-lang.msa=Malay
-lang.mya=Burmese
-lang.nep=Nepali
-lang.nld=Dutch; Flemish
-lang.nor=Norwegian
-lang.oci=Occitan (post 1500)
-lang.ori=Oriya
-lang.osd=Orientation and script detection module
-lang.pan=Panjabi, Punjabi
-lang.pol=Polish
-lang.por=Portuguese
-lang.pus=Pushto, Pashto
-lang.que=Quechua
-lang.ron=Romanian, Moldavian, Moldovan
-lang.rus=Russian
-lang.san=Sanskrit
-lang.sin=Sinhala, Sinhalese
-lang.slk=Slovak
-lang.slk_frak=Slovak (Fraktur)
-lang.slv=Slovenian
-lang.snd=Sindhi
-lang.spa=Spanish
-lang.spa_old=Spanish (Old)
-lang.sqi=Albanian
-lang.srp=Serbian
-lang.srp_latn=Serbian (Latin)
-lang.sun=Sundanese
-lang.swa=Swahili
-lang.swe=Swedish
-lang.syr=Syriac
-lang.tam=Tamil
-lang.tat=Tatar
-lang.tel=Telugu
-lang.tgk=Tajik
-lang.tgl=Tagalog
-lang.tha=Thai
-lang.tir=Tigrinya
-lang.ton=Tonga (Tonga Islands)
-lang.tur=Turkish
-lang.uig=Uighur, Uyghur
-lang.ukr=Ukrainian
-lang.urd=Urdu
-lang.uzb=Uzbek
-lang.uzb_cyrl=Uzbek (Cyrillic)
-lang.vie=Vietnamese
-lang.yid=Yiddish
-lang.yor=Yoruba
-
 addPageNumbers.fontSize=字型大小
 addPageNumbers.fontName=字型名稱
 pdfPrompt=選擇 PDF 檔案
@@ -212,7 +80,6 @@ color=顏色
 sponsor=贊助
 info=資訊
 pro=專業版
-proFeatures=Pro Features
 page=頁面
 pages=頁面
 loading=載入中...
@@ -220,12 +87,6 @@ addToDoc=新增至文件
 reset=重設
 apply=套用
 noFileSelected=未選擇檔案，請上傳一個。
-view=View
-cancel=Cancel
-
-back.toSettings=Back to Settings
-back.toHome=Back to Home
-back.toAdmin=Back to Admin
 
 legal.privacy=隱私權政策
 legal.terms=使用條款
@@ -266,7 +127,6 @@ enterpriseEdition.button=升級至專業版
 enterpriseEdition.warning=此功能僅提供給專業版使用者使用。
 enterpriseEdition.yamlAdvert=Stirling PDF 專業版支援 YAML 設定檔和其他單一登入 (SSO) 功能。
 enterpriseEdition.ssoAdvert=需要更多使用者管理功能嗎？請參考 Stirling PDF 專業版
-enterpriseEdition.proTeamFeatureDisabled=Team management features require a Pro licence or higher
 
 
 #################
@@ -347,8 +207,6 @@ account.property=屬性
 account.webBrowserSettings=網頁瀏覽器設定
 account.syncToBrowser=同步帳號 → 瀏覽器
 account.syncToAccount=同步帳號 ← 瀏覽器
-account.adminTitle=Administrator Tools
-account.adminNotif=You have admin privileges. Access system settings and user management.
 
 
 adminUserSettings.title=使用者控制設定
@@ -360,6 +218,7 @@ adminUserSettings.deleteUser=刪除使用者
 adminUserSettings.confirmDeleteUser=確定要刪除此使用者？
 adminUserSettings.confirmChangeUserStatus=是否要停用/啟用此使用者？
 adminUserSettings.usernameInfo=使用者名稱只能包含字母、數字和以下特殊字元 @._+- 或必須是有效的電子郵件地址。
+adminUserSettings.roles=角色
 adminUserSettings.role=角色
 adminUserSettings.actions=操作
 adminUserSettings.apiUser=受限制的 API 使用者
@@ -379,50 +238,6 @@ adminUserSettings.disabledUsers=已停用的使用者：
 adminUserSettings.totalUsers=使用者總數：
 adminUserSettings.lastRequest=最後請求時間
 adminUserSettings.usage=檢視使用情況
-adminUserSettings.teams=View/Edit Teams
-adminUserSettings.team=Team
-adminUserSettings.manageTeams=Manage Teams
-adminUserSettings.createTeam=Create Team
-adminUserSettings.viewTeam=View Team
-adminUserSettings.deleteTeam=Delete Team
-adminUserSettings.teamName=Team Name
-adminUserSettings.teamExists=Team already exists
-adminUserSettings.teamCreated=Team created successfully
-adminUserSettings.teamChanged=User's team was updated
-adminUserSettings.teamHidden=Hidden
-adminUserSettings.totalMembers=Total Members
-adminUserSettings.confirmDeleteTeam=Are you sure you want to delete this team?
-
-teamCreated=Team created successfully
-teamExists=A team with that name already exists
-teamNameExists=Another team with that name already exists
-teamNotFound=Team not found
-teamDeleted=Team deleted
-teamHasUsers=Cannot delete a team with users assigned
-teamRenamed=Team renamed successfully
-
-# Team user management
-team.addUser=Add User to Team
-team.selectUser=Select User
-team.warning.moveUser=Warning: This will move the user from "{0}" team to "{1}" team. Are you sure?
-team.confirm.moveUser=Are you sure you want to move this user from "{0}" team to "{1}" team?
-team.userAdded=User successfully added to team
-team.back=Back to Teams
-team.internal=Internal Team
-team.internalTeamNotAccessible=The Internal team is a system team and cannot be accessed
-team.cannotMoveInternalUsers=Users in the Internal team cannot be moved to other teams
-team.hidden=Hidden
-team.name=Team Name
-team.totalMembers=Total Members
-team.members=Members
-team.username=Username
-team.role=Role
-team.status=Status
-team.enabled=Enabled
-team.disabled=Disabled
-team.noMembers=This team has no members yet.
-
-
 
 endpointStatistics.title=端點統計
 endpointStatistics.header=端點統計
@@ -549,9 +364,9 @@ home.compressPdfs.title=壓縮
 home.compressPdfs.desc=壓縮 PDF 以減少其檔案大小。
 compressPdfs.tags=壓縮,小,微小
 
-home.unlockPDFForms.title=解鎖 PDF 表單
-home.unlockPDFForms.desc=移除 PDF 文件中表單欄位的唯讀屬性
-unlockPDFForms.tags=移除,刪除,表格,欄位,唯讀
+home.unlockPDFForms.title=Unlock PDF Forms
+home.unlockPDFForms.desc=Remove read-only property of form fields in a PDF document.
+unlockPDFForms.tags=remove,delete,form,field,readonly
 
 home.changeMetadata.title=變更中繼資料
 home.changeMetadata.desc=從 PDF 檔案中變更/移除/新增中繼資料
@@ -676,20 +491,20 @@ HTMLToPDF.tags=標記,網頁內容,轉換,轉檔
 
 #eml-to-pdf
 home.EMLToPDF.title=Email to PDF
-home.EMLToPDF.desc=將電子郵件 (EML) 檔案轉換為 PDF 格式，包含標頭、內文及內嵌圖片
-EMLToPDF.tags=電子郵件,轉換,EML,訊息,轉檔,轉換,郵件
+home.EMLToPDF.desc=Converts email (EML) files to PDF format including headers, body, and inline images
+EMLToPDF.tags=email,conversion,eml,message,transformation,convert,mail
 
-EMLToPDF.title=電子郵件轉 PDF
-EMLToPDF.header=電子郵件轉 PDF
-EMLToPDF.submit=轉換
-EMLToPDF.downloadHtml=下載 HTML 中繼檔案而非 PDF
-EMLToPDF.downloadHtmlHelp=可讓您在轉換為 PDF 前先檢視 HTML 版本，有助於除錯格式問題
-EMLToPDF.includeAttachments=在 PDF 中包含附件
-EMLToPDF.maxAttachmentSize=附件大小上限 (MB)
-EMLToPDF.help=將電子郵件 (EML) 檔案轉換為 PDF 格式，包含標頭、內文及內嵌圖片
-EMLToPDF.troubleshootingTip1=電子郵件轉 HTML 的流程較為穩定可靠，因此在批次處理時建議同時儲存兩種格式
-EMLToPDF.troubleshootingTip2=若電子郵件數量不多且 PDF 格式錯誤，您可下載 HTML 檔案並手動修正有問題的 HTML/CSS 程式碼
-EMLToPDF.troubleshootingTip3=然而，內嵌內容在 HTML 中無法正常運作
+EMLToPDF.title=Email To PDF
+EMLToPDF.header=Email To PDF
+EMLToPDF.submit=Convert
+EMLToPDF.downloadHtml=Download HTML intermediate file instead of PDF
+EMLToPDF.downloadHtmlHelp=This allows you to see the HTML version before PDF conversion and can help debug formatting issues
+EMLToPDF.includeAttachments=Include attachments in PDF
+EMLToPDF.maxAttachmentSize=Maximum attachment size (MB)
+EMLToPDF.help=Converts email (EML) files to PDF format including headers, body, and inline images
+EMLToPDF.troubleshootingTip1=Email to HTML is a more reliable process, so with batch-processing it is recommended to save both
+EMLToPDF.troubleshootingTip2=With a small number of Emails, if the PDF is malformed, you can download HTML and override some of the problematic HTML/CSS code.
+EMLToPDF.troubleshootingTip3=Embeddings, however, do not work with HTMLs
 
 home.MarkdownToPDF.title=Markdown 轉 PDF
 home.MarkdownToPDF.desc=將任何 Markdown 檔案轉換為 PDF
@@ -876,28 +691,28 @@ getPdfInfo.title=取得 PDF 資訊
 getPdfInfo.header=取得 PDF 資訊
 getPdfInfo.submit=取得資訊
 getPdfInfo.downloadJson=下載 JSON
-getPdfInfo.summary=PDF 摘要
-getPdfInfo.summary.encrypted=此 PDF 已加密，部分應用程式可能無法正常使用
-getPdfInfo.summary.permissions=此 PDF 有 {0} 項權限限制，可能會限制可執行的操作
-getPdfInfo.summary.compliance=此 PDF 符合 {0} 標準
-getPdfInfo.summary.basicInfo=基本資訊
-getPdfInfo.summary.docInfo=文件資訊
-getPdfInfo.summary.encrypted.alert=已加密的 PDF - 此文件受密碼保護
-getPdfInfo.summary.not.encrypted.alert=未加密的 PDF - 無密碼保護
-getPdfInfo.summary.permissions.alert=權限限制 - 不允許執行 {0} 項操作
-getPdfInfo.summary.all.permissions.alert=允許所有權限
-getPdfInfo.summary.compliance.alert=符合 {0} 標準
-getPdfInfo.summary.no.compliance.alert=未符合任何合規標準
-getPdfInfo.summary.security.section=安全性狀態
-getPdfInfo.section.BasicInfo=PDF 文件的基本資訊，包括檔案大小、頁數和語言
-getPdfInfo.section.Metadata=文件中繼資料，包括標題、作者、建立日期和其他文件屬性
-getPdfInfo.section.DocumentInfo=PDF 文件結構與版本的技術詳細資訊
-getPdfInfo.section.Compliancy=PDF 標準合規資訊 (PDF/A、PDF/X 等)
-getPdfInfo.section.Encryption=文件的安全性和加密詳細資訊
-getPdfInfo.section.Permissions=控制可執行操作的文件權限設定
-getPdfInfo.section.Other=其他文件元件，例如書籤、圖層與內嵌檔案
-getPdfInfo.section.FormFields=文件中的互動式表單欄位
-getPdfInfo.section.PerPageInfo=文件中每一頁的詳細資訊
+getPdfInfo.summary=PDF Summary
+getPdfInfo.summary.encrypted=This PDF is encrypted so may face issues with some applications
+getPdfInfo.summary.permissions=This PDF has {0} restricted permissions which may limit what you can do with it
+getPdfInfo.summary.compliance=This PDF complies with the {0} standard
+getPdfInfo.summary.basicInfo=Basic Information
+getPdfInfo.summary.docInfo=Document Information
+getPdfInfo.summary.encrypted.alert=Encrypted PDF - This document is password protected
+getPdfInfo.summary.not.encrypted.alert=Unencrypted PDF - No password protection
+getPdfInfo.summary.permissions.alert=Restricted Permissions - {0} actions are not allowed
+getPdfInfo.summary.all.permissions.alert=All Permissions Allowed
+getPdfInfo.summary.compliance.alert={0} Compliant
+getPdfInfo.summary.no.compliance.alert=No Compliance Standards
+getPdfInfo.summary.security.section=Security Status
+getPdfInfo.section.BasicInfo=Basic Information about the PDF document including file size, page count, and language
+getPdfInfo.section.Metadata=Document metadata including title, author, creation date and other document properties
+getPdfInfo.section.DocumentInfo=Technical details about the PDF document structure and version
+getPdfInfo.section.Compliancy=PDF standards compliance information (PDF/A, PDF/X, etc.)
+getPdfInfo.section.Encryption=Security and encryption details of the document
+getPdfInfo.section.Permissions=Document permission settings that control what actions can be performed
+getPdfInfo.section.Other=Additional document components like bookmarks, layers, and embedded files
+getPdfInfo.section.FormFields=Interactive form fields present in the document
+getPdfInfo.section.PerPageInfo=Detailed information about each page in the document
 
 
 #markdown-to-pdf
@@ -1211,7 +1026,6 @@ merge.header=合併多個 PDF
 merge.sortByName=依名稱排序
 merge.sortByDate=依日期排序
 merge.removeCertSign=是否移除合併後檔案的憑證簽章？
-merge.generateToc=Generate table of contents in the merged file?
 merge.submit=合併
 
 
@@ -1421,9 +1235,9 @@ changeMetadata.selectText.5=新增自訂中繼資料項目
 changeMetadata.submit=變更
 
 #unlockPDFForms
-unlockPDFForms.title=移除表單欄位的唯讀限制
-unlockPDFForms.header=解鎖 PDF 表單
-unlockPDFForms.submit=移除
+unlockPDFForms.title=Remove Read-Only from Form Fields
+unlockPDFForms.header=Unlock PDF Forms
+unlockPDFForms.submit=Remove
 
 #pdfToPDFA
 pdfToPDFA.title=PDF 轉 PDF/A
@@ -1641,7 +1455,7 @@ validateSignature.cert.bits=位元
 ####################
 cookieBanner.popUp.title=我們如何使用 Cookies
 cookieBanner.popUp.description.1=我們使用 Cookies 和其他技術來讓 Stirling PDF 變得更好——幫助我們改善工具並繼續創造您會喜愛的新功能
-cookieBanner.popUp.description.2=如果您仍不想，點選「不，謝謝」只會開啟必要的 Cookies 好讓網站功能保持運作
+cookieBanner.popUp.description.2=如果您仍不想，點擊「不，謝謝」只會開啟必要的 Cookies 好讓網站功能保持運作
 cookieBanner.popUp.acceptAllBtn=接受
 cookieBanner.popUp.acceptNecessaryBtn=不，謝謝
 cookieBanner.popUp.showPreferencesBtn=管理偏好設定
@@ -1659,57 +1473,5 @@ cookieBanner.preferencesModal.necessary.title.1=必要的 Cookies
 cookieBanner.preferencesModal.necessary.title.2=永遠開啟
 cookieBanner.preferencesModal.necessary.description=這些 Cookies 對網站正常運作至關重要。它們讓核心功能，像是隱私設定、登入、填入表格能夠運作——這也是為什麼它們不能被關掉。
 cookieBanner.preferencesModal.analytics.title=分析 Cookies
-cookieBanner.preferencesModal.analytics.description=這些 Cookies 幫助我們分析您如何使用我們的工具，好讓我們能專注在建構社群最重視的功能。儘管放心—— Stirling PDF 不會且永不追蹤您的文件
+cookieBanner.preferencesModal.analytics.description=這些 Cookies 幫助我們分析您如何使用我們的工具，好讓我們能專注在構建社群最重視的功能。儘管放心—— Stirling PDF 不會且永不追蹤您的文件
 
-#fakeScan
-fakeScan.title=Fake Scan
-fakeScan.header=Fake Scan
-fakeScan.description=Create a PDF that looks like it was scanned
-fakeScan.selectPDF=Select PDF:
-fakeScan.quality=Scan Quality
-fakeScan.quality.low=Low
-fakeScan.quality.medium=Medium
-fakeScan.quality.high=High
-fakeScan.rotation=Rotation Angle
-fakeScan.rotation.none=None
-fakeScan.rotation.slight=Slight
-fakeScan.rotation.moderate=Moderate
-fakeScan.rotation.severe=Severe
-fakeScan.submit=Create Fake Scan
-
-#home.fakeScan
-home.fakeScan.title=Fake Scan
-home.fakeScan.desc=Create a PDF that looks like it was scanned
-fakeScan.tags=scan,simulate,realistic,convert
-
-# FakeScan advanced settings (frontend)
-fakeScan.advancedSettings=Enable Advanced Scan Settings
-fakeScan.colorspace=Colorspace
-fakeScan.colorspace.grayscale=Grayscale
-fakeScan.colorspace.color=Color
-fakeScan.border=Border (px)
-fakeScan.rotate=Base Rotation (degrees)
-fakeScan.rotateVariance=Rotation Variance (degrees)
-fakeScan.brightness=Brightness
-fakeScan.contrast=Contrast
-fakeScan.blur=Blur
-fakeScan.noise=Noise
-fakeScan.yellowish=Yellowish (simulate old paper)
-fakeScan.resolution=Resolution (DPI)
-
-
-# Table of Contents Feature
-home.editTableOfContents.title=Edit Table of Contents
-home.editTableOfContents.desc=Add or edit bookmarks and table of contents in PDF documents
-
-editTableOfContents.tags=bookmarks,toc,navigation,index,table of contents,chapters,sections,outline
-editTableOfContents.title=Edit Table of Contents
-editTableOfContents.header=Add or Edit PDF Table of Contents
-editTableOfContents.replaceExisting=Replace existing bookmarks (uncheck to append to existing)
-editTableOfContents.editorTitle=Bookmark Editor
-editTableOfContents.editorDesc=Add and arrange bookmarks below. Click + to add child bookmarks.
-editTableOfContents.addBookmark=Add New Bookmark
-editTableOfContents.desc.1=This tool allows you to add or edit the table of contents (bookmarks) in a PDF document.
-editTableOfContents.desc.2=You can create a hierarchical structure by adding child bookmarks to parent bookmarks.
-editTableOfContents.desc.3=Each bookmark requires a title and target page number.
-editTableOfContents.submit=Apply Table of Contents

--- a/stirling-pdf/src/main/resources/messages_zh_TW.properties
+++ b/stirling-pdf/src/main/resources/messages_zh_TW.properties
@@ -3,6 +3,138 @@
 ###########
 # the direction that the language is written (ltr = left to right, rtl = right to left)
 language.direction=ltr
+
+# Language names for reuse throughout the application
+lang.afr=Afrikaans
+lang.amh=Amharic
+lang.ara=Arabic
+lang.asm=Assamese
+lang.aze=Azerbaijani
+lang.aze_cyrl=Azerbaijani (Cyrillic)
+lang.bel=Belarusian
+lang.ben=Bengali
+lang.bod=Tibetan
+lang.bos=Bosnian
+lang.bre=Breton
+lang.bul=Bulgarian
+lang.cat=Catalan
+lang.ceb=Cebuano
+lang.ces=Czech
+lang.chi_sim=Chinese (Simplified)
+lang.chi_sim_vert=Chinese (Simplified, Vertical)
+lang.chi_tra=Chinese (Traditional)
+lang.chi_tra_vert=Chinese (Traditional, Vertical)
+lang.chr=Cherokee
+lang.cos=Corsican
+lang.cym=Welsh
+lang.dan=Danish
+lang.dan_frak=Danish (Fraktur)
+lang.deu=German
+lang.deu_frak=German (Fraktur)
+lang.div=Divehi
+lang.dzo=Dzongkha
+lang.ell=Greek
+lang.eng=English
+lang.enm=English, Middle (1100-1500)
+lang.epo=Esperanto
+lang.equ=Math / equation detection module
+lang.est=Estonian
+lang.eus=Basque
+lang.fao=Faroese
+lang.fas=Persian
+lang.fil=Filipino
+lang.fin=Finnish
+lang.fra=French
+lang.frk=Frankish
+lang.frm=French, Middle (ca.1400-1600)
+lang.fry=Western Frisian
+lang.gla=Scottish Gaelic
+lang.gle=Irish
+lang.glg=Galician
+lang.grc=Ancient Greek
+lang.guj=Gujarati
+lang.hat=Haitian, Haitian Creole
+lang.heb=Hebrew
+lang.hin=Hindi
+lang.hrv=Croatian
+lang.hun=Hungarian
+lang.hye=Armenian
+lang.iku=Inuktitut
+lang.ind=Indonesian
+lang.isl=Icelandic
+lang.ita=Italian
+lang.ita_old=Italian (Old)
+lang.jav=Javanese
+lang.jpn=Japanese
+lang.jpn_vert=Japanese (Vertical)
+lang.kan=Kannada
+lang.kat=Georgian
+lang.kat_old=Georgian (Old)
+lang.kaz=Kazakh
+lang.khm=Central Khmer
+lang.kir=Kirghiz, Kyrgyz
+lang.kmr=Northern Kurdish
+lang.kor=Korean
+lang.kor_vert=Korean (Vertical)
+lang.lao=Lao
+lang.lat=Latin
+lang.lav=Latvian
+lang.lit=Lithuanian
+lang.ltz=Luxembourgish
+lang.mal=Malayalam
+lang.mar=Marathi
+lang.mkd=Macedonian
+lang.mlt=Maltese
+lang.mon=Mongolian
+lang.mri=Maori
+lang.msa=Malay
+lang.mya=Burmese
+lang.nep=Nepali
+lang.nld=Dutch; Flemish
+lang.nor=Norwegian
+lang.oci=Occitan (post 1500)
+lang.ori=Oriya
+lang.osd=Orientation and script detection module
+lang.pan=Panjabi, Punjabi
+lang.pol=Polish
+lang.por=Portuguese
+lang.pus=Pushto, Pashto
+lang.que=Quechua
+lang.ron=Romanian, Moldavian, Moldovan
+lang.rus=Russian
+lang.san=Sanskrit
+lang.sin=Sinhala, Sinhalese
+lang.slk=Slovak
+lang.slk_frak=Slovak (Fraktur)
+lang.slv=Slovenian
+lang.snd=Sindhi
+lang.spa=Spanish
+lang.spa_old=Spanish (Old)
+lang.sqi=Albanian
+lang.srp=Serbian
+lang.srp_latn=Serbian (Latin)
+lang.sun=Sundanese
+lang.swa=Swahili
+lang.swe=Swedish
+lang.syr=Syriac
+lang.tam=Tamil
+lang.tat=Tatar
+lang.tel=Telugu
+lang.tgk=Tajik
+lang.tgl=Tagalog
+lang.tha=Thai
+lang.tir=Tigrinya
+lang.ton=Tonga (Tonga Islands)
+lang.tur=Turkish
+lang.uig=Uighur, Uyghur
+lang.ukr=Ukrainian
+lang.urd=Urdu
+lang.uzb=Uzbek
+lang.uzb_cyrl=Uzbek (Cyrillic)
+lang.vie=Vietnamese
+lang.yid=Yiddish
+lang.yor=Yoruba
+
 addPageNumbers.fontSize=字型大小
 addPageNumbers.fontName=字型名稱
 pdfPrompt=選擇 PDF 檔案
@@ -80,6 +212,7 @@ color=顏色
 sponsor=贊助
 info=資訊
 pro=專業版
+proFeatures=Pro Features
 page=頁面
 pages=頁面
 loading=載入中...
@@ -87,6 +220,12 @@ addToDoc=新增至文件
 reset=重設
 apply=套用
 noFileSelected=未選擇檔案，請上傳一個。
+view=View
+cancel=Cancel
+
+back.toSettings=Back to Settings
+back.toHome=Back to Home
+back.toAdmin=Back to Admin
 
 legal.privacy=隱私權政策
 legal.terms=使用條款
@@ -127,6 +266,7 @@ enterpriseEdition.button=升級至專業版
 enterpriseEdition.warning=此功能僅提供給專業版使用者使用。
 enterpriseEdition.yamlAdvert=Stirling PDF 專業版支援 YAML 設定檔和其他單一登入 (SSO) 功能。
 enterpriseEdition.ssoAdvert=需要更多使用者管理功能嗎？請參考 Stirling PDF 專業版
+enterpriseEdition.proTeamFeatureDisabled=Team management features require a Pro licence or higher
 
 
 #################
@@ -207,6 +347,8 @@ account.property=屬性
 account.webBrowserSettings=網頁瀏覽器設定
 account.syncToBrowser=同步帳號 → 瀏覽器
 account.syncToAccount=同步帳號 ← 瀏覽器
+account.adminTitle=Administrator Tools
+account.adminNotif=You have admin privileges. Access system settings and user management.
 
 
 adminUserSettings.title=使用者控制設定
@@ -218,7 +360,6 @@ adminUserSettings.deleteUser=刪除使用者
 adminUserSettings.confirmDeleteUser=確定要刪除此使用者？
 adminUserSettings.confirmChangeUserStatus=是否要停用/啟用此使用者？
 adminUserSettings.usernameInfo=使用者名稱只能包含字母、數字和以下特殊字元 @._+- 或必須是有效的電子郵件地址。
-adminUserSettings.roles=角色
 adminUserSettings.role=角色
 adminUserSettings.actions=操作
 adminUserSettings.apiUser=受限制的 API 使用者
@@ -238,6 +379,50 @@ adminUserSettings.disabledUsers=已停用的使用者：
 adminUserSettings.totalUsers=使用者總數：
 adminUserSettings.lastRequest=最後請求時間
 adminUserSettings.usage=檢視使用情況
+adminUserSettings.teams=View/Edit Teams
+adminUserSettings.team=Team
+adminUserSettings.manageTeams=Manage Teams
+adminUserSettings.createTeam=Create Team
+adminUserSettings.viewTeam=View Team
+adminUserSettings.deleteTeam=Delete Team
+adminUserSettings.teamName=Team Name
+adminUserSettings.teamExists=Team already exists
+adminUserSettings.teamCreated=Team created successfully
+adminUserSettings.teamChanged=User's team was updated
+adminUserSettings.teamHidden=Hidden
+adminUserSettings.totalMembers=Total Members
+adminUserSettings.confirmDeleteTeam=Are you sure you want to delete this team?
+
+teamCreated=Team created successfully
+teamExists=A team with that name already exists
+teamNameExists=Another team with that name already exists
+teamNotFound=Team not found
+teamDeleted=Team deleted
+teamHasUsers=Cannot delete a team with users assigned
+teamRenamed=Team renamed successfully
+
+# Team user management
+team.addUser=Add User to Team
+team.selectUser=Select User
+team.warning.moveUser=Warning: This will move the user from "{0}" team to "{1}" team. Are you sure?
+team.confirm.moveUser=Are you sure you want to move this user from "{0}" team to "{1}" team?
+team.userAdded=User successfully added to team
+team.back=Back to Teams
+team.internal=Internal Team
+team.internalTeamNotAccessible=The Internal team is a system team and cannot be accessed
+team.cannotMoveInternalUsers=Users in the Internal team cannot be moved to other teams
+team.hidden=Hidden
+team.name=Team Name
+team.totalMembers=Total Members
+team.members=Members
+team.username=Username
+team.role=Role
+team.status=Status
+team.enabled=Enabled
+team.disabled=Disabled
+team.noMembers=This team has no members yet.
+
+
 
 endpointStatistics.title=端點統計
 endpointStatistics.header=端點統計
@@ -1026,6 +1211,7 @@ merge.header=合併多個 PDF
 merge.sortByName=依名稱排序
 merge.sortByDate=依日期排序
 merge.removeCertSign=是否移除合併後檔案的憑證簽章？
+merge.generateToc=Generate table of contents in the merged file?
 merge.submit=合併
 
 
@@ -1475,3 +1661,55 @@ cookieBanner.preferencesModal.necessary.description=這些 Cookies 對網站正�
 cookieBanner.preferencesModal.analytics.title=分析 Cookies
 cookieBanner.preferencesModal.analytics.description=這些 Cookies 幫助我們分析您如何使用我們的工具，好讓我們能專注在構建社群最重視的功能。儘管放心—— Stirling PDF 不會且永不追蹤您的文件
 
+#fakeScan
+fakeScan.title=Fake Scan
+fakeScan.header=Fake Scan
+fakeScan.description=Create a PDF that looks like it was scanned
+fakeScan.selectPDF=Select PDF:
+fakeScan.quality=Scan Quality
+fakeScan.quality.low=Low
+fakeScan.quality.medium=Medium
+fakeScan.quality.high=High
+fakeScan.rotation=Rotation Angle
+fakeScan.rotation.none=None
+fakeScan.rotation.slight=Slight
+fakeScan.rotation.moderate=Moderate
+fakeScan.rotation.severe=Severe
+fakeScan.submit=Create Fake Scan
+
+#home.fakeScan
+home.fakeScan.title=Fake Scan
+home.fakeScan.desc=Create a PDF that looks like it was scanned
+fakeScan.tags=scan,simulate,realistic,convert
+
+# FakeScan advanced settings (frontend)
+fakeScan.advancedSettings=Enable Advanced Scan Settings
+fakeScan.colorspace=Colorspace
+fakeScan.colorspace.grayscale=Grayscale
+fakeScan.colorspace.color=Color
+fakeScan.border=Border (px)
+fakeScan.rotate=Base Rotation (degrees)
+fakeScan.rotateVariance=Rotation Variance (degrees)
+fakeScan.brightness=Brightness
+fakeScan.contrast=Contrast
+fakeScan.blur=Blur
+fakeScan.noise=Noise
+fakeScan.yellowish=Yellowish (simulate old paper)
+fakeScan.resolution=Resolution (DPI)
+
+
+# Table of Contents Feature
+home.editTableOfContents.title=Edit Table of Contents
+home.editTableOfContents.desc=Add or edit bookmarks and table of contents in PDF documents
+
+editTableOfContents.tags=bookmarks,toc,navigation,index,table of contents,chapters,sections,outline
+editTableOfContents.title=Edit Table of Contents
+editTableOfContents.header=Add or Edit PDF Table of Contents
+editTableOfContents.replaceExisting=Replace existing bookmarks (uncheck to append to existing)
+editTableOfContents.editorTitle=Bookmark Editor
+editTableOfContents.editorDesc=Add and arrange bookmarks below. Click + to add child bookmarks.
+editTableOfContents.addBookmark=Add New Bookmark
+editTableOfContents.desc.1=This tool allows you to add or edit the table of contents (bookmarks) in a PDF document.
+editTableOfContents.desc.2=You can create a hierarchical structure by adding child bookmarks to parent bookmarks.
+editTableOfContents.desc.3=Each bookmark requires a title and target page number.
+editTableOfContents.submit=Apply Table of Contents


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

Revert changes to Chinese traditional file accidentally removing attribution to original translator 

Closes #(issue_number)

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
