### PR TITLE
Update multi-toolAdvert to respect SYSTEM_ROOTURIPATH.

### DIFF
--- a/stirling-pdf/src/main/resources/templates/fragments/multi-toolAdvert.html
+++ b/stirling-pdf/src/main/resources/templates/fragments/multi-toolAdvert.html
@@ -1,7 +1,7 @@
 <div th:fragment="multi-toolAdvert" class="mx-auto">
   <div id="multi-toolAdvert" class="multi-toolAdvert">
     <div>
-      <span th:utext="#{multiTool-advert.message(|/multi-tool|)}"></span>
+      <span th:utext="#{multiTool-advert.message(|multi-tool|)}"></span>
       <button id="closeMultiToolAdvert" style="position: absolute;
   inset-inline-end: 12px;
   inset-block-start: 10px;


### PR DESCRIPTION
Closes #3775

Currently, the advert link assumes `SYSTEM_ROOTURIPATH` to be `/`. As described in the issue, this isn't always the case. Simply removing `/` fixes the issue by taking the same approach to endpoints as `navbarEntry`.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
