### PR TITLE
fix(downloader): reset progress bar after completion

### DIFF
--- a/app/core/src/main/resources/static/js/downloader.js
+++ b/app/core/src/main/resources/static/js/downloader.js
@@ -483,7 +483,7 @@
     progressBar.css('width', '100%');
     progressBar.attr('aria-valuenow', Array.from(files).length);
     setTimeout(() => {
-      $('.progressBarContainer').hide();
+      progressBar.closest('.progressBarContainer').hide();
       progressBar.css('width', '0%');
       progressBar.attr('aria-valuenow', 0);
     }, 1000);

--- a/app/core/src/main/resources/static/js/downloader.js
+++ b/app/core/src/main/resources/static/js/downloader.js
@@ -482,6 +482,11 @@
     }
     progressBar.css('width', '100%');
     progressBar.attr('aria-valuenow', Array.from(files).length);
+    setTimeout(() => {
+      $('.progressBarContainer').hide();
+      progressBar.css('width', '0%');
+      progressBar.attr('aria-valuenow', 0);
+    }, 1000);
   }
 
   function updateProgressBar(progressBar, files) {


### PR DESCRIPTION
# Description of Changes

- Added a `setTimeout` to hide the `.progressBarContainer` 1 second after reaching 100%.
- Reset progress bar width to `0%` and `aria-valuenow` to `0` to prepare for future downloads.
- This change ensures the UI does not leave a full progress bar displayed after a completed download.


---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
