### PR TITLE
Disable cookie banner when analytics disabled

### DIFF
--- a/app/core/src/main/resources/templates/fragments/common.html
+++ b/app/core/src/main/resources/templates/fragments/common.html
@@ -200,8 +200,8 @@
   <link rel="stylesheet" th:href="@{'/css/footer.css'}">
 
   <link rel="preload" th:href="@{'/fonts/google-symbol.woff2'}" as="font" type="font/woff2" crossorigin="anonymous">
-  <link rel="stylesheet" th:href="@{'/css/cookieconsent.css'}">
-  <link rel="stylesheet" th:href="@{'/css/cookieconsentCustomisation.css'}">
+  <link rel="stylesheet" th:href="@{'/css/cookieconsent.css'}" th:if="${@analyticsEnabled}">
+  <link rel="stylesheet" th:href="@{'/css/cookieconsentCustomisation.css'}" th:if="${@analyticsEnabled}">
   <script th:src="@{'/js/thirdParty/fontfaceobserver.standalone.js'}"></script>
 
   <!-- Google MD Icons -->

--- a/app/core/src/main/resources/templates/fragments/footer.html
+++ b/app/core/src/main/resources/templates/fragments/footer.html
@@ -1,6 +1,6 @@
 <footer th:fragment="footer" id="footer" class="text-center">
   
-  <script type="module" th:src="@{'/js/thirdParty/cookieconsent-config.js'}"></script>
+  <script type="module" th:src="@{'/js/thirdParty/cookieconsent-config.js'}" th:if="${@analyticsEnabled}"></script>
   <div class="footer-center">
     <!-- Links section -->
     <div class="d-flex justify-content-center">
@@ -13,7 +13,7 @@
         <li th:if="${@accessibilityStatement != ''}"><a class="footer-link px-2" target="_blank" th:href="${@accessibilityStatement}" th:text="#{legal.accessibility}">accessibilityStatement</a></li>
         <li th:if="${@cookiePolicy != ''}"><a class="footer-link px-2" target="_blank" th:href="${@cookiePolicy}" th:text="#{legal.cookie}">cookiePolicy</a></li>
         <li th:if="${@impressum != ''}"><a class="footer-link px-2" target="_blank" th:href="${@impressum}" th:text="#{legal.impressum}">impressum</a></li>
-        <li><a class="footer-link px-2" id="cookieBanner" target="_blank"  th:text="#{legal.showCookieBanner}" onClick="CookieConsent.show(true)">Cookie Preferences</a></li>
+        <li th:if="${@analyticsEnabled}"><a class="footer-link px-2" id="cookieBanner" target="_blank"  th:text="#{legal.showCookieBanner}" onClick="CookieConsent.show(true)">Cookie Preferences</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
## Summary
- gate cookie consent resources behind the analytics flag
- hide the cookie preferences link in the footer when analytics are disabled

Generated with AI.

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_687c9568b2a8832891ffebddb65a9480