### PR TITLE
chore(templates): remove redundant `fetch-utils.js` script includes

### DIFF
--- a/app/core/src/main/resources/templates/home-legacy.html
+++ b/app/core/src/main/resources/templates/home-legacy.html
@@ -413,9 +413,6 @@
     </div>
   </div>
 
-
-
-  <script th:src="@{'/js/fetch-utils.js'}"></script>
   <script th:inline="javascript">
 
     /*<![CDATA[*/

--- a/app/core/src/main/resources/templates/home.html
+++ b/app/core/src/main/resources/templates/home.html
@@ -208,7 +208,6 @@
       color: gold;
     }
   </style>
-  <script th:src="@{'/js/fetch-utils.js'}"></script>
   <script th:inline="javascript">
     /*<![CDATA[*/
     window.analyticsPromptBoolean = /*[[${@analyticsPrompt}]]*/ false;

--- a/app/core/src/main/resources/templates/misc/scanner-effect.html
+++ b/app/core/src/main/resources/templates/misc/scanner-effect.html
@@ -98,7 +98,6 @@
       </div>
       <th:block th:insert="~{fragments/footer.html :: footer}"></th:block>
     </div>
-    <script th:src="@{'/js/fetch-utils.js'}"></script>
     <script th:inline="javascript">
       // Show/hide advanced settings
       document.getElementById('advancedSettingsToggle').addEventListener('change', function() {

--- a/app/core/src/main/resources/templates/misc/show-javascript.html
+++ b/app/core/src/main/resources/templates/misc/show-javascript.html
@@ -39,7 +39,6 @@
                 <!-- Button to download the JSON -->
                 <a href="#" id="downloadJS" class="btn btn-primary mt-3" style="display: none;" th:text="#{showJS.downloadJS}">Download JSON</a>
               </div>
-              <script th:src="@{'/js/fetch-utils.js'}"></script>
               <script>
                 document.querySelector('#pdfInfoForm').addEventListener('submit', function(event){
                   event.preventDefault();

--- a/app/core/src/main/resources/templates/pipeline.html
+++ b/app/core/src/main/resources/templates/pipeline.html
@@ -192,7 +192,6 @@
                     </div>
                   </div>
                 </div>
-                <script th:src="@{'/js/fetch-utils.js'}"></script>
                 <script th:src="@{'/js/pipeline.js'}"></script>
             </div>
           </div>

--- a/app/core/src/main/resources/templates/security/get-info-on-pdf.html
+++ b/app/core/src/main/resources/templates/security/get-info-on-pdf.html
@@ -106,7 +106,6 @@
                 <!-- Button to download the JSON -->
                 <a href="#" id="downloadJson" class="btn btn-primary mt-3" style="display: none;" th:text="#{getPdfInfo.downloadJson}">Download JSON</a>
               </div>
-              <script th:src="@{'/js/fetch-utils.js'}"></script>
               <script th:inline="javascript">
                 // Pre-load message translations
                 const getPdfInfoSummary = /*[[#{getPdfInfo.summary}]]*/ "PDF Summary";


### PR DESCRIPTION
# Description of Changes

- **What was changed**: Removed all explicit `<script th:src="@{'/js/fetch-utils.js'}"></script>` tags from various Thymeleaf templates (`home.html`, `home-legacy.html`, `scanner-effect.html`, etc.).
- **Why the change was made**: The `fetch-utils.js` script is already included globally via `<th:block th:insert="~{fragments/common :: head()}">` in `fragments/common.html` (line 156). Keeping redundant includes leads to unnecessary script loading and potential duplication.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
