### PR TITLE
fix(api): prevent `MultipartFile` binding errors in `StampController`

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -55,6 +55,12 @@ public class StampController {
     private final CustomPDFDocumentFactory pdfDocumentFactory;
     private final TempFileManager tempFileManager;
 
+    /**
+     * Initialize data binder for multipart file uploads.
+     * This method registers a custom editor for MultipartFile to handle file uploads.
+     * It sets the MultipartFile to null if the uploaded file is empty.
+     * This is necessary to avoid binding errors when the file is not present.
+     */
     @InitBinder
     public void initBinder(WebDataBinder binder) {
         binder.registerCustomEditor(


### PR DESCRIPTION
# Description of Changes

- **What was changed**
  - Added a Spring `@InitBinder` in `StampController` that registers a `PropertyEditorSupport` for `MultipartFile` to safely handle text inputs by setting the value to `null`.
  - Replaced multiple `switch` statements with modern Java **switch expressions**:
    - Margin selection (`customMargin`) now uses a concise expression.
    - Font selection (`alphabet` → font resource path) rewritten as an expression.
    - Position calculations (`calculatePositionX` / `calculatePositionY`) now return via switch expressions with `yield`.
  - Minor readability and maintainability improvements without changing public API or behavior (besides the binding fix).

- **Why the change was made**
  - The `@InitBinder` prevents conversion/binding issues when Spring attempts to map string form fields to `MultipartFile`, which could cause exceptions or unexpected behavior in multipart/form-data requests.
  - Using switch expressions reduces boilerplate, clarifies intent, and makes the control flow safer and more maintainable.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
