### PR TITLE
Jpackage Input Path Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,9 +141,9 @@ subprojects {
         useJUnitPlatform()
     }
 
-    tasks.named("processResources") {
-        dependsOn(rootProject.tasks.writeVersion)
-    }
+	tasks.named("processResources") {
+	  dependsOn(rootProject.tasks.writeVersion)
+	}
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -202,7 +202,6 @@ static def getMacVersion(String version) {
 }
 
 jpackage {
-    dependsOn ':stirling-pdf:bootJar'
     input = layout.projectDirectory.dir("stirling-pdf/build/libs")
     destination = layout.projectDirectory.dir("build/jpackage")
     mainJar = "Stirling-PDF-${project.version}.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -43,36 +43,6 @@ bootJar {
     enabled = false
 }
 
-sourceSets {
-    main {
-        java {
-            if (System.getenv('DOCKER_ENABLE_SECURITY') == 'false' || System.getenv('DISABLE_ADDITIONAL_FEATURES') == 'true'
-                || (project.hasProperty('DISABLE_ADDITIONAL_FEATURES')
-                && System.getProperty('DISABLE_ADDITIONAL_FEATURES') == 'true')) {
-                exclude 'stirling/software/proprietary/security/**'
-            }
-            if (System.getenv('STIRLING_PDF_DESKTOP_UI') == 'false') {
-                exclude 'stirling/software/SPDF/UI/impl/**'
-            }
-
-        }
-    }
-
-    test {
-        java {
-            if (System.getenv('DOCKER_ENABLE_SECURITY') == 'false' || System.getenv('DISABLE_ADDITIONAL_FEATURES') == 'true'
-                || (project.hasProperty('DISABLE_ADDITIONAL_FEATURES')
-                && System.getProperty('DISABLE_ADDITIONAL_FEATURES') == 'true')) {
-                exclude 'stirling/software/proprietary/security/**'
-            }
-
-            if (System.getenv('STIRLING_PDF_DESKTOP_UI') == 'false') {
-                exclude 'stirling/software/SPDF/UI/impl/**'
-            }
-        }
-    }
-}
-
 allprojects {
     group = 'stirling.software'
     version = '1.0.0'
@@ -170,10 +140,10 @@ subprojects {
     test {
         useJUnitPlatform()
     }
-    
-	tasks.named("processResources") {
-	  dependsOn(rootProject.tasks.writeVersion)
-	}
+
+    tasks.named("processResources") {
+        dependsOn(rootProject.tasks.writeVersion)
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -232,7 +202,8 @@ static def getMacVersion(String version) {
 }
 
 jpackage {
-    input = layout.projectDirectory.dir("build/libs")
+    dependsOn ':stirling-pdf:bootJar'
+    input = layout.projectDirectory.dir("stirling-pdf/build/libs")
     destination = layout.projectDirectory.dir("build/jpackage")
     mainJar = "Stirling-PDF-${project.version}.jar"
     appName = "Stirling PDF"
@@ -375,7 +346,7 @@ tasks.register('jpackageMacX64') {
             commandLine 'jpackage',
                 '--type', 'dmg',
                 '--name', 'Stirling PDF (x86_64)',
-                '--input', 'build/libs',
+                '--input', 'stirling-pdf/build/libs',
                 '--main-jar', "Stirling-PDF-${project.version}.jar",
                 '--main-class', 'org.springframework.boot.loader.launch.JarLauncher',
                 '--runtime-image', file(jrePath + "/zulu-17.jre/Contents/Home"),


### PR DESCRIPTION
Corrected input path for jpackage plugin

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
