### PR TITLE
ci(github-actions): improve concurrency grouping with PR number fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 # This ensures that jobs are grouped by the workflow and branch, allowing for cancellation of
 # in-progress jobs when a new commit is pushed to the same branch or a new pull request is opened.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -147,7 +147,7 @@ jobs:
 
       - name: Generate OpenAPI documentation
         run: ./gradlew :stirling-pdf:generateOpenApiDocs
-      
+
       - name: Upload OpenAPI Documentation
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/check_properties.yml
+++ b/.github/workflows/check_properties.yml
@@ -15,7 +15,7 @@ on:
 # This ensures that jobs are grouped by the workflow and branch, allowing for cancellation of
 # in-progress jobs when a new commit is pushed to the same branch or a new pull request is opened.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -127,7 +127,7 @@ jobs:
 
             // Filter for relevant files based on the PR changes
             const changedFiles = files
-              .filter(file => 
+              .filter(file =>
                 file.status !== "removed" &&
                 /^app\/core\/src\/main\/resources\/messages_[a-zA-Z_]{2}_[a-zA-Z_]{2,7}\.properties$/.test(file.filename)
               )

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -18,7 +18,7 @@ on:
 # This ensures that jobs are grouped by the workflow and branch, allowing for cancellation of
 # in-progress jobs when a new commit is pushed to the same branch or a new pull request is opened.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
# Description of Changes

- Updated the `concurrency.group` key in the following GitHub Actions workflows:
  - `.github/workflows/build.yml`
  - `.github/workflows/check_properties.yml`
  - `.github/workflows/sonarqube.yml`
- The grouping string now uses `github.event.pull_request.number` (if present) as a fallback before falling back to `ref_name` or `ref`.
- This helps ensure better grouping for PR-based workflows, improving job cancellation behavior and avoiding unnecessary parallel job execution when multiple pushes occur on the same PR.

No functional behavior is changed in the actual build or check logic.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
