### PR TITLE
chore(license-report): add `projects = [project]` to licenseReport to avoid deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 licenseReport {
+    projects = [project]
     renderers = [new JsonReportRenderer()]
     allowedLicensesFile = new File("$projectDir/allowed-licenses.json")
 }


### PR DESCRIPTION
# Description of Changes

- **What was changed**  
  Added the line `projects = [project]` to the `licenseReport` configuration in `build.gradle`.

- **Why the change was made**  
  Without specifying `projects`, the `licenseReport` plugin attempts to resolve configurations from a non-project context, resulting in numerous deprecation warnings. Explicitly setting `projects = [project]` scopes the report to the current project and silences these warnings.


```
    - [warn]  Resolution of the configuration :common:runtimeClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:detachedConfiguration146 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:detachedConfiguration147 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:detachedConfiguration148 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:detachedConfiguration149 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:detachedConfiguration150 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:detachedConfiguration151 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:detachedConfiguration152 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:developmentOnly was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :common:testAndDevelopmentOnly was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:runtimeClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:detachedConfiguration215 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:detachedConfiguration216 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:detachedConfiguration217 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:detachedConfiguration218 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:detachedConfiguration219 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:detachedConfiguration220 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:developmentOnly was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :proprietary:testAndDevelopmentOnly was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :stirling-pdf:runtimeClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :stirling-pdf:detachedConfiguration231 was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :stirling-pdf:developmentOnly was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
    - [warn]  Resolution of the configuration :stirling-pdf:testAndDevelopmentOnly was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated.
```


---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
