### PR TITLE
Replace uses of `Arrays.asList()` with either List.of() or Collections.singletonList()

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -1,19 +1,9 @@
 package stirling.software.SPDF.controller.api.pipeline;
 
-import java.io.*;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
+import io.github.pixee.security.Filenames;
+import io.github.pixee.security.ZipSecurity;
+import jakarta.servlet.ServletContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -23,14 +13,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
-
-import io.github.pixee.security.Filenames;
-import io.github.pixee.security.ZipSecurity;
-
-import jakarta.servlet.ServletContext;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.SPDFApplication;
 import stirling.software.SPDF.model.PipelineConfig;
 import stirling.software.SPDF.model.PipelineOperation;
@@ -38,6 +20,19 @@ import stirling.software.SPDF.model.PipelineResult;
 import stirling.software.SPDF.service.ApiDocService;
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.common.service.UserServiceInterface;
+
+import java.io.*;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 @Service
 @Slf4j
@@ -106,7 +101,7 @@ public class PipelineProcessor {
             Map<String, Object> parameters = pipelineOperation.getParameters();
             List<String> inputFileTypes = apiDocService.getExtensionTypes(false, operation);
             if (inputFileTypes == null) {
-                inputFileTypes = new ArrayList<String>(Arrays.asList("ALL"));
+                inputFileTypes = new ArrayList<>(List.of("ALL"));
             }
 
             if (!apiDocService.isValidOperation(operation, parameters)) {

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -1,26 +1,5 @@
 package stirling.software.SPDF.controller.api.pipeline;
 
-import io.github.pixee.security.Filenames;
-import io.github.pixee.security.ZipSecurity;
-import jakarta.servlet.ServletContext;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.Resource;
-import org.springframework.http.*;
-import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
-import stirling.software.SPDF.SPDFApplication;
-import stirling.software.SPDF.model.PipelineConfig;
-import stirling.software.SPDF.model.PipelineOperation;
-import stirling.software.SPDF.model.PipelineResult;
-import stirling.software.SPDF.service.ApiDocService;
-import stirling.software.common.model.enumeration.Role;
-import stirling.software.common.service.UserServiceInterface;
-
 import java.io.*;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -33,6 +12,31 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.github.pixee.security.Filenames;
+import io.github.pixee.security.ZipSecurity;
+
+import jakarta.servlet.ServletContext;
+
+import lombok.extern.slf4j.Slf4j;
+
+import stirling.software.SPDF.SPDFApplication;
+import stirling.software.SPDF.model.PipelineConfig;
+import stirling.software.SPDF.model.PipelineOperation;
+import stirling.software.SPDF.model.PipelineResult;
+import stirling.software.SPDF.service.ApiDocService;
+import stirling.software.common.model.enumeration.Role;
+import stirling.software.common.service.UserServiceInterface;
 
 @Service
 @Slf4j

--- a/app/core/src/main/java/stirling/software/SPDF/service/ApiDocService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/ApiDocService.java
@@ -1,12 +1,9 @@
 package stirling.software.SPDF.service;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -14,18 +11,17 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.ServletContext;
-
-import lombok.extern.slf4j.Slf4j;
-
 import stirling.software.SPDF.SPDFApplication;
 import stirling.software.SPDF.model.ApiEndpoint;
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.common.service.UserServiceInterface;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @Slf4j
@@ -53,7 +49,7 @@ public class ApiDocService {
 
     public List<String> getExtensionTypes(boolean output, String operationName) {
         if (outputToFileTypes.size() == 0) {
-            outputToFileTypes.put("PDF", Arrays.asList("pdf"));
+            outputToFileTypes.put("PDF", List.of("pdf"));
             outputToFileTypes.put(
                     "IMAGE",
                     Arrays.asList(
@@ -63,10 +59,10 @@ public class ApiDocService {
                     "ZIP",
                     Arrays.asList("zip", "rar", "7z", "tar", "gz", "bz2", "xz", "lz", "lzma", "z"));
             outputToFileTypes.put("WORD", Arrays.asList("doc", "docx", "odt", "rtf"));
-            outputToFileTypes.put("CSV", Arrays.asList("csv"));
+            outputToFileTypes.put("CSV", List.of("csv"));
             outputToFileTypes.put("JS", Arrays.asList("js", "jsx"));
             outputToFileTypes.put("HTML", Arrays.asList("html", "htm", "xhtml"));
-            outputToFileTypes.put("JSON", Arrays.asList("json"));
+            outputToFileTypes.put("JSON", List.of("json"));
             outputToFileTypes.put("TXT", Arrays.asList("txt", "text", "md", "markdown"));
             outputToFileTypes.put("PPT", Arrays.asList("ppt", "pptx", "odp"));
             outputToFileTypes.put("XML", Arrays.asList("xml", "xsd", "xsl"));

--- a/app/core/src/main/java/stirling/software/SPDF/service/ApiDocService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/ApiDocService.java
@@ -1,9 +1,12 @@
 package stirling.software.SPDF.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletContext;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -11,17 +14,18 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletContext;
+
+import lombok.extern.slf4j.Slf4j;
+
 import stirling.software.SPDF.SPDFApplication;
 import stirling.software.SPDF.model.ApiEndpoint;
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.common.service.UserServiceInterface;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Service
 @Slf4j

--- a/app/core/src/main/java/stirling/software/SPDF/service/CertificateValidationService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/CertificateValidationService.java
@@ -1,14 +1,16 @@
 package stirling.software.SPDF.service;
 
-import io.github.pixee.security.BoundedLineReader;
-import jakarta.annotation.PostConstruct;
-import org.springframework.stereotype.Service;
-
 import java.io.*;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.*;
 import java.util.*;
+
+import org.springframework.stereotype.Service;
+
+import io.github.pixee.security.BoundedLineReader;
+
+import jakarta.annotation.PostConstruct;
 
 @Service
 public class CertificateValidationService {

--- a/app/core/src/main/java/stirling/software/SPDF/service/CertificateValidationService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/CertificateValidationService.java
@@ -1,16 +1,14 @@
 package stirling.software.SPDF.service;
 
+import io.github.pixee.security.BoundedLineReader;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
 import java.io.*;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.*;
 import java.util.*;
-
-import org.springframework.stereotype.Service;
-
-import io.github.pixee.security.BoundedLineReader;
-
-import jakarta.annotation.PostConstruct;
 
 @Service
 public class CertificateValidationService {
@@ -77,7 +75,7 @@ public class CertificateValidationService {
         try {
             CertPathValidator validator = CertPathValidator.getInstance("PKIX");
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            List<X509Certificate> certList = Arrays.asList(cert);
+            List<X509Certificate> certList = Collections.singletonList(cert);
             CertPath certPath = cf.generateCertPath(certList);
 
             Set<TrustAnchor> anchors = new HashSet<>();

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/MergeControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/MergeControllerTest.java
@@ -1,5 +1,16 @@
 package stirling.software.SPDF.controller.api;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -14,18 +25,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
+
 import stirling.software.common.service.CustomPDFDocumentFactory;
-
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MergeControllerTest {

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/MergeControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/MergeControllerTest.java
@@ -1,14 +1,5 @@
 package stirling.software.SPDF.controller.api;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -23,8 +14,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
-
 import stirling.software.common.service.CustomPDFDocumentFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MergeControllerTest {
@@ -266,8 +267,8 @@ class MergeControllerTest {
         when(pdfDocumentFactory.createNewDocument()).thenReturn(mockMergedDocument);
         when(doc1.getPages()).thenReturn(pages1);
         when(doc2.getPages()).thenReturn(pages2);
-        when(pages1.iterator()).thenReturn(Arrays.asList(page1).iterator());
-        when(pages2.iterator()).thenReturn(Arrays.asList(page2).iterator());
+        when(pages1.iterator()).thenReturn(Collections.singletonList(page1).iterator());
+        when(pages2.iterator()).thenReturn(Collections.singletonList(page2).iterator());
 
         // When
         PDDocument result = mergeController.mergeDocuments(documents);
@@ -282,7 +283,7 @@ class MergeControllerTest {
     @Test
     void testMergeDocuments_EmptyList_ReturnsEmptyDocument() throws IOException {
         // Given
-        List<PDDocument> documents = Arrays.asList();
+        List<PDDocument> documents = List.of();
 
         when(pdfDocumentFactory.createNewDocument()).thenReturn(mockMergedDocument);
 

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfImageRemovalServiceTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfImageRemovalServiceTest.java
@@ -1,5 +1,11 @@
 package stirling.software.SPDF.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.*;
+
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -9,12 +15,6 @@ import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.util.*;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 class PdfImageRemovalServiceTest {
 

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfImageRemovalServiceTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfImageRemovalServiceTest.java
@@ -1,18 +1,5 @@
 package stirling.software.SPDF.service;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -22,6 +9,12 @@ import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 class PdfImageRemovalServiceTest {
 
@@ -42,7 +35,7 @@ class PdfImageRemovalServiceTest {
 
         // Configure page tree to iterate over our single page
         when(document.getPages()).thenReturn(pageTree);
-        Iterator<PDPage> pageIterator = Arrays.asList(page).iterator();
+        Iterator<PDPage> pageIterator = Collections.singletonList(page).iterator();
         when(pageTree.iterator()).thenReturn(pageIterator);
 
         // Set up page resources
@@ -80,7 +73,7 @@ class PdfImageRemovalServiceTest {
 
         // Configure page tree to iterate over our single page
         when(document.getPages()).thenReturn(pageTree);
-        Iterator<PDPage> pageIterator = Arrays.asList(page).iterator();
+        Iterator<PDPage> pageIterator = Collections.singletonList(page).iterator();
         when(pageTree.iterator()).thenReturn(pageIterator);
 
         // Set up page resources
@@ -118,12 +111,12 @@ class PdfImageRemovalServiceTest {
 
         // Set up image XObjects for page 1
         COSName img1 = COSName.getPDFName("Im1");
-        when(resources1.getXObjectNames()).thenReturn(Arrays.asList(img1));
+        when(resources1.getXObjectNames()).thenReturn(Collections.singletonList(img1));
         when(resources1.isImageXObject(img1)).thenReturn(true);
 
         // Set up image XObjects for page 2
         COSName img2 = COSName.getPDFName("Im2");
-        when(resources2.getXObjectNames()).thenReturn(Arrays.asList(img2));
+        when(resources2.getXObjectNames()).thenReturn(Collections.singletonList(img2));
         when(resources2.isImageXObject(img2)).thenReturn(true);
 
         // Execute the method


### PR DESCRIPTION
# Description of Changes

Replace uses of `Arrays.asList()` with either `List.of()` or `Collections.singletonList()` where appropriate. This change improves code readability and leverages more modern Java features for creating immutable lists.

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.