### PR TITLE
fix(pipeline): allow slashes in pipeline operation values

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -111,7 +111,8 @@ public class PipelineProcessor {
 
             if (!apiDocService.isValidOperation(operation, parameters)) {
                 log.error("Invalid operation or parameters: o:{} p:{}", operation, parameters);
-                throw new IllegalArgumentException("Invalid operation: " + operation);
+                throw new IllegalArgumentException(
+                        "Invalid operation: " + operation + " with parameters: " + parameters);
             }
 
             String url = getBaseUrl() + operation;
@@ -139,7 +140,7 @@ public class PipelineProcessor {
                             // skip
                             // this
                             // file
-                            if (operation.startsWith("filter-")
+                            if (operation.startsWith("/api/v1/filter/filter-")
                                     && (response.getBody() == null
                                             || response.getBody().length == 0)) {
                                 filtersApplied = true;

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -108,7 +108,11 @@ public class PipelineProcessor {
             if (inputFileTypes == null) {
                 inputFileTypes = new ArrayList<String>(Arrays.asList("ALL"));
             }
-            if (!operation.matches("^[a-zA-Z0-9_-]+$")) {
+            if (!operation.matches("^[a-zA-Z0-9/_-]+$")) {
+                log.error(
+                        "Invalid operation value received: {}. Only alphanumeric characters,"
+                            + " underscores, hyphens, and slashes are allowed.",
+                        operation);
                 throw new IllegalArgumentException("Invalid operation value received.");
             }
             String url = getBaseUrl() + operation;

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -108,13 +108,12 @@ public class PipelineProcessor {
             if (inputFileTypes == null) {
                 inputFileTypes = new ArrayList<String>(Arrays.asList("ALL"));
             }
-            if (!operation.matches("^[a-zA-Z0-9/_-]+$")) {
-                log.error(
-                        "Invalid operation value received: {}. Only alphanumeric characters,"
-                            + " underscores, hyphens, and slashes are allowed.",
-                        operation);
-                throw new IllegalArgumentException("Invalid operation value received.");
+
+            if (!apiDocService.isValidOperation(operation, parameters)) {
+                log.error("Invalid operation or parameters: o:{} p:{}", operation, parameters);
+                throw new IllegalArgumentException("Invalid operation: " + operation);
             }
+
             String url = getBaseUrl() + operation;
             List<Resource> newOutputFiles = new ArrayList<>();
             if (!isMultiInputOperation) {

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
@@ -45,7 +45,7 @@ class PipelineProcessorTest {
     @Test
     void runPipelineWithFilterSetsFlag() throws Exception {
         PipelineOperation op = new PipelineOperation();
-        op.setOperation("filter-page-count");
+        op.setOperation("/api/v1/filter/filter-page-count");
         op.setParameters(Map.of());
         PipelineConfig config = new PipelineConfig();
         config.setOperations(List.of(op));
@@ -59,8 +59,8 @@ class PipelineProcessorTest {
 
         List<Resource> files = List.of(file);
 
-        when(apiDocService.isMultiInput("filter-page-count")).thenReturn(false);
-        when(apiDocService.getExtensionTypes(false, "filter-page-count"))
+        when(apiDocService.isMultiInput("/api/v1/filter/filter-page-count")).thenReturn(false);
+        when(apiDocService.getExtensionTypes(false, "/api/v1/filter/filter-page-count"))
                 .thenReturn(List.of("pdf"));
 
         doReturn(new ResponseEntity<>(new byte[0], HttpStatus.OK))

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
@@ -50,18 +50,21 @@ class PipelineProcessorTest {
         PipelineConfig config = new PipelineConfig();
         config.setOperations(List.of(op));
 
-        Resource file = new ByteArrayResource("data".getBytes()) {
-            @Override
-            public String getFilename() {
-                return "test.pdf";
-            }
-        };
+        Resource file =
+                new ByteArrayResource("data".getBytes()) {
+                    @Override
+                    public String getFilename() {
+                        return "test.pdf";
+                    }
+                };
 
         List<Resource> files = List.of(file);
 
         when(apiDocService.isMultiInput("/api/v1/filter/filter-page-count")).thenReturn(false);
         when(apiDocService.getExtensionTypes(false, "/api/v1/filter/filter-page-count"))
                 .thenReturn(List.of("pdf"));
+        when(apiDocService.isValidOperation(eq("/api/v1/filter/filter-page-count"), anyMap()))
+                .thenReturn(true);
 
         doReturn(new ResponseEntity<>(new byte[0], HttpStatus.OK))
                 .when(pipelineProcessor)


### PR DESCRIPTION
# Description of Changes

- Extended the validation regex for `operation` in the pipeline processor to allow slashes (`/`), in addition to alphanumeric characters, underscores, and hyphens.
- This resolves the issue where valid operation strings (e.g., with subpaths like `/api/v1/general/remove-pages`) were incorrectly rejected.
- Added an explicit log message for better debugging in case of invalid `operation` values.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
