### PR TITLE
refactor: replace switch statements with modern switch expressions for better readability

### DIFF
--- a/app/common/src/main/java/stirling/software/common/service/SsrfProtectionService.java
+++ b/app/common/src/main/java/stirling/software/common/service/SsrfProtectionService.java
@@ -51,16 +51,11 @@ public class SsrfProtectionService {
 
         SsrfProtectionLevel level = parseProtectionLevel(config.getLevel());
 
-        switch (level) {
-            case OFF:
-                return true;
-            case MAX:
-                return isMaxSecurityAllowed(trimmedUrl, config);
-            case MEDIUM:
-                return isMediumSecurityAllowed(trimmedUrl, config);
-            default:
-                return false;
-        }
+        return switch (level) {
+            case OFF -> true;
+            case MAX -> isMaxSecurityAllowed(trimmedUrl, config);
+            case MEDIUM -> isMediumSecurityAllowed(trimmedUrl, config);
+        };
     }
 
     private SsrfProtectionLevel parseProtectionLevel(String level) {

--- a/app/common/src/main/java/stirling/software/common/util/ImageProcessingUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/ImageProcessingUtils.java
@@ -82,19 +82,16 @@ public class ImageProcessingUtils {
                 return 0;
             }
             int orientationTag = directory.getInt(ExifSubIFDDirectory.TAG_ORIENTATION);
-            switch (orientationTag) {
-                case 1:
-                    return 0;
-                case 6:
-                    return 90;
-                case 3:
-                    return 180;
-                case 8:
-                    return 270;
-                default:
+            return switch (orientationTag) {
+                case 1 -> 0;
+                case 6 -> 90;
+                case 3 -> 180;
+                case 8 -> 270;
+                default -> {
                     log.warn("Unknown orientation tag: {}", orientationTag);
-                    return 0;
-            }
+                    yield 0;
+                }
+            };
         } catch (ImageProcessingException | MetadataException e) {
             return 0;
         }

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
@@ -62,56 +62,50 @@ public class MergeController {
 
     // Returns a comparator for sorting MultipartFile arrays based on the given sort type
     private Comparator<MultipartFile> getSortComparator(String sortType) {
-        switch (sortType) {
-            case "byFileName":
-                return Comparator.comparing(MultipartFile::getOriginalFilename);
-            case "byDateModified":
-                return (file1, file2) -> {
-                    try {
-                        BasicFileAttributes attr1 =
-                                Files.readAttributes(
-                                        Paths.get(file1.getOriginalFilename()),
-                                        BasicFileAttributes.class);
-                        BasicFileAttributes attr2 =
-                                Files.readAttributes(
-                                        Paths.get(file2.getOriginalFilename()),
-                                        BasicFileAttributes.class);
-                        return attr1.lastModifiedTime().compareTo(attr2.lastModifiedTime());
-                    } catch (IOException e) {
-                        return 0; // If there's an error, treat them as equal
-                    }
-                };
-            case "byDateCreated":
-                return (file1, file2) -> {
-                    try {
-                        BasicFileAttributes attr1 =
-                                Files.readAttributes(
-                                        Paths.get(file1.getOriginalFilename()),
-                                        BasicFileAttributes.class);
-                        BasicFileAttributes attr2 =
-                                Files.readAttributes(
-                                        Paths.get(file2.getOriginalFilename()),
-                                        BasicFileAttributes.class);
-                        return attr1.creationTime().compareTo(attr2.creationTime());
-                    } catch (IOException e) {
-                        return 0; // If there's an error, treat them as equal
-                    }
-                };
-            case "byPDFTitle":
-                return (file1, file2) -> {
-                    try (PDDocument doc1 = pdfDocumentFactory.load(file1);
-                            PDDocument doc2 = pdfDocumentFactory.load(file2)) {
-                        String title1 = doc1.getDocumentInformation().getTitle();
-                        String title2 = doc2.getDocumentInformation().getTitle();
-                        return title1.compareTo(title2);
-                    } catch (IOException e) {
-                        return 0;
-                    }
-                };
-            case "orderProvided":
-            default:
-                return (file1, file2) -> 0; // Default is the order provided
-        }
+        return switch (sortType) {
+            case "byFileName" -> Comparator.comparing(MultipartFile::getOriginalFilename);
+            case "byDateModified" -> (file1, file2) -> {
+                try {
+                    BasicFileAttributes attr1 =
+                        Files.readAttributes(
+                            Paths.get(file1.getOriginalFilename()),
+                            BasicFileAttributes.class);
+                    BasicFileAttributes attr2 =
+                        Files.readAttributes(
+                            Paths.get(file2.getOriginalFilename()),
+                            BasicFileAttributes.class);
+                    return attr1.lastModifiedTime().compareTo(attr2.lastModifiedTime());
+                } catch (IOException e) {
+                    return 0; // If there's an error, treat them as equal
+                }
+            };
+            case "byDateCreated" -> (file1, file2) -> {
+                try {
+                    BasicFileAttributes attr1 =
+                        Files.readAttributes(
+                            Paths.get(file1.getOriginalFilename()),
+                            BasicFileAttributes.class);
+                    BasicFileAttributes attr2 =
+                        Files.readAttributes(
+                            Paths.get(file2.getOriginalFilename()),
+                            BasicFileAttributes.class);
+                    return attr1.creationTime().compareTo(attr2.creationTime());
+                } catch (IOException e) {
+                    return 0; // If there's an error, treat them as equal
+                }
+            };
+            case "byPDFTitle" -> (file1, file2) -> {
+                try (PDDocument doc1 = pdfDocumentFactory.load(file1);
+                     PDDocument doc2 = pdfDocumentFactory.load(file2)) {
+                    String title1 = doc1.getDocumentInformation().getTitle();
+                    String title2 = doc2.getDocumentInformation().getTitle();
+                    return title1.compareTo(title2);
+                } catch (IOException e) {
+                    return 0;
+                }
+            };
+            default -> (file1, file2) -> 0; // Default is the order provided
+        };
     }
 
     // Adds a table of contents to the merged document using filenames as chapter titles

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
@@ -207,30 +207,19 @@ public class RearrangePagesPDFController {
     private List<Integer> processSortTypes(String sortTypes, int totalPages, String pageOrder) {
         try {
             SortTypes mode = SortTypes.valueOf(sortTypes.toUpperCase());
-            switch (mode) {
-                case REVERSE_ORDER:
-                    return reverseOrder(totalPages);
-                case DUPLEX_SORT:
-                    return duplexSort(totalPages);
-                case BOOKLET_SORT:
-                    return bookletSort(totalPages);
-                case SIDE_STITCH_BOOKLET_SORT:
-                    return sideStitchBooklet(totalPages);
-                case ODD_EVEN_SPLIT:
-                    return oddEvenSplit(totalPages);
-                case ODD_EVEN_MERGE:
-                    return oddEvenMerge(totalPages);
-                case REMOVE_FIRST:
-                    return removeFirst(totalPages);
-                case REMOVE_LAST:
-                    return removeLast(totalPages);
-                case REMOVE_FIRST_AND_LAST:
-                    return removeFirstAndLast(totalPages);
-                case DUPLICATE:
-                    return duplicate(totalPages, pageOrder);
-                default:
-                    throw new IllegalArgumentException("Unsupported custom mode");
-            }
+            return switch (mode) {
+                case REVERSE_ORDER -> reverseOrder(totalPages);
+                case DUPLEX_SORT -> duplexSort(totalPages);
+                case BOOKLET_SORT -> bookletSort(totalPages);
+                case SIDE_STITCH_BOOKLET_SORT -> sideStitchBooklet(totalPages);
+                case ODD_EVEN_SPLIT -> oddEvenSplit(totalPages);
+                case ODD_EVEN_MERGE -> oddEvenMerge(totalPages);
+                case REMOVE_FIRST -> removeFirst(totalPages);
+                case REMOVE_LAST -> removeLast(totalPages);
+                case REMOVE_FIRST_AND_LAST -> removeFirstAndLast(totalPages);
+                case DUPLICATE -> duplicate(totalPages, pageOrder);
+                default -> throw new IllegalArgumentException("Unsupported custom mode");
+            };
         } catch (IllegalArgumentException e) {
             log.error("Unsupported custom mode", e);
             return null;

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/filters/FilterController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/filters/FilterController.java
@@ -84,21 +84,14 @@ public class FilterController {
         PDDocument document = pdfDocumentFactory.load(inputFile);
         int actualPageCount = document.getNumberOfPages();
 
-        boolean valid = false;
-        // Perform the comparison
-        switch (comparator) {
-            case "Greater":
-                valid = actualPageCount > pageCount;
-                break;
-            case "Equal":
-                valid = actualPageCount == pageCount;
-                break;
-            case "Less":
-                valid = actualPageCount < pageCount;
-                break;
-            default:
+        boolean valid = switch (comparator) {
+            case "Greater" -> actualPageCount > pageCount;
+            case "Equal" -> actualPageCount == pageCount;
+            case "Less" -> actualPageCount < pageCount;
+            default ->
                 throw ExceptionUtils.createInvalidArgumentException("comparator", comparator);
-        }
+        };
+        // Perform the comparison
 
         if (valid) return WebResponseUtils.multiPartFileToWebResponse(inputFile);
         return null;
@@ -127,21 +120,14 @@ public class FilterController {
         PDRectangle standardSize = PdfUtils.textToPageSize(standardPageSize);
         float standardArea = standardSize.getWidth() * standardSize.getHeight();
 
-        boolean valid = false;
-        // Perform the comparison
-        switch (comparator) {
-            case "Greater":
-                valid = actualArea > standardArea;
-                break;
-            case "Equal":
-                valid = actualArea == standardArea;
-                break;
-            case "Less":
-                valid = actualArea < standardArea;
-                break;
-            default:
+        boolean valid = switch (comparator) {
+            case "Greater" -> actualArea > standardArea;
+            case "Equal" -> actualArea == standardArea;
+            case "Less" -> actualArea < standardArea;
+            default ->
                 throw ExceptionUtils.createInvalidArgumentException("comparator", comparator);
-        }
+        };
+        // Perform the comparison
 
         if (valid) return WebResponseUtils.multiPartFileToWebResponse(inputFile);
         return null;
@@ -196,21 +182,14 @@ public class FilterController {
         // Get the rotation of the first page
         PDPage firstPage = document.getPage(0);
         int actualRotation = firstPage.getRotation();
-        boolean valid = false;
-        // Perform the comparison
-        switch (comparator) {
-            case "Greater":
-                valid = actualRotation > rotation;
-                break;
-            case "Equal":
-                valid = actualRotation == rotation;
-                break;
-            case "Less":
-                valid = actualRotation < rotation;
-                break;
-            default:
+        boolean valid = switch (comparator) {
+            case "Greater" -> actualRotation > rotation;
+            case "Equal" -> actualRotation == rotation;
+            case "Less" -> actualRotation < rotation;
+            default ->
                 throw ExceptionUtils.createInvalidArgumentException("comparator", comparator);
-        }
+        };
+        // Perform the comparison
 
         if (valid) return WebResponseUtils.multiPartFileToWebResponse(inputFile);
         return null;

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -83,25 +83,13 @@ public class StampController {
         float overrideY = request.getOverrideY(); // New field for Y override
 
         String customColor = request.getCustomColor();
-        float marginFactor;
-
-        switch (request.getCustomMargin().toLowerCase()) {
-            case "small":
-                marginFactor = 0.02f;
-                break;
-            case "medium":
-                marginFactor = 0.035f;
-                break;
-            case "large":
-                marginFactor = 0.05f;
-                break;
-            case "x-large":
-                marginFactor = 0.075f;
-                break;
-            default:
-                marginFactor = 0.035f;
-                break;
-        }
+        float marginFactor = switch (request.getCustomMargin().toLowerCase()) {
+            case "small" -> 0.02f;
+            case "medium" -> 0.035f;
+            case "large" -> 0.05f;
+            case "x-large" -> 0.075f;
+            default -> 0.035f;
+        };
 
         // Load the input PDF
         PDDocument document = pdfDocumentFactory.load(pdfFile);
@@ -177,27 +165,14 @@ public class StampController {
             throws IOException {
         String resourceDir = "";
         PDFont font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
-        switch (alphabet) {
-            case "arabic":
-                resourceDir = "static/fonts/NotoSansArabic-Regular.ttf";
-                break;
-            case "japanese":
-                resourceDir = "static/fonts/Meiryo.ttf";
-                break;
-            case "korean":
-                resourceDir = "static/fonts/malgun.ttf";
-                break;
-            case "chinese":
-                resourceDir = "static/fonts/SimSun.ttf";
-                break;
-            case "thai":
-                resourceDir = "static/fonts/NotoSansThai-Regular.ttf";
-                break;
-            case "roman":
-            default:
-                resourceDir = "static/fonts/NotoSans-Regular.ttf";
-                break;
-        }
+                resourceDir = switch (alphabet) {
+                    case "arabic" -> "static/fonts/NotoSansArabic-Regular.ttf";
+                    case "japanese" -> "static/fonts/Meiryo.ttf";
+                    case "korean" -> "static/fonts/malgun.ttf";
+                    case "chinese" -> "static/fonts/SimSun.ttf";
+                    case "thai" -> "static/fonts/NotoSansThai-Regular.ttf";
+                    default -> "static/fonts/NotoSans-Regular.ttf";
+                };
 
         if (!"".equals(resourceDir)) {
             ClassPathResource classPathResource = new ClassPathResource(resourceDir);
@@ -319,30 +294,28 @@ public class StampController {
             throws IOException {
         float actualWidth =
                 (text != null) ? calculateTextWidth(text, font, fontSize) : contentWidth;
-        switch (position % 3) {
-            case 1: // Left
-                return pageSize.getLowerLeftX() + margin;
-            case 2: // Center
-                return (pageSize.getWidth() - actualWidth) / 2;
-            case 0: // Right
-                return pageSize.getUpperRightX() - actualWidth - margin;
-            default:
-                return 0;
-        }
+        return switch (position % 3) {
+            case 1 -> // Left
+                pageSize.getLowerLeftX() + margin;
+            case 2 -> // Center
+                (pageSize.getWidth() - actualWidth) / 2;
+            case 0 -> // Right
+                pageSize.getUpperRightX() - actualWidth - margin;
+            default -> 0;
+        };
     }
 
     private float calculatePositionY(
             PDRectangle pageSize, int position, float height, float margin) {
-        switch ((position - 1) / 3) {
-            case 0: // Top
-                return pageSize.getUpperRightY() - height - margin;
-            case 1: // Middle
-                return (pageSize.getHeight() - height) / 2;
-            case 2: // Bottom
-                return pageSize.getLowerLeftY() + margin;
-            default:
-                return 0;
-        }
+        return switch ((position - 1) / 3) {
+            case 0 -> // Top
+                pageSize.getUpperRightY() - height - margin;
+            case 1 -> // Middle
+                (pageSize.getHeight() - height) / 2;
+            case 2 -> // Bottom
+                pageSize.getLowerLeftY() + margin;
+            default -> 0;
+        };
     }
 
     private float calculateTextWidth(String text, PDFont font, float fontSize) throws IOException {

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -169,27 +169,14 @@ public class WatermarkController {
             throws IOException {
         String resourceDir = "";
         PDFont font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
-        switch (alphabet) {
-            case "arabic":
-                resourceDir = "static/fonts/NotoSansArabic-Regular.ttf";
-                break;
-            case "japanese":
-                resourceDir = "static/fonts/Meiryo.ttf";
-                break;
-            case "korean":
-                resourceDir = "static/fonts/malgun.ttf";
-                break;
-            case "chinese":
-                resourceDir = "static/fonts/SimSun.ttf";
-                break;
-            case "thai":
-                resourceDir = "static/fonts/NotoSansThai-Regular.ttf";
-                break;
-            case "roman":
-            default:
-                resourceDir = "static/fonts/NotoSans-Regular.ttf";
-                break;
-        }
+        resourceDir = switch (alphabet) {
+            case "arabic" -> "static/fonts/NotoSansArabic-Regular.ttf";
+            case "japanese" -> "static/fonts/Meiryo.ttf";
+            case "korean" -> "static/fonts/malgun.ttf";
+            case "chinese" -> "static/fonts/SimSun.ttf";
+            case "thai" -> "static/fonts/NotoSansThai-Regular.ttf";
+            default -> "static/fonts/NotoSans-Regular.ttf";
+        };
 
         if (!"".equals(resourceDir)) {
             ClassPathResource classPathResource = new ClassPathResource(resourceDir);

--- a/app/core/src/main/java/stirling/software/SPDF/controller/web/GeneralWebController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/web/GeneralWebController.java
@@ -279,21 +279,16 @@ public class GeneralWebController {
     }
 
     public String getFormatFromExtension(String extension) {
-        switch (extension) {
-            case "ttf":
-                return "truetype";
-            case "woff":
-                return "woff";
-            case "woff2":
-                return "woff2";
-            case "eot":
-                return "embedded-opentype";
-            case "svg":
-                return "svg";
-            default:
+        return switch (extension) {
+            case "ttf" -> "truetype";
+            case "woff" -> "woff";
+            case "woff2" -> "woff2";
+            case "eot" -> "embedded-opentype";
+            case "svg" -> "svg";
+            default ->
                 // or throw an exception if an unexpected extension is encountered
-                return "";
-        }
+                "";
+        };
     }
 
     @GetMapping("/crop")


### PR DESCRIPTION
# Description of Changes

This pull request refactors multiple methods across the codebase to replace traditional `switch` statements with the more concise `switch` expressions introduced in modern Java. This change improves code readability and maintainability by reducing boilerplate and ensuring a more streamlined structure for conditional logic.


<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.