### PR TITLE
chore: reformat Java codebase and centralize Spotless config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
     springSecuritySamlVersion = "6.5.0"
     openSamlVersion = "4.3.2"
     commonmarkVersion = "0.24.0"
+    googleJavaFormatVersion = "1.27.0"
     tempJrePath = null
 }
 
@@ -475,7 +476,7 @@ spotless {
         target project(':proprietary').sourceSets.main.allJava
         target project(':stirling-pdf').sourceSets.main.allJava
 
-        googleJavaFormat("1.27.0").aosp().reorderImports(false)
+        googleJavaFormat(googleJavaFormatVersion).aosp().reorderImports(false)
 
         importOrder("java", "javax", "org", "com", "net", "io", "jakarta", "lombok", "me", "stirling")
         toggleOffOn()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,7 +2,12 @@
 bootRun {
     enabled = false
 }
-
+spotless {
+    java {
+        target sourceSets.main.allJava
+        googleJavaFormat(googleJavaFormatVersion).aosp()
+    }
+}
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-web'
     api 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/common/src/main/java/org/apache/pdfbox/examples/util/DeletingRandomAccessFile.java
+++ b/common/src/main/java/org/apache/pdfbox/examples/util/DeletingRandomAccessFile.java
@@ -4,10 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
-
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
 
 /** A custom RandomAccessRead implementation that deletes the file when closed */
 @Slf4j

--- a/common/src/main/java/stirling/software/common/configuration/AppConfig.java
+++ b/common/src/main/java/stirling/software/common/configuration/AppConfig.java
@@ -248,17 +248,16 @@ public class AppConfig {
         return applicationProperties.getSystem().getDatasource();
     }
 
-
     @Bean(name = "runningProOrHigher")
     @Profile("default")
     public boolean runningProOrHigher() {
-    	return false;
+        return false;
     }
 
     @Bean(name = "runningEE")
     @Profile("default")
     public boolean runningEnterprise() {
-    	return false;
+        return false;
     }
 
     @Bean(name = "GoogleDriveEnabled")
@@ -273,10 +272,9 @@ public class AppConfig {
         return "NORMAL";
     }
 
-
     @Bean(name = "disablePixel")
     public boolean disablePixel() {
-    	return Boolean.parseBoolean(env.getProperty("DISABLE_PIXEL", "false"));
+        return Boolean.parseBoolean(env.getProperty("DISABLE_PIXEL", "false"));
     }
 
     @Bean(name = "machineType")

--- a/common/src/main/java/stirling/software/common/configuration/ConfigInitializer.java
+++ b/common/src/main/java/stirling/software/common/configuration/ConfigInitializer.java
@@ -10,9 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.util.YamlHelper;
 
 /**

--- a/common/src/main/java/stirling/software/common/configuration/FileFallbackTemplateResolver.java
+++ b/common/src/main/java/stirling/software/common/configuration/FileFallbackTemplateResolver.java
@@ -3,16 +3,13 @@ package stirling.software.common.configuration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.templateresolver.AbstractConfigurableTemplateResolver;
 import org.thymeleaf.templateresource.FileTemplateResource;
 import org.thymeleaf.templateresource.ITemplateResource;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.InputStreamTemplateResource;
 
 @Slf4j

--- a/common/src/main/java/stirling/software/common/configuration/InstallationPathConfig.java
+++ b/common/src/main/java/stirling/software/common/configuration/InstallationPathConfig.java
@@ -2,7 +2,6 @@ package stirling.software.common.configuration;
 
 import java.io.File;
 import java.nio.file.Paths;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/common/src/main/java/stirling/software/common/configuration/PostHogConfig.java
+++ b/common/src/main/java/stirling/software/common/configuration/PostHogConfig.java
@@ -1,14 +1,11 @@
 package stirling.software.common.configuration;
 
+import com.posthog.java.PostHog;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import com.posthog.java.PostHog;
-
-import jakarta.annotation.PreDestroy;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @Slf4j

--- a/common/src/main/java/stirling/software/common/configuration/PostHogLoggerImpl.java
+++ b/common/src/main/java/stirling/software/common/configuration/PostHogLoggerImpl.java
@@ -1,10 +1,8 @@
 package stirling.software.common.configuration;
 
-import org.springframework.stereotype.Component;
-
 import com.posthog.java.PostHogLogger;
-
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component

--- a/common/src/main/java/stirling/software/common/configuration/RuntimePathConfig.java
+++ b/common/src/main/java/stirling/software/common/configuration/RuntimePathConfig.java
@@ -2,13 +2,10 @@ package stirling.software.common.configuration;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.annotation.Configuration;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Configuration;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.CustomPaths.Operations;
 import stirling.software.common.model.ApplicationProperties.CustomPaths.Pipeline;

--- a/common/src/main/java/stirling/software/common/configuration/YamlPropertySourceFactory.java
+++ b/common/src/main/java/stirling/software/common/configuration/YamlPropertySourceFactory.java
@@ -1,7 +1,6 @@
 package stirling.software.common.configuration;
 
 import java.util.Properties;
-
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySource;

--- a/common/src/main/java/stirling/software/common/model/ApplicationProperties.java
+++ b/common/src/main/java/stirling/software/common/model/ApplicationProperties.java
@@ -12,7 +12,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
@@ -24,13 +28,6 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.EncodedResource;
 import org.springframework.stereotype.Component;
-
-import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.configuration.InstallationPathConfig;
 import stirling.software.common.configuration.YamlPropertySourceFactory;
 import stirling.software.common.model.exception.UnsupportedProviderException;

--- a/common/src/main/java/stirling/software/common/model/FileInfo.java
+++ b/common/src/main/java/stirling/software/common/model/FileInfo.java
@@ -5,7 +5,6 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/common/src/main/java/stirling/software/common/model/InputStreamTemplateResource.java
+++ b/common/src/main/java/stirling/software/common/model/InputStreamTemplateResource.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-
 import org.thymeleaf.templateresource.ITemplateResource;
 
 public class InputStreamTemplateResource implements ITemplateResource {

--- a/common/src/main/java/stirling/software/common/model/PdfMetadata.java
+++ b/common/src/main/java/stirling/software/common/model/PdfMetadata.java
@@ -1,7 +1,6 @@
 package stirling.software.common.model;
 
 import java.util.Calendar;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/common/src/main/java/stirling/software/common/model/api/GeneralFile.java
+++ b/common/src/main/java/stirling/software/common/model/api/GeneralFile.java
@@ -1,11 +1,9 @@
 package stirling.software.common.model.api;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @EqualsAndHashCode

--- a/common/src/main/java/stirling/software/common/model/api/PDFFile.java
+++ b/common/src/main/java/stirling/software/common/model/api/PDFFile.java
@@ -1,12 +1,10 @@
 package stirling.software.common.model.api;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @NoArgsConstructor

--- a/common/src/main/java/stirling/software/common/model/api/converters/HTMLToPdfRequest.java
+++ b/common/src/main/java/stirling/software/common/model/api/converters/HTMLToPdfRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.common.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/common/src/main/java/stirling/software/common/model/api/security/RedactionArea.java
+++ b/common/src/main/java/stirling/software/common/model/api/security/RedactionArea.java
@@ -1,7 +1,6 @@
 package stirling.software.common.model.api.security;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/common/src/main/java/stirling/software/common/model/enumeration/Role.java
+++ b/common/src/main/java/stirling/software/common/model/enumeration/Role.java
@@ -2,7 +2,6 @@ package stirling.software.common.model.enumeration;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/common/src/main/java/stirling/software/common/model/oauth2/GitHubProvider.java
+++ b/common/src/main/java/stirling/software/common/model/oauth2/GitHubProvider.java
@@ -2,9 +2,7 @@ package stirling.software.common.model.oauth2;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
 import lombok.NoArgsConstructor;
-
 import stirling.software.common.model.enumeration.UsernameAttribute;
 
 @NoArgsConstructor

--- a/common/src/main/java/stirling/software/common/model/oauth2/GoogleProvider.java
+++ b/common/src/main/java/stirling/software/common/model/oauth2/GoogleProvider.java
@@ -2,9 +2,7 @@ package stirling.software.common.model.oauth2;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
 import lombok.NoArgsConstructor;
-
 import stirling.software.common.model.enumeration.UsernameAttribute;
 
 @NoArgsConstructor

--- a/common/src/main/java/stirling/software/common/model/oauth2/KeycloakProvider.java
+++ b/common/src/main/java/stirling/software/common/model/oauth2/KeycloakProvider.java
@@ -2,9 +2,7 @@ package stirling.software.common.model.oauth2;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
 import lombok.NoArgsConstructor;
-
 import stirling.software.common.model.enumeration.UsernameAttribute;
 
 @NoArgsConstructor

--- a/common/src/main/java/stirling/software/common/model/oauth2/Provider.java
+++ b/common/src/main/java/stirling/software/common/model/oauth2/Provider.java
@@ -5,10 +5,8 @@ import static stirling.software.common.model.enumeration.UsernameAttribute.EMAIL
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import stirling.software.common.model.enumeration.UsernameAttribute;
 import stirling.software.common.model.exception.UnsupportedClaimException;
 

--- a/common/src/main/java/stirling/software/common/service/CustomPDFDocumentFactory.java
+++ b/common/src/main/java/stirling/software/common/service/CustomPDFDocumentFactory.java
@@ -8,7 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.concurrent.atomic.AtomicLong;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.examples.util.DeletingRandomAccessFile;
 import org.apache.pdfbox.io.IOUtils;
@@ -18,10 +19,6 @@ import org.apache.pdfbox.io.ScratchFile;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.api.PDFFile;
 
 /**

--- a/common/src/main/java/stirling/software/common/service/PdfMetadataService.java
+++ b/common/src/main/java/stirling/software/common/service/PdfMetadataService.java
@@ -1,12 +1,10 @@
 package stirling.software.common.service;
 
 import java.util.Calendar;
-
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.PdfMetadata;
 

--- a/common/src/main/java/stirling/software/common/service/PostHogService.java
+++ b/common/src/main/java/stirling/software/common/service/PostHogService.java
@@ -1,5 +1,6 @@
 package stirling.software.common.service;
 
+import com.posthog.java.PostHog;
 import java.io.File;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
@@ -16,15 +17,11 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
-
-import com.posthog.java.PostHog;
-
 import stirling.software.common.model.ApplicationProperties;
 
 @Service

--- a/common/src/main/java/stirling/software/common/util/CheckProgramInstall.java
+++ b/common/src/main/java/stirling/software/common/util/CheckProgramInstall.java
@@ -3,7 +3,6 @@ package stirling.software.common.util;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-
 import stirling.software.common.util.ProcessExecutor.ProcessExecutorResult;
 
 public class CheckProgramInstall {

--- a/common/src/main/java/stirling/software/common/util/EmlToPdf.java
+++ b/common/src/main/java/stirling/software/common/util/EmlToPdf.java
@@ -19,7 +19,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
+import lombok.Data;
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -35,11 +38,6 @@ import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceStream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import lombok.Data;
-import lombok.Getter;
-import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 import stirling.software.common.model.api.converters.EmlToPdfRequest;
 
 @Slf4j
@@ -49,7 +47,8 @@ public class EmlToPdf {
     private static final class StyleConstants {
         // Font and layout constants
         static final int DEFAULT_FONT_SIZE = 12;
-        static final String DEFAULT_FONT_FAMILY = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
+        static final String DEFAULT_FONT_FAMILY =
+                "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
         static final float DEFAULT_LINE_HEIGHT = 1.4f;
         static final String DEFAULT_ZOOM = "1.0";
 
@@ -76,7 +75,8 @@ public class EmlToPdf {
     }
 
     private static final class MimeConstants {
-        static final Pattern MIME_ENCODED_PATTERN = Pattern.compile("=\\?([^?]+)\\?([BbQq])\\?([^?]*)\\?=");
+        static final Pattern MIME_ENCODED_PATTERN =
+                Pattern.compile("=\\?([^?]+)\\?([BbQq])\\?([^?]*)\\?=");
         static final String PAPERCLIP_EMOJI = "\uD83D\uDCCE"; // 📎
         static final String ATTACHMENT_ICON_PLACEHOLDER = "icon";
 
@@ -113,7 +113,8 @@ public class EmlToPdf {
         return jakartaMailAvailable;
     }
 
-    public static String convertEmlToHtml(byte[] emlBytes, EmlToPdfRequest request) throws IOException {
+    public static String convertEmlToHtml(byte[] emlBytes, EmlToPdfRequest request)
+            throws IOException {
         validateEmlInput(emlBytes);
 
         if (isJakartaMailAvailable()) {
@@ -147,11 +148,14 @@ public class EmlToPdf {
             }
 
             // Convert HTML to PDF
-            byte[] pdfBytes = convertHtmlToPdf(weasyprintPath, request, htmlContent, disableSanitize);
+            byte[] pdfBytes =
+                    convertHtmlToPdf(weasyprintPath, request, htmlContent, disableSanitize);
 
             // Attach files if available and requested
             if (shouldAttachFiles(emailContent, request)) {
-                pdfBytes = attachFilesToPdf(pdfBytes, emailContent.getAttachments(), pdfDocumentFactory);
+                pdfBytes =
+                        attachFilesToPdf(
+                                pdfBytes, emailContent.getAttachments(), pdfDocumentFactory);
             }
 
             return pdfBytes;
@@ -177,16 +181,20 @@ public class EmlToPdf {
 
     private static boolean shouldAttachFiles(EmailContent emailContent, EmlToPdfRequest request) {
         return emailContent != null
-            && request != null
-            && request.isIncludeAttachments()
-            && !emailContent.getAttachments().isEmpty();
+                && request != null
+                && request.isIncludeAttachments()
+                && !emailContent.getAttachments().isEmpty();
     }
 
-    private static byte[] convertHtmlToPdf(String weasyprintPath, EmlToPdfRequest request,
-                                         String htmlContent, boolean disableSanitize)
+    private static byte[] convertHtmlToPdf(
+            String weasyprintPath,
+            EmlToPdfRequest request,
+            String htmlContent,
+            boolean disableSanitize)
             throws IOException, InterruptedException {
 
-        stirling.software.common.model.api.converters.HTMLToPdfRequest htmlRequest = createHtmlRequest(request);
+        stirling.software.common.model.api.converters.HTMLToPdfRequest htmlRequest =
+                createHtmlRequest(request);
 
         try {
             return FileToPdf.convertHtmlToPdf(
@@ -218,8 +226,7 @@ public class EmlToPdf {
         return "attachment_" + filename.hashCode() + "_" + System.nanoTime();
     }
 
-    private static String convertEmlToHtmlBasic(
-            byte[] emlBytes, EmlToPdfRequest request) {
+    private static String convertEmlToHtmlBasic(byte[] emlBytes, EmlToPdfRequest request) {
         if (emlBytes == null || emlBytes.length == 0) {
             throw new IllegalArgumentException("EML file is empty or null");
         }
@@ -335,7 +342,6 @@ public class EmlToPdf {
             Object message =
                     mimeMessageConstructor.newInstance(session, new ByteArrayInputStream(emlBytes));
 
-
             return extractEmailContentAdvanced(message, request);
 
         } catch (ReflectiveOperationException e) {
@@ -346,8 +352,7 @@ public class EmlToPdf {
         }
     }
 
-    private static String convertEmlToHtmlAdvanced(
-            byte[] emlBytes, EmlToPdfRequest request) {
+    private static String convertEmlToHtmlAdvanced(byte[] emlBytes, EmlToPdfRequest request) {
         EmailContent content = extractEmailContentAdvanced(emlBytes, request);
         return generateEnhancedEmailHtml(content, request);
     }
@@ -479,8 +484,12 @@ public class EmlToPdf {
         // Create attachment info with paperclip emoji before filename
         attachmentInfo
                 .append("<div class=\"attachment-item\">")
-                .append("<span class=\"attachment-icon\">").append(MimeConstants.ATTACHMENT_ICON_PLACEHOLDER).append("</span> ")
-                .append("<span class=\"attachment-name\">").append(escapeHtml(filename)).append("</span>");
+                .append("<span class=\"attachment-icon\">")
+                .append(MimeConstants.ATTACHMENT_ICON_PLACEHOLDER)
+                .append("</span> ")
+                .append("<span class=\"attachment-name\">")
+                .append(escapeHtml(filename))
+                .append("</span>");
 
         // Add content type and encoding info
         if (!contentType.isEmpty() || !encoding.isEmpty()) {
@@ -503,17 +512,20 @@ public class EmlToPdf {
             String content = new String(emlBytes, 0, checkLength, StandardCharsets.UTF_8);
             String lowerContent = content.toLowerCase();
 
-            boolean hasFrom = lowerContent.contains("from:") || lowerContent.contains("return-path:");
+            boolean hasFrom =
+                    lowerContent.contains("from:") || lowerContent.contains("return-path:");
             boolean hasSubject = lowerContent.contains("subject:");
             boolean hasMessageId = lowerContent.contains("message-id:");
             boolean hasDate = lowerContent.contains("date:");
-            boolean hasTo = lowerContent.contains("to:")
-                    || lowerContent.contains("cc:")
-                    || lowerContent.contains("bcc:");
-            boolean hasMimeStructure = lowerContent.contains("multipart/")
-                    || lowerContent.contains("text/plain")
-                    || lowerContent.contains("text/html")
-                    || lowerContent.contains("boundary=");
+            boolean hasTo =
+                    lowerContent.contains("to:")
+                            || lowerContent.contains("cc:")
+                            || lowerContent.contains("bcc:");
+            boolean hasMimeStructure =
+                    lowerContent.contains("multipart/")
+                            || lowerContent.contains("text/plain")
+                            || lowerContent.contains("text/html")
+                            || lowerContent.contains("boundary=");
 
             int headerCount = 0;
             if (hasFrom) headerCount++;
@@ -684,17 +696,19 @@ public class EmlToPdf {
         html.append("  font-size: ").append(fontSize - 1).append("px;\n");
         html.append("}\n\n");
 
-
         html.append(".email-body {\n");
         html.append("  word-wrap: break-word;\n");
         html.append("}\n\n");
 
-
         html.append(".attachment-section {\n");
         html.append("  margin-top: 15px;\n");
         html.append("  padding: 10px;\n");
-        html.append("  background-color: ").append(StyleConstants.ATTACHMENT_BACKGROUND_COLOR).append(";\n");
-        html.append("  border: 1px solid ").append(StyleConstants.ATTACHMENT_BORDER_COLOR).append(";\n");
+        html.append("  background-color: ")
+                .append(StyleConstants.ATTACHMENT_BACKGROUND_COLOR)
+                .append(";\n");
+        html.append("  border: 1px solid ")
+                .append(StyleConstants.ATTACHMENT_BORDER_COLOR)
+                .append(";\n");
         html.append("  border-radius: 3px;\n");
         html.append("}\n\n");
         html.append(".attachment-section h3 {\n");
@@ -745,7 +759,6 @@ public class EmlToPdf {
         html.append("  font-style: italic;\n");
         html.append("  margin-left: 8px;\n");
         html.append("}\n\n");
-
 
         // Basic image styling: ensure images are responsive but not overly constrained.
         html.append("img {\n");
@@ -801,7 +814,9 @@ public class EmlToPdf {
             java.lang.reflect.Method getAllRecipients = messageClass.getMethod("getAllRecipients");
             Object[] recipients = (Object[]) getAllRecipients.invoke(message);
             content.setTo(
-                    recipients != null && recipients.length > 0 ? safeMimeDecode(recipients[0].toString()) : "");
+                    recipients != null && recipients.length > 0
+                            ? safeMimeDecode(recipients[0].toString())
+                            : "");
 
             java.lang.reflect.Method getSentDate = messageClass.getMethod("getSentDate");
             content.setDate((Date) getSentDate.invoke(message));
@@ -908,13 +923,14 @@ public class EmlToPdf {
                                 try {
                                     attachmentData = inputStream.readAllBytes();
                                 } catch (IOException e) {
-                                    log.warn("Failed to read InputStream attachment: {}", e.getMessage());
+                                    log.warn(
+                                            "Failed to read InputStream attachment: {}",
+                                            e.getMessage());
                                 }
                             } else if (attachmentContent instanceof byte[] byteArray) {
                                 attachmentData = byteArray;
                             } else if (attachmentContent instanceof String stringContent) {
-                                attachmentData =
-                                        stringContent.getBytes(StandardCharsets.UTF_8);
+                                attachmentData = stringContent.getBytes(StandardCharsets.UTF_8);
                             }
 
                             if (attachmentData != null) {
@@ -974,7 +990,9 @@ public class EmlToPdf {
         html.append("<div><strong>From:</strong> ")
                 .append(escapeHtml(content.getFrom()))
                 .append("</div>\n");
-        html.append("<div><strong>To:</strong> ").append(escapeHtml(content.getTo())).append("</div>\n");
+        html.append("<div><strong>To:</strong> ")
+                .append(escapeHtml(content.getTo()))
+                .append("</div>\n");
 
         if (content.getDate() != null) {
             html.append("<div><strong>Date:</strong> ")
@@ -1014,15 +1032,20 @@ public class EmlToPdf {
                                     ? attachment.getEmbeddedFilename()
                                     : attachment.getFilename());
 
-                    html.append("<div class=\"attachment-item\" id=\"").append(uniqueId).append("\">")
-                            .append("<span class=\"attachment-icon\">").append(MimeConstants.PAPERCLIP_EMOJI).append("</span> ")
+                    html.append("<div class=\"attachment-item\" id=\"")
+                            .append(uniqueId)
+                            .append("\">")
+                            .append("<span class=\"attachment-icon\">")
+                            .append(MimeConstants.PAPERCLIP_EMOJI)
+                            .append("</span> ")
                             .append("<span class=\"attachment-name\">")
                             .append(escapeHtml(safeMimeDecode(attachment.getFilename())))
                             .append("</span>");
 
                     String sizeStr = formatFileSize(attachment.getSizeBytes());
                     html.append(" <span class=\"attachment-details\">(").append(sizeStr);
-                    if (attachment.getContentType() != null && !attachment.getContentType().isEmpty()) {
+                    if (attachment.getContentType() != null
+                            && !attachment.getContentType().isEmpty()) {
                         html.append(", ").append(escapeHtml(attachment.getContentType()));
                     }
                     html.append(")</span></div>\n");
@@ -1031,8 +1054,7 @@ public class EmlToPdf {
 
             if (request.isIncludeAttachments()) {
                 html.append("<div class=\"attachment-info-note\">\n");
-                html.append(
-                        "<p><em>Attachments are embedded in the file.</em></p>\n");
+                html.append("<p><em>Attachments are embedded in the file.</em></p>\n");
                 html.append("</div>\n");
             } else {
                 html.append("<div class=\"attachment-info-note\">\n");
@@ -1050,7 +1072,10 @@ public class EmlToPdf {
         return html.toString();
     }
 
-    private static byte[] attachFilesToPdf(byte[] pdfBytes, List<EmailAttachment> attachments, stirling.software.common.service.CustomPDFDocumentFactory pdfDocumentFactory)
+    private static byte[] attachFilesToPdf(
+            byte[] pdfBytes,
+            List<EmailAttachment> attachments,
+            stirling.software.common.service.CustomPDFDocumentFactory pdfDocumentFactory)
             throws IOException {
         try (PDDocument document = pdfDocumentFactory.load(pdfBytes);
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
@@ -1104,7 +1129,8 @@ public class EmlToPdf {
 
                     // Create embedded file
                     PDEmbeddedFile embeddedFile =
-                            new PDEmbeddedFile(document, new ByteArrayInputStream(attachment.getData()));
+                            new PDEmbeddedFile(
+                                    document, new ByteArrayInputStream(attachment.getData()));
                     embeddedFile.setSize(attachment.getData().length);
                     embeddedFile.setCreationDate(new GregorianCalendar());
                     if (attachment.getContentType() != null) {
@@ -1150,11 +1176,13 @@ public class EmlToPdf {
         }
     }
 
-    private static String getUniqueFilename(String filename, List<String> embeddedFiles, Map<String, PDComplexFileSpecification> efMap) {
+    private static String getUniqueFilename(
+            String filename,
+            List<String> embeddedFiles,
+            Map<String, PDComplexFileSpecification> efMap) {
         String uniqueFilename = filename;
         int counter = 1;
-        while (embeddedFiles.contains(uniqueFilename)
-                || efMap.containsKey(uniqueFilename)) {
+        while (embeddedFiles.contains(uniqueFilename) || efMap.containsKey(uniqueFilename)) {
             String extension = "";
             String baseName = filename;
             int lastDot = filename.lastIndexOf('.');
@@ -1203,8 +1231,8 @@ public class EmlToPdf {
     }
 
     private static void addAttachmentAnnotationToPage(
-        PDDocument document, PDPage page, EmailAttachment attachment, float x, float y)
-        throws IOException {
+            PDDocument document, PDPage page, EmailAttachment attachment, float x, float y)
+            throws IOException {
 
         PDAnnotationFileAttachment fileAnnotation = new PDAnnotationFileAttachment();
 
@@ -1226,11 +1254,12 @@ public class EmlToPdf {
 
         // Set invisibility flags but keep it functional
         fileAnnotation.setInvisible(true);
-        fileAnnotation.setHidden(false);  // Must be false to remain clickable
-        fileAnnotation.setNoView(false);  // Must be false to remain clickable
+        fileAnnotation.setHidden(false); // Must be false to remain clickable
+        fileAnnotation.setNoView(false); // Must be false to remain clickable
         fileAnnotation.setPrinted(false);
 
-        PDEmbeddedFilesNameTreeNode efTree = document.getDocumentCatalog().getNames().getEmbeddedFiles();
+        PDEmbeddedFilesNameTreeNode efTree =
+                document.getDocumentCatalog().getNames().getEmbeddedFiles();
         if (efTree != null) {
             Map<String, PDComplexFileSpecification> efMap = efTree.getNames();
             if (efMap != null) {
@@ -1246,24 +1275,27 @@ public class EmlToPdf {
 
         page.getAnnotations().add(fileAnnotation);
 
-        log.info("Added attachment annotation for '{}' on page {}",
-            attachment.getFilename(), document.getPages().indexOf(page) + 1);
+        log.info(
+                "Added attachment annotation for '{}' on page {}",
+                attachment.getFilename(),
+                document.getPages().indexOf(page) + 1);
     }
 
     private static @NotNull PDRectangle getPdRectangle(PDPage page, float x, float y) {
         PDRectangle mediaBox = page.getMediaBox();
         float pdfY = mediaBox.getHeight() - y;
 
-        float iconWidth = StyleConstants.ATTACHMENT_ICON_WIDTH;  // Keep original size for clickability
-        float iconHeight = StyleConstants.ATTACHMENT_ICON_HEIGHT; // Keep original size for clickability
+        float iconWidth =
+                StyleConstants.ATTACHMENT_ICON_WIDTH; // Keep original size for clickability
+        float iconHeight =
+                StyleConstants.ATTACHMENT_ICON_HEIGHT; // Keep original size for clickability
 
         // Keep the full-size rectangle so it remains clickable
         return new PDRectangle(
-            x + StyleConstants.ANNOTATION_X_OFFSET,
-            pdfY - iconHeight + StyleConstants.ANNOTATION_Y_OFFSET,
-            iconWidth,
-            iconHeight
-        );
+                x + StyleConstants.ANNOTATION_X_OFFSET,
+                pdfY - iconHeight + StyleConstants.ANNOTATION_Y_OFFSET,
+                iconWidth,
+                iconHeight);
     }
 
     private static String formatEmailDate(Date date) {
@@ -1293,23 +1325,27 @@ public class EmlToPdf {
                 COSDictionary catalogDict = catalog.getCOSObject();
 
                 // Set PageMode to UseAttachments - this is the standard PDF specification approach
-                // PageMode values: UseNone, UseOutlines, UseThumbs, FullScreen, UseOC, UseAttachments
+                // PageMode values: UseNone, UseOutlines, UseThumbs, FullScreen, UseOC,
+                // UseAttachments
                 catalogDict.setName(COSName.PAGE_MODE, "UseAttachments");
 
                 // Also set viewer preferences for better attachment viewing experience
-                COSDictionary viewerPrefs = (COSDictionary) catalogDict.getDictionaryObject(COSName.VIEWER_PREFERENCES);
+                COSDictionary viewerPrefs =
+                        (COSDictionary) catalogDict.getDictionaryObject(COSName.VIEWER_PREFERENCES);
                 if (viewerPrefs == null) {
                     viewerPrefs = new COSDictionary();
                     catalogDict.setItem(COSName.VIEWER_PREFERENCES, viewerPrefs);
                 }
 
-                // Set NonFullScreenPageMode to UseAttachments as fallback for viewers that support it
+                // Set NonFullScreenPageMode to UseAttachments as fallback for viewers that support
+                // it
                 viewerPrefs.setName(COSName.getPDFName("NonFullScreenPageMode"), "UseAttachments");
 
                 // Additional viewer preferences that may help with attachment display
                 viewerPrefs.setBoolean(COSName.getPDFName("DisplayDocTitle"), true);
 
-                log.info("Set PDF PageMode to UseAttachments to automatically show attachments pane");
+                log.info(
+                        "Set PDF PageMode to UseAttachments to automatically show attachments pane");
             }
         } catch (Exception e) {
             // Log warning but don't fail the entire operation for viewer preferences
@@ -1391,7 +1427,7 @@ public class EmlToPdf {
                     }
                 }
                 case '_' -> // In RFC 2047, underscore represents space
-                    result.append(' ');
+                        result.append(' ');
                 default -> result.append(c);
             }
         }
@@ -1464,8 +1500,7 @@ public class EmlToPdf {
         private float y;
         private String character;
 
-        public EmojiPosition() {
-        }
+        public EmojiPosition() {}
 
         public EmojiPosition(int pageIndex, float x, float y, String character) {
             this.pageIndex = pageIndex;
@@ -1475,9 +1510,8 @@ public class EmlToPdf {
         }
     }
 
-     public static class EmojiPositionFinder extends org.apache.pdfbox.text.PDFTextStripper {
-        @Getter
-        private final List<EmojiPosition> positions = new ArrayList<>();
+    public static class EmojiPositionFinder extends org.apache.pdfbox.text.PDFTextStripper {
+        @Getter private final List<EmojiPosition> positions = new ArrayList<>();
         private int currentPageIndex;
         private boolean sortByPosition;
         private boolean isInAttachmentSection;
@@ -1503,7 +1537,9 @@ public class EmlToPdf {
         }
 
         @Override
-        protected void writeString(String string, List<org.apache.pdfbox.text.TextPosition> textPositions) throws IOException {
+        protected void writeString(
+                String string, List<org.apache.pdfbox.text.TextPosition> textPositions)
+                throws IOException {
             // Check if we are entering or exiting the attachment section
             String lowerString = string.toLowerCase();
 
@@ -1513,10 +1549,14 @@ public class EmlToPdf {
                 attachmentSectionFound = true;
             }
 
-            // Look for attachment section end markers (common patterns that indicate end of attachments)
-            if (isInAttachmentSection && (lowerString.contains("</body>") ||
-                                         lowerString.contains("</html>") ||
-                                         (attachmentSectionFound && lowerString.trim().isEmpty() && string.length() > 50))) {
+            // Look for attachment section end markers (common patterns that indicate end of
+            // attachments)
+            if (isInAttachmentSection
+                    && (lowerString.contains("</body>")
+                            || lowerString.contains("</html>")
+                            || (attachmentSectionFound
+                                    && lowerString.trim().isEmpty()
+                                    && string.length() > 50))) {
                 isInAttachmentSection = false;
             }
 
@@ -1527,17 +1567,17 @@ public class EmlToPdf {
 
                 for (int i = 0; i < string.length(); i++) {
                     // Check if we have a complete paperclip emoji at this position
-                    if (i < string.length() - 1 &&
-                        string.substring(i, i + 2).equals(paperclipEmoji) &&
-                        i < textPositions.size()) {
+                    if (i < string.length() - 1
+                            && string.substring(i, i + 2).equals(paperclipEmoji)
+                            && i < textPositions.size()) {
 
                         org.apache.pdfbox.text.TextPosition textPosition = textPositions.get(i);
-                        EmojiPosition position = new EmojiPosition(
-                            currentPageIndex,
-                            textPosition.getXDirAdj(),
-                            textPosition.getYDirAdj(),
-                            paperclipEmoji
-                        );
+                        EmojiPosition position =
+                                new EmojiPosition(
+                                        currentPageIndex,
+                                        textPosition.getXDirAdj(),
+                                        textPosition.getYDirAdj(),
+                                        paperclipEmoji);
                         positions.add(position);
                     }
                 }
@@ -1553,7 +1593,6 @@ public class EmlToPdf {
         public boolean isSortByPosition() {
             return sortByPosition;
         }
-
 
         public void reset() {
             positions.clear();

--- a/common/src/main/java/stirling/software/common/util/ErrorUtils.java
+++ b/common/src/main/java/stirling/software/common/util/ErrorUtils.java
@@ -2,7 +2,6 @@ package stirling.software.common.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-
 import org.springframework.ui.Model;
 import org.springframework.web.servlet.ModelAndView;
 

--- a/common/src/main/java/stirling/software/common/util/FileMonitor.java
+++ b/common/src/main/java/stirling/software/common/util/FileMonitor.java
@@ -11,13 +11,10 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.configuration.RuntimePathConfig;
 
 @Component

--- a/common/src/main/java/stirling/software/common/util/FileToPdf.java
+++ b/common/src/main/java/stirling/software/common/util/FileToPdf.java
@@ -1,5 +1,6 @@
 package stirling.software.common.util;
 
+import io.github.pixee.security.ZipSecurity;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
@@ -13,9 +14,6 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
-
-import io.github.pixee.security.ZipSecurity;
-
 import stirling.software.common.model.api.converters.HTMLToPdfRequest;
 import stirling.software.common.util.ProcessExecutor.ProcessExecutorResult;
 

--- a/common/src/main/java/stirling/software/common/util/ImageProcessingUtils.java
+++ b/common/src/main/java/stirling/software/common/util/ImageProcessingUtils.java
@@ -1,22 +1,18 @@
 package stirling.software.common.util;
 
-import java.awt.geom.AffineTransform;
-import java.awt.image.*;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-
-import javax.imageio.ImageIO;
-
-import org.springframework.web.multipart.MultipartFile;
-
 import com.drew.imaging.ImageMetadataReader;
 import com.drew.imaging.ImageProcessingException;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.MetadataException;
 import com.drew.metadata.exif.ExifSubIFDDirectory;
-
+import java.awt.geom.AffineTransform;
+import java.awt.image.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 public class ImageProcessingUtils {

--- a/common/src/main/java/stirling/software/common/util/PDFToFile.java
+++ b/common/src/main/java/stirling/software/common/util/PDFToFile.java
@@ -1,5 +1,8 @@
 package stirling.software.common.util;
 
+import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import io.github.pixee.security.Filenames;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -12,22 +15,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
-import com.vladsch.flexmark.util.data.MutableDataSet;
-
-import io.github.pixee.security.Filenames;
-
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.util.ProcessExecutor.ProcessExecutorResult;
 
 @Slf4j

--- a/common/src/main/java/stirling/software/common/util/PdfUtils.java
+++ b/common/src/main/java/stirling/software/common/util/PdfUtils.java
@@ -1,5 +1,6 @@
 package stirling.software.common.util;
 
+import io.github.pixee.security.Filenames;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
@@ -10,10 +11,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.imageio.*;
 import javax.imageio.stream.ImageOutputStream;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -30,11 +30,6 @@ import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.service.CustomPDFDocumentFactory;
 
 @Slf4j

--- a/common/src/main/java/stirling/software/common/util/ProcessExecutor.java
+++ b/common/src/main/java/stirling/software/common/util/ProcessExecutor.java
@@ -1,5 +1,6 @@
 package stirling.software.common.util;
 
+import io.github.pixee.security.BoundedLineReader;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -12,11 +13,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-
-import io.github.pixee.security.BoundedLineReader;
-
 import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 
 @Slf4j

--- a/common/src/main/java/stirling/software/common/util/UrlUtils.java
+++ b/common/src/main/java/stirling/software/common/util/UrlUtils.java
@@ -1,9 +1,8 @@
 package stirling.software.common.util;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.ServerSocket;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 public class UrlUtils {
 

--- a/common/src/main/java/stirling/software/common/util/WebResponseUtils.java
+++ b/common/src/main/java/stirling/software/common/util/WebResponseUtils.java
@@ -1,18 +1,16 @@
 package stirling.software.common.util;
 
+import io.github.pixee.security.Filenames;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
 
 public class WebResponseUtils {
 

--- a/common/src/main/java/stirling/software/common/util/misc/CustomColorReplaceStrategy.java
+++ b/common/src/main/java/stirling/software/common/util/misc/CustomColorReplaceStrategy.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -21,9 +21,6 @@ import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.pdfbox.text.TextPosition;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.web.multipart.MultipartFile;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.api.misc.HighContrastColorCombination;
 import stirling.software.common.model.api.misc.ReplaceAndInvert;
 

--- a/common/src/main/java/stirling/software/common/util/misc/InvertFullColorStrategy.java
+++ b/common/src/main/java/stirling/software/common/util/misc/InvertFullColorStrategy.java
@@ -7,9 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-
 import javax.imageio.ImageIO;
-
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -18,7 +16,6 @@ import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.web.multipart.MultipartFile;
-
 import stirling.software.common.model.api.misc.ReplaceAndInvert;
 
 public class InvertFullColorStrategy extends ReplaceAndInvertColorStrategy {

--- a/common/src/main/java/stirling/software/common/util/misc/PdfTextStripperCustom.java
+++ b/common/src/main/java/stirling/software/common/util/misc/PdfTextStripperCustom.java
@@ -3,7 +3,6 @@ package stirling.software.common.util.misc;
 import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 import java.util.List;
-
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.text.PDFTextStripperByArea;
 import org.apache.pdfbox.text.TextPosition;

--- a/common/src/main/java/stirling/software/common/util/misc/ReplaceAndInvertColorStrategy.java
+++ b/common/src/main/java/stirling/software/common/util/misc/ReplaceAndInvertColorStrategy.java
@@ -1,13 +1,10 @@
 package stirling.software.common.util.misc;
 
 import java.io.IOException;
-
-import org.springframework.core.io.InputStreamResource;
-import org.springframework.web.multipart.MultipartFile;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.web.multipart.MultipartFile;
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.model.api.misc.ReplaceAndInvert;
 

--- a/common/src/main/java/stirling/software/common/util/propertyeditor/StringToArrayListPropertyEditor.java
+++ b/common/src/main/java/stirling/software/common/util/propertyeditor/StringToArrayListPropertyEditor.java
@@ -1,15 +1,12 @@
 package stirling.software.common.util.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import java.beans.PropertyEditorSupport;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.api.security.RedactionArea;
 
 @Slf4j

--- a/common/src/main/java/stirling/software/common/util/propertyeditor/StringToMapPropertyEditor.java
+++ b/common/src/main/java/stirling/software/common/util/propertyeditor/StringToMapPropertyEditor.java
@@ -1,11 +1,10 @@
 package stirling.software.common.util.propertyeditor;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.beans.PropertyEditorSupport;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class StringToMapPropertyEditor extends PropertyEditorSupport {
 

--- a/proprietary/build.gradle
+++ b/proprietary/build.gradle
@@ -4,6 +4,12 @@ repositories {
 bootRun {
     enabled = false
 }
+spotless {
+    java {
+        target sourceSets.main.allJava
+        googleJavaFormat(googleJavaFormatVersion).aosp()
+    }
+}
 dependencies {
     implementation project(':common')
 

--- a/proprietary/src/main/java/stirling/software/proprietary/model/Team.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/model/Team.java
@@ -1,13 +1,10 @@
 package stirling.software.proprietary.model;
 
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-
-import jakarta.persistence.*;
-
 import lombok.*;
-
 import stirling.software.proprietary.security.model.User;
 
 @Entity

--- a/proprietary/src/main/java/stirling/software/proprietary/model/dto/TeamWithUserCountDTO.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/model/dto/TeamWithUserCountDTO.java
@@ -1,6 +1,5 @@
 package stirling.software.proprietary.model.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/CustomAuthenticationFailureHandler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/CustomAuthenticationFailureHandler.java
@@ -1,8 +1,11 @@
 package stirling.software.proprietary.security;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
@@ -10,13 +13,6 @@ import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.service.LoginAttemptService;
 import stirling.software.proprietary.security.service.UserService;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/CustomAuthenticationSuccessHandler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/CustomAuthenticationSuccessHandler.java
@@ -1,18 +1,14 @@
 package stirling.software.proprietary.security;
 
-import java.io.IOException;
-
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
-import org.springframework.security.web.savedrequest.SavedRequest;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.SavedRequest;
 import stirling.software.common.util.RequestUriUtils;
 import stirling.software.proprietary.security.service.LoginAttemptService;
 import stirling.software.proprietary.security.service.UserService;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/CustomLogoutSuccessHandler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/CustomLogoutSuccessHandler.java
@@ -1,27 +1,22 @@
 package stirling.software.proprietary.security;
 
+import com.coveo.saml.SamlClient;
+import com.coveo.saml.SamlException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.ArrayList;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
-
-import com.coveo.saml.SamlClient;
-import com.coveo.saml.SamlException;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.configuration.AppConfig;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security.OAUTH2;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/InitialSecuritySetup.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/InitialSecuritySetup.java
@@ -1,17 +1,13 @@
 package stirling.software.proprietary.security;
 
+import jakarta.annotation.PostConstruct;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import org.springframework.stereotype.Component;
-
-import jakarta.annotation.PostConstruct;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.stereotype.Component;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.common.model.exception.UnsupportedProviderException;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/RateLimitResetScheduler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/RateLimitResetScheduler.java
@@ -1,10 +1,8 @@
 package stirling.software.proprietary.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.proprietary.security.filter.IPRateLimitingFilter;
 
 @Component

--- a/proprietary/src/main/java/stirling/software/proprietary/security/config/AccountWebController.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/config/AccountWebController.java
@@ -2,6 +2,10 @@ package stirling.software.proprietary.security.config;
 
 import static stirling.software.common.util.ProviderUtils.validateProvider;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -10,7 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -19,16 +23,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import jakarta.servlet.http.HttpServletRequest;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security;
 import stirling.software.common.model.ApplicationProperties.Security.OAUTH2;
@@ -239,7 +233,8 @@ public class AccountWebController {
                 }
 
                 // Also check if user is part of the Internal team
-                if (user.getTeam() != null && user.getTeam().getName().equals(TeamService.INTERNAL_TEAM_NAME)) {
+                if (user.getTeam() != null
+                        && user.getTeam().getName().equals(TeamService.INTERNAL_TEAM_NAME)) {
                     shouldRemove = true;
                 }
 
@@ -351,10 +346,16 @@ public class AccountWebController {
         model.addAttribute("disabledUsers", disabledUsers);
 
         // Get all teams but filter out the Internal team
-        List<Team> allTeams = teamRepository.findAll()
-                .stream()
-                .filter(team -> !team.getName().equals(stirling.software.proprietary.security.service.TeamService.INTERNAL_TEAM_NAME))
-                .toList();
+        List<Team> allTeams =
+                teamRepository.findAll().stream()
+                        .filter(
+                                team ->
+                                        !team.getName()
+                                                .equals(
+                                                        stirling.software.proprietary.security
+                                                                .service.TeamService
+                                                                .INTERNAL_TEAM_NAME))
+                        .toList();
         model.addAttribute("teams", allTeams);
 
         model.addAttribute("maxPaidUsers", applicationProperties.getPremium().getMaxUsers());

--- a/proprietary/src/main/java/stirling/software/proprietary/security/configuration/DatabaseConfig.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/configuration/DatabaseConfig.java
@@ -1,7 +1,8 @@
 package stirling.software.proprietary.security.configuration;
 
 import javax.sql.DataSource;
-
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -11,10 +12,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.configuration.InstallationPathConfig;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.exception.UnsupportedProviderException;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/configuration/MailConfig.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/configuration/MailConfig.java
@@ -1,16 +1,13 @@
 package stirling.software.proprietary.security.configuration;
 
 import java.util.Properties;
-
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 
 /**

--- a/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
@@ -1,7 +1,7 @@
 package stirling.software.proprietary.security.configuration;
 
 import java.util.Optional;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -27,9 +27,6 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.configuration.AppConfig;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.proprietary.security.CustomAuthenticationFailureHandler;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/KeygenLicenseVerifier.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/KeygenLicenseVerifier.java
@@ -1,24 +1,20 @@
 package stirling.software.proprietary.security.configuration.ee;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.posthog.java.shaded.org.json.JSONException;
+import com.posthog.java.shaded.org.json.JSONObject;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Base64;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
 import org.bouncycastle.util.encoders.Hex;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.posthog.java.shaded.org.json.JSONException;
-import com.posthog.java.shaded.org.json.JSONObject;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.util.GeneralUtils;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/LicenseKeyChecker.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/LicenseKeyChecker.java
@@ -4,12 +4,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.util.GeneralUtils;
 import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVerifier.License;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/DatabaseController.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/DatabaseController.java
@@ -1,12 +1,17 @@
 package stirling.software.proprietary.security.controller.api;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.http.HttpStatus;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.core.io.InputStreamResource;
@@ -18,15 +23,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
-import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.proprietary.security.database.H2SQLCondition;
 import stirling.software.proprietary.security.service.DatabaseService;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/EmailController.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/EmailController.java
@@ -1,5 +1,11 @@
 package stirling.software.proprietary.security.controller.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,16 +14,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import jakarta.mail.MessagingException;
-import jakarta.validation.Valid;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.proprietary.security.model.api.Email;
 import stirling.software.proprietary.security.service.EmailService;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/TeamController.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/TeamController.java
@@ -1,19 +1,14 @@
 package stirling.software.proprietary.security.controller.api;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.transaction.Transactional;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import jakarta.transaction.Transactional;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.proprietary.model.Team;
 import stirling.software.proprietary.security.config.PremiumEndpoint;
 import stirling.software.proprietary.security.database.repository.UserRepository;
@@ -96,12 +91,13 @@ public class TeamController {
     @PostMapping("/addUser")
     @Transactional
     public RedirectView addUserToTeam(
-            @RequestParam("teamId") Long teamId,
-            @RequestParam("userId") Long userId) {
+            @RequestParam("teamId") Long teamId, @RequestParam("userId") Long userId) {
 
         // Find the team
-        Team team = teamRepository.findById(teamId)
-                .orElseThrow(() -> new RuntimeException("Team not found"));
+        Team team =
+                teamRepository
+                        .findById(teamId)
+                        .orElseThrow(() -> new RuntimeException("Team not found"));
 
         // Prevent adding users to the Internal team
         if (team.getName().equals(TeamService.INTERNAL_TEAM_NAME)) {
@@ -109,11 +105,14 @@ public class TeamController {
         }
 
         // Find the user
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new RuntimeException("User not found"));
 
         // Check if user is in the Internal team - prevent moving them
-        if (user.getTeam() != null && user.getTeam().getName().equals(TeamService.INTERNAL_TEAM_NAME)) {
+        if (user.getTeam() != null
+                && user.getTeam().getName().equals(TeamService.INTERNAL_TEAM_NAME)) {
             return new RedirectView("/teams/" + teamId + "?error=cannotMoveInternalUsers");
         }
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
@@ -1,12 +1,17 @@
 package stirling.software.proprietary.security.controller.api;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.security.Principal;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,16 +25,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.RedirectView;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.transaction.Transactional;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.common.model.exception.UnsupportedProviderException;
@@ -57,6 +52,7 @@ public class UserController {
     private final ApplicationProperties applicationProperties;
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
+
     @PreAuthorize("!hasAuthority('ROLE_DEMO_USER')")
     @PostMapping("/register")
     public String register(@ModelAttribute UsernameAndPass requestModel, Model model)
@@ -250,15 +246,18 @@ public class UserController {
         // Use teamId if provided, otherwise use default team
         Long effectiveTeamId = teamId;
         if (effectiveTeamId == null) {
-            Team defaultTeam = teamRepository.findByName(TeamService.DEFAULT_TEAM_NAME).orElse(null);
+            Team defaultTeam =
+                    teamRepository.findByName(TeamService.DEFAULT_TEAM_NAME).orElse(null);
             if (defaultTeam != null) {
                 effectiveTeamId = defaultTeam.getId();
             }
         } else {
             // Check if the selected team is Internal - prevent assigning to it
             Team selectedTeam = teamRepository.findById(effectiveTeamId).orElse(null);
-            if (selectedTeam != null && TeamService.INTERNAL_TEAM_NAME.equals(selectedTeam.getName())) {
-                return new RedirectView("/adminSettings?messageType=internalTeamNotAccessible", true);
+            if (selectedTeam != null
+                    && TeamService.INTERNAL_TEAM_NAME.equals(selectedTeam.getName())) {
+                return new RedirectView(
+                        "/adminSettings?messageType=internalTeamNotAccessible", true);
             }
         }
 
@@ -316,12 +315,15 @@ public class UserController {
             if (team != null) {
                 // Prevent assigning to Internal team
                 if (TeamService.INTERNAL_TEAM_NAME.equals(team.getName())) {
-                    return new RedirectView("/adminSettings?messageType=internalTeamNotAccessible", true);
+                    return new RedirectView(
+                            "/adminSettings?messageType=internalTeamNotAccessible", true);
                 }
 
                 // Prevent moving users from Internal team
-                if (user.getTeam() != null && TeamService.INTERNAL_TEAM_NAME.equals(user.getTeam().getName())) {
-                    return new RedirectView("/adminSettings?messageType=cannotMoveInternalUsers", true);
+                if (user.getTeam() != null
+                        && TeamService.INTERNAL_TEAM_NAME.equals(user.getTeam().getName())) {
+                    return new RedirectView(
+                            "/adminSettings?messageType=cannotMoveInternalUsers", true);
                 }
 
                 user.setTeam(team);

--- a/proprietary/src/main/java/stirling/software/proprietary/security/controller/web/DatabaseWebController.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/controller/web/DatabaseWebController.java
@@ -1,19 +1,14 @@
 package stirling.software.proprietary.security.controller.web;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import jakarta.servlet.http.HttpServletRequest;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.FileInfo;
 import stirling.software.proprietary.security.service.DatabaseService;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/controller/web/TeamWebController.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/controller/web/TeamWebController.java
@@ -4,17 +4,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.proprietary.model.Team;
 import stirling.software.proprietary.model.dto.TeamWithUserCountDTO;
 import stirling.software.proprietary.security.database.repository.SessionRepository;
@@ -40,9 +37,10 @@ public class TeamWebController {
         List<TeamWithUserCountDTO> allTeamsWithCounts = teamRepository.findAllTeamsWithUserCount();
 
         // Filter out the Internal team
-        List<TeamWithUserCountDTO> teamsWithCounts = allTeamsWithCounts.stream()
-                .filter(team -> !team.getName().equals(TeamService.INTERNAL_TEAM_NAME))
-                .toList();
+        List<TeamWithUserCountDTO> teamsWithCounts =
+                allTeamsWithCounts.stream()
+                        .filter(team -> !team.getName().equals(TeamService.INTERNAL_TEAM_NAME))
+                        .toList();
 
         // Get the latest activity for each team
         List<Object[]> teamActivities = sessionRepository.findLatestActivityByTeam();
@@ -66,8 +64,10 @@ public class TeamWebController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String viewTeamDetails(@PathVariable("id") Long id, Model model) {
         // Get the team
-        Team team = teamRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Team not found"));
+        Team team =
+                teamRepository
+                        .findById(id)
+                        .orElseThrow(() -> new RuntimeException("Team not found"));
 
         // Prevent access to Internal team
         if (team.getName().equals(TeamService.INTERNAL_TEAM_NAME)) {
@@ -80,10 +80,19 @@ public class TeamWebController {
         // Get all users not in this team for the Add User to Team dropdown
         // Exclude users that are in the Internal team
         List<User> allUsers = userRepository.findAllWithTeam();
-        List<User> availableUsers = allUsers.stream()
-                .filter(user -> (user.getTeam() == null || !user.getTeam().getId().equals(id)) &&
-                               (user.getTeam() == null || !user.getTeam().getName().equals(TeamService.INTERNAL_TEAM_NAME)))
-                .toList();
+        List<User> availableUsers =
+                allUsers.stream()
+                        .filter(
+                                user ->
+                                        (user.getTeam() == null
+                                                        || !user.getTeam().getId().equals(id))
+                                                && (user.getTeam() == null
+                                                        || !user.getTeam()
+                                                                .getName()
+                                                                .equals(
+                                                                        TeamService
+                                                                                .INTERNAL_TEAM_NAME)))
+                        .toList();
 
         // Get the latest session for each user in the team
         List<Object[]> userSessions = sessionRepository.findLatestSessionByTeamId(id);

--- a/proprietary/src/main/java/stirling/software/proprietary/security/database/ScheduledTasks.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/database/ScheduledTasks.java
@@ -1,13 +1,10 @@
 package stirling.software.proprietary.security.database;
 
 import java.sql.SQLException;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.exception.UnsupportedProviderException;
 import stirling.software.proprietary.security.service.DatabaseServiceInterface;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/AuthorityRepository.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/AuthorityRepository.java
@@ -1,10 +1,8 @@
 package stirling.software.proprietary.security.database.repository;
 
 import java.util.Set;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import stirling.software.proprietary.security.model.Authority;
 
 @Repository

--- a/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/JPATokenRepositoryImpl.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/JPATokenRepositoryImpl.java
@@ -1,11 +1,9 @@
 package stirling.software.proprietary.security.database.repository;
 
 import java.util.Date;
-
 import org.springframework.security.web.authentication.rememberme.PersistentRememberMeToken;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
 import org.springframework.transaction.annotation.Transactional;
-
 import stirling.software.proprietary.security.model.PersistentLogin;
 
 public class JPATokenRepositoryImpl implements PersistentTokenRepository {

--- a/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/PersistentLoginRepository.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/PersistentLoginRepository.java
@@ -2,7 +2,6 @@ package stirling.software.proprietary.security.database.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import stirling.software.proprietary.security.model.PersistentLogin;
 
 @Repository

--- a/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/SessionRepository.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/SessionRepository.java
@@ -1,16 +1,13 @@
 package stirling.software.proprietary.security.database.repository;
 
+import jakarta.transaction.Transactional;
 import java.util.Date;
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import jakarta.transaction.Transactional;
-
 import stirling.software.proprietary.security.model.SessionEntity;
 
 @Repository

--- a/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/UserRepository.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/database/repository/UserRepository.java
@@ -2,12 +2,10 @@ package stirling.software.proprietary.security.database.repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 import stirling.software.proprietary.model.Team;
 import stirling.software.proprietary.security.model.User;
 
@@ -30,7 +28,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "SELECT u FROM User u LEFT JOIN FETCH u.team")
     List<User> findAllWithTeam();
 
-    @Query("SELECT u FROM User u JOIN FETCH u.authorities JOIN FETCH u.team WHERE u.team.id = :teamId")
+    @Query(
+            "SELECT u FROM User u JOIN FETCH u.authorities JOIN FETCH u.team WHERE u.team.id = :teamId")
     List<User> findAllByTeamId(@Param("teamId") Long teamId);
 
     long countByTeam(Team team);

--- a/proprietary/src/main/java/stirling/software/proprietary/security/filter/EnterpriseEndpointFilter.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/filter/EnterpriseEndpointFilter.java
@@ -1,16 +1,14 @@
 package stirling.software.proprietary.security.filter;
 
-import java.io.IOException;
-
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 public class EnterpriseEndpointFilter extends OncePerRequestFilter {

--- a/proprietary/src/main/java/stirling/software/proprietary/security/filter/FirstLoginFilter.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/filter/FirstLoginFilter.java
@@ -1,24 +1,20 @@
 package stirling.software.proprietary.security.filter;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Optional;
-
-import org.springframework.context.annotation.Lazy;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 import stirling.software.common.util.RequestUriUtils;
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.service.UserService;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/filter/IPRateLimitingFilter.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/filter/IPRateLimitingFilter.java
@@ -1,18 +1,15 @@
 package stirling.software.proprietary.security.filter;
 
-import java.io.IOException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
-
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.util.RequestUriUtils;
 
 @RequiredArgsConstructor

--- a/proprietary/src/main/java/stirling/software/proprietary/security/filter/UserAuthenticationFilter.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/filter/UserAuthenticationFilter.java
@@ -1,9 +1,13 @@
 package stirling.software.proprietary.security.filter;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
@@ -16,14 +20,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security.OAUTH2;
 import stirling.software.common.model.ApplicationProperties.Security.SAML2;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/filter/UserBasedRateLimitingFilter.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/filter/UserBasedRateLimitingFilter.java
@@ -1,10 +1,17 @@
 package stirling.software.proprietary.security.filter;
 
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.pixee.security.Newlines;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
@@ -13,17 +20,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import io.github.bucket4j.Bandwidth;
-import io.github.bucket4j.Bucket;
-import io.github.bucket4j.ConsumptionProbe;
-import io.github.pixee.security.Newlines;
-
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import stirling.software.common.model.enumeration.Role;
 
 @Component

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/ApiKeyAuthenticationToken.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/ApiKeyAuthenticationToken.java
@@ -1,7 +1,6 @@
 package stirling.software.proprietary.security.model;
 
 import java.util.Collection;
-
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/Authority.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/Authority.java
@@ -1,7 +1,5 @@
 package stirling.software.proprietary.security.model;
 
-import java.io.Serializable;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -10,7 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
+import java.io.Serializable;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/PersistentLogin.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/PersistentLogin.java
@@ -1,12 +1,10 @@
 package stirling.software.proprietary.security.model;
 
-import java.util.Date;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
+import java.util.Date;
 import lombok.Data;
 
 @Entity

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/SessionEntity.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/SessionEntity.java
@@ -1,12 +1,10 @@
 package stirling.software.proprietary.security.model;
 
-import java.io.Serializable;
-import java.util.Date;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
+import java.io.Serializable;
+import java.util.Date;
 import lombok.Data;
 
 @Entity

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/User.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/User.java
@@ -1,20 +1,17 @@
 package stirling.software.proprietary.security.model;
 
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import jakarta.persistence.*;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.proprietary.model.Team;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/api/Email.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/api/Email.java
@@ -1,13 +1,10 @@
 package stirling.software.proprietary.security.model.api;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import stirling.software.common.model.api.GeneralFile;
 
 @Data

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/UpdateUserDetails.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/UpdateUserDetails.java
@@ -1,7 +1,6 @@
 package stirling.software.proprietary.security.model.api.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/UpdateUserUsername.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/UpdateUserUsername.java
@@ -1,7 +1,6 @@
 package stirling.software.proprietary.security.model.api.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/Username.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/Username.java
@@ -1,7 +1,6 @@
 package stirling.software.proprietary.security.model.api.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/UsernameAndPass.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/model/api/user/UsernameAndPass.java
@@ -1,7 +1,6 @@
 package stirling.software.proprietary.security.model.api.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/oauth2/CustomOAuth2AuthenticationFailureHandler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/oauth2/CustomOAuth2AuthenticationFailureHandler.java
@@ -1,7 +1,10 @@
 package stirling.software.proprietary.security.oauth2;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.LockedException;
@@ -9,12 +12,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CustomOAuth2AuthenticationFailureHandler

--- a/proprietary/src/main/java/stirling/software/proprietary/security/oauth2/CustomOAuth2AuthenticationSuccessHandler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/oauth2/CustomOAuth2AuthenticationSuccessHandler.java
@@ -1,22 +1,18 @@
 package stirling.software.proprietary.security.oauth2;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.sql.SQLException;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.savedrequest.SavedRequest;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security.OAUTH2;
 import stirling.software.common.model.exception.UnsupportedProviderException;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/oauth2/OAuth2Configuration.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/oauth2/OAuth2Configuration.java
@@ -9,7 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -23,9 +23,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security.OAUTH2;
 import stirling.software.common.model.ApplicationProperties.Security.OAUTH2.Client;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/repository/TeamRepository.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/repository/TeamRepository.java
@@ -2,12 +2,9 @@ package stirling.software.proprietary.security.repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 import stirling.software.proprietary.model.Team;
 import stirling.software.proprietary.model.dto.TeamWithUserCountDTO;
 
@@ -15,8 +12,9 @@ import stirling.software.proprietary.model.dto.TeamWithUserCountDTO;
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByName(String name);
 
-    @Query("SELECT new stirling.software.proprietary.model.dto.TeamWithUserCountDTO(t.id, t.name, COUNT(u)) " +
-           "FROM Team t LEFT JOIN t.users u GROUP BY t.id, t.name")
+    @Query(
+            "SELECT new stirling.software.proprietary.model.dto.TeamWithUserCountDTO(t.id, t.name, COUNT(u)) "
+                    + "FROM Team t LEFT JOIN t.users u GROUP BY t.id, t.name")
     List<TeamWithUserCountDTO> findAllTeamsWithUserCount();
 
     boolean existsByNameIgnoreCase(String name);

--- a/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CertificateUtils.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CertificateUtils.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
-
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2AuthenticatedPrincipal.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2AuthenticatedPrincipal.java
@@ -3,7 +3,6 @@ package stirling.software.proprietary.security.saml2;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2AuthenticationFailureHandler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2AuthenticationFailureHandler.java
@@ -1,18 +1,15 @@
 package stirling.software.proprietary.security.saml2;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @ConditionalOnProperty(name = "security.saml2.enabled", havingValue = "true")

--- a/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2AuthenticationSuccessHandler.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2AuthenticationSuccessHandler.java
@@ -1,21 +1,17 @@
 package stirling.software.proprietary.security.saml2;
 
-import java.io.IOException;
-import java.sql.SQLException;
-
-import org.springframework.security.authentication.LockedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
-import org.springframework.security.web.savedrequest.SavedRequest;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-
+import java.io.IOException;
+import java.sql.SQLException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.SavedRequest;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security.SAML2;
 import stirling.software.common.model.exception.UnsupportedProviderException;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2ResponseAuthenticationConverter.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/saml2/CustomSaml2ResponseAuthenticationConverter.java
@@ -5,7 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
@@ -16,10 +17,6 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.saml2.provider.service.authentication.OpenSaml4AuthenticationProvider.ResponseToken;
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.service.UserService;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/saml2/SAML2Configuration.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/saml2/SAML2Configuration.java
@@ -1,9 +1,11 @@
 package stirling.software.proprietary.security.saml2;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.UUID;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -18,12 +20,6 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 import org.springframework.security.saml2.provider.service.web.HttpSessionSaml2AuthenticationRequestRepository;
 import org.springframework.security.saml2.provider.service.web.authentication.OpenSaml4AuthenticationRequestResolver;
-
-import jakarta.servlet.http.HttpServletRequest;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security.SAML2;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/AppUpdateAuthService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/AppUpdateAuthService.java
@@ -1,13 +1,10 @@
 package stirling.software.proprietary.security.service;
 
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.configuration.interfaces.ShowAdminInterface;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.proprietary.security.database.repository.UserRepository;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/CustomOAuth2UserService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/CustomOAuth2UserService.java
@@ -1,7 +1,7 @@
 package stirling.software.proprietary.security.service;
 
 import java.util.Optional;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
@@ -10,9 +10,6 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.ApplicationProperties.Security.OAUTH2;
 import stirling.software.common.model.enumeration.UsernameAttribute;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/CustomUserDetailsService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/CustomUserDetailsService.java
@@ -2,7 +2,7 @@ package stirling.software.proprietary.security.service;
 
 import java.util.Collection;
 import java.util.Set;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -10,9 +10,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.Authority;
 import stirling.software.proprietary.security.model.User;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/DatabaseService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/DatabaseService.java
@@ -18,15 +18,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import javax.sql.DataSource;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.datasource.init.CannotReadScriptException;
 import org.springframework.jdbc.datasource.init.ScriptException;
 import org.springframework.stereotype.Service;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.configuration.InstallationPathConfig;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.FileInfo;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/DatabaseServiceInterface.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/DatabaseServiceInterface.java
@@ -2,7 +2,6 @@ package stirling.software.proprietary.security.service;
 
 import java.sql.SQLException;
 import java.util.List;
-
 import stirling.software.common.model.FileInfo;
 import stirling.software.common.model.exception.UnsupportedProviderException;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/EmailService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/EmailService.java
@@ -1,17 +1,14 @@
 package stirling.software.proprietary.security.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.proprietary.security.model.api.Email;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/LoginAttemptService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/LoginAttemptService.java
@@ -1,15 +1,11 @@
 package stirling.software.proprietary.security.service;
 
+import jakarta.annotation.PostConstruct;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-
-import org.springframework.stereotype.Service;
-
-import jakarta.annotation.PostConstruct;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.stereotype.Service;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.proprietary.security.model.AttemptCounter;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/TeamService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/TeamService.java
@@ -1,9 +1,7 @@
 package stirling.software.proprietary.security.service;
 
-import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.stereotype.Service;
 import stirling.software.proprietary.model.Team;
 import stirling.software.proprietary.security.repository.TeamRepository;
 

--- a/proprietary/src/main/java/stirling/software/proprietary/security/service/UserService.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/service/UserService.java
@@ -9,7 +9,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,10 +25,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.common.model.exception.UnsupportedProviderException;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/session/CustomHttpSessionListener.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/session/CustomHttpSessionListener.java
@@ -1,11 +1,9 @@
 package stirling.software.proprietary.security.session;
 
-import org.springframework.stereotype.Component;
-
 import jakarta.servlet.http.HttpSessionEvent;
 import jakarta.servlet.http.HttpSessionListener;
-
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j

--- a/proprietary/src/main/java/stirling/software/proprietary/security/session/SessionPersistentRegistry.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/session/SessionPersistentRegistry.java
@@ -1,5 +1,6 @@
 package stirling.software.proprietary.security.session;
 
+import jakarta.transaction.Transactional;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -7,18 +8,13 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
-
-import jakarta.transaction.Transactional;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.proprietary.security.database.repository.SessionRepository;
 import stirling.software.proprietary.security.model.SessionEntity;
 import stirling.software.proprietary.security.saml2.CustomSaml2AuthenticatedPrincipal;

--- a/proprietary/src/main/java/stirling/software/proprietary/security/session/SessionRegistryConfig.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/session/SessionRegistryConfig.java
@@ -3,7 +3,6 @@ package stirling.software.proprietary.security.session;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.session.SessionRegistryImpl;
-
 import stirling.software.proprietary.security.database.repository.SessionRepository;
 
 @Configuration

--- a/proprietary/src/main/java/stirling/software/proprietary/security/session/SessionScheduled.java
+++ b/proprietary/src/main/java/stirling/software/proprietary/security/session/SessionScheduled.java
@@ -4,12 +4,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.session.SessionInformation;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/stirling-pdf/build.gradle
+++ b/stirling-pdf/build.gradle
@@ -12,6 +12,13 @@ configurations {
     }
 }
 
+spotless {
+    java {
+        target sourceSets.main.allJava
+        googleJavaFormat(googleJavaFormatVersion).aosp()
+    }
+}
+
 dependencies {
     if (System.getenv('STIRLING_PDF_DESKTOP_UI') != 'false'
         || (project.hasProperty('STIRLING_PDF_DESKTOP_UI')
@@ -99,7 +106,7 @@ sourceSets {
             }
         }
     }
-    
+
 }
 
 
@@ -118,7 +125,7 @@ bootJar {
     // from {
     //     configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     // }
-    
+
     // Exclude signature files to prevent "Invalid signature file digest" errors
     exclude 'META-INF/*.SF'
     exclude 'META-INF/*.DSA'

--- a/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/CMSProcessableInputStream.java
+++ b/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/CMSProcessableInputStream.java
@@ -19,7 +19,6 @@ package org.apache.pdfbox.examples.signature;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.cms.CMSObjectIdentifiers;
 import org.bouncycastle.cms.CMSException;

--- a/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/CreateSignatureBase.java
+++ b/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/CreateSignatureBase.java
@@ -30,7 +30,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Enumeration;
-
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureInterface;
 import org.bouncycastle.cert.jcajce.JcaCertStore;
 import org.bouncycastle.cms.CMSException;

--- a/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/TSAClient.java
+++ b/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/TSAClient.java
@@ -28,7 +28,6 @@ import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Random;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;

--- a/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/ValidationTimeStamp.java
+++ b/stirling-pdf/src/main/java/org/apache/pdfbox/examples/signature/ValidationTimeStamp.java
@@ -27,7 +27,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/Factories/ReplaceAndInvertColorFactory.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/Factories/ReplaceAndInvertColorFactory.java
@@ -2,7 +2,6 @@ package stirling.software.SPDF.Factories;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-
 import stirling.software.common.model.api.misc.HighContrastColorCombination;
 import stirling.software.common.model.api.misc.ReplaceAndInvert;
 import stirling.software.common.util.misc.CustomColorReplaceStrategy;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/LibreOfficeListener.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/LibreOfficeListener.java
@@ -1,13 +1,11 @@
 package stirling.software.SPDF;
 
+import io.github.pixee.security.SystemCommand;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import io.github.pixee.security.SystemCommand;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/SPDFApplication.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/SPDFApplication.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF;
 
+import io.github.pixee.security.SystemCommand;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -9,20 +12,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.EnableScheduling;
-
-import io.github.pixee.security.SystemCommand;
-
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.UI.WebBrowser;
 import stirling.software.common.configuration.AppConfig;
 import stirling.software.common.configuration.ConfigInitializer;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/UI/impl/DesktopBrowser.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/UI/impl/DesktopBrowser.java
@@ -1,5 +1,6 @@
 package stirling.software.SPDF.UI.impl;
 
+import jakarta.annotation.PreDestroy;
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Frame;
@@ -14,13 +15,16 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
 import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
-
+import lombok.extern.slf4j.Slf4j;
+import me.friwi.jcefmaven.CefAppBuilder;
+import me.friwi.jcefmaven.EnumProgress;
+import me.friwi.jcefmaven.MavenCefAppHandlerAdapter;
+import me.friwi.jcefmaven.impl.progress.ConsoleProgressHandler;
 import org.cef.CefApp;
 import org.cef.CefClient;
 import org.cef.CefSettings;
@@ -32,16 +36,6 @@ import org.cef.handler.CefDownloadHandlerAdapter;
 import org.cef.handler.CefLoadHandlerAdapter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-
-import jakarta.annotation.PreDestroy;
-
-import lombok.extern.slf4j.Slf4j;
-
-import me.friwi.jcefmaven.CefAppBuilder;
-import me.friwi.jcefmaven.EnumProgress;
-import me.friwi.jcefmaven.MavenCefAppHandlerAdapter;
-import me.friwi.jcefmaven.impl.progress.ConsoleProgressHandler;
-
 import stirling.software.SPDF.UI.WebBrowser;
 import stirling.software.common.configuration.InstallationPathConfig;
 import stirling.software.common.util.UIScaling;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/UI/impl/LoadingWindow.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/UI/impl/LoadingWindow.java
@@ -1,5 +1,6 @@
 package stirling.software.SPDF.UI.impl;
 
+import io.github.pixee.security.BoundedLineReader;
 import java.awt.*;
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -7,14 +8,9 @@ import java.io.InputStreamReader;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import javax.imageio.ImageIO;
 import javax.swing.*;
-
-import io.github.pixee.security.BoundedLineReader;
-
 import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.util.UIScaling;
 
 @Slf4j

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/AppUpdateService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/AppUpdateService.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
-
 import stirling.software.common.configuration.interfaces.ShowAdminInterface;
 import stirling.software.common.model.ApplicationProperties;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/CleanUrlInterceptor.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/CleanUrlInterceptor.java
@@ -1,15 +1,13 @@
 package stirling.software.SPDF.config;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public class CleanUrlInterceptor implements HandlerInterceptor {
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
@@ -5,12 +5,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 
 @Service

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/EndpointInspector.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/EndpointInspector.java
@@ -5,7 +5,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -16,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/EndpointInterceptor.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/EndpointInterceptor.java
@@ -1,13 +1,11 @@
 package stirling.software.SPDF.config;
 
-import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
 @Slf4j

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/ExternalAppDepConfig.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/ExternalAppDepConfig.java
@@ -1,17 +1,13 @@
 package stirling.software.SPDF.config;
 
+import jakarta.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.springframework.context.annotation.Configuration;
-
-import jakarta.annotation.PostConstruct;
-
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.context.annotation.Configuration;
 import stirling.software.common.configuration.RuntimePathConfig;
 
 @Configuration

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/InitialSetup.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/InitialSetup.java
@@ -1,22 +1,17 @@
 package stirling.software.SPDF.config;
 
+import io.micrometer.common.util.StringUtils;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.UUID;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
-
-import io.micrometer.common.util.StringUtils;
-
-import jakarta.annotation.PostConstruct;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.util.GeneralUtils;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/LocaleConfiguration.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/LocaleConfiguration.java
@@ -1,7 +1,7 @@
 package stirling.software.SPDF.config;
 
 import java.util.Locale;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.LocaleResolver;
@@ -9,9 +9,6 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.i18n.SessionLocaleResolver;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.ApplicationProperties;
 
 @Configuration

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/LogbackPropertyLoader.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/LogbackPropertyLoader.java
@@ -1,8 +1,7 @@
 package stirling.software.SPDF.config;
 
-import stirling.software.common.configuration.InstallationPathConfig;
-
 import ch.qos.logback.core.PropertyDefinerBase;
+import stirling.software.common.configuration.InstallationPathConfig;
 
 public class LogbackPropertyLoader extends PropertyDefinerBase {
     @Override

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/MetricsConfig.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/MetricsConfig.java
@@ -1,11 +1,10 @@
 package stirling.software.SPDF.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MetricsConfig {

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/MetricsFilter.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/MetricsFilter.java
@@ -1,21 +1,16 @@
 package stirling.software.SPDF.config;
 
-import java.io.IOException;
-
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 import stirling.software.common.util.RequestUriUtils;
 
 @Component

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/OpenApiConfig.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/OpenApiConfig.java
@@ -1,8 +1,5 @@
 package stirling.software.SPDF.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
@@ -10,9 +7,9 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import stirling.software.common.model.ApplicationProperties;
 
 @Configuration

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/StartupApplicationListener.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/StartupApplicationListener.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.config;
 
 import java.time.LocalDateTime;
-
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/config/WebMvcConfig.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/config/WebMvcConfig.java
@@ -1,12 +1,10 @@
 package stirling.software.SPDF.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.configuration.InstallationPathConfig;
 
 @Configuration

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/AdditionalLanguageJsController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/AdditionalLanguageJsController.java
@@ -1,21 +1,16 @@
 package stirling.software.SPDF.controller.api;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Hidden;
-
-import jakarta.servlet.http.HttpServletResponse;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.service.LanguageService;
 
 @RestController

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/AnalysisController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/AnalysisController.java
@@ -1,8 +1,10 @@
 package stirling.software.SPDF.controller.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.*;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
@@ -12,12 +14,6 @@ import org.apache.pdfbox.pdmodel.encryption.PDEncryption;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.springframework.web.bind.annotation.*;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/CropController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/CropController.java
@@ -1,8 +1,10 @@
 package stirling.software.SPDF.controller.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -15,12 +17,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.general.CropPdfForm;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/EditTableOfContentsController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/EditTableOfContentsController.java
@@ -1,11 +1,16 @@
 package stirling.software.SPDF.controller.api;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
@@ -20,16 +25,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.EditTableOfContentsRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
@@ -1,5 +1,7 @@
 package stirling.software.SPDF.controller.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -10,7 +12,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
@@ -26,13 +29,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.general.MergePdfsRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.GeneralUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/MultiPageLayoutController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/MultiPageLayoutController.java
@@ -1,9 +1,12 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -17,13 +20,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.general.MergeMultiplePagesRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/PdfImageRemovalController.java
@@ -1,20 +1,16 @@
 package stirling.software.SPDF.controller.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.service.PdfImageRemovalService;
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/PdfOverlayController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/PdfOverlayController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -8,7 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.multipdf.Overlay;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -19,13 +22,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.general.OverlayPdfsRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.GeneralUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
@@ -1,10 +1,14 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.springframework.http.ResponseEntity;
@@ -13,14 +17,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.SortTypes;
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 import stirling.software.SPDF.model.api.general.RearrangePagesRequest;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/RotationController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/RotationController.java
@@ -1,7 +1,10 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
@@ -11,13 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.general.RotatePDFRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/ScalePagesController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/ScalePagesController.java
@@ -1,10 +1,13 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -18,13 +21,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.general.ScalePagesRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SettingsController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SettingsController.java
@@ -1,8 +1,10 @@
 package stirling.software.SPDF.controller.api;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -10,12 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.config.EndpointConfiguration;
 import stirling.software.common.configuration.InstallationPathConfig;
 import stirling.software.common.model.ApplicationProperties;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPDFController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPDFController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,7 +12,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.springframework.http.MediaType;
@@ -19,14 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -7,7 +10,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
@@ -19,18 +27,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.SplitPdfByChaptersRequest;
 import stirling.software.common.model.PdfMetadata;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -8,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -24,13 +27,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.SplitPdfBySectionsRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySizeController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySizeController.java
@@ -1,12 +1,16 @@
 package stirling.software.SPDF.controller.api;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.springframework.http.MediaType;
@@ -16,14 +20,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.general.SplitPdfBySizeOrCountRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.GeneralUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/ToSinglePageController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/ToSinglePageController.java
@@ -1,9 +1,11 @@
 package stirling.software.SPDF.controller.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.geom.AffineTransform;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.multipdf.LayerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -15,12 +17,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertEmlToPDF.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertEmlToPDF.java
@@ -1,8 +1,12 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -12,14 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.configuration.RuntimePathConfig;
 import stirling.software.common.model.api.converters.EmlToPdfRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertHtmlToPDF.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertHtmlToPDF.java
@@ -1,18 +1,15 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.configuration.RuntimePathConfig;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.api.converters.HTMLToPdfRequest;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -10,7 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -22,14 +26,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.converters.ConvertToImageRequest;
 import stirling.software.SPDF.model.api.converters.ConvertToPdfRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertMarkdownToPdf.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertMarkdownToPdf.java
@@ -1,8 +1,11 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.TableBlock;
 import org.commonmark.ext.gfm.tables.TablesExtension;
@@ -16,13 +19,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.configuration.RuntimePathConfig;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.api.GeneralFile;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertOfficeController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertOfficeController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -7,7 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.springframework.http.ResponseEntity;
@@ -16,13 +19,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.configuration.RuntimePathConfig;
 import stirling.software.common.model.api.GeneralFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToHtml.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToHtml.java
@@ -1,15 +1,13 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.util.PDFToFile;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToOffice.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToOffice.java
@@ -1,7 +1,10 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.http.MediaType;
@@ -11,13 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.converters.PdfToPresentationRequest;
 import stirling.software.SPDF.model.api.converters.PdfToTextOrRTFRequest;
 import stirling.software.SPDF.model.api.converters.PdfToWordRequest;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
@@ -1,12 +1,15 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,13 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.converters.PdfToPdfARequest;
 import stirling.software.common.util.ProcessExecutor;
 import stirling.software.common.util.ProcessExecutor.ProcessExecutorResult;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPDF.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertWebsiteToPDF.java
@@ -1,24 +1,20 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.converters.UrlToPdfRequest;
 import stirling.software.common.configuration.RuntimePathConfig;
 import stirling.software.common.model.ApplicationProperties;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ExtractCSVController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/converters/ExtractCSVController.java
@@ -1,5 +1,7 @@
 package stirling.software.SPDF.controller.api.converters;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -9,7 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.QuoteMode;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -21,17 +24,9 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 import stirling.software.SPDF.pdf.FlexibleCSVWriter;
 import stirling.software.common.service.CustomPDFDocumentFactory;
-
 import technology.tabula.ObjectExtractor;
 import technology.tabula.Page;
 import technology.tabula.Table;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/filters/FilterController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/filters/FilterController.java
@@ -1,7 +1,10 @@
 package stirling.software.SPDF.controller.api.filters;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
@@ -11,13 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.PDFComparisonAndCount;
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 import stirling.software.SPDF.model.api.filter.ContainsTextRequest;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/AutoRenameController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/AutoRenameController.java
@@ -1,10 +1,14 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.pdfbox.text.TextPosition;
@@ -14,14 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.ExtractHeaderRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
@@ -1,5 +1,10 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import com.google.zxing.*;
+import com.google.zxing.common.HybridBinarizer;
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
 import java.awt.image.DataBufferInt;
@@ -13,7 +18,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.springframework.http.MediaType;
@@ -23,17 +29,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.google.zxing.*;
-import com.google.zxing.common.HybridBinarizer;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.AutoSplitPdfRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/BlankPageController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/BlankPageController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -7,7 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
@@ -21,14 +25,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.RemoveBlankPagesRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.PdfUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -17,14 +20,17 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.ImageOutputStream;
-
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -38,17 +44,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.config.EndpointConfiguration;
 import stirling.software.SPDF.model.api.misc.OptimizePdfRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/DecompressPdfController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/DecompressPdfController.java
@@ -1,11 +1,14 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Set;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.*;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdfwriter.compress.CompressParameters;
@@ -17,13 +20,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImageScansController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImageScansController.java
@@ -1,5 +1,7 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.image.BufferedImage;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -10,9 +12,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.imageio.ImageIO;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -23,13 +25,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.ExtractImageScansRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.CheckProgramInstall;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImagesController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImagesController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
@@ -17,9 +20,9 @@ import java.util.concurrent.Future;
 import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.imageio.ImageIO;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -31,14 +34,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.PDFExtractImagesRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.ImageProcessingUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/FakeScanController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/FakeScanController.java
@@ -1,5 +1,9 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -8,7 +12,8 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -23,16 +28,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import jakarta.validation.Valid;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.FakeScanRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/FlattenController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/FlattenController.java
@@ -1,8 +1,12 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -17,14 +21,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.FlattenRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/MetadataController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/MetadataController.java
@@ -1,12 +1,16 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.Map.Entry;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
@@ -14,14 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.MetadataRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/OCRController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/OCRController.java
@@ -1,5 +1,9 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.BoundedLineReader;
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.nio.file.Files;
@@ -7,9 +11,9 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.imageio.ImageIO;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -22,15 +26,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.BoundedLineReader;
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.ProcessPdfWithOcrRequest;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/OverlayImageController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/OverlayImageController.java
@@ -1,7 +1,11 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -9,14 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.OverlayImageRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.PdfUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/PageNumbersController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/PageNumbersController.java
@@ -1,9 +1,12 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -17,13 +20,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.misc.AddPageNumbersRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.GeneralUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/PrintFileController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/PrintFileController.java
@@ -1,5 +1,6 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.print.PageFormat;
@@ -8,11 +9,10 @@ import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import java.io.IOException;
 import java.util.Arrays;
-
 import javax.imageio.ImageIO;
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.printing.PDFPageable;
@@ -22,11 +22,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.misc.PrintFileRequest;
 
 @RestController

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/RepairController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/RepairController.java
@@ -1,24 +1,20 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.ProcessExecutor;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ReplaceAndInvertColorController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ReplaceAndInvertColorController.java
@@ -1,7 +1,9 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -10,12 +12,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.misc.ReplaceAndInvertColorRequest;
 import stirling.software.SPDF.service.misc.ReplaceAndInvertColorService;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ShowJavascript.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/ShowJavascript.java
@@ -1,8 +1,11 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.common.PDNameTreeNode;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionJavaScript;
@@ -13,13 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -8,9 +11,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
-
 import javax.imageio.ImageIO;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -31,13 +33,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.misc.AddStampRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/UnlockPDFFormsController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/UnlockPDFFormsController.java
@@ -1,10 +1,13 @@
 package stirling.software.SPDF.controller.api.misc;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.*;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.common.PDStream;
@@ -16,13 +19,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineController.java
@@ -1,5 +1,9 @@
 package stirling.software.SPDF.controller.api.pipeline;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -7,7 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -16,16 +21,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.PipelineConfig;
 import stirling.software.SPDF.model.PipelineOperation;
 import stirling.software.SPDF.model.PipelineResult;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineDirectoryProcessor.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineDirectoryProcessor.java
@@ -1,5 +1,6 @@
 package stirling.software.SPDF.controller.api.pipeline;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -22,16 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.PipelineConfig;
 import stirling.software.SPDF.model.PipelineOperation;
 import stirling.software.SPDF.model.PipelineResult;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.pipeline;
 
+import io.github.pixee.security.Filenames;
+import io.github.pixee.security.ZipSecurity;
+import jakarta.servlet.ServletContext;
 import java.io.*;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -13,7 +16,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -23,14 +26,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.github.pixee.security.ZipSecurity;
-
-import jakarta.servlet.ServletContext;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.SPDFApplication;
 import stirling.software.SPDF.model.PipelineConfig;
 import stirling.software.SPDF.model.PipelineOperation;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.security;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.beans.PropertyEditorSupport;
 import java.io.*;
@@ -11,7 +14,8 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.examples.signature.CreateSignatureBase;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -63,14 +67,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.api.security.SignPDFWithCertRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/GetInfoOnPDF.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/GetInfoOnPDF.java
@@ -1,11 +1,17 @@
 package stirling.software.SPDF.controller.api.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.cos.COSInputStream;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSString;
@@ -50,17 +56,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/PasswordController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/PasswordController.java
@@ -1,7 +1,10 @@
 package stirling.software.SPDF.controller.api.security;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
@@ -11,13 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.security.AddPasswordRequest;
 import stirling.software.SPDF.model.api.security.PDFPasswordRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/RedactController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/RedactController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.security;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -8,7 +11,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -22,14 +26,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.PDFText;
 import stirling.software.SPDF.model.api.security.ManualRedactPdfRequest;
 import stirling.software.SPDF.model.api.security.RedactPdfRequest;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/RemoveCertSignController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/RemoveCertSignController.java
@@ -1,7 +1,10 @@
 package stirling.software.SPDF.controller.api.security;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
@@ -13,13 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/SanitizeController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/SanitizeController.java
@@ -1,7 +1,10 @@
 package stirling.software.SPDF.controller.api.security;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -27,13 +30,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.security.SanitizePdfRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.WebResponseUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/ValidateSignatureController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/ValidateSignatureController.java
@@ -1,5 +1,7 @@
 package stirling.software.SPDF.controller.api.security;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.beans.PropertyEditorSupport;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -10,7 +12,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -31,12 +33,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.security.SignatureValidationRequest;
 import stirling.software.SPDF.model.api.security.SignatureValidationResult;
 import stirling.software.SPDF.service.CertificateValidationService;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -1,5 +1,8 @@
 package stirling.software.SPDF.controller.api.security;
 
+import io.github.pixee.security.Filenames;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyEditorSupport;
@@ -8,9 +11,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-
 import javax.imageio.ImageIO;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -32,13 +34,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.model.api.security.AddWatermarkRequest;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.PdfUtils;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/ConverterWebController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/ConverterWebController.java
@@ -1,13 +1,11 @@
 package stirling.software.SPDF.controller.web;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
-
-import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
 import stirling.software.common.util.CheckProgramInstall;
 
 @Controller

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/GeneralWebController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/GeneralWebController.java
@@ -1,5 +1,9 @@
 package stirling.software.SPDF.controller.web;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -8,22 +12,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.SignatureFile;
 import stirling.software.SPDF.service.SignatureService;
 import stirling.software.common.configuration.InstallationPathConfig;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/HomeWebController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/HomeWebController.java
@@ -1,11 +1,15 @@
 package stirling.software.SPDF.controller.web;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Hidden;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
@@ -13,15 +17,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.swagger.v3.oas.annotations.Hidden;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.Dependency;
 import stirling.software.common.model.ApplicationProperties;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/MetricsController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/MetricsController.java
@@ -1,27 +1,22 @@
 package stirling.software.SPDF.controller.web;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import jakarta.annotation.PostConstruct;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.config.EndpointInspector;
 import stirling.software.SPDF.config.StartupApplicationListener;
 import stirling.software.common.model.ApplicationProperties;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/OtherWebController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/OtherWebController.java
@@ -1,20 +1,16 @@
 package stirling.software.SPDF.controller.web;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
-
-import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.util.CheckProgramInstall;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/SecurityWebController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/SecurityWebController.java
@@ -1,11 +1,10 @@
 package stirling.software.SPDF.controller.web;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Controller
 @Tag(name = "Security", description = "Security APIs")

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/SignatureController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/SignatureController.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.controller.web;
 
 import java.io.IOException;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -10,7 +9,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-
 import stirling.software.SPDF.service.SignatureService;
 import stirling.software.common.service.UserServiceInterface;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/UploadLimitService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/web/UploadLimitService.java
@@ -2,12 +2,9 @@ package stirling.software.SPDF.controller.web;
 
 import java.util.Locale;
 import java.util.regex.Pattern;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 
 @Service

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/ApiEndpoint.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/ApiEndpoint.java
@@ -1,9 +1,8 @@
 package stirling.software.SPDF.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 public class ApiEndpoint {
     private final String name;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/PipelineConfig.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/PipelineConfig.java
@@ -1,9 +1,7 @@
 package stirling.software.SPDF.model;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+import java.util.List;
 import lombok.Data;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/PipelineOperation.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/PipelineOperation.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.model;
 
 import java.util.Map;
-
 import lombok.Data;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/PipelineResult.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/PipelineResult.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model;
 
 import java.util.List;
-
-import org.springframework.core.io.Resource;
-
 import lombok.Data;
+import org.springframework.core.io.Resource;
 
 @Data
 public class PipelineResult {

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/EditTableOfContentsRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/EditTableOfContentsRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/HandleDataRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/HandleDataRequest.java
@@ -1,11 +1,9 @@
 package stirling.software.SPDF.model.api;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @EqualsAndHashCode

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/ImageFile.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/ImageFile.java
@@ -1,11 +1,9 @@
 package stirling.software.SPDF.model.api;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @EqualsAndHashCode

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/MultiplePDFFiles.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/MultiplePDFFiles.java
@@ -1,11 +1,9 @@
 package stirling.software.SPDF.model.api;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @EqualsAndHashCode

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFComparison.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFComparison.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFComparisonAndCount.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFComparisonAndCount.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFExtractImagesRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFExtractImagesRequest.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFWithImageFormatRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFWithImageFormatRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFWithPageNums.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFWithPageNums.java
@@ -1,16 +1,12 @@
 package stirling.software.SPDF.model.api;
 
-import java.util.List;
-
-import org.apache.pdfbox.pdmodel.PDDocument;
-
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-
+import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.apache.pdfbox.pdmodel.PDDocument;
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.util.GeneralUtils;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFWithPageSize.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/PDFWithPageSize.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/SplitPdfByChaptersRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/SplitPdfByChaptersRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/ConvertPDFToMarkdown.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/ConvertPDFToMarkdown.java
@@ -1,15 +1,13 @@
 package stirling.software.SPDF.model.api.converters;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.util.PDFToFile;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToPdfRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToPdfRequest.java
@@ -1,11 +1,9 @@
 package stirling.software.SPDF.model.api.converters;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @EqualsAndHashCode

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToBookRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToBookRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPdfARequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPdfARequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPresentationRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPresentationRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToTextOrRTFRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToTextOrRTFRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToWordRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/PdfToWordRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/UrlToPdfRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/converters/UrlToPdfRequest.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.model.api.converters;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/ContainsTextRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/ContainsTextRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.filter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/FileSizeRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/FileSizeRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.filter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFComparison;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/PageRotationRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/PageRotationRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.filter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFComparison;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/PageSizeRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/filter/PageSizeRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.filter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFComparison;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/CropPdfForm.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/CropPdfForm.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.general;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/MergeMultiplePagesRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/MergeMultiplePagesRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.general;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/MergePdfsRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/MergePdfsRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.general;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.MultiplePDFFiles;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/OverlayPdfsRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/OverlayPdfsRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.general;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.springframework.web.multipart.MultipartFile;
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/RearrangePagesRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/RearrangePagesRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.general;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.SortTypes;
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/RotatePDFRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/RotatePDFRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.general;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/ScalePagesRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/ScalePagesRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.general;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFWithPageSize;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/SplitPdfBySizeOrCountRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/general/SplitPdfBySizeOrCountRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.general;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/AddPageNumbersRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/AddPageNumbersRequest.java
@@ -2,10 +2,8 @@ package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/AddStampRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/AddStampRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.misc;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.springframework.web.multipart.MultipartFile;
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/AutoSplitPdfRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/AutoSplitPdfRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ExtractHeaderRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ExtractHeaderRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ExtractImageScansRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ExtractImageScansRequest.java
@@ -1,11 +1,9 @@
 package stirling.software.SPDF.model.api.misc;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @EqualsAndHashCode

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/FakeScanRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/FakeScanRequest.java
@@ -1,13 +1,10 @@
 package stirling.software.SPDF.model.api.misc;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import jakarta.validation.constraints.NotNull;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @EqualsAndHashCode

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/FlattenRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/FlattenRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/MetadataRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/MetadataRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.misc;
 
-import java.util.Map;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/OptimizePdfRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/OptimizePdfRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/OverlayImageRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/OverlayImageRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.misc;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.springframework.web.multipart.MultipartFile;
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/PrintFileRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/PrintFileRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ProcessPdfWithOcrRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ProcessPdfWithOcrRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.misc;
 
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
+import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/RemoveBlankPagesRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/RemoveBlankPagesRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ReplaceAndInvertColorRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/misc/ReplaceAndInvertColorRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.misc;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.model.api.misc.HighContrastColorCombination;
 import stirling.software.common.model.api.misc.ReplaceAndInvert;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/AddPasswordRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/AddPasswordRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.security;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.security;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.springframework.web.multipart.MultipartFile;
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/ManualRedactPdfRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/ManualRedactPdfRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.security;
 
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
+import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.SPDF.model.api.PDFWithPageNums;
 import stirling.software.common.model.api.security.RedactionArea;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/PDFPasswordRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/PDFPasswordRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.security;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/RedactPdfRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/RedactPdfRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.security;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SanitizePdfRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SanitizePdfRequest.java
@@ -1,10 +1,8 @@
 package stirling.software.SPDF.model.api.security;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.security;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.springframework.web.multipart.MultipartFile;
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SignatureValidationRequest.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SignatureValidationRequest.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.model.api.security;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
+import org.springframework.web.multipart.MultipartFile;
 import stirling.software.common.model.api.PDFFile;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SignatureValidationResult.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/model/api/security/SignatureValidationResult.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.model.api.security;
 
 import java.util.List;
-
 import lombok.Data;
 
 @Data

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/pdf/FlexibleCSVWriter.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/pdf/FlexibleCSVWriter.java
@@ -1,7 +1,6 @@
 package stirling.software.SPDF.pdf;
 
 import org.apache.commons.csv.CSVFormat;
-
 import technology.tabula.writers.CSVWriter;
 
 public class FlexibleCSVWriter extends CSVWriter {

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/pdf/TextFinder.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/pdf/TextFinder.java
@@ -5,13 +5,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.pdfbox.text.TextPosition;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.PDFText;
 
 @Slf4j

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/ApiDocService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/ApiDocService.java
@@ -1,12 +1,15 @@
 package stirling.software.SPDF.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletContext;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -14,14 +17,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.ServletContext;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.SPDFApplication;
 import stirling.software.SPDF.model.ApiEndpoint;
 import stirling.software.common.model.enumeration.Role;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/CertificateValidationService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/CertificateValidationService.java
@@ -1,16 +1,13 @@
 package stirling.software.SPDF.service;
 
+import io.github.pixee.security.BoundedLineReader;
+import jakarta.annotation.PostConstruct;
 import java.io.*;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.*;
 import java.util.*;
-
 import org.springframework.stereotype.Service;
-
-import io.github.pixee.security.BoundedLineReader;
-
-import jakarta.annotation.PostConstruct;
 
 @Service
 public class CertificateValidationService {

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/LanguageService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/LanguageService.java
@@ -5,13 +5,10 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Service;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.common.model.ApplicationProperties;
 
 @Service

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/MetricsAggregatorService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/MetricsAggregatorService.java
@@ -1,19 +1,15 @@
 package stirling.software.SPDF.service;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.search.Search;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.config.EndpointInspector;
 import stirling.software.common.service.PostHogService;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/PdfImageRemovalService.java
@@ -3,7 +3,6 @@ package stirling.software.SPDF.service;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/SignatureService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/SignatureService.java
@@ -7,12 +7,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.util.StringUtils;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.model.SignatureFile;
 import stirling.software.common.configuration.InstallationPathConfig;
 

--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/misc/ReplaceAndInvertColorService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/misc/ReplaceAndInvertColorService.java
@@ -1,13 +1,10 @@
 package stirling.software.SPDF.service.misc;
 
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import lombok.RequiredArgsConstructor;
-
 import stirling.software.SPDF.Factories.ReplaceAndInvertColorFactory;
 import stirling.software.common.model.api.misc.HighContrastColorCombination;
 import stirling.software.common.model.api.misc.ReplaceAndInvert;


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- Extracted the `googleJavaFormatVersion` into a centralized Gradle property for easier management across modules.
- Added consistent `spotless` formatting configuration to `common`, `proprietary`, and `stirling-pdf` modules.
- Applied automatic import ordering and removed unused imports in numerous Java files.
- Reordered and grouped imports consistently, improving overall code readability.
- Removed excessive blank lines and standardized spacing.
- Ensured a uniform coding style throughout the codebase using Spotless and Google Java Format with AOSP style.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
