### PR TITLE
fix(css): correct selector for free text editor overlay in PDF viewer CSS

### DIFF
--- a/stirling-pdf/src/main/resources/static/pdfjs-legacy/css/viewer-redact.css
+++ b/stirling-pdf/src/main/resources/static/pdfjs-legacy/css/viewer-redact.css
@@ -1838,7 +1838,7 @@
   height: 100%;
 }
 
-.annotationEditorLayer freeTextEditor .overlay.enabled {
+.annotationEditorLayer .freeTextEditor .overlay.enabled {
   display: block;
 }
 

--- a/stirling-pdf/src/main/resources/static/pdfjs-legacy/css/viewer.css
+++ b/stirling-pdf/src/main/resources/static/pdfjs-legacy/css/viewer.css
@@ -1852,7 +1852,7 @@
   height:100%;
 }
 
-.annotationEditorLayer freeTextEditor .overlay.enabled{
+.annotationEditorLayer .freeTextEditor .overlay.enabled{
   display:block;
 }
 


### PR DESCRIPTION
# Description of Changes


**What was changed:**  

- The CSS selector in `viewer-redact.css` and `viewer.css` was updated from  
  ```.annotationEditorLayer freeTextEditor .overlay.enabled```  
  to  
  ```.annotationEditorLayer .freeTextEditor .overlay.enabled```  
  to properly target the `.freeTextEditor` element under `.annotationEditorLayer`.

**Why the change was made:**  

- The previous selector was missing the dot before `freeTextEditor`, so the overlay for free-text annotations was not being displayed as intended.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
