### PR TITLE
fix(workflows): correct YAML indentation in frontend license update workflow

### DIFF
--- a/.github/workflows/frontend-licenses-update.yml
+++ b/.github/workflows/frontend-licenses-update.yml
@@ -126,19 +126,19 @@ jobs:
               
               commentBody = `## ❌ Frontend License Check Failed
               
-The frontend license check has detected compatibility warnings that require review:
+              The frontend license check has detected compatibility warnings that require review:
 
-${warningDetails}
+              ${warningDetails}
 
-**Action Required:** Please review these licenses to ensure they are acceptable for your use case before merging.
+              **Action Required:** Please review these licenses to ensure they are acceptable for your use case before merging.
 
-_This check will fail the PR until license issues are resolved._`;
+              _This check will fail the PR until license issues are resolved._`;
             } else {
               commentBody = `## ✅ Frontend License Check Passed
               
-All frontend licenses have been validated and no compatibility warnings were detected.
+              All frontend licenses have been validated and no compatibility warnings were detected.
 
-The frontend license report has been updated successfully.`;
+              The frontend license report has been updated successfully.`;
             }
             
             await github.rest.issues.createComment({


### PR DESCRIPTION
…orkflow

# Description of Changes

- Fixed invalid YAML syntax caused by inconsistent indentation inside a multi-line JavaScript template string in `.github/workflows/frontend-licenses-update.yml`.
- The incorrect indentation broke the GitHub Actions runner with a syntax error on line 131.
- This change ensures that the entire `commentBody = \`...\`;` block is treated as a valid JavaScript string inside the `run:` shell context.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
