### PR TITLE
Add new keys to zh_TW Traditional Chinese ignore translation list

### DIFF
--- a/scripts/ignore_translation.toml
+++ b/scripts/ignore_translation.toml
@@ -1027,4 +1027,6 @@ ignore = [
 [zh_TW]
 ignore = [
     'language.direction',
+    'poweredBy',
+    'showJS.tags',
 ]


### PR DESCRIPTION
# Description of Changes

Summary from GitHub Copilot:

> This pull request updates the `scripts/ignore_translation.toml` file to add new translation keys to the ignore list for the `zh_TW` locale.
> 
> * [`scripts/ignore_translation.toml`](diffhunk://#diff-607e01559fa08179f8efe9ee6f73dbbedaac20cdd2e6d50968253445d1cd00c7R1030-R1031): Added `poweredBy` and `showJS.tags` to the `ignore` list for the `zh_TW` locale.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
