### PR TITLE
Redesgin ToolOperationConfig so types are known for single/multiple/custom tools

### DIFF
--- a/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.test.ts
+++ b/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.test.ts
@@ -20,13 +20,13 @@ vi.mock('../../../utils/toolErrorHandler', () => ({
 }));
 
 // Import the mocked function
-import { ToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
+import { SingleFileToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
 
 
 describe('useAddPasswordOperation', () => {
   const mockUseToolOperation = vi.mocked(useToolOperation);
 
-  const getToolConfig = (): ToolOperationConfig<AddPasswordFullParameters> => mockUseToolOperation.mock.calls[0][0] as ToolOperationConfig<AddPasswordFullParameters>;
+  const getToolConfig = () => mockUseToolOperation.mock.calls[0][0] as SingleFileToolOperationConfig<AddPasswordFullParameters>;
 
   const mockToolOperationReturn: ToolOperationHook<unknown> = {
     files: [],
@@ -91,7 +91,7 @@ describe('useAddPasswordOperation', () => {
     };
 
     const testFile = new File(['test content'], 'test.pdf', { type: 'application/pdf' });
-    const formData = buildFormData(testParameters, testFile as any /* FIX ME */);
+    const formData = buildFormData(testParameters, testFile);
 
     // Verify the form data contains the file
     expect(formData.get('fileInput')).toBe(testFile);
@@ -112,7 +112,7 @@ describe('useAddPasswordOperation', () => {
   });
 
   test.each([
-    { property: 'multiFileEndpoint' as const, expectedValue: false },
+    { property: 'toolType' as const, expectedValue: 'singleFile' },
     { property: 'endpoint' as const, expectedValue: '/api/v1/security/add-password' },
     { property: 'filePrefix' as const, expectedValue: 'translated-addPassword.filenamePrefix_' },
     { property: 'operationType' as const, expectedValue: 'addPassword' }

--- a/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.test.ts
+++ b/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.test.ts
@@ -4,9 +4,13 @@ import { useAddPasswordOperation } from './useAddPasswordOperation';
 import type { AddPasswordFullParameters, AddPasswordParameters } from './useAddPasswordParameters';
 
 // Mock the useToolOperation hook
-vi.mock('../shared/useToolOperation', () => ({
-  useToolOperation: vi.fn()
-}));
+vi.mock('../shared/useToolOperation', async () => {
+  const actual = await vi.importActual('../shared/useToolOperation');  // Need to keep ToolType etc.
+  return {
+    ...actual,
+    useToolOperation: vi.fn()
+  };
+});
 
 // Mock the translation hook
 const mockT = vi.fn((key: string) => `translated-${key}`);
@@ -20,7 +24,7 @@ vi.mock('../../../utils/toolErrorHandler', () => ({
 }));
 
 // Import the mocked function
-import { SingleFileToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
+import { SingleFileToolOperationConfig, ToolOperationHook, ToolType, useToolOperation } from '../shared/useToolOperation';
 
 
 describe('useAddPasswordOperation', () => {
@@ -112,7 +116,7 @@ describe('useAddPasswordOperation', () => {
   });
 
   test.each([
-    { property: 'toolType' as const, expectedValue: 'singleFile' },
+    { property: 'toolType' as const, expectedValue: ToolType.singleFile },
     { property: 'endpoint' as const, expectedValue: '/api/v1/security/add-password' },
     { property: 'filePrefix' as const, expectedValue: 'translated-addPassword.filenamePrefix_' },
     { property: 'operationType' as const, expectedValue: 'addPassword' }

--- a/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.ts
+++ b/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.ts
@@ -26,11 +26,11 @@ const fullDefaultParameters: AddPasswordFullParameters = {
 
 // Static configuration object
 export const addPasswordOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildAddPasswordFormData,
   operationType: 'addPassword',
   endpoint: '/api/v1/security/add-password',
-  buildFormData: buildAddPasswordFormData,
   filePrefix: 'encrypted_', // Will be overridden in hook with translation
-  multiFileEndpoint: false,
   defaultParameters: fullDefaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.ts
+++ b/frontend/src/hooks/tools/addPassword/useAddPasswordOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { AddPasswordFullParameters, defaultParameters } from './useAddPasswordParameters';
 import { defaultParameters as permissionsDefaults } from '../changePermissions/useChangePermissionsParameters';
@@ -26,7 +26,7 @@ const fullDefaultParameters: AddPasswordFullParameters = {
 
 // Static configuration object
 export const addPasswordOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildAddPasswordFormData,
   operationType: 'addPassword',
   endpoint: '/api/v1/security/add-password',

--- a/frontend/src/hooks/tools/addWatermark/useAddWatermarkOperation.ts
+++ b/frontend/src/hooks/tools/addWatermark/useAddWatermarkOperation.ts
@@ -35,11 +35,11 @@ export const buildAddWatermarkFormData = (parameters: AddWatermarkParameters, fi
 
 // Static configuration object
 export const addWatermarkOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildAddWatermarkFormData,
   operationType: 'watermark',
   endpoint: '/api/v1/security/add-watermark',
-  buildFormData: buildAddWatermarkFormData,
   filePrefix: 'watermarked_', // Will be overridden in hook with translation
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/addWatermark/useAddWatermarkOperation.ts
+++ b/frontend/src/hooks/tools/addWatermark/useAddWatermarkOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { AddWatermarkParameters, defaultParameters } from './useAddWatermarkParameters';
 
@@ -35,7 +35,7 @@ export const buildAddWatermarkFormData = (parameters: AddWatermarkParameters, fi
 
 // Static configuration object
 export const addWatermarkOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildAddWatermarkFormData,
   operationType: 'watermark',
   endpoint: '/api/v1/security/add-watermark',

--- a/frontend/src/hooks/tools/automate/useAutomateOperation.ts
+++ b/frontend/src/hooks/tools/automate/useAutomateOperation.ts
@@ -1,4 +1,4 @@
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { useCallback } from 'react';
 import { executeAutomationSequence } from '../../../utils/automationExecutor';
 import { useFlatToolRegistry } from '../../../data/useTranslatedToolRegistry';
@@ -40,7 +40,7 @@ export function useAutomateOperation() {
   }, [toolRegistry]);
 
   return useToolOperation<AutomateParameters>({
-    toolType: 'custom',
+    toolType: ToolType.custom,
     operationType: 'automate',
     customProcessor,
     filePrefix: '' // No prefix needed since automation handles naming internally

--- a/frontend/src/hooks/tools/automate/useAutomateOperation.ts
+++ b/frontend/src/hooks/tools/automate/useAutomateOperation.ts
@@ -10,7 +10,7 @@ export function useAutomateOperation() {
 
   const customProcessor = useCallback(async (params: AutomateParameters, files: File[]) => {
     console.log('🚀 Starting automation execution via customProcessor', { params, files });
-    
+
     if (!params.automationConfig) {
       throw new Error('No automation configuration provided');
     }
@@ -40,9 +40,8 @@ export function useAutomateOperation() {
   }, [toolRegistry]);
 
   return useToolOperation<AutomateParameters>({
+    toolType: 'custom',
     operationType: 'automate',
-    endpoint: '/api/v1/pipeline/handleData', // Not used with customProcessor
-    buildFormData: () => new FormData(), // Not used with customProcessor
     customProcessor,
     filePrefix: '' // No prefix needed since automation handles naming internally
   });

--- a/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.test.ts
+++ b/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.test.ts
@@ -4,9 +4,13 @@ import { useChangePermissionsOperation } from './useChangePermissionsOperation';
 import type { ChangePermissionsParameters } from './useChangePermissionsParameters';
 
 // Mock the useToolOperation hook
-vi.mock('../shared/useToolOperation', () => ({
-  useToolOperation: vi.fn()
-}));
+vi.mock('../shared/useToolOperation', async () => {
+  const actual = await vi.importActual('../shared/useToolOperation');  // Need to keep ToolType etc.
+  return {
+    ...actual,
+    useToolOperation: vi.fn()
+  };
+});
 
 // Mock the translation hook
 const mockT = vi.fn((key: string) => `translated-${key}`);
@@ -20,7 +24,7 @@ vi.mock('../../../utils/toolErrorHandler', () => ({
 }));
 
 // Import the mocked function
-import { SingleFileToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
+import { SingleFileToolOperationConfig, ToolOperationHook, ToolType, useToolOperation } from '../shared/useToolOperation';
 
 describe('useChangePermissionsOperation', () => {
   const mockUseToolOperation = vi.mocked(useToolOperation);
@@ -106,7 +110,7 @@ describe('useChangePermissionsOperation', () => {
   });
 
   test.each([
-    { property: 'toolType' as const, expectedValue: 'singleFile' },
+    { property: 'toolType' as const, expectedValue: ToolType.singleFile },
     { property: 'endpoint' as const, expectedValue: '/api/v1/security/add-password' },
     { property: 'filePrefix' as const, expectedValue: 'permissions_' },
     { property: 'operationType' as const, expectedValue: 'change-permissions' }

--- a/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.test.ts
+++ b/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.test.ts
@@ -20,12 +20,12 @@ vi.mock('../../../utils/toolErrorHandler', () => ({
 }));
 
 // Import the mocked function
-import { ToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
+import { SingleFileToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
 
 describe('useChangePermissionsOperation', () => {
   const mockUseToolOperation = vi.mocked(useToolOperation);
 
-  const getToolConfig = (): ToolOperationConfig<ChangePermissionsParameters> => mockUseToolOperation.mock.calls[0][0] as ToolOperationConfig<ChangePermissionsParameters>;
+  const getToolConfig = () => mockUseToolOperation.mock.calls[0][0] as SingleFileToolOperationConfig<ChangePermissionsParameters>;
 
   const mockToolOperationReturn: ToolOperationHook<unknown> = {
     files: [],
@@ -86,7 +86,7 @@ describe('useChangePermissionsOperation', () => {
     const buildFormData = callArgs.buildFormData;
 
     const testFile = new File(['test content'], 'test.pdf', { type: 'application/pdf' });
-    const formData = buildFormData(testParameters, testFile as any /* FIX ME */);
+    const formData = buildFormData(testParameters, testFile);
 
     // Verify the form data contains the file
     expect(formData.get('fileInput')).toBe(testFile);
@@ -106,7 +106,7 @@ describe('useChangePermissionsOperation', () => {
   });
 
   test.each([
-    { property: 'multiFileEndpoint' as const, expectedValue: false },
+    { property: 'toolType' as const, expectedValue: 'singleFile' },
     { property: 'endpoint' as const, expectedValue: '/api/v1/security/add-password' },
     { property: 'filePrefix' as const, expectedValue: 'permissions_' },
     { property: 'operationType' as const, expectedValue: 'change-permissions' }

--- a/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.ts
+++ b/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.ts
@@ -24,11 +24,11 @@ export const buildChangePermissionsFormData = (parameters: ChangePermissionsPara
 
 // Static configuration object
 export const changePermissionsOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildChangePermissionsFormData,
   operationType: 'change-permissions',
   endpoint: '/api/v1/security/add-password', // Change Permissions is a fake endpoint for the Add Password tool
-  buildFormData: buildChangePermissionsFormData,
   filePrefix: 'permissions_',
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 
@@ -39,6 +39,6 @@ export const useChangePermissionsOperation = () => {
     ...changePermissionsOperationConfig,
     getErrorMessage: createStandardErrorHandler(
       t('changePermissions.error.failed', 'An error occurred while changing PDF permissions.')
-    )
+    ),
   });
 };

--- a/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.ts
+++ b/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { ChangePermissionsParameters, defaultParameters } from './useChangePermissionsParameters';
 
@@ -24,7 +24,7 @@ export const buildChangePermissionsFormData = (parameters: ChangePermissionsPara
 
 // Static configuration object
 export const changePermissionsOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildChangePermissionsFormData,
   operationType: 'change-permissions',
   endpoint: '/api/v1/security/add-password', // Change Permissions is a fake endpoint for the Add Password tool

--- a/frontend/src/hooks/tools/compress/useCompressOperation.ts
+++ b/frontend/src/hooks/tools/compress/useCompressOperation.ts
@@ -24,11 +24,11 @@ export const buildCompressFormData = (parameters: CompressParameters, file: File
 
 // Static configuration object
 export const compressOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildCompressFormData,
   operationType: 'compress',
   endpoint: '/api/v1/misc/compress-pdf',
-  buildFormData: buildCompressFormData,
   filePrefix: 'compressed_',
-  multiFileEndpoint: false, // Individual API calls per file
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/compress/useCompressOperation.ts
+++ b/frontend/src/hooks/tools/compress/useCompressOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation, ToolOperationConfig } from '../shared/useToolOperation';
+import { useToolOperation, ToolOperationConfig, ToolType } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { CompressParameters, defaultParameters } from './useCompressParameters';
 
@@ -24,7 +24,7 @@ export const buildCompressFormData = (parameters: CompressParameters, file: File
 
 // Static configuration object
 export const compressOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildCompressFormData,
   operationType: 'compress',
   endpoint: '/api/v1/misc/compress-pdf',

--- a/frontend/src/hooks/tools/convert/useConvertOperation.ts
+++ b/frontend/src/hooks/tools/convert/useConvertOperation.ts
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ConvertParameters, defaultParameters } from './useConvertParameters';
 import { detectFileExtension } from '../../../utils/fileUtils';
 import { createFileFromApiResponse } from '../../../utils/fileResponseUtils';
-import { useToolOperation, ToolOperationConfig } from '../shared/useToolOperation';
+import { useToolOperation, ToolOperationConfig, ToolType } from '../shared/useToolOperation';
 import { getEndpointUrl, isImageFormat, isWebFormat } from '../../../utils/convertUtils';
 
 // Static function that can be used by both the hook and automation executor
@@ -129,7 +129,7 @@ export const convertProcessor = async (
 
 // Static configuration object
 export const convertOperationConfig = {
-  toolType: 'custom',
+  toolType: ToolType.custom,
   customProcessor: convertProcessor, // Can't use callback version here
   operationType: 'convert',
   filePrefix: 'converted_',

--- a/frontend/src/hooks/tools/convert/useConvertOperation.ts
+++ b/frontend/src/hooks/tools/convert/useConvertOperation.ts
@@ -129,11 +129,10 @@ export const convertProcessor = async (
 
 // Static configuration object
 export const convertOperationConfig = {
+  toolType: 'custom',
+  customProcessor: convertProcessor, // Can't use callback version here
   operationType: 'convert',
-  endpoint: '', // Not used with customProcessor but required
-  buildFormData: buildConvertFormData, // Not used with customProcessor but required
   filePrefix: 'converted_',
-  customProcessor: convertProcessor,
   defaultParameters,
 } as const;
 
@@ -158,6 +157,6 @@ export const useConvertOperation = () => {
         return error.message;
       }
       return t("convert.errorConversion", "An error occurred while converting the file.");
-    }
+    },
   });
 };

--- a/frontend/src/hooks/tools/ocr/useOCROperation.ts
+++ b/frontend/src/hooks/tools/ocr/useOCROperation.ts
@@ -52,7 +52,7 @@ export const buildOCRFormData = (parameters: OCRParameters, file: File): FormDat
   return formData;
 };
 
-// Static response handler for OCR - can be used by automation executor  
+// Static response handler for OCR - can be used by automation executor
 export const ocrResponseHandler = async (blob: Blob, originalFiles: File[], extractZipFiles: (blob: Blob) => Promise<File[]>): Promise<File[]> => {
   const headBuf = await blob.slice(0, 8).arrayBuffer();
   const head = new TextDecoder().decode(new Uint8Array(headBuf));
@@ -94,11 +94,11 @@ export const ocrResponseHandler = async (blob: Blob, originalFiles: File[], extr
 
 // Static configuration object (without t function dependencies)
 export const ocrOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildOCRFormData,
   operationType: 'ocr',
   endpoint: '/api/v1/misc/ocr-pdf',
-  buildFormData: buildOCRFormData,
   filePrefix: 'ocr_',
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/ocr/useOCROperation.ts
+++ b/frontend/src/hooks/tools/ocr/useOCROperation.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { OCRParameters, defaultParameters } from './useOCRParameters';
-import { useToolOperation, ToolOperationConfig } from '../shared/useToolOperation';
+import { useToolOperation, ToolOperationConfig, ToolType } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { useToolResources } from '../shared/useToolResources';
 
@@ -94,7 +94,7 @@ export const ocrResponseHandler = async (blob: Blob, originalFiles: File[], extr
 
 // Static configuration object (without t function dependencies)
 export const ocrOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildOCRFormData,
   operationType: 'ocr',
   endpoint: '/api/v1/misc/ocr-pdf',

--- a/frontend/src/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
+++ b/frontend/src/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { RemoveCertificateSignParameters, defaultParameters } from './useRemoveCertificateSignParameters';
 
@@ -12,7 +12,7 @@ export const buildRemoveCertificateSignFormData = (parameters: RemoveCertificate
 
 // Static configuration object
 export const removeCertificateSignOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildRemoveCertificateSignFormData,
   operationType: 'remove-certificate-sign',
   endpoint: '/api/v1/security/remove-cert-sign',

--- a/frontend/src/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
+++ b/frontend/src/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
@@ -12,11 +12,11 @@ export const buildRemoveCertificateSignFormData = (parameters: RemoveCertificate
 
 // Static configuration object
 export const removeCertificateSignOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildRemoveCertificateSignFormData,
   operationType: 'remove-certificate-sign',
   endpoint: '/api/v1/security/remove-cert-sign',
-  buildFormData: buildRemoveCertificateSignFormData,
   filePrefix: 'unsigned_', // Will be overridden in hook with translation
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.test.ts
+++ b/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.test.ts
@@ -3,10 +3,13 @@ import { renderHook } from '@testing-library/react';
 import { useRemovePasswordOperation } from './useRemovePasswordOperation';
 import type { RemovePasswordParameters } from './useRemovePasswordParameters';
 
-// Mock the useToolOperation hook
-vi.mock('../shared/useToolOperation', () => ({
-  useToolOperation: vi.fn()
-}));
+vi.mock('../shared/useToolOperation', async () => {
+  const actual = await vi.importActual('../shared/useToolOperation');  // Need to keep ToolType etc.
+  return {
+    ...actual,
+    useToolOperation: vi.fn()
+  };
+});
 
 // Mock the translation hook
 const mockT = vi.fn((key: string) => `translated-${key}`);
@@ -20,7 +23,7 @@ vi.mock('../../../utils/toolErrorHandler', () => ({
 }));
 
 // Import the mocked function
-import { SingleFileToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
+import { SingleFileToolOperationConfig, ToolOperationHook, ToolType, useToolOperation } from '../shared/useToolOperation';
 
 describe('useRemovePasswordOperation', () => {
   const mockUseToolOperation = vi.mocked(useToolOperation);
@@ -91,7 +94,7 @@ describe('useRemovePasswordOperation', () => {
   });
 
   test.each([
-    { property: 'toolType' as const, expectedValue: 'singleFile' },
+    { property: 'toolType' as const, expectedValue: ToolType.singleFile },
     { property: 'endpoint' as const, expectedValue: '/api/v1/security/remove-password' },
     { property: 'filePrefix' as const, expectedValue: 'translated-removePassword.filenamePrefix_' },
     { property: 'operationType' as const, expectedValue: 'removePassword' }

--- a/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.test.ts
+++ b/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.test.ts
@@ -20,12 +20,12 @@ vi.mock('../../../utils/toolErrorHandler', () => ({
 }));
 
 // Import the mocked function
-import { ToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
+import { SingleFileToolOperationConfig, ToolOperationHook, useToolOperation } from '../shared/useToolOperation';
 
 describe('useRemovePasswordOperation', () => {
   const mockUseToolOperation = vi.mocked(useToolOperation);
 
-  const getToolConfig = (): ToolOperationConfig<RemovePasswordParameters> => mockUseToolOperation.mock.calls[0][0] as ToolOperationConfig<RemovePasswordParameters>;
+  const getToolConfig = () => mockUseToolOperation.mock.calls[0][0] as SingleFileToolOperationConfig<RemovePasswordParameters>;
 
   const mockToolOperationReturn: ToolOperationHook<unknown> = {
     files: [],
@@ -91,7 +91,7 @@ describe('useRemovePasswordOperation', () => {
   });
 
   test.each([
-    { property: 'multiFileEndpoint' as const, expectedValue: false },
+    { property: 'toolType' as const, expectedValue: 'singleFile' },
     { property: 'endpoint' as const, expectedValue: '/api/v1/security/remove-password' },
     { property: 'filePrefix' as const, expectedValue: 'translated-removePassword.filenamePrefix_' },
     { property: 'operationType' as const, expectedValue: 'removePassword' }

--- a/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.ts
+++ b/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.ts
@@ -13,11 +13,11 @@ export const buildRemovePasswordFormData = (parameters: RemovePasswordParameters
 
 // Static configuration object
 export const removePasswordOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildRemovePasswordFormData,
   operationType: 'removePassword',
   endpoint: '/api/v1/security/remove-password',
-  buildFormData: buildRemovePasswordFormData,
   filePrefix: 'decrypted_', // Will be overridden in hook with translation
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.ts
+++ b/frontend/src/hooks/tools/removePassword/useRemovePasswordOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { RemovePasswordParameters, defaultParameters } from './useRemovePasswordParameters';
 
@@ -13,7 +13,7 @@ export const buildRemovePasswordFormData = (parameters: RemovePasswordParameters
 
 // Static configuration object
 export const removePasswordOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildRemovePasswordFormData,
   operationType: 'removePassword',
   endpoint: '/api/v1/security/remove-password',

--- a/frontend/src/hooks/tools/repair/useRepairOperation.ts
+++ b/frontend/src/hooks/tools/repair/useRepairOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { RepairParameters, defaultParameters } from './useRepairParameters';
 
@@ -12,7 +12,7 @@ export const buildRepairFormData = (parameters: RepairParameters, file: File): F
 
 // Static configuration object
 export const repairOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildRepairFormData,
   operationType: 'repair',
   endpoint: '/api/v1/misc/repair',

--- a/frontend/src/hooks/tools/repair/useRepairOperation.ts
+++ b/frontend/src/hooks/tools/repair/useRepairOperation.ts
@@ -12,11 +12,11 @@ export const buildRepairFormData = (parameters: RepairParameters, file: File): F
 
 // Static configuration object
 export const repairOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildRepairFormData,
   operationType: 'repair',
   endpoint: '/api/v1/misc/repair',
-  buildFormData: buildRepairFormData,
   filePrefix: 'repaired_', // Will be overridden in hook with translation
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/sanitize/useSanitizeOperation.ts
+++ b/frontend/src/hooks/tools/sanitize/useSanitizeOperation.ts
@@ -21,9 +21,10 @@ export const buildSanitizeFormData = (parameters: SanitizeParameters, file: File
 
 // Static configuration object
 export const sanitizeOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildSanitizeFormData,
   operationType: 'sanitize',
   endpoint: '/api/v1/security/sanitize-pdf',
-  buildFormData: buildSanitizeFormData,
   filePrefix: 'sanitized_', // Will be overridden in hook with translation
   multiFileEndpoint: false,
   defaultParameters,

--- a/frontend/src/hooks/tools/sanitize/useSanitizeOperation.ts
+++ b/frontend/src/hooks/tools/sanitize/useSanitizeOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { SanitizeParameters, defaultParameters } from './useSanitizeParameters';
 
@@ -21,7 +21,7 @@ export const buildSanitizeFormData = (parameters: SanitizeParameters, file: File
 
 // Static configuration object
 export const sanitizeOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildSanitizeFormData,
   operationType: 'sanitize',
   endpoint: '/api/v1/security/sanitize-pdf',

--- a/frontend/src/hooks/tools/shared/useToolOperation.ts
+++ b/frontend/src/hooks/tools/shared/useToolOperation.ts
@@ -12,6 +12,8 @@ import { ResponseHandler } from '../../../utils/toolResponseProcessor';
 // Re-export for backwards compatibility
 export type { ProcessingProgress, ResponseHandler };
 
+export type ToolConfigType = 'singleFile' | 'multiFile' | 'custom';
+
 /**
  * Configuration for tool operations defining processing behavior and API integration.
  *
@@ -20,44 +22,15 @@ export type { ProcessingProgress, ResponseHandler };
  * 2. Multi-file tools: multiFileEndpoint: true, single API call with all files
  * 3. Complex tools: customProcessor handles all processing logic
  */
-export interface ToolOperationConfig<TParams = void> {
+interface BaseToolOperationConfig<TParams> {
   /** Operation identifier for tracking and logging */
   operationType: string;
-
-  /**
-   * API endpoint for the operation. Can be static string or function for dynamic routing.
-   * Not used when customProcessor is provided.
-   */
-  endpoint: string | ((params: TParams) => string);
-
-  /**
-   * Builds FormData for API request. Signature determines processing approach:
-   * - (params, file: File) => FormData: Single-file processing
-   * - (params, files: File[]) => FormData: Multi-file processing
-   * Not used when customProcessor is provided.
-   */
-  buildFormData: ((params: TParams, file: File) => FormData) | ((params: TParams, files: File[]) => FormData); /* FIX ME */
 
   /** Prefix added to processed filenames (e.g., 'compressed_', 'split_') */
   filePrefix: string;
 
-  /**
-   * Whether this tool uses backends that accept MultipartFile[] arrays.
-   * - true: Single API call with all files (backend uses MultipartFile[])
-   * - false/undefined: Individual API calls per file (backend uses single MultipartFile)
-   * Ignored when customProcessor is provided.
-   */
-  multiFileEndpoint?: boolean;
-
   /** How to handle API responses (e.g., ZIP extraction, single file response) */
   responseHandler?: ResponseHandler;
-
-  /**
-   * Custom processing logic that completely bypasses standard file processing.
-   * When provided, tool handles all API calls, response processing, and file creation.
-   * Use for tools with complex routing logic or non-standard processing requirements.
-   */
-  customProcessor?: (params: TParams, files: File[]) => Promise<File[]>;
 
   /** Extract user-friendly error messages from API errors */
   getErrorMessage?: (error: any) => string;
@@ -65,6 +38,49 @@ export interface ToolOperationConfig<TParams = void> {
   /** Default parameter values for automation */
   defaultParameters?: TParams;
 }
+
+export interface SingleFileToolOperationConfig<TParams> extends BaseToolOperationConfig<TParams> {
+  /** This tool processes one file at a time. */
+  toolType: 'singleFile';
+
+  /** Builds FormData for API request. */
+  buildFormData: ((params: TParams, file: File) => FormData);
+
+  /** API endpoint for the operation. Can be static string or function for dynamic routing. */
+  endpoint: string | ((params: TParams) => string);
+
+  customProcessor?: undefined;
+}
+
+export interface MultiFileToolOperationConfig<TParams> extends BaseToolOperationConfig<TParams> {
+  /** This tool processes multiple files at once. */
+  toolType: 'multiFile';
+
+  /** Builds FormData for API request. */
+  buildFormData: ((params: TParams, files: File[]) => FormData);
+
+  /** API endpoint for the operation. Can be static string or function for dynamic routing. */
+  endpoint: string | ((params: TParams) => string);
+
+  customProcessor?: undefined;
+}
+
+export interface CustomToolOperationConfig<TParams> extends BaseToolOperationConfig<TParams> {
+  /** This tool has custom behaviour. */
+  toolType: 'custom';
+
+  buildFormData?: undefined;
+  endpoint?: undefined;
+
+  /**
+   * Custom processing logic that completely bypasses standard file processing.
+   * This tool handles all API calls, response processing, and file creation.
+   * Use for tools with complex routing logic or non-standard processing requirements.
+   */
+  customProcessor: (params: TParams, files: File[]) => Promise<File[]>;
+}
+
+export type ToolOperationConfig<TParams = void> = SingleFileToolOperationConfig<TParams> | MultiFileToolOperationConfig<TParams> | CustomToolOperationConfig<TParams>;
 
 /**
  * Complete tool operation interface with execution capability
@@ -103,7 +119,7 @@ export { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
  * @param config - Tool operation configuration
  * @returns Hook interface with state and execution methods
  */
-export const useToolOperation = <TParams = void>(
+export const useToolOperation = <TParams>(
   config: ToolOperationConfig<TParams>
 ): ToolOperationHook<TParams> => {
   const { t } = useTranslation();
@@ -143,15 +159,28 @@ export const useToolOperation = <TParams = void>(
     try {
       let processedFiles: File[];
 
-      if (config.customProcessor) {
-        actions.setStatus('Processing files...');
-        processedFiles = await config.customProcessor(params, validFiles);
-      } else {
-        // Use explicit multiFileEndpoint flag to determine processing approach
-        if (config.multiFileEndpoint) {
+      switch (config.toolType) {
+        case 'singleFile':
+          // Individual file processing - separate API call per file
+          const apiCallsConfig: ApiCallsConfig<TParams> = {
+            endpoint: config.endpoint,
+            buildFormData: config.buildFormData,
+            filePrefix: config.filePrefix,
+            responseHandler: config.responseHandler
+          };
+          processedFiles = await processFiles(
+            params,
+            validFiles,
+            apiCallsConfig,
+            actions.setProgress,
+            actions.setStatus
+          );
+          break;
+
+        case 'multiFile':
           // Multi-file processing - single API call with all files
           actions.setStatus('Processing files...');
-          const formData = (config.buildFormData as (params: TParams, files: File[]) => FormData)(params, validFiles);
+          const formData = config.buildFormData(params, validFiles);
           const endpoint = typeof config.endpoint === 'function' ? config.endpoint(params) : config.endpoint;
 
           const response = await axios.post(endpoint, formData, { responseType: 'blob' });
@@ -175,22 +204,12 @@ export const useToolOperation = <TParams = void>(
               processedFiles = await extractAllZipFiles(response.data);
             }
           }
-        } else {
-          // Individual file processing - separate API call per file
-          const apiCallsConfig: ApiCallsConfig<TParams> = {
-            endpoint: config.endpoint,
-            buildFormData: config.buildFormData as (params: TParams, file: File) => FormData,
-            filePrefix: config.filePrefix,
-            responseHandler: config.responseHandler
-          };
-          processedFiles = await processFiles(
-            params,
-            validFiles,
-            apiCallsConfig,
-            actions.setProgress,
-            actions.setStatus
-          );
-        }
+          break;
+
+        case 'custom':
+          actions.setStatus('Processing files...');
+          processedFiles = await config.customProcessor(params, validFiles);
+          break;
       }
 
       if (processedFiles.length > 0) {

--- a/frontend/src/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
+++ b/frontend/src/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
@@ -12,11 +12,11 @@ export const buildSingleLargePageFormData = (parameters: SingleLargePageParamete
 
 // Static configuration object
 export const singleLargePageOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildSingleLargePageFormData,
   operationType: 'single-large-page',
   endpoint: '/api/v1/general/pdf-to-single-page',
-  buildFormData: buildSingleLargePageFormData,
   filePrefix: 'single_page_', // Will be overridden in hook with translation
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
+++ b/frontend/src/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { SingleLargePageParameters, defaultParameters } from './useSingleLargePageParameters';
 
@@ -12,7 +12,7 @@ export const buildSingleLargePageFormData = (parameters: SingleLargePageParamete
 
 // Static configuration object
 export const singleLargePageOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildSingleLargePageFormData,
   operationType: 'single-large-page',
   endpoint: '/api/v1/general/pdf-to-single-page',

--- a/frontend/src/hooks/tools/split/useSplitOperation.ts
+++ b/frontend/src/hooks/tools/split/useSplitOperation.ts
@@ -57,11 +57,11 @@ export const getSplitEndpoint = (parameters: SplitParameters): string => {
 
 // Static configuration object
 export const splitOperationConfig = {
+  toolType: 'multiFile',
+  buildFormData: buildSplitFormData,
   operationType: 'splitPdf',
   endpoint: getSplitEndpoint,
-  buildFormData: buildSplitFormData,
   filePrefix: 'split_',
-  multiFileEndpoint: true, // Single API call with all files
   defaultParameters,
 } as const;
 

--- a/frontend/src/hooks/tools/split/useSplitOperation.ts
+++ b/frontend/src/hooks/tools/split/useSplitOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { SplitParameters, defaultParameters } from './useSplitParameters';
 import { SPLIT_MODES } from '../../../constants/splitConstants';
@@ -57,7 +57,7 @@ export const getSplitEndpoint = (parameters: SplitParameters): string => {
 
 // Static configuration object
 export const splitOperationConfig = {
-  toolType: 'multiFile',
+  toolType: ToolType.multiFile,
   buildFormData: buildSplitFormData,
   operationType: 'splitPdf',
   endpoint: getSplitEndpoint,

--- a/frontend/src/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
+++ b/frontend/src/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useToolOperation } from '../shared/useToolOperation';
+import { ToolType, useToolOperation } from '../shared/useToolOperation';
 import { createStandardErrorHandler } from '../../../utils/toolErrorHandler';
 import { UnlockPdfFormsParameters, defaultParameters } from './useUnlockPdfFormsParameters';
 
@@ -12,7 +12,7 @@ export const buildUnlockPdfFormsFormData = (parameters: UnlockPdfFormsParameters
 
 // Static configuration object
 export const unlockPdfFormsOperationConfig = {
-  toolType: 'singleFile',
+  toolType: ToolType.singleFile,
   buildFormData: buildUnlockPdfFormsFormData,
   operationType: 'unlock-pdf-forms',
   endpoint: '/api/v1/misc/unlock-pdf-forms',

--- a/frontend/src/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
+++ b/frontend/src/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
@@ -12,11 +12,11 @@ export const buildUnlockPdfFormsFormData = (parameters: UnlockPdfFormsParameters
 
 // Static configuration object
 export const unlockPdfFormsOperationConfig = {
+  toolType: 'singleFile',
+  buildFormData: buildUnlockPdfFormsFormData,
   operationType: 'unlock-pdf-forms',
   endpoint: '/api/v1/misc/unlock-pdf-forms',
-  buildFormData: buildUnlockPdfFormsFormData,
   filePrefix: 'unlocked_forms_', // Will be overridden in hook with translation
-  multiFileEndpoint: false,
   defaultParameters,
 } as const;
 

--- a/frontend/src/utils/automationExecutor.ts
+++ b/frontend/src/utils/automationExecutor.ts
@@ -4,6 +4,7 @@ import { AutomationConfig, AutomationExecutionCallbacks } from '../types/automat
 import { AUTOMATION_CONSTANTS } from '../constants/automation';
 import { AutomationFileProcessor } from './automationFileProcessor';
 import { ResourceManager } from './resourceManager';
+import { ToolType } from '../hooks/tools/shared/useToolOperation';
 
 
 /**
@@ -47,7 +48,7 @@ export const executeToolOperationWithPrefix = async (
       return resultFiles;
     }
 
-    if (config.toolType === 'multiFile') {
+    if (config.toolType === ToolType.multiFile) {
       // Multi-file processing - single API call with all files
       const endpoint = typeof config.endpoint === 'function'
         ? config.endpoint(parameters)


### PR DESCRIPTION
# Description of Changes
Redesigns `ToolOperationConfig` so that the types of the functions are always known depending on whether the tool runs on single files, multiple files, or uses custom behaviour