### PR TITLE
V2 Make FileId type opaque and use consistently throughout project

### DIFF
--- a/frontend/src/components/fileEditor/FileEditor.tsx
+++ b/frontend/src/components/fileEditor/FileEditor.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { useFileSelection, useFileState, useFileManagement, useFileActions } from '../../contexts/FileContext';
 import { useNavigationActions } from '../../contexts/NavigationContext';
-import { FileId, FileOperation } from '../../types/fileContext';
+import { FileOperation } from '../../types/fileContext';
 import { fileStorage } from '../../services/fileStorage';
 import { generateThumbnailForFile } from '../../utils/thumbnailUtils';
 import { zipFileService } from '../../services/zipFileService';
@@ -16,6 +16,7 @@ import styles from './FileEditor.module.css';
 import FileEditorThumbnail from './FileEditorThumbnail';
 import FilePickerModal from '../shared/FilePickerModal';
 import SkeletonLoader from '../shared/SkeletonLoader';
+import { FileId } from '../../types/file';
 
 
 interface FileEditorProps {

--- a/frontend/src/components/fileEditor/FileEditorThumbnail.tsx
+++ b/frontend/src/components/fileEditor/FileEditorThumbnail.tsx
@@ -11,7 +11,7 @@ import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-d
 
 import styles from './FileEditor.module.css';
 import { useFileContext } from '../../contexts/FileContext';
-import { FileId } from '../../types/fileContext';
+import { FileId } from '../../types/file';
 
 interface FileItem {
   id: FileId;

--- a/frontend/src/components/fileEditor/FileEditorThumbnail.tsx
+++ b/frontend/src/components/fileEditor/FileEditorThumbnail.tsx
@@ -11,9 +11,10 @@ import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-d
 
 import styles from './FileEditor.module.css';
 import { useFileContext } from '../../contexts/FileContext';
+import { FileId } from '../../types/fileContext';
 
 interface FileItem {
-  id: string;
+  id: FileId;
   name: string;
   pageCount: number;
   thumbnail: string | null;
@@ -25,14 +26,14 @@ interface FileEditorThumbnailProps {
   file: FileItem;
   index: number;
   totalFiles: number;
-  selectedFiles: string[];
+  selectedFiles: FileId[];
   selectionMode: boolean;
-  onToggleFile: (fileId: string) => void;
-  onDeleteFile: (fileId: string) => void;
-  onViewFile: (fileId: string) => void;
+  onToggleFile: (fileId: FileId) => void;
+  onDeleteFile: (fileId: FileId) => void;
+  onViewFile: (fileId: FileId) => void;
   onSetStatus: (status: string) => void;
-  onReorderFiles?: (sourceFileId: string, targetFileId: string, selectedFileIds: string[]) => void;
-  onDownloadFile?: (fileId: string) => void;
+  onReorderFiles?: (sourceFileId: FileId, targetFileId: FileId, selectedFileIds: FileId[]) => void;
+  onDownloadFile?: (fileId: FileId) => void;
   toolMode?: boolean;
   isSupported?: boolean;
 }
@@ -161,8 +162,8 @@ const FileEditorThumbnail = ({
       onDrop: ({ source }) => {
         const sourceData = source.data;
         if (sourceData.type === 'file' && onReorderFiles) {
-          const sourceFileId = sourceData.fileId as string;
-          const selectedFileIds = sourceData.selectedFiles as string[];
+          const sourceFileId = sourceData.fileId as FileId;
+          const selectedFileIds = sourceData.selectedFiles as FileId[];
           onReorderFiles(sourceFileId, file.id, selectedFileIds);
         }
       }
@@ -332,7 +333,7 @@ const FileEditorThumbnail = ({
       )}
 
       {/* Title + meta line */}
-      <div 
+      <div
       style={{
         padding: '0.5rem',
         textAlign: 'center',

--- a/frontend/src/components/history/FileOperationHistory.tsx
+++ b/frontend/src/components/history/FileOperationHistory.tsx
@@ -12,11 +12,11 @@ import {
   Divider
 } from '@mantine/core';
 // FileContext no longer needed - these were stub functions anyway
-import { FileOperation, FileOperationHistory as FileOperationHistoryType } from '../../types/fileContext';
+import { FileId, FileOperation, FileOperationHistory as FileOperationHistoryType } from '../../types/fileContext';
 import { PageOperation } from '../../types/pageEditor';
 
 interface FileOperationHistoryProps {
-  fileId: string;
+  fileId: FileId;
   showOnlyApplied?: boolean;
   maxHeight?: number;
 }
@@ -27,8 +27,8 @@ const FileOperationHistory: React.FC<FileOperationHistoryProps> = ({
   maxHeight = 400
 }) => {
   // These were stub functions in the old context - replace with empty stubs
-  const getFileHistory = (fileId: string) => ({ operations: [], createdAt: Date.now(), lastModified: Date.now() });
-  const getAppliedOperations = (fileId: string) => [];
+  const getFileHistory = (fileId: FileId) => ({ operations: [], createdAt: Date.now(), lastModified: Date.now() });
+  const getAppliedOperations = (fileId: FileId) => [];
 
   const history = getFileHistory(fileId);
   const allOperations = showOnlyApplied ? getAppliedOperations(fileId) : history?.operations || [];

--- a/frontend/src/components/history/FileOperationHistory.tsx
+++ b/frontend/src/components/history/FileOperationHistory.tsx
@@ -12,8 +12,9 @@ import {
   Divider
 } from '@mantine/core';
 // FileContext no longer needed - these were stub functions anyway
-import { FileId, FileOperation, FileOperationHistory as FileOperationHistoryType } from '../../types/fileContext';
+import {  FileOperation, FileOperationHistory as FileOperationHistoryType } from '../../types/fileContext';
 import { PageOperation } from '../../types/pageEditor';
+import { FileId } from '../../types/file';
 
 interface FileOperationHistoryProps {
   fileId: FileId;

--- a/frontend/src/components/pageEditor/FileThumbnail.tsx
+++ b/frontend/src/components/pageEditor/FileThumbnail.tsx
@@ -11,7 +11,7 @@ import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-d
 
 import styles from './PageEditor.module.css';
 import { useFileContext } from '../../contexts/FileContext';
-import { FileId } from '../../types/fileContext';
+import { FileId } from '../../types/file';
 
 interface FileItem {
   id: FileId;

--- a/frontend/src/components/pageEditor/FileThumbnail.tsx
+++ b/frontend/src/components/pageEditor/FileThumbnail.tsx
@@ -11,9 +11,10 @@ import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-d
 
 import styles from './PageEditor.module.css';
 import { useFileContext } from '../../contexts/FileContext';
+import { FileId } from '../../types/fileContext';
 
 interface FileItem {
-  id: string;
+  id: FileId;
   name: string;
   pageCount: number;
   thumbnail: string | null;
@@ -27,12 +28,12 @@ interface FileThumbnailProps {
   totalFiles: number;
   selectedFiles: string[];
   selectionMode: boolean;
-  onToggleFile: (fileId: string) => void;
-  onDeleteFile: (fileId: string) => void;
-  onViewFile: (fileId: string) => void;
+  onToggleFile: (fileId: FileId) => void;
+  onDeleteFile: (fileId: FileId) => void;
+  onViewFile: (fileId: FileId) => void;
   onSetStatus: (status: string) => void;
-  onReorderFiles?: (sourceFileId: string, targetFileId: string, selectedFileIds: string[]) => void;
-  onDownloadFile?: (fileId: string) => void;
+  onReorderFiles?: (sourceFileId: FileId, targetFileId: FileId, selectedFileIds: FileId[]) => void;
+  onDownloadFile?: (fileId: FileId) => void;
   toolMode?: boolean;
   isSupported?: boolean;
 }
@@ -161,8 +162,8 @@ const FileThumbnail = ({
       onDrop: ({ source }) => {
         const sourceData = source.data;
         if (sourceData.type === 'file' && onReorderFiles) {
-          const sourceFileId = sourceData.fileId as string;
-          const selectedFileIds = sourceData.selectedFiles as string[];
+          const sourceFileId = sourceData.fileId as FileId;
+          const selectedFileIds = sourceData.selectedFiles as FileId[];
           onReorderFiles(sourceFileId, file.id, selectedFileIds);
         }
       }

--- a/frontend/src/components/pageEditor/PageEditor.tsx
+++ b/frontend/src/components/pageEditor/PageEditor.tsx
@@ -17,6 +17,7 @@ import PageThumbnail from './PageThumbnail';
 import DragDropGrid from './DragDropGrid';
 import SkeletonLoader from '../shared/SkeletonLoader';
 import NavigationWarningModal from '../shared/NavigationWarningModal';
+import { FileId } from "../../types/fileContext";
 
 import {
   DOMCommand,
@@ -83,7 +84,7 @@ const PageEditor = ({
 
   // Grid container ref for positioning split indicators
   const gridContainerRef = useRef<HTMLDivElement>(null);
-  
+
   // State to trigger re-renders when container size changes
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
 
@@ -173,7 +174,8 @@ const PageEditor = ({
   const createRotateCommand = useCallback((pageIds: string[], rotation: number) => ({
     execute: () => {
       const bulkRotateCommand = new BulkRotateCommand(pageIds, rotation);
-      undoManagerRef.current.executeCommand(bulkRotateCommand);
+
+    undoManagerRef.current.executeCommand(bulkRotateCommand);
     }
   }), []);
 
@@ -182,7 +184,8 @@ const PageEditor = ({
       if (!displayDocument) return;
 
       const pagesToDelete = pageIds.map(pageId => {
-        const page = displayDocument.pages.find(p => p.id === pageId);
+
+    const page = displayDocument.pages.find(p => p.id === pageId);
         return page?.pageNumber || 0;
       }).filter(num => num > 0);
 
@@ -213,7 +216,7 @@ const PageEditor = ({
       );
       undoManagerRef.current.executeCommand(splitCommand);
     }
-  }), [splitPositions]);
+}), [splitPositions]);
 
   // Command executor for PageThumbnail
   const executeCommand = useCallback((command: any) => {
@@ -296,14 +299,14 @@ const PageEditor = ({
     // Smart toggle logic: follow the majority, default to adding splits if equal
     const existingSplitsCount = selectedPositions.filter(pos => splitPositions.has(pos)).length;
     const noSplitsCount = selectedPositions.length - existingSplitsCount;
-    
+
     // Remove splits only if majority already have splits
     // If equal (50/50), default to adding splits
     const shouldRemoveSplits = existingSplitsCount > noSplitsCount;
-    
+
 
     const newSplitPositions = new Set(splitPositions);
-    
+
     if (shouldRemoveSplits) {
       // Remove splits from all selected positions
       selectedPositions.forEach(pos => newSplitPositions.delete(pos));
@@ -316,8 +319,8 @@ const PageEditor = ({
     const smartSplitCommand = {
       execute: () => setSplitPositions(newSplitPositions),
       undo: () => setSplitPositions(splitPositions),
-      description: shouldRemoveSplits 
-        ? `Remove ${selectedPositions.length} split(s)` 
+      description: shouldRemoveSplits
+        ? `Remove ${selectedPositions.length} split(s)`
         : `Add ${selectedPositions.length - existingSplitsCount} split(s)`
     };
 
@@ -343,13 +346,13 @@ const PageEditor = ({
     // Smart toggle logic: follow the majority, default to adding splits if equal
     const existingSplitsCount = selectedPositions.filter(pos => splitPositions.has(pos)).length;
     const noSplitsCount = selectedPositions.length - existingSplitsCount;
-    
+
     // Remove splits only if majority already have splits
     // If equal (50/50), default to adding splits
     const shouldRemoveSplits = existingSplitsCount > noSplitsCount;
-    
+
     const newSplitPositions = new Set(splitPositions);
-    
+
     if (shouldRemoveSplits) {
       // Remove splits from all selected positions
       selectedPositions.forEach(pos => newSplitPositions.delete(pos));
@@ -362,8 +365,8 @@ const PageEditor = ({
     const smartSplitCommand = {
       execute: () => setSplitPositions(newSplitPositions),
       undo: () => setSplitPositions(splitPositions),
-      description: shouldRemoveSplits 
-        ? `Remove ${selectedPositions.length} split(s)` 
+      description: shouldRemoveSplits
+        ? `Remove ${selectedPositions.length} split(s)`
         : `Add ${selectedPositions.length - existingSplitsCount} split(s)`
     };
 
@@ -404,7 +407,7 @@ const PageEditor = ({
     try {
       const targetPage = displayDocument.pages.find(p => p.pageNumber === insertAfterPage);
       if (!targetPage) return;
-      
+
       await actions.addFiles(files, { insertAfterPageId: targetPage.id });
     } catch (error) {
       console.error('Failed to insert files:', error);
@@ -457,7 +460,7 @@ const PageEditor = ({
     // Use multi-file export if we have multiple original files
     const hasInsertedFiles = false;
     const hasMultipleOriginalFiles = activeFileIds.length > 1;
-    
+
     if (!hasInsertedFiles && !hasMultipleOriginalFiles) {
       return null; // Use single-file export method
     }
@@ -551,11 +554,11 @@ const PageEditor = ({
         const sourceFiles = getSourceFiles();
         const baseExportFilename = getExportFilename();
         const baseName = baseExportFilename.replace(/\.pdf$/i, '');
-        
+
         for (let i = 0; i < processedDocuments.length; i++) {
           const doc = processedDocuments[i];
           const partFilename = `${baseName}_part_${i + 1}.pdf`;
-          
+
           const result = sourceFiles
             ? await pdfExportService.exportPDFMultiFile(doc, sourceFiles, [], { filename: partFilename })
             : await pdfExportService.exportPDF(doc, [], { filename: partFilename });
@@ -622,6 +625,7 @@ const PageEditor = ({
 
   const closePdf = useCallback(() => {
     actions.clearAllFiles();
+
     undoManagerRef.current.clear();
     setSelectedPageIds([]);
     setSelectionMode(false);
@@ -632,7 +636,7 @@ const PageEditor = ({
     if (!displayDocument) return;
 
     // For now, trigger the actual export directly
-    // In the original, this would show a preview modal first
+   // In the original, this would show a preview modal first
     if (selectedOnly) {
       onExportSelected();
     } else {
@@ -723,23 +727,23 @@ const PageEditor = ({
               const ITEM_WIDTH = parseFloat(GRID_CONSTANTS.ITEM_WIDTH) * remToPx;
               const ITEM_HEIGHT = parseFloat(GRID_CONSTANTS.ITEM_HEIGHT) * remToPx;
               const ITEM_GAP = parseFloat(GRID_CONSTANTS.ITEM_GAP) * remToPx;
-              
+
               return Array.from(splitPositions).map((position) => {
-              
+
               // Calculate items per row using DragDropGrid's logic
               const availableWidth = containerWidth - ITEM_GAP; // Account for first gap
               const itemWithGap = ITEM_WIDTH + ITEM_GAP;
               const itemsPerRow = Math.max(1, Math.floor(availableWidth / itemWithGap));
-              
+
               // Calculate position within the grid (same as DragDropGrid)
               const row = Math.floor(position / itemsPerRow);
               const col = position % itemsPerRow;
-              
+
               // Position split line between pages (after the current page)
               // Calculate grid centering offset (same as DragDropGrid)
               const gridWidth = itemsPerRow * ITEM_WIDTH + (itemsPerRow - 1) * ITEM_GAP;
               const gridOffset = Math.max(0, (containerWidth - gridWidth) / 2);
-              
+
               const leftPosition = gridOffset + col * itemWithGap + ITEM_WIDTH + (ITEM_GAP / 2);
               const topPosition = row * ITEM_HEIGHT + (ITEM_HEIGHT * 0.05); // Center vertically (5% offset since page is 90% height)
 

--- a/frontend/src/components/pageEditor/PageEditor.tsx
+++ b/frontend/src/components/pageEditor/PageEditor.tsx
@@ -17,7 +17,7 @@ import PageThumbnail from './PageThumbnail';
 import DragDropGrid from './DragDropGrid';
 import SkeletonLoader from '../shared/SkeletonLoader';
 import NavigationWarningModal from '../shared/NavigationWarningModal';
-import { FileId } from "../../types/fileContext";
+import { FileId } from "../../types/file";
 
 import {
   DOMCommand,
@@ -129,7 +129,7 @@ const PageEditor = ({
 
   // Interface functions for parent component
   const displayDocument = editedDocument || mergedPdfDocument;
-  
+
   // Utility functions to convert between page IDs and page numbers
   const getPageNumbersFromIds = useCallback((pageIds: string[]): number[] => {
     if (!displayDocument) return [];
@@ -138,7 +138,7 @@ const PageEditor = ({
       return page?.pageNumber || 0;
     }).filter(num => num > 0);
   }, [displayDocument]);
-  
+
   const getPageIdsFromNumbers = useCallback((pageNumbers: number[]): string[] => {
     if (!displayDocument) return [];
     return pageNumbers.map(num => {
@@ -146,10 +146,10 @@ const PageEditor = ({
       return page?.id || '';
     }).filter(id => id !== '');
   }, [displayDocument]);
-  
+
   // Convert selectedPageIds to numbers for components that still need numbers
-  const selectedPageNumbers = useMemo(() => 
-    getPageNumbersFromIds(selectedPageIds), 
+  const selectedPageNumbers = useMemo(() =>
+    getPageNumbersFromIds(selectedPageIds),
     [selectedPageIds, getPageNumbersFromIds]
   );
 
@@ -237,7 +237,7 @@ const PageEditor = ({
   const handleRotate = useCallback((direction: 'left' | 'right') => {
     if (!displayDocument || selectedPageIds.length === 0) return;
     const rotation = direction === 'left' ? -90 : 90;
-    
+
     handleRotatePages(selectedPageIds, rotation);
   }, [displayDocument, selectedPageIds, handleRotatePages]);
 
@@ -446,8 +446,8 @@ const PageEditor = ({
   }, [displayDocument, getPageNumbersFromIds]);
 
   // Helper function to collect source files for multi-file export
-  const getSourceFiles = useCallback((): Map<string, File> | null => {
-    const sourceFiles = new Map<string, File>();
+  const getSourceFiles = useCallback((): Map<FileId, File> | null => {
+    const sourceFiles = new Map<FileId, File>();
 
     // Always include original files
     activeFileIds.forEach(fileId => {
@@ -502,7 +502,7 @@ const PageEditor = ({
 
       // Step 2: Use the already selected page IDs
       // Filter to only include IDs that exist in the document with DOM state
-      const validSelectedPageIds = selectedPageIds.filter(pageId => 
+      const validSelectedPageIds = selectedPageIds.filter(pageId =>
         documentWithDOMState.pages.some(p => p.id === pageId)
       );
 

--- a/frontend/src/components/pageEditor/commands/pageCommands.ts
+++ b/frontend/src/components/pageEditor/commands/pageCommands.ts
@@ -1,4 +1,4 @@
-import { FileId } from '../../../types/fileContext';
+import { FileId } from '../../../types/file';
 import { PDFDocument, PDFPage } from '../../../types/pageEditor';
 
 // V1-style DOM-first command system (replaces the old React state commands)

--- a/frontend/src/components/pageEditor/hooks/usePageDocument.ts
+++ b/frontend/src/components/pageEditor/hooks/usePageDocument.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useFileState } from '../../../contexts/FileContext';
 import { PDFDocument, PDFPage } from '../../../types/pageEditor';
+import { FileId } from '../../../types/fileContext';
 
 export interface PageDocumentHook {
   document: PDFDocument | null;
@@ -14,17 +15,17 @@ export interface PageDocumentHook {
  */
 export function usePageDocument(): PageDocumentHook {
   const { state, selectors } = useFileState();
-  
+
   // Prefer IDs + selectors to avoid array identity churn
   const activeFileIds = state.files.ids;
   const primaryFileId = activeFileIds[0] ?? null;
-  
+
   // Stable signature for effects (prevents loops)
   const filesSignature = selectors.getFilesSignature();
-  
+
   // UI state
   const globalProcessing = state.ui.isProcessing;
-  
+
   // Get primary file record outside useMemo to track processedFile changes
   const primaryFileRecord = primaryFileId ? selectors.getFileRecord(primaryFileId) : null;
   const processedFilePages = primaryFileRecord?.processedFile?.pages;
@@ -35,7 +36,7 @@ export function usePageDocument(): PageDocumentHook {
     if (activeFileIds.length === 0) return null;
 
     const primaryFile = primaryFileId ? selectors.getFile(primaryFileId) : null;
-    
+
     // If we have file IDs but no file record, something is wrong - return null to show loading
     if (!primaryFileRecord) {
       console.log('🎬 PageEditor: No primary file record found, showing loading');
@@ -50,9 +51,9 @@ export function usePageDocument(): PageDocumentHook {
             .join(' + ');
 
     // Build page insertion map from files with insertion positions
-    const insertionMap = new Map<string, string[]>(); // insertAfterPageId -> fileIds
-    const originalFileIds: string[] = [];
-    
+    const insertionMap = new Map<string, FileId[]>(); // insertAfterPageId -> fileIds
+    const originalFileIds: FileId[] = [];
+
     activeFileIds.forEach(fileId => {
       const record = selectors.getFileRecord(fileId);
       if (record?.insertAfterPageId !== undefined) {
@@ -64,21 +65,21 @@ export function usePageDocument(): PageDocumentHook {
         originalFileIds.push(fileId);
       }
     });
-    
+
     // Build pages by interleaving original pages with insertions
     let pages: PDFPage[] = [];
     let totalPageCount = 0;
-    
+
     // Helper function to create pages from a file
-    const createPagesFromFile = (fileId: string, startPageNumber: number): PDFPage[] => {
+    const createPagesFromFile = (fileId: FileId, startPageNumber: number): PDFPage[] => {
       const fileRecord = selectors.getFileRecord(fileId);
       if (!fileRecord) {
         return [];
       }
-      
+
       const processedFile = fileRecord.processedFile;
       let filePages: PDFPage[] = [];
-      
+
       if (processedFile?.pages && processedFile.pages.length > 0) {
         // Use fully processed pages with thumbnails
         filePages = processedFile.pages.map((page, pageIndex) => ({
@@ -104,7 +105,7 @@ export function usePageDocument(): PageDocumentHook {
           splitAfter: false,
         }));
       }
-      
+
       return filePages;
     };
 
@@ -114,35 +115,35 @@ export function usePageDocument(): PageDocumentHook {
       const filePages = createPagesFromFile(fileId, 1); // Temporary numbering
       originalFilePages.push(...filePages);
     });
-    
-    // Start with all original pages numbered sequentially  
+
+    // Start with all original pages numbered sequentially
     pages = originalFilePages.map((page, index) => ({
       ...page,
       pageNumber: index + 1
     }));
-    
+
     // Process each insertion by finding the page ID and inserting after it
     for (const [insertAfterPageId, fileIds] of insertionMap.entries()) {
       const targetPageIndex = pages.findIndex(p => p.id === insertAfterPageId);
-      
+
       if (targetPageIndex === -1) continue;
-      
+
       // Collect all pages to insert
       const allNewPages: PDFPage[] = [];
       fileIds.forEach(fileId => {
         const insertedPages = createPagesFromFile(fileId, 1);
         allNewPages.push(...insertedPages);
       });
-      
+
       // Insert all new pages after the target page
       pages.splice(targetPageIndex + 1, 0, ...allNewPages);
-      
+
       // Renumber all pages after insertion
       pages.forEach((page, index) => {
         page.pageNumber = index + 1;
       });
     }
-    
+
     totalPageCount = pages.length;
 
     if (pages.length === 0) {

--- a/frontend/src/components/pageEditor/hooks/usePageDocument.ts
+++ b/frontend/src/components/pageEditor/hooks/usePageDocument.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useFileState } from '../../../contexts/FileContext';
 import { PDFDocument, PDFPage } from '../../../types/pageEditor';
-import { FileId } from '../../../types/fileContext';
+import { FileId } from '../../../types/file';
 
 export interface PageDocumentHook {
   document: PDFDocument | null;

--- a/frontend/src/components/shared/FileGrid.tsx
+++ b/frontend/src/components/shared/FileGrid.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import SearchIcon from "@mui/icons-material/Search";
 import SortIcon from "@mui/icons-material/Sort";
 import FileCard from "./FileCard";
-import { FileRecord } from "../../types/fileContext";
+import { FileId, FileRecord } from "../../types/fileContext";
 
 interface FileGridProps {
   files: Array<{ file: File; record?: FileRecord }>;
@@ -12,8 +12,8 @@ interface FileGridProps {
   onDoubleClick?: (item: { file: File; record?: FileRecord }) => void;
   onView?: (item: { file: File; record?: FileRecord }) => void;
   onEdit?: (item: { file: File; record?: FileRecord }) => void;
-  onSelect?: (fileId: string) => void;
-  selectedFiles?: string[];
+  onSelect?: (fileId: FileId) => void;
+  selectedFiles?: FileId[];
   showSearch?: boolean;
   showSort?: boolean;
   maxDisplay?: number; // If set, shows only this many files with "Show All" option
@@ -119,11 +119,11 @@ const FileGrid = ({
         direction="row"
         wrap="wrap"
         gap="md"
-        h="30rem" 
+        h="30rem"
         style={{ overflowY: "auto", width: "100%" }}
       >
         {displayFiles.map((item, idx) => {
-          const fileId = item.record?.id || item.file.name;
+          const fileId = item.record?.id || item.file.name as FileId /* FIX ME: This doesn't seem right */;
           const originalIdx = files.findIndex(f => (f.record?.id || f.file.name) === fileId);
           const supported = isFileSupported ? isFileSupported(item.file.name) : true;
           return (

--- a/frontend/src/components/shared/FileGrid.tsx
+++ b/frontend/src/components/shared/FileGrid.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from "react-i18next";
 import SearchIcon from "@mui/icons-material/Search";
 import SortIcon from "@mui/icons-material/Sort";
 import FileCard from "./FileCard";
-import { FileId, FileRecord } from "../../types/fileContext";
+import { FileRecord } from "../../types/fileContext";
+import { FileId } from "../../types/file";
 
 interface FileGridProps {
   files: Array<{ file: File; record?: FileRecord }>;

--- a/frontend/src/components/shared/FilePickerModal.tsx
+++ b/frontend/src/components/shared/FilePickerModal.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import { useTranslation } from 'react-i18next';
-import { FileId } from '../../types/fileContext';
+import { FileId } from '../../types/file';
 
 interface FilePickerModalProps {
   opened: boolean;

--- a/frontend/src/components/shared/FilePickerModal.tsx
+++ b/frontend/src/components/shared/FilePickerModal.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  Modal, 
-  Text, 
-  Button, 
-  Group, 
-  Stack, 
-  Checkbox, 
-  ScrollArea, 
+import {
+  Modal,
+  Text,
+  Button,
+  Group,
+  Stack,
+  Checkbox,
+  ScrollArea,
   Box,
   Image,
   Badge,
@@ -15,6 +15,7 @@ import {
 } from '@mantine/core';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import { useTranslation } from 'react-i18next';
+import { FileId } from '../../types/fileContext';
 
 interface FilePickerModalProps {
   opened: boolean;
@@ -30,7 +31,7 @@ const FilePickerModal = ({
   onSelectFiles,
 }: FilePickerModalProps) => {
   const { t } = useTranslation();
-  const [selectedFileIds, setSelectedFileIds] = useState<string[]>([]);
+  const [selectedFileIds, setSelectedFileIds] = useState<FileId[]>([]);
 
   // Reset selection when modal opens
   useEffect(() => {
@@ -39,9 +40,9 @@ const FilePickerModal = ({
     }
   }, [opened]);
 
-  const toggleFileSelection = (fileId: string) => {
+  const toggleFileSelection = (fileId: FileId) => {
     setSelectedFileIds(prev => {
-      return prev.includes(fileId) 
+      return prev.includes(fileId)
         ? prev.filter(id => id !== fileId)
         : [...prev, fileId];
     });
@@ -56,10 +57,10 @@ const FilePickerModal = ({
   };
 
   const handleConfirm = async () => {
-    const selectedFiles = storedFiles.filter(f => 
+    const selectedFiles = storedFiles.filter(f =>
       selectedFileIds.includes(f.id)
     );
-    
+
     // Convert stored files to File objects
     const convertedFiles = await Promise.all(
       selectedFiles.map(async (fileItem) => {
@@ -68,12 +69,12 @@ const FilePickerModal = ({
           if (fileItem instanceof File) {
             return fileItem;
           }
-          
+
           // If it has a file property, use that
           if (fileItem.file && fileItem.file instanceof File) {
             return fileItem.file;
           }
-          
+
           // If it's from IndexedDB storage, reconstruct the File
           if (fileItem.arrayBuffer && typeof fileItem.arrayBuffer === 'function') {
             const arrayBuffer = await fileItem.arrayBuffer();
@@ -83,8 +84,8 @@ const FilePickerModal = ({
               lastModified: fileItem.lastModified || Date.now()
             });
           }
-          
-          // If it has data property, reconstruct the File  
+
+          // If it has data property, reconstruct the File
           if (fileItem.data) {
             const blob = new Blob([fileItem.data], { type: fileItem.type || 'application/pdf' });
             return new File([blob], fileItem.name, {
@@ -92,7 +93,7 @@ const FilePickerModal = ({
               lastModified: fileItem.lastModified || Date.now()
             });
           }
-          
+
           console.warn('Could not convert file item:', fileItem);
           return null;
         } catch (error) {
@@ -101,10 +102,10 @@ const FilePickerModal = ({
         }
       })
     );
-    
+
     // Filter out any null values and return valid Files
     const validFiles = convertedFiles.filter((f): f is File => f !== null);
-    
+
     onSelectFiles(validFiles);
     onClose();
   };
@@ -156,18 +157,18 @@ const FilePickerModal = ({
                 {storedFiles.map((file) => {
                   const fileId = file.id;
                   const isSelected = selectedFileIds.includes(fileId);
-                  
+
                   return (
                     <Box
                       key={fileId}
                       p="sm"
                       style={{
-                        border: isSelected 
-                          ? '2px solid var(--mantine-color-blue-6)' 
+                        border: isSelected
+                          ? '2px solid var(--mantine-color-blue-6)'
                           : '1px solid var(--mantine-color-gray-3)',
                         borderRadius: 8,
-                        backgroundColor: isSelected 
-                          ? 'var(--mantine-color-blue-0)' 
+                        backgroundColor: isSelected
+                          ? 'var(--mantine-color-blue-0)'
                           : 'transparent',
                         cursor: 'pointer',
                         transition: 'all 0.2s ease'
@@ -180,7 +181,7 @@ const FilePickerModal = ({
                           onChange={() => toggleFileSelection(fileId)}
                           onClick={(e) => e.stopPropagation()}
                         />
-                        
+
                         {/* Thumbnail */}
                         <Box
                           style={{
@@ -246,11 +247,11 @@ const FilePickerModal = ({
           <Button variant="light" onClick={onClose}>
             {t("close", "Cancel")}
           </Button>
-          <Button 
+          <Button
             onClick={handleConfirm}
             disabled={selectedFileIds.length === 0}
           >
-            {selectedFileIds.length > 0 
+            {selectedFileIds.length > 0
               ? `${t("fileUpload.loadFromStorage", "Load")} ${selectedFileIds.length} ${t("fileUpload.uploadFiles", "Files")}`
               : t("fileUpload.loadFromStorage", "Load Files")
             }

--- a/frontend/src/components/tools/convert/ConvertSettings.tsx
+++ b/frontend/src/components/tools/convert/ConvertSettings.tsx
@@ -15,13 +15,14 @@ import ConvertFromWebSettings from "./ConvertFromWebSettings";
 import ConvertFromEmailSettings from "./ConvertFromEmailSettings";
 import ConvertToPdfaSettings from "./ConvertToPdfaSettings";
 import { ConvertParameters } from "../../../hooks/tools/convert/useConvertParameters";
-import { 
+import {
   FROM_FORMAT_OPTIONS,
   EXTENSION_TO_ENDPOINT,
   COLOR_TYPES,
   OUTPUT_OPTIONS,
   FIT_OPTIONS
 } from "../../../constants/convertConstants";
+import { FileId } from "../../../types/fileContext";
 
 interface ConvertSettingsProps {
   parameters: ConvertParameters;
@@ -31,8 +32,8 @@ interface ConvertSettingsProps {
   disabled?: boolean;
 }
 
-const ConvertSettings = ({ 
-  parameters, 
+const ConvertSettings = ({
+  parameters,
   onParameterChange,
   getAvailableToExtensions,
   selectedFiles,
@@ -52,7 +53,7 @@ const ConvertSettings = ({
   const isConversionAvailable = (fromExt: string, toExt: string): boolean => {
     const endpointKey = EXTENSION_TO_ENDPOINT[fromExt]?.[toExt];
     if (!endpointKey) return false;
-    
+
     return endpointStatus[endpointKey] === true;
   };
 
@@ -61,10 +62,10 @@ const ConvertSettings = ({
     const baseOptions = FROM_FORMAT_OPTIONS.map(option => {
       // Check if this source format has any available conversions
       const availableConversions = getAvailableToExtensions(option.value) || [];
-      const hasAvailableConversions = availableConversions.some(targetOption => 
+      const hasAvailableConversions = availableConversions.some(targetOption =>
         isConversionAvailable(option.value, targetOption.value)
       );
-      
+
       return {
         ...option,
         enabled: hasAvailableConversions
@@ -80,18 +81,18 @@ const ConvertSettings = ({
         group: 'File',
         enabled: true
       };
-      
+
       // Add the dynamic option at the beginning
       return [dynamicOption, ...baseOptions];
     }
-    
+
     return baseOptions;
   }, [parameters.fromExtension, endpointStatus]);
 
-  // Enhanced TO options with endpoint availability  
+  // Enhanced TO options with endpoint availability
   const enhancedToOptions = useMemo(() => {
     if (!parameters.fromExtension) return [];
-    
+
     const availableOptions = getAvailableToExtensions(parameters.fromExtension) || [];
     return availableOptions.map(option => ({
       ...option,
@@ -131,7 +132,7 @@ const ConvertSettings = ({
     const files = activeFiles.map(fileId => selectors.getFile(fileId)).filter(Boolean) as File[];
     return files.filter(file => {
       const fileExtension = detectFileExtension(file.name);
-      
+
       if (extension === 'any') {
         return true;
       } else if (extension === 'image') {
@@ -148,15 +149,15 @@ const ConvertSettings = ({
       // Find the file ID by matching file properties
       const fileRecord = state.files.ids
         .map(id => selectors.getFileRecord(id))
-        .find(record => 
-          record && 
-          record.name === file.name && 
-          record.size === file.size && 
+        .find(record =>
+          record &&
+          record.name === file.name &&
+          record.size === file.size &&
           record.lastModified === file.lastModified
         );
       return fileRecord?.id;
-    }).filter((id): id is string => id !== undefined); // Type guard to ensure only strings
-    
+    }).filter((id): id is FileId => id !== undefined); // Type guard to ensure only strings
+
     setSelectedFiles(fileIds);
   };
 
@@ -164,7 +165,7 @@ const ConvertSettings = ({
     onParameterChange('fromExtension', value);
     setAutoTargetExtension(value);
     resetParametersToDefaults();
-    
+
     if (activeFiles.length > 0) {
       const matchingFiles = filterFilesByExtension(value);
       updateFileSelection(matchingFiles);
@@ -232,11 +233,11 @@ const ConvertSettings = ({
           >
             <Group justify="space-between">
               <Text size="sm">{t("convert.selectSourceFormatFirst", "Select a source format first")}</Text>
-              <KeyboardArrowDownIcon 
-                style={{ 
+              <KeyboardArrowDownIcon
+                style={{
                   fontSize: '1rem',
                   color: colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[6]
-                }} 
+                }}
               />
             </Group>
           </UnstyledButton>
@@ -266,9 +267,9 @@ const ConvertSettings = ({
         </>
       )}
 
-      
+
       {/* Color options for image to PDF conversion */}
-      {(isImageFormat(parameters.fromExtension) && parameters.toExtension === 'pdf') || 
+      {(isImageFormat(parameters.fromExtension) && parameters.toExtension === 'pdf') ||
        (parameters.isSmartDetection && parameters.smartDetectionType === 'images') ? (
         <>
           <Divider />
@@ -281,7 +282,7 @@ const ConvertSettings = ({
       ) : null}
 
       {/* Web to PDF options */}
-      {((isWebFormat(parameters.fromExtension) && parameters.toExtension === 'pdf') || 
+      {((isWebFormat(parameters.fromExtension) && parameters.toExtension === 'pdf') ||
        (parameters.isSmartDetection && parameters.smartDetectionType === 'web')) ? (
         <>
           <Divider />

--- a/frontend/src/components/tools/convert/ConvertSettings.tsx
+++ b/frontend/src/components/tools/convert/ConvertSettings.tsx
@@ -22,7 +22,7 @@ import {
   OUTPUT_OPTIONS,
   FIT_OPTIONS
 } from "../../../constants/convertConstants";
-import { FileId } from "../../../types/fileContext";
+import { FileId } from "../../../types/file";
 
 interface ConvertSettingsProps {
   parameters: ConvertParameters;

--- a/frontend/src/components/viewer/Viewer.tsx
+++ b/frontend/src/components/viewer/Viewer.tsx
@@ -15,7 +15,7 @@ import { fileStorage } from "../../services/fileStorage";
 import SkeletonLoader from '../shared/SkeletonLoader';
 import { useFileState, useFileActions, useCurrentFile } from "../../contexts/FileContext";
 import { useFileWithUrl } from "../../hooks/useFileWithUrl";
-import { FileId } from "../../types/fileContext";
+import { FileId } from "../../types/file";
 
 
 // Lazy loading page image component

--- a/frontend/src/components/viewer/Viewer.tsx
+++ b/frontend/src/components/viewer/Viewer.tsx
@@ -15,6 +15,7 @@ import { fileStorage } from "../../services/fileStorage";
 import SkeletonLoader from '../shared/SkeletonLoader';
 import { useFileState, useFileActions, useCurrentFile } from "../../contexts/FileContext";
 import { useFileWithUrl } from "../../hooks/useFileWithUrl";
+import { FileId } from "../../types/fileContext";
 
 
 // Lazy loading page image component
@@ -152,7 +153,7 @@ const Viewer = ({
   const { selectors } = useFileState();
   const { actions } = useFileActions();
   const currentFile = useCurrentFile();
-  
+
   const getCurrentFile = () => currentFile.file;
   const getCurrentProcessedFile = () => currentFile.record?.processedFile || undefined;
   const clearAllFiles = actions.clearAllFiles;
@@ -378,7 +379,7 @@ const Viewer = ({
         }
         // Handle special IndexedDB URLs for large files
         else if (effectiveFile.url?.startsWith('indexeddb:')) {
-          const fileId = effectiveFile.url.replace('indexeddb:', '');
+          const fileId = effectiveFile.url.replace('indexeddb:', '') as FileId /* FIX ME: Not sure this is right - at least probably not the right place for this logic */;
 
           // Get data directly from IndexedDB
           const arrayBuffer = await fileStorage.getFileData(fileId);

--- a/frontend/src/contexts/FileContext.tsx
+++ b/frontend/src/contexts/FileContext.tsx
@@ -19,7 +19,6 @@ import {
   FileContextStateValue,
   FileContextActionsValue,
   FileContextActions,
-  FileId,
   FileRecord
 } from '../types/fileContext';
 
@@ -30,6 +29,7 @@ import { addFiles, consumeFiles, createFileActions } from './file/fileActions';
 import { FileLifecycleManager } from './file/lifecycle';
 import { FileStateContext, FileActionsContext } from './file/contexts';
 import { IndexedDBProvider, useIndexedDB } from './IndexedDBContext';
+import { FileId } from '../types/file';
 
 const DEBUG = process.env.NODE_ENV === 'development';
 

--- a/frontend/src/contexts/FileManagerContext.tsx
+++ b/frontend/src/contexts/FileManagerContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useState, useRef, useCallback, useEff
 import { FileMetadata } from '../types/file';
 import { StoredFile, fileStorage } from '../services/fileStorage';
 import { downloadFiles } from '../utils/downloadUtils';
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 
 // Type for the context value - now contains everything directly
 interface FileManagerContextValue {

--- a/frontend/src/contexts/FileManagerContext.tsx
+++ b/frontend/src/contexts/FileManagerContext.tsx
@@ -2,12 +2,13 @@ import React, { createContext, useContext, useState, useRef, useCallback, useEff
 import { FileMetadata } from '../types/file';
 import { StoredFile, fileStorage } from '../services/fileStorage';
 import { downloadFiles } from '../utils/downloadUtils';
+import { FileId } from '../types/fileContext';
 
 // Type for the context value - now contains everything directly
 interface FileManagerContextValue {
   // State
   activeSource: 'recent' | 'local' | 'drive';
-  selectedFileIds: string[];
+  selectedFileIds: FileId[];
   searchTerm: string;
   selectedFiles: FileMetadata[];
   filteredFiles: FileMetadata[];
@@ -64,7 +65,7 @@ export const FileManagerProvider: React.FC<FileManagerProviderProps> = ({
   refreshRecentFiles,
 }) => {
   const [activeSource, setActiveSource] = useState<'recent' | 'local' | 'drive'>('recent');
-  const [selectedFileIds, setSelectedFileIds] = useState<string[]>([]);
+  const [selectedFileIds, setSelectedFileIds] = useState<FileId[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [lastClickedIndex, setLastClickedIndex] = useState<number | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -74,10 +75,10 @@ export const FileManagerProvider: React.FC<FileManagerProviderProps> = ({
 
   // Computed values (with null safety)
   const selectedFilesSet = new Set(selectedFileIds);
-  
-  const selectedFiles = selectedFileIds.length === 0 ? [] : 
+
+  const selectedFiles = selectedFileIds.length === 0 ? [] :
     (recentFiles || []).filter(file => selectedFilesSet.has(file.id));
-  
+
   const filteredFiles = !searchTerm ? recentFiles || [] :
     (recentFiles || []).filter(file =>
       file.name.toLowerCase().includes(searchTerm.toLowerCase())
@@ -99,15 +100,15 @@ export const FileManagerProvider: React.FC<FileManagerProviderProps> = ({
   const handleFileSelect = useCallback((file: FileMetadata, currentIndex: number, shiftKey?: boolean) => {
     const fileId = file.id;
     if (!fileId) return;
-    
+
     if (shiftKey && lastClickedIndex !== null) {
       // Range selection with shift-click
       const startIndex = Math.min(lastClickedIndex, currentIndex);
       const endIndex = Math.max(lastClickedIndex, currentIndex);
-      
+
       setSelectedFileIds(prev => {
         const selectedSet = new Set(prev);
-        
+
         // Add all files in the range to selection
         for (let i = startIndex; i <= endIndex; i++) {
           const rangeFileId = filteredFiles[i]?.id;
@@ -115,23 +116,23 @@ export const FileManagerProvider: React.FC<FileManagerProviderProps> = ({
             selectedSet.add(rangeFileId);
           }
         }
-        
+
         return Array.from(selectedSet);
       });
     } else {
       // Normal click behavior - optimized with Set for O(1) lookup
       setSelectedFileIds(prev => {
         const selectedSet = new Set(prev);
-        
+
         if (selectedSet.has(fileId)) {
           selectedSet.delete(fileId);
         } else {
           selectedSet.add(fileId);
         }
-        
+
         return Array.from(selectedSet);
       });
-      
+
       // Update last clicked index for future range selections
       setLastClickedIndex(currentIndex);
     }
@@ -196,7 +197,7 @@ export const FileManagerProvider: React.FC<FileManagerProviderProps> = ({
 
     try {
       // Get files to delete based on current filtered view
-      const filesToDelete = filteredFiles.filter(file => 
+      const filesToDelete = filteredFiles.filter(file =>
         selectedFileIds.includes(file.id)
       );
 
@@ -221,7 +222,7 @@ export const FileManagerProvider: React.FC<FileManagerProviderProps> = ({
 
     try {
       // Get selected files
-      const selectedFilesToDownload = filteredFiles.filter(file => 
+      const selectedFilesToDownload = filteredFiles.filter(file =>
         selectedFileIds.includes(file.id)
       );
 

--- a/frontend/src/contexts/FilesModalContext.tsx
+++ b/frontend/src/contexts/FilesModalContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import { useFileHandler } from '../hooks/useFileHandler';
 import { FileMetadata } from '../types/file';
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 
 interface FilesModalContextType {
   isFilesModalOpen: boolean;

--- a/frontend/src/contexts/FilesModalContext.tsx
+++ b/frontend/src/contexts/FilesModalContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import { useFileHandler } from '../hooks/useFileHandler';
 import { FileMetadata } from '../types/file';
+import { FileId } from '../types/fileContext';
 
 interface FilesModalContextType {
   isFilesModalOpen: boolean;
@@ -8,7 +9,7 @@ interface FilesModalContextType {
   closeFilesModal: () => void;
   onFileSelect: (file: File) => void;
   onFilesSelect: (files: File[]) => void;
-  onStoredFilesSelect: (filesWithMetadata: Array<{ file: File; originalId: string; metadata: FileMetadata }>) => void;
+  onStoredFilesSelect: (filesWithMetadata: Array<{ file: File; originalId: FileId; metadata: FileMetadata }>) => void;
   onModalClose?: () => void;
   setOnModalClose: (callback: () => void) => void;
 }
@@ -57,7 +58,7 @@ export const FilesModalProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     closeFilesModal();
   }, [addMultipleFiles, closeFilesModal, insertAfterPage, customHandler]);
 
-  const handleStoredFilesSelect = useCallback((filesWithMetadata: Array<{ file: File; originalId: string; metadata: FileMetadata }>) => {
+  const handleStoredFilesSelect = useCallback((filesWithMetadata: Array<{ file: File; originalId: FileId; metadata: FileMetadata }>) => {
     if (customHandler) {
       // Use custom handler for special cases (like page insertion)
       const files = filesWithMetadata.map(item => item.file);

--- a/frontend/src/contexts/IndexedDBContext.tsx
+++ b/frontend/src/contexts/IndexedDBContext.tsx
@@ -7,7 +7,7 @@ import React, { createContext, useContext, useCallback, useRef } from 'react';
 
 const DEBUG = process.env.NODE_ENV === 'development';
 import { fileStorage, StoredFile } from '../services/fileStorage';
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 import { FileMetadata } from '../types/file';
 import { generateThumbnailForFile } from '../utils/thumbnailUtils';
 
@@ -17,12 +17,12 @@ interface IndexedDBContextValue {
   loadFile: (fileId: FileId) => Promise<File | null>;
   loadMetadata: (fileId: FileId) => Promise<FileMetadata | null>;
   deleteFile: (fileId: FileId) => Promise<void>;
-  
+
   // Batch operations
   loadAllMetadata: () => Promise<FileMetadata[]>;
   deleteMultiple: (fileIds: FileId[]) => Promise<void>;
   clearAll: () => Promise<void>;
-  
+
   // Utilities
   getStorageStats: () => Promise<{ used: number; available: number; fileCount: number }>;
   updateThumbnail: (fileId: FileId, thumbnail: string) => Promise<boolean>;
@@ -59,14 +59,14 @@ export function IndexedDBProvider({ children }: IndexedDBProviderProps) {
   const saveFile = useCallback(async (file: File, fileId: FileId, existingThumbnail?: string): Promise<FileMetadata> => {
     // Use existing thumbnail or generate new one if none provided
     const thumbnail = existingThumbnail || await generateThumbnailForFile(file);
-    
+
     // Store in IndexedDB
     const storedFile = await fileStorage.storeFile(file, fileId, thumbnail);
-    
+
     // Cache the file object for immediate reuse
     fileCache.current.set(fileId, { file, lastAccessed: Date.now() });
     evictLRUEntries();
-    
+
     // Return metadata
     return {
       id: fileId,
@@ -121,7 +121,7 @@ export function IndexedDBProvider({ children }: IndexedDBProviderProps) {
     // Load metadata from IndexedDB (efficient - no data field)
     const metadata = await fileStorage.getAllFileMetadata();
     const fileMetadata = metadata.find(m => m.id === fileId);
-    
+
     if (!fileMetadata) return null;
 
     return {
@@ -137,14 +137,14 @@ export function IndexedDBProvider({ children }: IndexedDBProviderProps) {
   const deleteFile = useCallback(async (fileId: FileId): Promise<void> => {
     // Remove from cache
     fileCache.current.delete(fileId);
-    
+
     // Remove from IndexedDB
     await fileStorage.deleteFile(fileId);
   }, []);
 
   const loadAllMetadata = useCallback(async (): Promise<FileMetadata[]> => {
     const metadata = await fileStorage.getAllFileMetadata();
-    
+
     return metadata.map(m => ({
       id: m.id,
       name: m.name,
@@ -158,7 +158,7 @@ export function IndexedDBProvider({ children }: IndexedDBProviderProps) {
   const deleteMultiple = useCallback(async (fileIds: FileId[]): Promise<void> => {
     // Remove from cache
     fileIds.forEach(id => fileCache.current.delete(id));
-    
+
     // Remove from IndexedDB in parallel
     await Promise.all(fileIds.map(id => fileStorage.deleteFile(id)));
   }, []);
@@ -166,7 +166,7 @@ export function IndexedDBProvider({ children }: IndexedDBProviderProps) {
   const clearAll = useCallback(async (): Promise<void> => {
     // Clear cache
     fileCache.current.clear();
-    
+
     // Clear IndexedDB
     await fileStorage.clearAll();
   }, []);

--- a/frontend/src/contexts/file/FileReducer.ts
+++ b/frontend/src/contexts/file/FileReducer.ts
@@ -2,10 +2,10 @@
  * FileContext reducer - Pure state management for file operations
  */
 
-import { 
-  FileContextState, 
-  FileContextAction, 
-  FileId, 
+import { FileId } from '../../types/file';
+import {
+  FileContextState,
+  FileContextAction,
   FileRecord
 } from '../../types/fileContext';
 
@@ -32,7 +32,7 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
       const { fileRecords } = action.payload;
       const newIds: FileId[] = [];
       const newById: Record<FileId, FileRecord> = { ...state.files.byId };
-      
+
       fileRecords.forEach(record => {
         // Only add if not already present (dedupe by stable ID)
         if (!newById[record.id]) {
@@ -40,7 +40,7 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
           newById[record.id] = record;
         }
       });
-      
+
       return {
         ...state,
         files: {
@@ -49,20 +49,20 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'REMOVE_FILES': {
       const { fileIds } = action.payload;
       const remainingIds = state.files.ids.filter(id => !fileIds.includes(id));
       const newById = { ...state.files.byId };
-      
+
       // Remove files from state (resource cleanup handled by lifecycle manager)
       fileIds.forEach(id => {
         delete newById[id];
       });
-      
+
       // Clear selections that reference removed files
       const validSelectedFileIds = state.ui.selectedFileIds.filter(id => !fileIds.includes(id));
-      
+
       return {
         ...state,
         files: {
@@ -75,15 +75,15 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'UPDATE_FILE_RECORD': {
       const { id, updates } = action.payload;
       const existingRecord = state.files.byId[id];
-      
+
       if (!existingRecord) {
         return state; // File doesn't exist, no-op
       }
-      
+
       return {
         ...state,
         files: {
@@ -98,13 +98,13 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'REORDER_FILES': {
       const { orderedFileIds } = action.payload;
-      
+
       // Validate that all IDs exist in current state
       const validIds = orderedFileIds.filter(id => state.files.byId[id]);
-      
+
       return {
         ...state,
         files: {
@@ -113,7 +113,7 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'SET_SELECTED_FILES': {
       const { fileIds } = action.payload;
       return {
@@ -124,7 +124,7 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'SET_SELECTED_PAGES': {
       const { pageNumbers } = action.payload;
       return {
@@ -135,7 +135,7 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'CLEAR_SELECTIONS': {
       return {
         ...state,
@@ -146,7 +146,7 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'SET_PROCESSING': {
       const { isProcessing, progress } = action.payload;
       return {
@@ -158,7 +158,7 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'SET_UNSAVED_CHANGES': {
       return {
         ...state,
@@ -168,42 +168,42 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'PIN_FILE': {
       const { fileId } = action.payload;
       const newPinnedFiles = new Set(state.pinnedFiles);
       newPinnedFiles.add(fileId);
-      
+
       return {
         ...state,
         pinnedFiles: newPinnedFiles
       };
     }
-    
+
     case 'UNPIN_FILE': {
       const { fileId } = action.payload;
       const newPinnedFiles = new Set(state.pinnedFiles);
       newPinnedFiles.delete(fileId);
-      
+
       return {
         ...state,
         pinnedFiles: newPinnedFiles
       };
     }
-    
+
     case 'CONSUME_FILES': {
       const { inputFileIds, outputFileRecords } = action.payload;
-      
+
       // Only remove unpinned input files
       const unpinnedInputIds = inputFileIds.filter(id => !state.pinnedFiles.has(id));
       const remainingIds = state.files.ids.filter(id => !unpinnedInputIds.includes(id));
-      
+
       // Remove unpinned files from state
       const newById = { ...state.files.byId };
       unpinnedInputIds.forEach(id => {
         delete newById[id];
       });
-      
+
       // Add output files
       const outputIds: FileId[] = [];
       outputFileRecords.forEach(record => {
@@ -212,10 +212,10 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
           newById[record.id] = record;
         }
       });
-      
+
       // Clear selections that reference removed files
       const validSelectedFileIds = state.ui.selectedFileIds.filter(id => !unpinnedInputIds.includes(id));
-      
+
       return {
         ...state,
         files: {
@@ -228,12 +228,12 @@ export function fileContextReducer(state: FileContextState, action: FileContextA
         }
       };
     }
-    
+
     case 'RESET_CONTEXT': {
       // Reset UI state to clean slate (resource cleanup handled by lifecycle manager)
       return { ...initialFileContextState };
     }
-    
+
     default:
       return state;
   }

--- a/frontend/src/contexts/file/fileHooks.ts
+++ b/frontend/src/contexts/file/fileHooks.ts
@@ -9,7 +9,8 @@ import {
   FileContextStateValue,
   FileContextActionsValue
 } from './contexts';
-import { FileId, FileRecord } from '../../types/fileContext';
+import { FileRecord } from '../../types/fileContext';
+import { FileId } from '../../types/file';
 
 /**
  * Hook for accessing file state (will re-render on any state change)

--- a/frontend/src/contexts/file/fileHooks.ts
+++ b/frontend/src/contexts/file/fileHooks.ts
@@ -3,11 +3,11 @@
  */
 
 import { useContext, useMemo } from 'react';
-import { 
-  FileStateContext, 
+import {
+  FileStateContext,
   FileActionsContext,
   FileContextStateValue,
-  FileContextActionsValue 
+  FileContextActionsValue
 } from './contexts';
 import { FileId, FileRecord } from '../../types/fileContext';
 
@@ -39,7 +39,7 @@ export function useFileActions(): FileContextActionsValue {
  */
 export function useCurrentFile(): { file?: File; record?: FileRecord } {
   const { state, selectors } = useFileState();
-  
+
   const primaryFileId = state.files.ids[0];
   return useMemo(() => ({
     file: primaryFileId ? selectors.getFile(primaryFileId) : undefined,
@@ -81,7 +81,7 @@ export function useFileSelection() {
  */
 export function useFileManagement() {
   const { actions } = useFileActions();
-  
+
   return useMemo(() => ({
     addFiles: actions.addFiles,
     removeFiles: actions.removeFiles,
@@ -112,7 +112,7 @@ export function useFileUI() {
  */
 export function useFileRecord(fileId: FileId): { file?: File; record?: FileRecord } {
   const { selectors } = useFileState();
-  
+
   return useMemo(() => ({
     file: selectors.getFile(fileId),
     record: selectors.getFileRecord(fileId)
@@ -124,7 +124,7 @@ export function useFileRecord(fileId: FileId): { file?: File; record?: FileRecor
  */
 export function useAllFiles(): { files: File[]; records: FileRecord[]; fileIds: FileId[] } {
   const { state, selectors } = useFileState();
-  
+
   return useMemo(() => ({
     files: selectors.getFiles(),
     records: selectors.getFileRecords(),
@@ -137,7 +137,7 @@ export function useAllFiles(): { files: File[]; records: FileRecord[]; fileIds: 
  */
 export function useSelectedFiles(): { files: File[]; records: FileRecord[]; fileIds: FileId[] } {
   const { state, selectors } = useFileState();
-  
+
   return useMemo(() => ({
     files: selectors.getSelectedFiles(),
     records: selectors.getSelectedFileRecords(),
@@ -160,31 +160,31 @@ export function useFileContext() {
     trackBlobUrl: actions.trackBlobUrl,
     scheduleCleanup: actions.scheduleCleanup,
     setUnsavedChanges: actions.setHasUnsavedChanges,
-    
+
     // File management
     addFiles: actions.addFiles,
     consumeFiles: actions.consumeFiles,
-    recordOperation: (fileId: string, operation: any) => {}, // Operation tracking not implemented
-    markOperationApplied: (fileId: string, operationId: string) => {}, // Operation tracking not implemented  
-    markOperationFailed: (fileId: string, operationId: string, error: string) => {}, // Operation tracking not implemented
-    
+    recordOperation: (fileId: FileId, operation: any) => {}, // Operation tracking not implemented
+    markOperationApplied: (fileId: FileId, operationId: string) => {}, // Operation tracking not implemented
+    markOperationFailed: (fileId: FileId, operationId: string, error: string) => {}, // Operation tracking not implemented
+
     // File ID lookup
     findFileId: (file: File) => {
       return state.files.ids.find(id => {
         const record = state.files.byId[id];
-        return record && 
-               record.name === file.name && 
-               record.size === file.size && 
+        return record &&
+               record.name === file.name &&
+               record.size === file.size &&
                record.lastModified === file.lastModified;
       });
     },
-    
+
     // Pinned files
     pinnedFiles: state.pinnedFiles,
     pinFile: actions.pinFile,
     unpinFile: actions.unpinFile,
     isFilePinned: selectors.isFilePinned,
-    
+
     // Active files
     activeFiles: selectors.getFiles()
   }), [state, selectors, actions]);

--- a/frontend/src/contexts/file/fileSelectors.ts
+++ b/frontend/src/contexts/file/fileSelectors.ts
@@ -2,8 +2,8 @@
  * File selectors - Pure functions for accessing file state
  */
 
+import { FileId } from '../../types/file';
 import {
-  FileId,
   FileRecord,
   FileContextState,
   FileContextSelectors

--- a/frontend/src/contexts/file/fileSelectors.ts
+++ b/frontend/src/contexts/file/fileSelectors.ts
@@ -2,11 +2,11 @@
  * File selectors - Pure functions for accessing file state
  */
 
-import { 
-  FileId, 
-  FileRecord, 
+import {
+  FileId,
+  FileRecord,
   FileContextState,
-  FileContextSelectors 
+  FileContextSelectors
 } from '../../types/fileContext';
 
 /**
@@ -18,62 +18,62 @@ export function createFileSelectors(
 ): FileContextSelectors {
   return {
     getFile: (id: FileId) => filesRef.current.get(id),
-    
+
     getFiles: (ids?: FileId[]) => {
       const currentIds = ids || stateRef.current.files.ids;
       return currentIds.map(id => filesRef.current.get(id)).filter(Boolean) as File[];
     },
-    
+
     getFileRecord: (id: FileId) => stateRef.current.files.byId[id],
-    
+
     getFileRecords: (ids?: FileId[]) => {
       const currentIds = ids || stateRef.current.files.ids;
       return currentIds.map(id => stateRef.current.files.byId[id]).filter(Boolean);
     },
-    
+
     getAllFileIds: () => stateRef.current.files.ids,
-    
+
     getSelectedFiles: () => {
       return stateRef.current.ui.selectedFileIds
         .map(id => filesRef.current.get(id))
         .filter(Boolean) as File[];
     },
-    
+
     getSelectedFileRecords: () => {
       return stateRef.current.ui.selectedFileIds
         .map(id => stateRef.current.files.byId[id])
         .filter(Boolean);
     },
-    
+
     // Pinned files selectors
     getPinnedFileIds: () => {
       return Array.from(stateRef.current.pinnedFiles);
     },
-    
+
     getPinnedFiles: () => {
       return Array.from(stateRef.current.pinnedFiles)
         .map(id => filesRef.current.get(id))
         .filter(Boolean) as File[];
     },
-    
+
     getPinnedFileRecords: () => {
       return Array.from(stateRef.current.pinnedFiles)
         .map(id => stateRef.current.files.byId[id])
         .filter(Boolean);
     },
-    
+
     isFilePinned: (file: File) => {
       // Find FileId by matching File object properties
-      const fileId = Object.keys(stateRef.current.files.byId).find(id => {
+      const fileId = (Object.keys(stateRef.current.files.byId) as FileId[]).find(id => {
         const storedFile = filesRef.current.get(id);
-        return storedFile && 
-               storedFile.name === file.name && 
-               storedFile.size === file.size && 
+        return storedFile &&
+               storedFile.name === file.name &&
+               storedFile.size === file.size &&
                storedFile.lastModified === file.lastModified;
       });
       return fileId ? stateRef.current.pinnedFiles.has(fileId) : false;
     },
-    
+
     // Stable signature for effects - prevents unnecessary re-renders
     getFilesSignature: () => {
       return stateRef.current.files.ids
@@ -122,7 +122,7 @@ export function getPrimaryFile(
 ): { file?: File; record?: FileRecord } {
   const primaryFileId = stateRef.current.files.ids[0];
   if (!primaryFileId) return {};
-  
+
   return {
     file: filesRef.current.get(primaryFileId),
     record: stateRef.current.files.byId[primaryFileId]

--- a/frontend/src/contexts/file/lifecycle.ts
+++ b/frontend/src/contexts/file/lifecycle.ts
@@ -33,10 +33,10 @@ export class FileLifecycleManager {
   /**
    * Clean up resources for a specific file (with stateRef access for complete cleanup)
    */
-  cleanupFile = (fileId: string, stateRef?: React.MutableRefObject<any>): void => {
+  cleanupFile = (fileId: FileId, stateRef?: React.MutableRefObject<any>): void => {
     // Use comprehensive cleanup (same as removeFiles)
     this.cleanupAllResourcesForFile(fileId, stateRef);
-    
+
     // Remove file from state
     this.dispatch({ type: 'REMOVE_FILES', payload: { fileIds: [fileId] } });
   };
@@ -54,12 +54,12 @@ export class FileLifecycleManager {
       }
     });
     this.blobUrls.clear();
-    
+
     // Clear all cleanup timers and generations
     this.cleanupTimers.forEach(timer => clearTimeout(timer));
     this.cleanupTimers.clear();
     this.fileGenerations.clear();
-    
+
     // Clear files ref
     this.filesRef.current.clear();
   };
@@ -67,7 +67,7 @@ export class FileLifecycleManager {
   /**
    * Schedule delayed cleanup for a file with generation token to prevent stale cleanup
    */
-  scheduleCleanup = (fileId: string, delay: number = 30000, stateRef?: React.MutableRefObject<any>): void => {
+  scheduleCleanup = (fileId: FileId, delay: number = 30000, stateRef?: React.MutableRefObject<any>): void => {
     // Cancel existing timer
     const existingTimer = this.cleanupTimers.get(fileId);
     if (existingTimer) {
@@ -105,7 +105,7 @@ export class FileLifecycleManager {
       // Clean up all resources for this file
       this.cleanupAllResourcesForFile(fileId, stateRef);
     });
-    
+
     // Dispatch removal action once for all files (reducer only updates state)
     this.dispatch({ type: 'REMOVE_FILES', payload: { fileIds } });
   };
@@ -116,7 +116,7 @@ export class FileLifecycleManager {
   private cleanupAllResourcesForFile = (fileId: FileId, stateRef?: React.MutableRefObject<any>): void => {
     // Remove from files ref
     this.filesRef.current.delete(fileId);
-    
+
     // Cancel cleanup timer and generation
     const timer = this.cleanupTimers.get(fileId);
     if (timer) {
@@ -124,7 +124,7 @@ export class FileLifecycleManager {
       this.cleanupTimers.delete(fileId);
     }
     this.fileGenerations.delete(fileId);
-    
+
     // Clean up blob URLs from file record if we have access to state
     if (stateRef) {
       const record = stateRef.current.files.byId[fileId];
@@ -137,7 +137,7 @@ export class FileLifecycleManager {
             // Ignore revocation errors
           }
         }
-        
+
         if (record.blobUrl && record.blobUrl.startsWith('blob:')) {
           try {
             URL.revokeObjectURL(record.blobUrl);
@@ -145,7 +145,7 @@ export class FileLifecycleManager {
             // Ignore revocation errors
           }
         }
-        
+
         // Clean up processed file thumbnails
         if (record.processedFile?.pages) {
           record.processedFile.pages.forEach((page: ProcessedFilePage, index: number) => {
@@ -171,13 +171,13 @@ export class FileLifecycleManager {
       if (DEBUG) console.warn(`🗂️ Attempted to update removed file (filesRef): ${fileId}`);
       return;
     }
-    
+
     // Additional state guard for rare race conditions
     if (stateRef && !stateRef.current.files.byId[fileId]) {
       if (DEBUG) console.warn(`🗂️ Attempted to update removed file (state): ${fileId}`);
       return;
     }
-    
+
     this.dispatch({ type: 'UPDATE_FILE_RECORD', payload: { id: fileId, updates } });
   };
 

--- a/frontend/src/contexts/file/lifecycle.ts
+++ b/frontend/src/contexts/file/lifecycle.ts
@@ -2,7 +2,8 @@
  * File lifecycle management - Resource cleanup and memory management
  */
 
-import { FileId, FileContextAction, FileRecord, ProcessedFilePage } from '../../types/fileContext';
+import { FileId } from '../../types/file';
+import { FileContextAction, FileRecord, ProcessedFilePage } from '../../types/fileContext';
 
 const DEBUG = process.env.NODE_ENV === 'development';
 

--- a/frontend/src/hooks/tools/shared/useToolOperation.ts
+++ b/frontend/src/hooks/tools/shared/useToolOperation.ts
@@ -8,6 +8,7 @@ import { useToolResources } from './useToolResources';
 import { extractErrorMessage } from '../../../utils/toolErrorHandler';
 import { createOperation } from '../../../utils/toolOperationTracker';
 import { ResponseHandler } from '../../../utils/toolResponseProcessor';
+import { FileId } from '../../../types/fileContext';
 
 // Re-export for backwards compatibility
 export type { ProcessingProgress, ResponseHandler };
@@ -231,7 +232,7 @@ export const useToolOperation = <TParams>(
         actions.setDownloadInfo(downloadInfo.url, downloadInfo.filename);
 
         // Replace input files with processed files (consumeFiles handles pinning)
-        const inputFileIds = validFiles.map(file => findFileId(file)).filter(Boolean) as string[];
+        const inputFileIds = validFiles.map(file => findFileId(file)).filter(Boolean) as FileId[];
         await consumeFiles(inputFileIds, processedFiles);
 
         markOperationApplied(fileId, operationId);

--- a/frontend/src/hooks/tools/shared/useToolOperation.ts
+++ b/frontend/src/hooks/tools/shared/useToolOperation.ts
@@ -8,7 +8,7 @@ import { useToolResources } from './useToolResources';
 import { extractErrorMessage } from '../../../utils/toolErrorHandler';
 import { createOperation } from '../../../utils/toolOperationTracker';
 import { ResponseHandler } from '../../../utils/toolResponseProcessor';
-import { FileId } from '../../../types/fileContext';
+import { FileId } from '../../../types/file';
 
 // Re-export for backwards compatibility
 export type { ProcessingProgress, ResponseHandler };

--- a/frontend/src/hooks/useFileHandler.ts
+++ b/frontend/src/hooks/useFileHandler.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useFileState, useFileActions } from '../contexts/FileContext';
 import { FileMetadata } from '../types/file';
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 
 export const useFileHandler = () => {
   const { state } = useFileState(); // Still needed for addStoredFiles

--- a/frontend/src/hooks/useFileHandler.ts
+++ b/frontend/src/hooks/useFileHandler.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useFileState, useFileActions } from '../contexts/FileContext';
 import { FileMetadata } from '../types/file';
+import { FileId } from '../types/fileContext';
 
 export const useFileHandler = () => {
   const { state } = useFileState(); // Still needed for addStoredFiles
@@ -17,16 +18,16 @@ export const useFileHandler = () => {
   }, [actions.addFiles]);
 
   // Add stored files preserving their original IDs to prevent session duplicates
-  const addStoredFiles = useCallback(async (filesWithMetadata: Array<{ file: File; originalId: string; metadata: FileMetadata }>) => {
+  const addStoredFiles = useCallback(async (filesWithMetadata: Array<{ file: File; originalId: FileId; metadata: FileMetadata }>) => {
     // Filter out files that already exist with the same ID (exact match)
     const newFiles = filesWithMetadata.filter(({ originalId }) => {
       return state.files.byId[originalId] === undefined;
     });
-    
+
     if (newFiles.length > 0) {
       await actions.addStoredFiles(newFiles);
     }
-    
+
     console.log(`📁 Added ${newFiles.length} stored files (${filesWithMetadata.length - newFiles.length} skipped as duplicates)`);
   }, [state.files.byId, actions.addStoredFiles]);
 

--- a/frontend/src/hooks/useFileManager.ts
+++ b/frontend/src/hooks/useFileManager.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { useIndexedDB } from '../contexts/IndexedDBContext';
 import { FileMetadata } from '../types/file';
 import { generateThumbnailForFile } from '../utils/thumbnailUtils';
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 
 export const useFileManager = () => {
   const [loading, setLoading] = useState(false);

--- a/frontend/src/hooks/useFileManager.ts
+++ b/frontend/src/hooks/useFileManager.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { useIndexedDB } from '../contexts/IndexedDBContext';
 import { FileMetadata } from '../types/file';
 import { generateThumbnailForFile } from '../utils/thumbnailUtils';
+import { FileId } from '../types/fileContext';
 
 export const useFileManager = () => {
   const [loading, setLoading] = useState(false);
@@ -11,19 +12,19 @@ export const useFileManager = () => {
     if (!indexedDB) {
       throw new Error('IndexedDB context not available');
     }
-    
+
     // Handle drafts differently from regular files
     if (fileMetadata.isDraft) {
       // Load draft from the drafts database
       try {
         const { indexedDBManager, DATABASE_CONFIGS } = await import('../services/indexedDBManager');
         const db = await indexedDBManager.openDatabase(DATABASE_CONFIGS.DRAFTS);
-        
+
         return new Promise((resolve, reject) => {
           const transaction = db.transaction(['drafts'], 'readonly');
           const store = transaction.objectStore('drafts');
           const request = store.get(fileMetadata.id);
-          
+
           request.onsuccess = () => {
             const draft = request.result;
             if (draft && draft.pdfData) {
@@ -36,14 +37,14 @@ export const useFileManager = () => {
               reject(new Error('Draft data not found'));
             }
           };
-          
+
           request.onerror = () => reject(request.error);
         });
       } catch (error) {
         throw new Error(`Failed to load draft: ${fileMetadata.name} (${error})`);
       }
     }
-    
+
     // Regular file loading
     if (fileMetadata.id) {
       const file = await indexedDB.loadFile(fileMetadata.id);
@@ -60,14 +61,14 @@ export const useFileManager = () => {
       if (!indexedDB) {
         return [];
       }
-      
+
       // Load regular files metadata only
       const storedFileMetadata = await indexedDB.loadAllMetadata();
-      
+
       // For now, only regular files - drafts will be handled separately in the future
       const allFiles = storedFileMetadata;
       const sortedFiles = allFiles.sort((a, b) => (b.lastModified || 0) - (a.lastModified || 0));
-      
+
       return sortedFiles;
     } catch (error) {
       console.error('Failed to load recent files:', error);
@@ -94,7 +95,7 @@ export const useFileManager = () => {
     }
   }, [indexedDB]);
 
-  const storeFile = useCallback(async (file: File, fileId: string) => {
+  const storeFile = useCallback(async (file: File, fileId: FileId) => {
     if (!indexedDB) {
       throw new Error('IndexedDB context not available');
     }
@@ -104,7 +105,7 @@ export const useFileManager = () => {
 
       // Convert file to ArrayBuffer for StoredFile interface compatibility
       const arrayBuffer = await file.arrayBuffer();
-      
+
       // Return StoredFile format for compatibility with old API
       return {
         id: fileId,
@@ -122,10 +123,10 @@ export const useFileManager = () => {
   }, [indexedDB]);
 
   const createFileSelectionHandlers = useCallback((
-    selectedFiles: string[],
-    setSelectedFiles: (files: string[]) => void
+    selectedFiles: FileId[],
+    setSelectedFiles: (files: FileId[]) => void
   ) => {
-    const toggleSelection = (fileId: string) => {
+    const toggleSelection = (fileId: FileId) => {
       setSelectedFiles(
         selectedFiles.includes(fileId)
           ? selectedFiles.filter(id => id !== fileId)
@@ -137,13 +138,13 @@ export const useFileManager = () => {
       setSelectedFiles([]);
     };
 
-    const selectMultipleFiles = async (files: FileMetadata[], onStoredFilesSelect: (filesWithMetadata: Array<{ file: File; originalId: string; metadata: FileMetadata }>) => void) => {
+    const selectMultipleFiles = async (files: FileMetadata[], onStoredFilesSelect: (filesWithMetadata: Array<{ file: File; originalId: FileId; metadata: FileMetadata }>) => void) => {
       if (selectedFiles.length === 0) return;
 
       try {
         // Filter by UUID and convert to File objects
         const selectedFileObjects = files.filter(f => selectedFiles.includes(f.id));
-        
+
         // Use stored files flow that preserves IDs
         const filesWithMetadata = await Promise.all(
           selectedFileObjects.map(async (metadata) => ({
@@ -153,7 +154,7 @@ export const useFileManager = () => {
           }))
         );
         onStoredFilesSelect(filesWithMetadata);
-        
+
         clearSelection();
       } catch (error) {
         console.error('Failed to load selected files:', error);
@@ -168,7 +169,7 @@ export const useFileManager = () => {
     };
   }, [convertToFile]);
 
-  const touchFile = useCallback(async (id: string) => {
+  const touchFile = useCallback(async (id: FileId) => {
     if (!indexedDB) {
       console.warn('IndexedDB context not available for touch operation');
       return;

--- a/frontend/src/hooks/useThumbnailGeneration.ts
+++ b/frontend/src/hooks/useThumbnailGeneration.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { thumbnailGenerationService } from '../services/thumbnailGenerationService';
+import { FileId } from '../types/fileContext';
 
 // Request queue to handle concurrent thumbnail requests
 interface ThumbnailRequest {
@@ -35,44 +36,44 @@ async function processRequestQueue() {
     while (requestQueue.length > 0) {
       // Sort queue by page number to prioritize visible pages first
       requestQueue.sort((a, b) => a.pageNumber - b.pageNumber);
-      
+
       // Take a batch of requests (same file only for efficiency)
       const batchSize = Math.min(BATCH_SIZE, requestQueue.length);
       const batch = requestQueue.splice(0, batchSize);
-      
+
       // Group by file to process efficiently
       const fileGroups = new Map<File, ThumbnailRequest[]>();
-      
+
       // First, resolve any cached thumbnails immediately
       const uncachedRequests: ThumbnailRequest[] = [];
-      
+
       for (const request of batch) {
         const cached = thumbnailGenerationService.getThumbnailFromCache(request.pageId);
         if (cached) {
           request.resolve(cached);
         } else {
           uncachedRequests.push(request);
-          
+
           if (!fileGroups.has(request.file)) {
             fileGroups.set(request.file, []);
           }
           fileGroups.get(request.file)!.push(request);
         }
       }
-      
+
       // Process each file group with batch thumbnail generation
       for (const [file, requests] of fileGroups) {
         if (requests.length === 0) continue;
-        
+
         try {
           const pageNumbers = requests.map(req => req.pageNumber);
           const arrayBuffer = await file.arrayBuffer();
-          
+
           console.log(`📸 Batch generating ${requests.length} thumbnails for pages: ${pageNumbers.slice(0, 5).join(', ')}${pageNumbers.length > 5 ? '...' : ''}`);
-          
+
           // Use file name as fileId for PDF document caching
-          const fileId = file.name + '_' + file.size + '_' + file.lastModified;
-          
+          const fileId = file.name + '_' + file.size + '_' + file.lastModified as FileId;
+
           const results = await thumbnailGenerationService.generateThumbnails(
             fileId,
             arrayBuffer,
@@ -83,11 +84,11 @@ async function processRequestQueue() {
               console.log(`📸 Batch progress: ${progress.completed}/${progress.total} thumbnails generated`);
             }
           );
-          
+
           // Match results back to requests and resolve
           for (const request of requests) {
             const result = results.find(r => r.pageNumber === request.pageNumber);
-            
+
             if (result && result.success && result.thumbnail) {
               thumbnailGenerationService.addThumbnailToCache(request.pageId, result.thumbnail);
               request.resolve(result.thumbnail);
@@ -96,7 +97,7 @@ async function processRequestQueue() {
               request.resolve(null);
             }
           }
-          
+
         } catch (error) {
           console.warn(`Batch thumbnail generation failed for ${requests.length} pages:`, error);
           // Reject all requests in this batch
@@ -115,7 +116,7 @@ async function processRequestQueue() {
  */
 export function useThumbnailGeneration() {
   const generateThumbnails = useCallback(async (
-    fileId: string,
+    fileId: FileId,
     pdfArrayBuffer: ArrayBuffer,
     pageNumbers: number[],
     options: {
@@ -157,22 +158,22 @@ export function useThumbnailGeneration() {
       clearTimeout(batchTimer);
       batchTimer = null;
     }
-    
+
     // Clear the queue and active requests
     requestQueue.length = 0;
     activeRequests.clear();
     isProcessingQueue = false;
-    
+
     thumbnailGenerationService.destroy();
   }, []);
 
-  const clearPDFCacheForFile = useCallback((fileId: string) => {
+  const clearPDFCacheForFile = useCallback((fileId: FileId) => {
     thumbnailGenerationService.clearPDFCacheForFile(fileId);
   }, []);
 
   const requestThumbnail = useCallback(async (
-    pageId: string, 
-    file: File, 
+    pageId: string,
+    file: File,
     pageNumber: number
   ): Promise<string | null> => {
     // Check cache first for immediate return
@@ -202,16 +203,16 @@ export function useThumbnailGeneration() {
           reject(error);
         }
       });
-      
+
       // Schedule batch processing with a small delay to collect more requests
       if (batchTimer) {
         clearTimeout(batchTimer);
       }
-      
+
       // Use shorter delay for the first batch (pages 1-50) to show visible content faster
       const isFirstBatch = requestQueue.length <= BATCH_SIZE && requestQueue.every(req => req.pageNumber <= BATCH_SIZE);
       const delay = isFirstBatch ? PRIORITY_BATCH_DELAY : BATCH_DELAY;
-      
+
       batchTimer = window.setTimeout(() => {
         processRequestQueue().catch(error => {
           console.error('Error processing thumbnail request queue:', error);
@@ -222,7 +223,7 @@ export function useThumbnailGeneration() {
 
     // Track this request to prevent duplicates
     activeRequests.set(pageId, requestPromise);
-    
+
     return requestPromise;
   }, []);
 

--- a/frontend/src/hooks/useThumbnailGeneration.ts
+++ b/frontend/src/hooks/useThumbnailGeneration.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { thumbnailGenerationService } from '../services/thumbnailGenerationService';
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 
 // Request queue to handle concurrent thumbnail requests
 interface ThumbnailRequest {

--- a/frontend/src/hooks/useToolManagement.tsx
+++ b/frontend/src/hooks/useToolManagement.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useFlatToolRegistry } from "../data/useTranslatedToolRegistry";
 import { getAllEndpoints, type ToolRegistryEntry } from "../data/toolsTaxonomy";
 import { useMultipleEndpointsEnabled } from "./useEndpointConfig";
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 
 interface ToolManagementResult {
   selectedTool: ToolRegistryEntry | null;

--- a/frontend/src/hooks/useToolManagement.tsx
+++ b/frontend/src/hooks/useToolManagement.tsx
@@ -3,19 +3,20 @@ import { useTranslation } from 'react-i18next';
 import { useFlatToolRegistry } from "../data/useTranslatedToolRegistry";
 import { getAllEndpoints, type ToolRegistryEntry } from "../data/toolsTaxonomy";
 import { useMultipleEndpointsEnabled } from "./useEndpointConfig";
+import { FileId } from '../types/fileContext';
 
 interface ToolManagementResult {
   selectedTool: ToolRegistryEntry | null;
-  toolSelectedFileIds: string[];
+  toolSelectedFileIds: FileId[];
   toolRegistry: Record<string, ToolRegistryEntry>;
-  setToolSelectedFileIds: (fileIds: string[]) => void;
+  setToolSelectedFileIds: (fileIds: FileId[]) => void;
   getSelectedTool: (toolKey: string | null) => ToolRegistryEntry | null;
 }
 
 export const useToolManagement = (): ToolManagementResult => {
   const { t } = useTranslation();
 
-  const [toolSelectedFileIds, setToolSelectedFileIds] = useState<string[]>([]);
+  const [toolSelectedFileIds, setToolSelectedFileIds] = useState<FileId[]>([]);
 
   // Build endpoints list from registry entries with fallback to legacy mapping
   const baseRegistry = useFlatToolRegistry();

--- a/frontend/src/services/fileProcessingService.ts
+++ b/frontend/src/services/fileProcessingService.ts
@@ -7,7 +7,7 @@
 import * as pdfjsLib from 'pdfjs-dist';
 import { generateThumbnailForFile } from '../utils/thumbnailUtils';
 import { pdfWorkerManager } from './pdfWorkerManager';
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 
 export interface ProcessedFileMetadata {
   totalPages: number;

--- a/frontend/src/services/fileProcessingService.ts
+++ b/frontend/src/services/fileProcessingService.ts
@@ -7,6 +7,7 @@
 import * as pdfjsLib from 'pdfjs-dist';
 import { generateThumbnailForFile } from '../utils/thumbnailUtils';
 import { pdfWorkerManager } from './pdfWorkerManager';
+import { FileId } from '../types/fileContext';
 
 export interface ProcessedFileMetadata {
   totalPages: number;
@@ -38,7 +39,7 @@ class FileProcessingService {
    * Process a file to extract metadata, page count, and generate thumbnails
    * This is the single source of truth for file processing
    */
-  async processFile(file: File, fileId: string): Promise<FileProcessingResult> {
+  async processFile(file: File, fileId: FileId): Promise<FileProcessingResult> {
     // Check if we're already processing this file
     const existingOperation = this.processingCache.get(fileId);
     if (existingOperation) {
@@ -48,10 +49,10 @@ class FileProcessingService {
 
     // Create abort controller for this operation
     const abortController = new AbortController();
-    
+
     // Create processing promise
     const processingPromise = this.performProcessing(file, fileId, abortController);
-    
+
     // Store operation with abort controller
     const operation: ProcessingOperation = {
       promise: processingPromise,
@@ -67,7 +68,7 @@ class FileProcessingService {
     return processingPromise;
   }
 
-  private async performProcessing(file: File, fileId: string, abortController: AbortController): Promise<FileProcessingResult> {
+  private async performProcessing(file: File, fileId: FileId, abortController: AbortController): Promise<FileProcessingResult> {
     console.log(`📁 FileProcessingService: Starting processing for ${file.name} (${fileId})`);
 
     try {
@@ -83,12 +84,12 @@ class FileProcessingService {
       if (file.type === 'application/pdf') {
         // Read arrayBuffer once and reuse for both PDF.js and fallback
         const arrayBuffer = await file.arrayBuffer();
-        
+
         // Check for cancellation after async operation
         if (abortController.signal.aborted) {
           throw new Error('Processing cancelled');
         }
-        
+
         // Discover page count using PDF.js (most accurate)
         try {
           const pdfDoc = await pdfWorkerManager.createDocument(arrayBuffer, {
@@ -101,7 +102,7 @@ class FileProcessingService {
 
           // Clean up immediately
           pdfWorkerManager.destroyDocument(pdfDoc);
-          
+
           // Check for cancellation after PDF.js processing
           if (abortController.signal.aborted) {
             throw new Error('Processing cancelled');
@@ -116,7 +117,7 @@ class FileProcessingService {
       try {
         thumbnailUrl = await generateThumbnailForFile(file);
         console.log(`📁 FileProcessingService: Generated thumbnail for ${file.name}`);
-        
+
         // Check for cancellation after thumbnail generation
         if (abortController.signal.aborted) {
           throw new Error('Processing cancelled');
@@ -141,7 +142,7 @@ class FileProcessingService {
       };
 
       console.log(`📁 FileProcessingService: Processing complete for ${file.name} - ${totalPages} pages`);
-      
+
       return {
         success: true,
         metadata
@@ -149,7 +150,7 @@ class FileProcessingService {
 
     } catch (error) {
       console.error(`📁 FileProcessingService: Processing failed for ${file.name}:`, error);
-      
+
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown processing error'
@@ -167,14 +168,14 @@ class FileProcessingService {
   /**
    * Check if a file is currently being processed
    */
-  isProcessing(fileId: string): boolean {
+  isProcessing(fileId: FileId): boolean {
     return this.processingCache.has(fileId);
   }
 
   /**
    * Cancel processing for a specific file
    */
-  cancelProcessing(fileId: string): boolean {
+  cancelProcessing(fileId: FileId): boolean {
     const operation = this.processingCache.get(fileId);
     if (operation) {
       operation.abortController.abort();

--- a/frontend/src/services/fileStorage.ts
+++ b/frontend/src/services/fileStorage.ts
@@ -4,7 +4,7 @@
  * Now uses centralized IndexedDB manager
  */
 
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 import { indexedDBManager, DATABASE_CONFIGS } from './indexedDBManager';
 
 export interface StoredFile {

--- a/frontend/src/services/thumbnailGenerationService.ts
+++ b/frontend/src/services/thumbnailGenerationService.ts
@@ -2,7 +2,7 @@
  * High-performance thumbnail generation service using main thread processing
  */
 
-import { FileId } from '../types/fileContext';
+import { FileId } from '../types/file';
 import { pdfWorkerManager } from './pdfWorkerManager';
 
 interface ThumbnailResult {

--- a/frontend/src/types/file.ts
+++ b/frontend/src/types/file.ts
@@ -3,8 +3,8 @@
  * FileContext uses pure File objects with separate ID tracking
  */
 
-import { FileId } from "./fileContext";
-
+declare const tag: unique symbol;
+export type FileId = string & { readonly [tag]: 'FileId' };
 
 /**
  * File metadata for efficient operations without loading full file data

--- a/frontend/src/types/file.ts
+++ b/frontend/src/types/file.ts
@@ -3,13 +3,15 @@
  * FileContext uses pure File objects with separate ID tracking
  */
 
+import { FileId } from "./fileContext";
+
 
 /**
  * File metadata for efficient operations without loading full file data
  * Used by IndexedDBContext and FileContext for lazy file loading
  */
 export interface FileMetadata {
-  id: string;
+  id: FileId;
   name: string;
   type: string;
   size: number;
@@ -36,9 +38,9 @@ export const defaultStorageConfig: StorageConfig = {
 export const initializeStorageConfig = async (): Promise<StorageConfig> => {
   const tenGB = 10 * 1024 * 1024 * 1024; // 10GB in bytes
   const oneGB = 1024 * 1024 * 1024; // 1GB fallback
-  
+
   let maxTotalStorage = oneGB; // Default fallback
-  
+
   // Try to estimate available storage
   if ('storage' in navigator && 'estimate' in navigator.storage) {
     try {
@@ -51,7 +53,7 @@ export const initializeStorageConfig = async (): Promise<StorageConfig> => {
       console.warn('Could not estimate storage quota, using 1GB default:', error);
     }
   }
-  
+
   return {
     ...defaultStorageConfig,
     maxTotalStorage

--- a/frontend/src/types/fileContext.ts
+++ b/frontend/src/types/fileContext.ts
@@ -2,9 +2,8 @@
  * Types for global file context management across views and tools
  */
 
-import { ProcessedFile } from './processing';
-import { PDFDocument, PDFPage, PageOperation } from './pageEditor';
-import { FileMetadata } from './file';
+import { PageOperation } from './pageEditor';
+import { FileId, FileMetadata } from './file';
 
 export type ModeType =
   | 'viewer'
@@ -26,9 +25,6 @@ export type ModeType =
   | 'removeCertificateSign';
 
 // Normalized state types
-declare const tag: unique symbol;
-export type FileId = string & { readonly [tag]: 'FileId' };
-
 export interface ProcessedFilePage {
   thumbnail?: string;
   pageNumber?: number;

--- a/frontend/src/types/pageEditor.ts
+++ b/frontend/src/types/pageEditor.ts
@@ -1,3 +1,5 @@
+import { FileId } from './fileContext';
+
 export interface PDFPage {
   id: string;
   pageNumber: number;
@@ -7,7 +9,7 @@ export interface PDFPage {
   selected: boolean;
   splitAfter?: boolean;
   isBlankPage?: boolean;
-  originalFileId?: string;
+  originalFileId?: FileId;
 }
 
 export interface PDFDocument {

--- a/frontend/src/types/pageEditor.ts
+++ b/frontend/src/types/pageEditor.ts
@@ -1,4 +1,4 @@
-import { FileId } from './fileContext';
+import { FileId } from './file';
 
 export interface PDFPage {
   id: string;

--- a/frontend/src/utils/toolOperationTracker.ts
+++ b/frontend/src/utils/toolOperationTracker.ts
@@ -1,4 +1,5 @@
-import { FileId, FileOperation } from '../types/fileContext';
+import { FileId } from '../types/file';
+import { FileOperation } from '../types/fileContext';
 
 /**
  * Creates operation tracking data for FileContext integration

--- a/frontend/src/utils/toolOperationTracker.ts
+++ b/frontend/src/utils/toolOperationTracker.ts
@@ -1,4 +1,4 @@
-import { FileOperation } from '../types/fileContext';
+import { FileId, FileOperation } from '../types/fileContext';
 
 /**
  * Creates operation tracking data for FileContext integration
@@ -7,9 +7,9 @@ export const createOperation = <TParams = void>(
   operationType: string,
   params: TParams,
   selectedFiles: File[]
-): { operation: FileOperation; operationId: string; fileId: string } => {
+): { operation: FileOperation; operationId: string; fileId: FileId } => {
   const operationId = `${operationType}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-  const fileId = selectedFiles.map(f => f.name).join(',');
+  const fileId = selectedFiles.map(f => f.name).join(',') as FileId;
 
   const operation: FileOperation = {
     id: operationId,


### PR DESCRIPTION
# Description of Changes
The `FileId` type in V2 currently is just defined to be a string. This makes it really easy to accidentally pass strings into things accepting file IDs (such as file names). This PR makes the `FileId` type [an opaque type](https://www.geeksforgeeks.org/typescript/opaque-types-in-typescript/), so it is compatible with things accepting strings (arguably not ideal for this...) but strings are not compatible with it without explicit conversion. 

The PR also includes changes to use `FileId` consistently throughout the project (everywhere I could find uses of `fileId: string`), so that we have the maximum benefit from the type safety.

> [!note]
> I've marked quite a few things as `FIX ME` where we're passing names in as IDs. If that is intended behaviour, I'm happy to remove the fix me and insert a cast instead, but they probably need comments explaining why we're using a file name as an ID.