### PR TITLE
fix(h2): refine SQL condition check for custom database flag

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/database/H2SQLCondition.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/database/H2SQLCondition.java
@@ -8,16 +8,15 @@ public class H2SQLCondition implements Condition {
 
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        var env = context.getEnvironment();
         boolean enableCustomDatabase =
-                Boolean.parseBoolean(
-                        context.getEnvironment()
-                                .getProperty("system.datasource.enableCustomDatabase"));
+                env.getProperty("system.datasource.enableCustomDatabase", Boolean.class, false);
 
-        if (!enableCustomDatabase) {
+        String dataSourceType = env.getProperty("system.datasource.type", String.class, "");
+
+        if (enableCustomDatabase && !"h2".equalsIgnoreCase(dataSourceType)) {
             return false;
         }
-
-        String dataSourceType = context.getEnvironment().getProperty("system.datasource.type");
-        return "h2".equalsIgnoreCase(dataSourceType);
+        return true;
     }
 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/database/H2SQLCondition.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/database/H2SQLCondition.java
@@ -12,11 +12,11 @@ public class H2SQLCondition implements Condition {
         boolean enableCustomDatabase =
                 env.getProperty("system.datasource.enableCustomDatabase", Boolean.class, false);
 
-        String dataSourceType = env.getProperty("system.datasource.type", String.class, "");
-
-        if (enableCustomDatabase && !"h2".equalsIgnoreCase(dataSourceType)) {
+        if (enableCustomDatabase) {
             return false;
         }
-        return true;
+
+        String dataSourceType = env.getProperty("system.datasource.type", String.class, "");
+        return "h2".equalsIgnoreCase(dataSourceType);
     }
 }


### PR DESCRIPTION
# Description of Changes

- Refactored `H2SQLCondition.matches` to use `env.getProperty` with proper default values and types.
- Adjusted logic to only return `false` when a custom database is enabled and datasource type is not `h2`.
- Simplified environment variable handling for better readability and robustness.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
