### PR TITLE
Improve temp cleanup performance

### DIFF
--- a/app/common/src/main/java/stirling/software/common/config/CleanupAsyncConfig.java
+++ b/app/common/src/main/java/stirling/software/common/config/CleanupAsyncConfig.java
@@ -23,53 +23,60 @@ public class CleanupAsyncConfig {
         exec.setMaxPoolSize(1);
         exec.setQueueCapacity(100);
         exec.setThreadNamePrefix("cleanup-");
-        
+
         // Set custom rejection handler to log when queue is full
-        exec.setRejectedExecutionHandler(new RejectedExecutionHandler() {
-            private volatile long lastRejectionTime = 0;
-            private volatile int rejectionCount = 0;
-            
-            @Override
-            public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-                long currentTime = System.currentTimeMillis();
-                rejectionCount++;
-                
-                // Rate-limit logging to avoid spam
-                if (currentTime - lastRejectionTime > 60000) { // Log at most once per minute
-                    log.warn("Cleanup task rejected #{} - queue full! Active: {}, Queue size: {}, Pool size: {}",
-                        rejectionCount,
-                        executor.getActiveCount(),
-                        executor.getQueue().size(),
-                        executor.getPoolSize());
-                    lastRejectionTime = currentTime;
-                }
-                
-                // Try to discard oldest task and add this one
-                if (executor.getQueue().poll() != null) {
-                    log.debug("Discarded oldest queued cleanup task to make room");
-                    try {
-                        executor.execute(r);
-                        return;
-                    } catch (Exception e) {
-                        // If still rejected, fall back to caller-runs
+        exec.setRejectedExecutionHandler(
+                new RejectedExecutionHandler() {
+                    private volatile long lastRejectionTime = 0;
+                    private volatile int rejectionCount = 0;
+
+                    @Override
+                    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+                        long currentTime = System.currentTimeMillis();
+                        rejectionCount++;
+
+                        // Rate-limit logging to avoid spam
+                        if (currentTime - lastRejectionTime
+                                > 60000) { // Log at most once per minute
+                            log.warn(
+                                    "Cleanup task rejected #{} - queue full! Active: {}, Queue size: {}, Pool size: {}",
+                                    rejectionCount,
+                                    executor.getActiveCount(),
+                                    executor.getQueue().size(),
+                                    executor.getPoolSize());
+                            lastRejectionTime = currentTime;
+                        }
+
+                        // Try to discard oldest task and add this one
+                        if (executor.getQueue().poll() != null) {
+                            log.debug("Discarded oldest queued cleanup task to make room");
+                            try {
+                                executor.execute(r);
+                                return;
+                            } catch (Exception e) {
+                                // If still rejected, fall back to caller-runs
+                            }
+                        }
+
+                        // Last resort: caller-runs with timeout protection
+                        log.warn(
+                                "Executing cleanup task #{} on scheduler thread as last resort",
+                                rejectionCount);
+                        long startTime = System.currentTimeMillis();
+                        try {
+                            r.run();
+                            long duration = System.currentTimeMillis() - startTime;
+                            if (duration > 30000) { // Warn if cleanup blocks scheduler for >30s
+                                log.warn(
+                                        "Cleanup task on scheduler thread took {}ms - consider tuning",
+                                        duration);
+                            }
+                        } catch (Exception e) {
+                            log.error("Cleanup task failed on scheduler thread", e);
+                        }
                     }
-                }
-                
-                // Last resort: caller-runs with timeout protection
-                log.warn("Executing cleanup task #{} on scheduler thread as last resort", rejectionCount);
-                long startTime = System.currentTimeMillis();
-                try {
-                    r.run();
-                    long duration = System.currentTimeMillis() - startTime;
-                    if (duration > 30000) { // Warn if cleanup blocks scheduler for >30s
-                        log.warn("Cleanup task on scheduler thread took {}ms - consider tuning", duration);
-                    }
-                } catch (Exception e) {
-                    log.error("Cleanup task failed on scheduler thread", e);
-                }
-            }
-        });
-        
+                });
+
         exec.initialize();
         return exec;
     }

--- a/app/common/src/main/java/stirling/software/common/config/CleanupAsyncConfig.java
+++ b/app/common/src/main/java/stirling/software/common/config/CleanupAsyncConfig.java
@@ -1,0 +1,24 @@
+package stirling.software.common.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class CleanupAsyncConfig {
+
+    @Bean(name = "cleanupExecutor")
+    public Executor cleanupExecutor() {
+        ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+        exec.setCorePoolSize(1);
+        exec.setMaxPoolSize(1);
+        exec.setQueueCapacity(100);
+        exec.setThreadNamePrefix("cleanup-");
+        exec.initialize();
+        return exec;
+    }
+}

--- a/app/common/src/main/java/stirling/software/common/config/CleanupAsyncConfig.java
+++ b/app/common/src/main/java/stirling/software/common/config/CleanupAsyncConfig.java
@@ -1,14 +1,19 @@
 package stirling.software.common.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Configuration
 @EnableAsync
+@Slf4j
 public class CleanupAsyncConfig {
 
     @Bean(name = "cleanupExecutor")
@@ -18,6 +23,23 @@ public class CleanupAsyncConfig {
         exec.setMaxPoolSize(1);
         exec.setQueueCapacity(100);
         exec.setThreadNamePrefix("cleanup-");
+        
+        // Set custom rejection handler to log when queue is full
+        exec.setRejectedExecutionHandler(new RejectedExecutionHandler() {
+            @Override
+            public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+                log.warn("Cleanup task rejected - queue full! Active: {}, Queue size: {}, Pool size: {}",
+                    executor.getActiveCount(),
+                    executor.getQueue().size(),
+                    executor.getPoolSize());
+                
+                // Use caller-runs policy as fallback - this will block the scheduler thread
+                // but ensures the cleanup still happens
+                log.warn("Executing cleanup task on scheduler thread as fallback");
+                r.run();
+            }
+        });
+        
         exec.initialize();
         return exec;
     }

--- a/app/common/src/main/java/stirling/software/common/model/ApplicationProperties.java
+++ b/app/common/src/main/java/stirling/software/common/model/ApplicationProperties.java
@@ -328,8 +328,8 @@ public class ApplicationProperties {
         private long cleanupIntervalMinutes = 30;
         private boolean startupCleanup = true;
         private boolean cleanupSystemTemp = false;
-        private int batchSize = 0;
-        private long pauseBetweenBatchesMs = 0;
+        private int batchSize = 1000;
+        private long pauseBetweenBatchesMs = 50;
 
         public String getBaseTmpDir() {
             return baseTmpDir != null && !baseTmpDir.isEmpty()

--- a/app/common/src/main/java/stirling/software/common/model/ApplicationProperties.java
+++ b/app/common/src/main/java/stirling/software/common/model/ApplicationProperties.java
@@ -328,6 +328,8 @@ public class ApplicationProperties {
         private long cleanupIntervalMinutes = 30;
         private boolean startupCleanup = true;
         private boolean cleanupSystemTemp = false;
+        private int batchSize = 0;
+        private long pauseBetweenBatchesMs = 0;
 
         public String getBaseTmpDir() {
             return baseTmpDir != null && !baseTmpDir.isEmpty()

--- a/app/common/src/test/java/stirling/software/common/service/TempFileCleanupServiceTest.java
+++ b/app/common/src/test/java/stirling/software/common/service/TempFileCleanupServiceTest.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
+import java.nio.file.DirectoryStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -142,20 +142,27 @@ public class TempFileCleanupServiceTest {
 
         // Use MockedStatic to mock Files operations
         try (MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
-            // Mock Files.list for each directory we'll process
-            mockedFiles.when(() -> Files.list(eq(systemTempDir)))
-                    .thenReturn(Stream.of(
-                            ourTempFile1, ourTempFile2, oldTempFile, sysTempFile1,
-                            jettyFile1, jettyFile2, regularFile, emptyFile, nestedDir));
+            // Mock Files.newDirectoryStream for each directory we'll process
+            mockedFiles.when(() -> Files.newDirectoryStream(eq(systemTempDir)))
+                    .thenReturn(directoryStreamOf(
+                            ourTempFile1,
+                            ourTempFile2,
+                            oldTempFile,
+                            sysTempFile1,
+                            jettyFile1,
+                            jettyFile2,
+                            regularFile,
+                            emptyFile,
+                            nestedDir));
 
-            mockedFiles.when(() -> Files.list(eq(customTempDir)))
-                    .thenReturn(Stream.of(ourTempFile3, ourTempFile4, sysTempFile2, sysTempFile3));
+            mockedFiles.when(() -> Files.newDirectoryStream(eq(customTempDir)))
+                    .thenReturn(directoryStreamOf(ourTempFile3, ourTempFile4, sysTempFile2, sysTempFile3));
 
-            mockedFiles.when(() -> Files.list(eq(libreOfficeTempDir)))
-                    .thenReturn(Stream.of(ourTempFile5));
+            mockedFiles.when(() -> Files.newDirectoryStream(eq(libreOfficeTempDir)))
+                    .thenReturn(directoryStreamOf(ourTempFile5));
 
-            mockedFiles.when(() -> Files.list(eq(nestedDir)))
-                    .thenReturn(Stream.of(nestedTempFile));
+            mockedFiles.when(() -> Files.newDirectoryStream(eq(nestedDir)))
+                    .thenReturn(directoryStreamOf(nestedTempFile));
 
             // Configure Files.isDirectory for each path
             mockedFiles.when(() -> Files.isDirectory(eq(nestedDir))).thenReturn(true);
@@ -251,9 +258,10 @@ public class TempFileCleanupServiceTest {
 
         // Use MockedStatic to mock Files operations
         try (MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
-            // Mock Files.list for systemTempDir
-            mockedFiles.when(() -> Files.list(eq(systemTempDir)))
-                    .thenReturn(Stream.of(ourTempFile, sysTempFile, regularFile));
+            // Mock Files.newDirectoryStream for systemTempDir
+            mockedFiles
+                    .when(() -> Files.newDirectoryStream(eq(systemTempDir)))
+                    .thenReturn(directoryStreamOf(ourTempFile, sysTempFile, regularFile));
 
             // Configure Files.isDirectory
             mockedFiles.when(() -> Files.isDirectory(any(Path.class))).thenReturn(false);
@@ -302,9 +310,10 @@ public class TempFileCleanupServiceTest {
 
         // Use MockedStatic to mock Files operations
         try (MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
-            // Mock Files.list for systemTempDir
-            mockedFiles.when(() -> Files.list(eq(systemTempDir)))
-                    .thenReturn(Stream.of(emptyFile, recentEmptyFile));
+            // Mock Files.newDirectoryStream for systemTempDir
+            mockedFiles
+                    .when(() -> Files.newDirectoryStream(eq(systemTempDir)))
+                    .thenReturn(directoryStreamOf(emptyFile, recentEmptyFile));
 
             // Configure Files.isDirectory
             mockedFiles.when(() -> Files.isDirectory(any(Path.class))).thenReturn(false);
@@ -369,18 +378,22 @@ public class TempFileCleanupServiceTest {
 
         // Use MockedStatic to mock Files operations
         try (MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
-            // Mock Files.list for each directory
-            mockedFiles.when(() -> Files.list(eq(systemTempDir)))
-                    .thenReturn(Stream.of(dir1));
+            // Mock Files.newDirectoryStream for each directory
+            mockedFiles
+                    .when(() -> Files.newDirectoryStream(eq(systemTempDir)))
+                    .thenReturn(directoryStreamOf(dir1));
 
-            mockedFiles.when(() -> Files.list(eq(dir1)))
-                    .thenReturn(Stream.of(tempFile1, dir2));
+            mockedFiles
+                    .when(() -> Files.newDirectoryStream(eq(dir1)))
+                    .thenReturn(directoryStreamOf(tempFile1, dir2));
 
-            mockedFiles.when(() -> Files.list(eq(dir2)))
-                    .thenReturn(Stream.of(tempFile2, dir3));
+            mockedFiles
+                    .when(() -> Files.newDirectoryStream(eq(dir2)))
+                    .thenReturn(directoryStreamOf(tempFile2, dir3));
 
-            mockedFiles.when(() -> Files.list(eq(dir3)))
-                    .thenReturn(Stream.of(tempFile3));
+            mockedFiles
+                    .when(() -> Files.newDirectoryStream(eq(dir3)))
+                    .thenReturn(directoryStreamOf(tempFile3));
 
             // Configure Files.isDirectory for each path
             mockedFiles.when(() -> Files.isDirectory(eq(dir1))).thenReturn(true);
@@ -460,5 +473,17 @@ public class TempFileCleanupServiceTest {
     // Matcher for exact path equality
     private static Path eq(Path path) {
         return argThat(arg -> arg != null && arg.equals(path));
+    }
+
+    private static DirectoryStream<Path> directoryStreamOf(Path... paths) {
+        return new DirectoryStream<>() {
+            @Override
+            public java.util.Iterator<Path> iterator() {
+                return java.util.Arrays.asList(paths).iterator();
+            }
+
+            @Override
+            public void close() {}
+        };
     }
 }

--- a/app/common/src/test/java/stirling/software/common/service/TempFileCleanupServiceTest.java
+++ b/app/common/src/test/java/stirling/software/common/service/TempFileCleanupServiceTest.java
@@ -182,7 +182,7 @@ public class TempFileCleanupServiceTest {
                             return FileTime.fromMillis(System.currentTimeMillis() - 5000000);
                         }
                         // For empty.tmp file, return a timestamp older than 5 minutes (for empty file test)
-                        else if (fileName.equals("empty.tmp")) {
+                        else if ("empty.tmp".equals(fileName)) {
                             return FileTime.fromMillis(System.currentTimeMillis() - 6 * 60 * 1000);
                         }
                         // For all other files, return a recent timestamp
@@ -198,7 +198,7 @@ public class TempFileCleanupServiceTest {
                         String fileName = path.getFileName().toString();
 
                         // Return 0 bytes for the empty file
-                        if (fileName.equals("empty.tmp")) {
+                        if ("empty.tmp".equals(fileName)) {
                             return 0L;
                         }
                         // Return normal size for all other files
@@ -327,7 +327,7 @@ public class TempFileCleanupServiceTest {
                         Path path = invocation.getArgument(0);
                         String fileName = path.getFileName().toString();
 
-                        if (fileName.equals("empty.tmp")) {
+                        if ("empty.tmp".equals(fileName)) {
                             // More than 5 minutes old
                             return FileTime.fromMillis(System.currentTimeMillis() - 6 * 60 * 1000);
                         } else {

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
@@ -232,7 +232,8 @@ public class ConvertImgPDFController {
                 PdfUtils.imageToPdf(file, fitOption, autoRotate, colorType, pdfDocumentFactory);
         return WebResponseUtils.bytesToWebResponse(
                 bytes,
-                new File(file[0].getOriginalFilename()).getName().replaceFirst("[.][^.]+$", "") + "_converted.pdf");
+                new File(file[0].getOriginalFilename()).getName().replaceFirst("[.][^.]+$", "")
+                        + "_converted.pdf");
     }
 
     private String getMediaType(String imageFormat) {

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/PrintFileController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/PrintFileController.java
@@ -47,7 +47,8 @@ public class PrintFileController {
             throws IOException {
         MultipartFile file = request.getFileInput();
         String originalFilename = file.getOriginalFilename();
-        if (originalFilename != null && (originalFilename.contains("..") || Paths.get(originalFilename).isAbsolute())) {
+        if (originalFilename != null
+                && (originalFilename.contains("..") || Paths.get(originalFilename).isAbsolute())) {
             throw new IOException("Invalid file path detected: " + originalFilename);
         }
         String printerName = request.getPrinterName();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -42,7 +42,6 @@ import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.TempFile;
 import stirling.software.common.util.TempFileManager;
 import stirling.software.common.util.WebResponseUtils;
-import java.lang.IllegalArgumentException;
 
 @RestController
 @RequestMapping("/api/v1/misc")
@@ -67,7 +66,7 @@ public class StampController {
         if (pdfFileName.contains("..") || pdfFileName.startsWith("/")) {
             throw new IllegalArgumentException("Invalid PDF file path");
         }
-        
+
         String stampType = request.getStampType();
         String stampText = request.getStampText();
         MultipartFile stampImage = request.getStampImage();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -331,7 +331,8 @@ public class PipelineProcessor {
         for (File file : files) {
             Path normalizedPath = Paths.get(file.getName()).normalize();
             if (normalizedPath.startsWith("..")) {
-                throw new SecurityException("Potential path traversal attempt in file name: " + file.getName());
+                throw new SecurityException(
+                        "Potential path traversal attempt in file name: " + file.getName());
             }
             Path path = Paths.get(file.getAbsolutePath());
             // debug statement

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -83,7 +83,9 @@ public class WatermarkController {
         MultipartFile watermarkImage = request.getWatermarkImage();
         if (watermarkImage != null) {
             String watermarkImageFileName = watermarkImage.getOriginalFilename();
-            if (watermarkImageFileName != null && (watermarkImageFileName.contains("..") || watermarkImageFileName.startsWith("/"))) {
+            if (watermarkImageFileName != null
+                    && (watermarkImageFileName.contains("..")
+                            || watermarkImageFileName.startsWith("/"))) {
                 throw new SecurityException("Invalid file path in watermarkImage");
             }
         }

--- a/app/core/src/main/resources/settings.yml.template
+++ b/app/core/src/main/resources/settings.yml.template
@@ -134,8 +134,8 @@ system:
     cleanupIntervalMinutes: 30 # How often to run cleanup (in minutes)
     startupCleanup: true # Clean up old temp files on startup
     cleanupSystemTemp: false # Whether to clean broader system temp directory
-    batchSize: 0 # Number of entries processed before optional pause (0 = unlimited)
-    pauseBetweenBatchesMs: 0 # Pause duration in milliseconds between batches
+    batchSize: 1000 # Number of entries processed before optional pause (0 = unlimited)
+    pauseBetweenBatchesMs: 50 # Pause duration in milliseconds between batches
 
 ui:
   appName: '' # application's visible name

--- a/app/core/src/main/resources/settings.yml.template
+++ b/app/core/src/main/resources/settings.yml.template
@@ -134,6 +134,8 @@ system:
     cleanupIntervalMinutes: 30 # How often to run cleanup (in minutes)
     startupCleanup: true # Clean up old temp files on startup
     cleanupSystemTemp: false # Whether to clean broader system temp directory
+    batchSize: 0 # Number of entries processed before optional pause (0 = unlimited)
+    pauseBetweenBatchesMs: 0 # Pause duration in milliseconds between batches
 
 ui:
   appName: '' # application's visible name


### PR DESCRIPTION
## Summary
- add async executor for cleanup tasks
- replace `Files.list` with `DirectoryStream` and support batching
- expose new `batchSize` and `pauseBetweenBatchesMs` settings
- update tests for streaming logic

## Testing
- `./gradlew spotlessApply`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_687c96b541688328a177d53d01d1ba97