### PR TITLE
Added mockTempFileManager to tests in EML-to-PDF mockito to resolve errors

### DIFF
--- a/common/src/test/java/stirling/software/common/util/EmlToPdfTest.java
+++ b/common/src/test/java/stirling/software/common/util/EmlToPdfTest.java
@@ -503,6 +503,8 @@ class EmlToPdfTest {
 
         @Mock private PDDocument mockPdDocument;
 
+        @Mock private TempFileManager mockTempFileManager;
+
         @Test
         @DisplayName("Should convert EML to PDF without attachments when not requested")
         void convertEmlToPdfWithoutAttachments() throws Exception {
@@ -530,7 +532,8 @@ class EmlToPdfTest {
                                 any(),
                                 any(byte[].class),
                                 anyString(),
-                                anyBoolean()))
+                                anyBoolean(),
+                                any(TempFileManager.class)))
                     .thenReturn(fakePdfBytes);
 
                 byte[] resultPdf =
@@ -540,7 +543,8 @@ class EmlToPdfTest {
                         emlBytes,
                         "test.eml",
                         false,
-                        mockPdfDocumentFactory);
+                        mockPdfDocumentFactory,
+                        mockTempFileManager);
 
                 assertArrayEquals(fakePdfBytes, resultPdf);
 
@@ -556,7 +560,8 @@ class EmlToPdfTest {
                             any(),
                             any(byte[].class),
                             anyString(),
-                            anyBoolean()));
+                            anyBoolean(),
+                            any(TempFileManager.class)));
                 verify(mockPdfDocumentFactory).load(resultPdf);
             }
         }
@@ -595,7 +600,8 @@ class EmlToPdfTest {
                                 any(),
                                 any(byte[].class),
                                 anyString(),
-                                anyBoolean()))
+                                anyBoolean(),
+                                any(TempFileManager.class)))
                     .thenReturn(fakePdfBytes);
 
                 try (MockedStatic<EmlToPdf> ignored =
@@ -616,7 +622,8 @@ class EmlToPdfTest {
                             emlBytes,
                             "test.eml",
                             false,
-                            mockPdfDocumentFactory);
+                            mockPdfDocumentFactory,
+                            mockTempFileManager);
 
                     assertArrayEquals(fakePdfBytes, resultPdf);
 
@@ -632,7 +639,8 @@ class EmlToPdfTest {
                                 any(),
                                 any(byte[].class),
                                 anyString(),
-                                anyBoolean()));
+                                anyBoolean(),
+                                any(TempFileManager.class)));
 
                     verify(mockPdfDocumentFactory).load(resultPdf);
                 }
@@ -657,7 +665,8 @@ class EmlToPdfTest {
                                 any(),
                                 any(byte[].class),
                                 anyString(),
-                                anyBoolean()))
+                                anyBoolean(),
+                                any(TempFileManager.class)))
                     .thenThrow(new IOException(errorMessage));
 
                 IOException exception = assertThrows(
@@ -668,7 +677,8 @@ class EmlToPdfTest {
                         emlBytes,
                         "test.eml",
                         false,
-                        mockPdfDocumentFactory));
+                        mockPdfDocumentFactory,
+                        mockTempFileManager));
 
                 assertTrue(exception.getMessage().contains(errorMessage));
             }


### PR DESCRIPTION
# Description of Changes

Resolving conflict that comes from conflicts between #3797 and #3806

#3797 modified the code:
- The convertEmlToPdf and convertHtmlToPdf methods now require a TempFileManager tempFileManager argument.
- All code (including tests) that calls these methods must now provide a valid TempFileManager instance.

After that however, #3806 did not account for these changes, specifically the changes to the required arguments.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
