### PR TITLE
style(vscode): add ESLint, Prettier, and React snippets + expand Java cleanup actions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,6 +16,9 @@
     "GitHub.copilot", // GitHub Copilot AI pair programmer for Visual Studio Code
     "GitHub.vscode-pull-request-github", // GitHub Pull Requests extension for Visual Studio Code
     "charliermarsh.ruff", // Ruff code formatter for Python to follow the Ruff Style Guide
+    "dbaeumer.vscode-eslint", // ESLint extension for linting JavaScript and TypeScript
+    "esbenp.prettier-vscode", // Prettier code formatter for consistent styling
+    "dsznajder.es7-react-js-snippets", // ES7 React/Redux/React-Native snippets for faster development
     "yzhang.markdown-all-in-one", // Markdown All-in-One extension for enhanced Markdown editing
     "stylelint.vscode-stylelint", // Stylelint extension for CSS and SCSS linting
     "redhat.vscode-yaml", // YAML extension for Visual Studio Code

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,7 +16,6 @@
     "GitHub.copilot", // GitHub Copilot AI pair programmer for Visual Studio Code
     "GitHub.vscode-pull-request-github", // GitHub Pull Requests extension for Visual Studio Code
     "charliermarsh.ruff", // Ruff code formatter for Python to follow the Ruff Style Guide
-    "dbaeumer.vscode-eslint", // ESLint extension for linting JavaScript and TypeScript
     "esbenp.prettier-vscode", // Prettier code formatter for consistent styling
     "dsznajder.es7-react-js-snippets", // ES7 React/Redux/React-Native snippets for faster development
     "yzhang.markdown-all-in-one", // Markdown All-in-One extension for enhanced Markdown editing

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,30 @@
 {
-  "editor.wordSegmenterLocales": "",
+  "editor.wordSegmenterLocales": [
+    "en-GB",
+    "en-US"
+  ],
   "editor.guides.bracketPairs": "active",
   "editor.guides.bracketPairsHorizontal": "active",
   "editor.defaultFormatter": "EditorConfig.EditorConfig",
   "cSpell.enabled": false,
+  "cSpell.language": "en-GB,en-US",
   "[feature]": {
     "editor.defaultFormatter": "alexkrechik.cucumberautocomplete"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "vscode.html-language-features"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[java]": {
     "editor.defaultFormatter": "josevseb.google-java-format-for-vs-code"
@@ -53,7 +72,21 @@
   "java.saveActions.cleanup": true,
   "java.cleanup.actions": [
     "invertEquals", // Inverts calls to Object.equals(Object) and String.equalsIgnoreCase(String) to avoid useless null pointer exception.
-    "instanceofPatternMatch" // Replaces instanceof checks with pattern matching.
+    "instanceofPatternMatch", // Replaces instanceof checks with pattern matching.
+    "useSwitchForInstanceofPattern", // Replaces instanceof checks with switch expressions.
+    "renameUnusedLocalVariables", // Renames unused local variables.
+    "switchExpression", // Replaces switch statements with switch expressions.
+    "lambdaExpressionFromAnonymousClass", // Replaces anonymous classes with lambda expressions.
+    "tryWithResource", // Replaces try-with-resources statements with the new syntax.
+    "lambdaExpression", // Converts anonymous classes to lambda expressions.
+    "redundantComparisonStatement", // Removes redundant comparison statements.
+    "redundantFallingThroughBlockEnd", // Removes redundant block ends in switch statements.
+    "redundantIfCondition", // Removes redundant if conditions.
+    "redundantModifiers", // Removes redundant modifiers.
+    "addOverride", // Adds @Override annotations where applicable.
+    "addDeprecated", // Adds @Deprecated annotations where applicable.
+    // "addFinalModifier", // Adds final modifiers to fields and methods where applicable.
+    "redundantSuperCall", // Removes redundant super calls in constructors.
   ],
   // (DE) Aktiviert die Code-Vervollständigung für Java.
   // (EN) Enables code completion for Java.
@@ -135,9 +168,22 @@
   "html.format.preserveNewLines": true,
   "html.format.maxPreserveNewLines": 2,
   "stylelint.configFile": "devTools/.stylelintrc.json",
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "emmet.includeLanguages": {
+    "javascript": "javascriptreact",
+    "typescript": "typescriptreact"
+  },
   "java.project.sourcePaths": [
     "app/core/src/main/java",
     "app/common/src/main/java",
     "app/proprietary/src/main/java"
-  ]
+  ],
+  "java.compile.nullAnalysis.nonnull": [],
+  "java.compile.nullAnalysis.nullable": [],
+  "java.errors.incompleteClasspath.severity": "warning",
 }


### PR DESCRIPTION
# Description of Changes

- **Added new VS Code extensions**: ESLint, Prettier, and ES7 React/Redux/React-Native snippets for improved JS/TS workflow.
- **Updated formatter settings**: Prettier is now the default for JavaScript, TypeScript, and React files.
- **Enhanced Java cleanup actions**: introduced rules for `useSwitchForInstanceofPattern`, lambda conversions, redundant code removal, `@Override`, `@Deprecated`, and more.
- **Expanded editor configurations**:
  - Enabled multi-locale word segmentation (`en-GB`, `en-US`).
  - Configured ESLint validation for JS/TS.
  - Improved Emmet support for React development.
  - Adjusted Java null analysis and classpath error severity.

These changes improve code consistency, readability, and developer productivity across Java, JavaScript, and TypeScript codebases.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
