### PR TITLE
fix: adjust margin of bookmark editor

### DIFF
--- a/app/core/src/main/resources/static/css/edit-table-of-contents.css
+++ b/app/core/src/main/resources/static/css/edit-table-of-contents.css
@@ -1,6 +1,6 @@
 /* Main bookmark container styles */
 .bookmark-editor {
-  margin-top: 20px;
+  margin-bottom: 20px;
   padding: 20px;
   border: 1px solid var(--border-color, #ced4da);
   border-radius: 0.25rem;


### PR DESCRIPTION
# Description of Changes

- remove overlapping margins of bookmark editor to the checkbox above
- add bottom margin for the bookmark editor element to the "Info"-button below
- I guess this simply was a typo `margin-top` vs. `margin-bottom` as the margin to the element above is overlapping

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)
  *before / after*:
  <p float="left">
    <img width="300" alt="before edit with margin highlighted" src="https://github.com/user-attachments/assets/e7f20a94-8aa0-4f37-96b4-59d1506e1045" />
    <img width="300" alt="after edit with margin highlighted" src="https://github.com/user-attachments/assets/3caad04a-0b51-4590-9846-ea9be4985b6e" />
  </p>

  before / after with margin highlighted:
  <p float="left">
    <img width="300" alt="before edit with margin highlighted" src="https://github.com/user-attachments/assets/219bd2e4-87c4-4a94-b53f-4c3b730a4da6" />
    <img width="300" alt="after edit with margin highlighted" src="https://github.com/user-attachments/assets/5e97f06f-f34e-41b7-98f4-68ced466dca8" />
  </p>



### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
