### PR TITLE
Fix for `generateOpenApiDocs` Task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ plugins {
 
 import com.github.jk1.license.render.*
 import org.gradle.internal.os.OperatingSystem
+import org.panteleyev.jpackage.ImageType
+
 import java.nio.file.Files
 import java.time.Year
 
@@ -43,6 +45,16 @@ bootJar {
     enabled = false
 }
 
+// Configure main class for the root project
+springBoot {
+    mainClass = 'stirling.software.SPDF.SPDFApplication'
+}
+
+repositories {
+    mavenCentral()
+    maven { url = 'https://build.shibboleth.net/maven/releases' }
+}
+
 allprojects {
     group = 'stirling.software'
     version = '1.0.1'
@@ -52,7 +64,6 @@ allprojects {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-tomcat"
     }
 }
-
 
 tasks.register('writeVersion') {
     def propsFile = file("$projectDir/common/src/main/resources/version.properties")
@@ -200,6 +211,14 @@ openApi {
     waitTimeInSeconds = 60 // Increase the wait time to 60 seconds
 }
 
+// Configure the forked spring boot run task to properly delegate to the stirling-pdf module
+tasks.named('forkedSpringBootRun') {
+    dependsOn ':stirling-pdf:bootRun'
+    doFirst {
+        println "Delegating forkedSpringBootRun to :stirling-pdf:bootRun"
+    }
+}
+
 //0.11.5 to 2024.11.5
 static def getMacVersion(String version) {
     def currentYear = Year.now().getValue()
@@ -251,7 +270,7 @@ jpackage {
         winUpgradeUuid = "2a43ed0c-b8c2-40cf-89e1-751129b87641" // Unique identifier for updates
         winHelpUrl = "https://github.com/Stirling-Tools/Stirling-PDF"
         winUpdateUrl = "https://github.com/Stirling-Tools/Stirling-PDF/releases"
-        type = "exe"
+        type = ImageType.EXE
         installDir = "C:/Program Files/Stirling-PDF"
     }
 
@@ -259,7 +278,7 @@ jpackage {
     mac {
         appVersion = getMacVersion(project.version.toString())
         icon = layout.projectDirectory.file("stirling-pdf/src/main/resources/static/favicon.icns")
-        type = "dmg"
+        type = ImageType.DMG
         macPackageIdentifier = "Stirling PDF"
         macPackageName = "Stirling PDF"
         macAppCategory = "public.app-category.productivity"
@@ -281,7 +300,7 @@ jpackage {
     linux {
         appVersion = project.version
         icon = layout.projectDirectory.file("stirling-pdf/src/main/resources/static/favicon.png")
-        type = "deb" // Can also use "rpm" for Red Hat-based systems
+        type = ImageType.DEB // Can also use "rpm" for Red Hat-based systems
 
         // Debian package configuration
         //linuxPackageName = "stirlingpdf"
@@ -514,6 +533,14 @@ swaggerhubUpload {
 }
 
 dependencies {
+    implementation project(':stirling-pdf')
+    implementation project(':common')
+    if (System.getenv('DISABLE_ADDITIONAL_FEATURES') != 'true'
+        || (project.hasProperty('DISABLE_ADDITIONAL_FEATURES')
+        && System.getProperty('DISABLE_ADDITIONAL_FEATURES') != 'true')) {
+        implementation project(':proprietary')
+    }
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 allprojects {
     group = 'stirling.software'
-    version = '1.0.1'
+    version = '1.0.2'
 
     configurations.configureEach {
         exclude group: 'commons-logging', module: 'commons-logging'

--- a/common/src/main/java/stirling/software/common/configuration/AppConfig.java
+++ b/common/src/main/java/stirling/software/common/configuration/AppConfig.java
@@ -21,6 +21,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.ClassUtils;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import lombok.Getter;
@@ -148,23 +149,11 @@ public class AppConfig {
     }
 
     @Bean(name = "activeSecurity")
-    public boolean activeSecurity() {
-        String disableAdditionalFeatures = env.getProperty("DISABLE_ADDITIONAL_FEATURES");
-
-        if (disableAdditionalFeatures != null) {
-            // DISABLE_ADDITIONAL_FEATURES=true means security OFF, so return false
-            // DISABLE_ADDITIONAL_FEATURES=false means security ON, so return true
-            return !Boolean.parseBoolean(disableAdditionalFeatures);
-        }
-
-        return env.getProperty("DOCKER_ENABLE_SECURITY", Boolean.class, true);
-    }
-
-    @Bean(name = "missingActiveSecurity")
-    @ConditionalOnMissingClass(
-            "stirling.software.proprietary.security.configuration.SecurityConfiguration")
     public boolean missingActiveSecurity() {
-        return true;
+        return ClassUtils.isPresent(
+            "stirling.software.proprietary.security.configuration.SecurityConfiguration",
+            this.getClass().getClassLoader()
+        );
     }
 
     @Bean(name = "directoryFilter")

--- a/stirling-pdf/build.gradle
+++ b/stirling-pdf/build.gradle
@@ -146,5 +146,10 @@ bootJar {
     }
 }
 
+// Configure main class for Spring Boot
+springBoot {
+    mainClass = 'stirling.software.SPDF.SPDFApplication'
+}
+
 bootJar.dependsOn ':common:jar'
 bootJar.dependsOn ':proprietary:jar'


### PR DESCRIPTION
# Description of Changes

Fix for `generateOpenApiDocs` task

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
