### PR TITLE
fix(ci): correct variable name for deployment comment check in PR-Demo-cleanup workflow

### DIFF
--- a/.github/workflows/PR-Demo-cleanup.yml
+++ b/.github/workflows/PR-Demo-cleanup.yml
@@ -47,7 +47,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Hole alle Labels auf dem PR
+            // Get all labels on the PR
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner,
               repo,
@@ -68,14 +68,13 @@ jobs:
               console.log("Label 'pr-deployed' not found. Nothing to do.");
             }
 
-            // Find existing comment
-            const comments = await github.rest.issues.listComments({
+            // Find existing bot comments about the deployment
+            const { data: comments } = await github.rest.issues.listComments({
               owner,
               repo,
               issue_number: prNumber
             });
-
-            const deploymentComments = comments.data.filter(c =>
+            const deploymentComments = comments.filter(c =>
               c.body?.includes("## 🚀 PR Test Deployment") &&
               c.user?.type === "Bot"
             );
@@ -92,7 +91,11 @@ jobs:
             } else {
               console.log("No matching deployment comments found.");
             }
-            core.setOutput('present', hasLabel || deploymentComment ? 'true' : 'false');
+
+            // Set flag if either label or comment was present
+            const hasDeploymentComment = deploymentComments.length > 0;
+            core.setOutput('present', (hasLabel || hasDeploymentComment) ? 'true' : 'false');
+
 
       - name: Set up SSH
         if: steps.remove-label-comment.outputs.present == 'true'


### PR DESCRIPTION
# Description of Changes

- **What was changed**  
  - In `.github/workflows/PR-Demo-cleanup.yml`, updated the GitHub Script step to properly destructure the list of comments and renamed the flag from the undefined `deploymentComment` to `hasDeploymentComment`.  
  - Enhanced output logic to set the `present` flag based on either label presence or comment presence.  

- **Why the change was made**  
  - The cleanup job was failing with a `ReferenceError: deploymentComment is not defined` because the variable used in `core.setOutput()` did not exist.  
  - Ensuring the flag accurately reflects whether a deployment label or comment was present prevents unexpected workflow failures. 

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
