### PR TITLE
fix(security): prevent NPE on logout when JWT service is unavailable

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/CustomLogoutSuccessHandler.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/CustomLogoutSuccessHandler.java
@@ -71,11 +71,12 @@ public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
                             authentication.getClass().getSimpleName());
                     getRedirectStrategy().sendRedirect(request, response, LOGOUT_PATH);
                 }
-            } else if (jwtService != null
-                    && jwtService.extractToken(request) != null
-                    && !jwtService.extractToken(request).isBlank()) {
-                jwtService.clearToken(response);
-                getRedirectStrategy().sendRedirect(request, response, LOGOUT_PATH);
+            } else if (jwtService != null) {
+                String token = jwtService.extractToken(request);
+                if (token != null && !token.isBlank()) {
+                    jwtService.clearToken(response);
+                    getRedirectStrategy().sendRedirect(request, response, LOGOUT_PATH);
+                }
             } else {
                 // Redirect to login page after logout
                 String path = checkForErrors(request);
@@ -167,7 +168,8 @@ public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
                     log.info("Redirecting to Keycloak logout URL: {}", logoutUrl);
                 } else {
                     log.info(
-                            "No redirect URL for {} available. Redirecting to default logout URL: {}",
+                            "No redirect URL for {} available. Redirecting to default logout URL:"
+                                    + " {}",
                             registrationId,
                             logoutUrl);
                 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/CustomLogoutSuccessHandler.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/CustomLogoutSuccessHandler.java
@@ -71,7 +71,9 @@ public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
                             authentication.getClass().getSimpleName());
                     getRedirectStrategy().sendRedirect(request, response, LOGOUT_PATH);
                 }
-            } else if (!jwtService.extractToken(request).isBlank()) {
+            } else if (jwtService != null
+                    && jwtService.extractToken(request) != null
+                    && !jwtService.extractToken(request).isBlank()) {
                 jwtService.clearToken(response);
                 getRedirectStrategy().sendRedirect(request, response, LOGOUT_PATH);
             } else {


### PR DESCRIPTION
# Description of Changes

- Updated `CustomLogoutSuccessHandler` to add null checks before accessing `jwtService`.
- Ensures `extractToken(request)` is not null or blank before clearing the token and redirecting.
- Fix prevents potential `NullPointerException` during logout when `jwtService` is not initialized.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
