### PR TITLE
feat: add Thai language option for stamp feature

### DIFF
--- a/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -181,6 +181,9 @@ public class StampController {
             case "chinese":
                 resourceDir = "static/fonts/SimSun.ttf";
                 break;
+            case "thai":
+                resourceDir = "static/fonts/NotoSansThai-Regular.ttf";
+                break;
             case "roman":
             default:
                 resourceDir = "static/fonts/NotoSans-Regular.ttf";

--- a/stirling-pdf/src/main/resources/templates/misc/stamp.html
+++ b/stirling-pdf/src/main/resources/templates/misc/stamp.html
@@ -88,6 +88,7 @@
                     <option value="japanese">日本語</option>
                     <option value="korean">한국어</option>
                     <option value="chinese">简体中文</option>
+                    <option value="thai">ไทย</option>
                   </select>
                 </div>
 


### PR DESCRIPTION
# Description of Changes


This pull request adds support for Thai language text stamps in the `StampController` and updates the corresponding HTML template to include Thai as an option in the language selection dropdown.

### Thai language support:

* [`stirling-pdf/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java`](diffhunk://#diff-1fc63d07188744082edc3780d43868119bf9876868c8c8db6ce324b57c60284eR184-R186): Added a case for "thai" in the `addTextStamp` method, specifying the font file `NotoSansThai-Regular.ttf` for Thai language support.
* [`stirling-pdf/src/main/resources/templates/misc/stamp.html`](diffhunk://#diff-29cf511e86ebd2b1d4f378e4f0bd301aa5e024e6dc66f93672206c2b1ffa526cR91): Added a new `<option>` for Thai language ("ไทย") in the dropdown menu for language selection.


### Preview:



---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
