### PR TITLE
refactor: replace deprecated `fields()` with `propertyStream()` in ApiDocService

### DIFF
--- a/stirling-pdf/src/main/java/stirling/software/SPDF/service/ApiDocService.java
+++ b/stirling-pdf/src/main/java/stirling/software/SPDF/service/ApiDocService.java
@@ -120,8 +120,8 @@ public class ApiDocService {
             ObjectMapper mapper = new ObjectMapper();
             apiDocsJsonRootNode = mapper.readTree(apiDocsJson);
             JsonNode paths = apiDocsJsonRootNode.path("paths");
-            paths.fields()
-                    .forEachRemaining(
+            paths.propertyStream()
+                    .forEach(
                             entry -> {
                                 String path = entry.getKey();
                                 JsonNode pathNode = entry.getValue();


### PR DESCRIPTION
# Description of Changes

- Replaced usage of the deprecated `fields()` method on `JsonNode` with `propertyStream()` in `ApiDocService`.
- This change ensures compatibility with future Jackson versions and avoids deprecation warnings.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#6-testing) for more details.
