### PR TITLE
chore: expand allowed license list with additional Eclipse Public License variants

### DIFF
--- a/allowed-licenses.json
+++ b/allowed-licenses.json
@@ -126,7 +126,15 @@
     },
     {
       "moduleName": ".*",
+      "moduleLicense": "Eclipse Public License 1.0"
+    },
+    {
+      "moduleName": ".*",
       "moduleLicense": "Eclipse Public License - v 1.0"
+    },
+    {
+      "moduleName": ".*",
+      "moduleLicense": "Eclipse Public License v2.0"
     },
     {
       "moduleName": ".*",


### PR DESCRIPTION
# Description of Changes

- Added support for additional variants of the Eclipse Public License to the `allowed-licenses.json` file:
  - "Eclipse Public License 1.0"
  - "Eclipse Public License v2.0"

Fix: https://github.com/Stirling-Tools/Stirling-PDF/pull/3630

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
