### PR TITLE
Fix dark mode tooltip

### DIFF
--- a/app/core/src/main/resources/messages_en_GB.properties
+++ b/app/core/src/main/resources/messages_en_GB.properties
@@ -347,6 +347,7 @@ analytics.settings=You can change the settings for analytics in the config/setti
 navbar.favorite=Favorites
 navbar.recent=New and recently updated
 navbar.darkmode=Dark Mode
+navbar.lightmode=Light Mode
 navbar.language=Languages
 navbar.settings=Settings
 navbar.allTools=Tools

--- a/app/core/src/main/resources/static/js/darkmode.js
+++ b/app/core/src/main/resources/static/js/darkmode.js
@@ -6,6 +6,8 @@ var elements = {
   darkModeStyles: null,
   rainbowModeStyles: null,
   darkModeIcon: null,
+  darkModeToggle: null,
+  darkModeText: null,
   searchBar: null,
   formControls: null,
   navIcons: null,
@@ -17,6 +19,8 @@ function getElements() {
   elements.darkModeStyles = document.getElementById("dark-mode-styles");
   elements.rainbowModeStyles = document.getElementById("rainbow-mode-styles");
   elements.darkModeIcon = document.getElementById("dark-mode-icon");
+  elements.darkModeToggle = document.getElementById("dark-mode-toggle");
+  elements.darkModeText = document.getElementById("dark-mode-text");
   elements.searchBar = document.getElementById("searchBar");
   elements.formControls = document.querySelectorAll(".form-control");
   elements.navDropdownMenus = document.querySelectorAll(".dropdown-menu");
@@ -41,6 +45,11 @@ function setMode(mode) {
     if (elements && elements.darkModeIcon) {
       elements.darkModeIcon.textContent = "dark_mode";
     }
+    if (elements && elements.darkModeToggle && elements.darkModeText) {
+      elements.darkModeToggle.title = elements.darkModeToggle.dataset.lightTitle;
+      elements.darkModeText.textContent = elements.darkModeText.dataset.lightText;
+      elements.darkModeText.setAttribute("data-text", elements.darkModeText.dataset.lightText);
+    }
     var tables = document.querySelectorAll(".table");
     tables.forEach((table) => {
       table.classList.add("table-dark");
@@ -49,6 +58,11 @@ function setMode(mode) {
     if (elements && elements.darkModeIcon) {
       elements.darkModeIcon.textContent = "light_mode";
     }
+    if (elements && elements.darkModeToggle && elements.darkModeText) {
+      elements.darkModeToggle.title = elements.darkModeToggle.dataset.darkTitle;
+      elements.darkModeText.textContent = elements.darkModeText.dataset.darkText;
+      elements.darkModeText.setAttribute("data-text", elements.darkModeText.dataset.darkText);
+    }
     var tables = document.querySelectorAll(".table-dark");
     tables.forEach((table) => {
       table.classList.remove("table-dark");
@@ -56,6 +70,11 @@ function setMode(mode) {
   } else if (mode === "rainbow") {
     if (elements && elements.darkModeIcon) {
       elements.darkModeIcon.textContent = "looks";
+    }
+    if (elements && elements.darkModeToggle && elements.darkModeText) {
+      elements.darkModeToggle.title = elements.darkModeToggle.dataset.darkTitle;
+      elements.darkModeText.textContent = elements.darkModeText.dataset.darkText;
+      elements.darkModeText.setAttribute("data-text", elements.darkModeText.dataset.darkText);
     }
   }
 }

--- a/app/core/src/main/resources/templates/fragments/navbar.html
+++ b/app/core/src/main/resources/templates/fragments/navbar.html
@@ -127,12 +127,12 @@
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" id="dark-mode-toggle" href="#" th:title="#{navbar.darkmode}">
+            <a class="nav-link" id="dark-mode-toggle" href="#" th:title="#{navbar.darkmode}" data-dark-title="#{navbar.darkmode}" data-light-title="#{navbar.lightmode}">
               <span class="material-symbols-rounded" id="dark-mode-icon">
                 dark_mode
               </span>
               <span class="icon-text icon-hide" id="dark-mode-text" th:data-text="#{navbar.darkmode}"
-                th:text="#{navbar.darkmode}"></span>
+                th:text="#{navbar.darkmode}" data-dark-text="#{navbar.darkmode}" data-light-text="#{navbar.lightmode}"></span>
             </a>
           </li>
           <li class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- change theme toggle tooltip to reflect current mode
- update JS to switch tooltip text and title dynamically
- add en_GB translation for light mode

## Testing
- `./gradlew spotlessApply`
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_687c980eab3883289875443d9183e884