### PR TITLE
fix(stamp): validate image filename only for image stamp type

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -72,7 +72,7 @@ public class StampController {
         MultipartFile stampImage = request.getStampImage();
         if ("image".equalsIgnoreCase(stampType)) {
             String stampImageName = stampImage.getOriginalFilename();
-            if (stampImageName.contains("..") || stampImageName.startsWith("/")) {
+            if (stampImageName == null || stampImageName.contains("..") || stampImageName.startsWith("/")) {
                 throw new IllegalArgumentException("Invalid stamp image file path");
             }
         }

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -70,9 +70,11 @@ public class StampController {
         String stampType = request.getStampType();
         String stampText = request.getStampText();
         MultipartFile stampImage = request.getStampImage();
-        String stampImageName = stampImage.getOriginalFilename();
-        if (stampImageName.contains("..") || stampImageName.startsWith("/")) {
-            throw new IllegalArgumentException("Invalid stamp image file path");
+        if ("image".equalsIgnoreCase(stampType)) {
+            String stampImageName = stampImage.getOriginalFilename();
+            if (stampImageName.contains("..") || stampImageName.startsWith("/")) {
+                throw new IllegalArgumentException("Invalid stamp image file path");
+            }
         }
         String alphabet = request.getAlphabet();
         float fontSize = request.getFontSize();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -71,6 +71,9 @@ public class StampController {
         String stampText = request.getStampText();
         MultipartFile stampImage = request.getStampImage();
         if ("image".equalsIgnoreCase(stampType)) {
+            if (stampImage == null) {
+                throw new IllegalArgumentException("Stamp image file must be provided when stamp type is 'image'");
+            }
             String stampImageName = stampImage.getOriginalFilename();
             if (stampImageName == null || stampImageName.contains("..") || stampImageName.startsWith("/")) {
                 throw new IllegalArgumentException("Invalid stamp image file path");


### PR DESCRIPTION
# Description of Changes

- **What was changed**: Moved the filename validation logic for `stampImage` inside a condition that checks whether the stamp type is `"image"`.
- **Why the change was made**: Previously, the validation was applied regardless of stamp type, leading to unnecessary errors for non-image-based stamps where no `stampImage` is provided.

Closes #4097

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
