### PR TITLE
chore(labeler): add new 'v2' label and expand matching rules

### DIFF
--- a/.github/labeler-config-srvaroa.yml
+++ b/.github/labeler-config-srvaroa.yml
@@ -46,6 +46,9 @@ labels:
   - label: 'API'
     title: '.*openapi.*|.*swagger.*|.*api.*'
 
+  - label: 'v2'
+    base-branch: 'V2'
+
   - label: 'Translation'
     files:
       - 'app/core/src/main/resources/messages_[a-zA-Z_]{2}_[a-zA-Z_]{2,7}.properties'
@@ -62,6 +65,7 @@ labels:
       - 'app/core/src/main/java/stirling/software/SPDF/controller/web/.*'
       - 'app/core/src/main/java/stirling/software/SPDF/UI/.*'
       - 'app/proprietary/src/main/java/stirling/software/proprietary/security/controller/web/.*'
+      - 'frontend/**'
 
   - label: 'Java'
     files:
@@ -120,6 +124,7 @@ labels:
       - 'scripts/installFonts.sh'
       - 'test.sh'
       - 'test2.sh'
+      - 'docker/**'
 
   - label: 'Devtools'
     files:
@@ -130,7 +135,6 @@ labels:
       - '.pre-commit-config'
       - '.github/workflows/pre_commit.yml'
       - 'devGuide/.*'
-      - 'devTools/.*'
       - 'devTools/.*'
 
   - label: 'Test'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -83,6 +83,7 @@
   color: "DEDEDE"
 - name: "v2"
   color: "FFFF00"
+  description: "Issues or pull requests related to the v2 branch"
 - name: "wontfix"
   description: "This will not be worked on"
   color: "FFFFFF"


### PR DESCRIPTION
# Description of Changes

- **Added** a new `v2` label with `base-branch` targeting `V2`
- **Extended** the 'UI' label matching to include `frontend/**` files
- **Extended** the 'Scripts' label matching to include `docker/**` files
- **Removed** duplicate `devTools/.*` entry from 'Devtools' label configuration

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
