### PR TITLE
feat: custom error handling when calling renderImageWithDPI, controllers to respect global DPI

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/ExceptionUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/ExceptionUtils.java
@@ -326,6 +326,28 @@ public class ExceptionUtils {
     }
 
     /**
+     * Create a RuntimeException for memory/image size errors when rendering PDF images with DPI.
+     * Handles OutOfMemoryError and related conditions (e.g., NegativeArraySizeException) that
+     * result from images exceeding Java's array/memory limits.
+     *
+     * @param pageNumber the page number that caused the error
+     * @param dpi the DPI value used
+     * @param cause the original error/exception (e.g., OutOfMemoryError,
+     *     NegativeArraySizeException)
+     * @return RuntimeException with user-friendly message
+     */
+    public static RuntimeException createOutOfMemoryDpiException(
+            int pageNumber, int dpi, Throwable cause) {
+        String message =
+                MessageFormat.format(
+                        "Out of memory or image-too-large error while rendering PDF page {0} at {1} DPI. "
+                                + "This can occur when the resulting image exceeds Java's array/memory limits (e.g., NegativeArraySizeException). "
+                                + "Please use a lower DPI value (recommended: 150 or less) or process the document in smaller chunks.",
+                        pageNumber, dpi);
+        return new RuntimeException(message, cause);
+    }
+
+    /**
      * Create a RuntimeException for OutOfMemoryError when rendering PDF images with DPI.
      *
      * @param pageNumber the page number that caused the error
@@ -335,29 +357,30 @@ public class ExceptionUtils {
      */
     public static RuntimeException createOutOfMemoryDpiException(
             int pageNumber, int dpi, OutOfMemoryError cause) {
-        String message =
-                MessageFormat.format(
-                        "Out of memory error occurred while rendering PDF page {0} at {1} DPI. "
-                                + "The image is too large to fit in memory. Please try using a lower DPI value "
-                                + "(recommended: 150 or less) or process the document in smaller chunks.",
-                        pageNumber, dpi);
-        return new RuntimeException(message, cause);
+        return createOutOfMemoryDpiException(pageNumber, dpi, (Throwable) cause);
     }
 
     /**
-     * Create a RuntimeException for OutOfMemoryError when rendering PDF images with DPI.
+     * Create a RuntimeException for memory/image size errors when rendering PDF images with DPI.
+     * Handles OutOfMemoryError and related conditions (e.g., NegativeArraySizeException) that
+     * result from images exceeding Java's array/memory limits.
      *
      * @param dpi the DPI value used
-     * @param cause the original OutOfMemoryError
+     * @param cause the original error/exception (e.g., OutOfMemoryError,
+     *     NegativeArraySizeException)
      * @return RuntimeException with user-friendly message
      */
-    public static RuntimeException createOutOfMemoryDpiException(int dpi, OutOfMemoryError cause) {
+    public static RuntimeException createOutOfMemoryDpiException(int dpi, Throwable cause) {
         String message =
                 MessageFormat.format(
-                        "Out of memory error occurred while rendering PDF at {0} DPI. "
-                                + "The image is too large to fit in memory. Please try using a lower DPI value "
-                                + "(recommended: 150 or less) or process the document in smaller chunks.",
+                        "Out of memory or image-too-large error while rendering PDF at {0} DPI. "
+                                + "This can occur when the resulting image exceeds Java's array/memory limits (e.g., NegativeArraySizeException). "
+                                + "Please use a lower DPI value (recommended: 150 or less) or process the document in smaller chunks.",
                         dpi);
         return new RuntimeException(message, cause);
+    }
+
+    public static RuntimeException createOutOfMemoryDpiException(int dpi, OutOfMemoryError cause) {
+        return createOutOfMemoryDpiException(dpi, (Throwable) cause);
     }
 }

--- a/app/common/src/main/java/stirling/software/common/util/PdfUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/PdfUtils.java
@@ -207,6 +207,8 @@ public class PdfUtils {
                                 throw e;
                             } catch (OutOfMemoryError e) {
                                 throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
+                            } catch (NegativeArraySizeException e) {
+                                throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
                             }
                             writer.writeToSequence(new IIOImage(image, null, null), param);
                         }
@@ -257,6 +259,8 @@ public class PdfUtils {
                                 throw e;
                             } catch (OutOfMemoryError e) {
                                 throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
+                            } catch (NegativeArraySizeException e) {
+                                throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
                             }
                             pdfSizeImageIndex = i;
                             dimension =
@@ -302,6 +306,8 @@ public class PdfUtils {
                                 throw e;
                             } catch (OutOfMemoryError e) {
                                 throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
+                            } catch (NegativeArraySizeException e) {
+                                throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
                             }
                         }
 
@@ -337,6 +343,8 @@ public class PdfUtils {
                             }
                             throw e;
                         } catch (OutOfMemoryError e) {
+                            throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
+                        } catch (NegativeArraySizeException e) {
                             throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, DPI, e);
                         }
                         try (ByteArrayOutputStream baosImage = new ByteArrayOutputStream()) {
@@ -400,6 +408,8 @@ public class PdfUtils {
                 }
                 throw e;
             } catch (OutOfMemoryError e) {
+                throw ExceptionUtils.createOutOfMemoryDpiException(page + 1, 300, e);
+            } catch (NegativeArraySizeException e) {
                 throw ExceptionUtils.createOutOfMemoryDpiException(page + 1, 300, e);
             }
             PDPage originalPage = document.getPage(page);

--- a/app/common/src/main/java/stirling/software/common/util/misc/InvertFullColorStrategy.java
+++ b/app/common/src/main/java/stirling/software/common/util/misc/InvertFullColorStrategy.java
@@ -63,6 +63,8 @@ public class InvertFullColorStrategy extends ReplaceAndInvertColorStrategy {
                                     page, renderDpi); // Render page with global DPI setting
                 } catch (OutOfMemoryError e) {
                     throw ExceptionUtils.createOutOfMemoryDpiException(page + 1, renderDpi, e);
+                } catch (NegativeArraySizeException e) {
+                    throw ExceptionUtils.createOutOfMemoryDpiException(page + 1, renderDpi, e);
                 }
 
                 // Invert the colors

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
@@ -145,6 +145,8 @@ public class AutoSplitPdfController {
                     bim = pdfRenderer.renderImageWithDPI(page, renderDpi);
                 } catch (OutOfMemoryError e) {
                     throw ExceptionUtils.createOutOfMemoryDpiException(page + 1, renderDpi, e);
+                } catch (NegativeArraySizeException e) {
+                    throw ExceptionUtils.createOutOfMemoryDpiException(page + 1, renderDpi, e);
                 }
                 String result = decodeQRCode(bim);
 

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/BlankPageController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/BlankPageController.java
@@ -126,6 +126,9 @@ public class BlankPageController {
                         } catch (OutOfMemoryError e) {
                             throw ExceptionUtils.createOutOfMemoryDpiException(
                                     pageIndex + 1, renderDpi, e);
+                        } catch (NegativeArraySizeException e) {
+                            throw ExceptionUtils.createOutOfMemoryDpiException(
+                                    pageIndex + 1, renderDpi, e);
                         }
                         blank = isBlankImage(image, threshold, whitePercent, threshold);
                     }

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImageScansController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImageScansController.java
@@ -113,6 +113,8 @@ public class ExtractImageScansController {
                             image = pdfRenderer.renderImageWithDPI(i, renderDpi);
                         } catch (OutOfMemoryError e) {
                             throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, renderDpi, e);
+                        } catch (NegativeArraySizeException e) {
+                            throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, renderDpi, e);
                         }
                         ImageIO.write(image, "png", tempFile.toFile());
 

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/FlattenController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/FlattenController.java
@@ -84,6 +84,8 @@ public class FlattenController {
                         image = pdfRenderer.renderImageWithDPI(i, renderDpi, ImageType.RGB);
                     } catch (OutOfMemoryError e) {
                         throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, renderDpi, e);
+                    } catch (NegativeArraySizeException e) {
+                        throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, renderDpi, e);
                     }
                     PDPage page = new PDPage();
                     page.setMediaBox(document.getPage(i).getMediaBox());

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/OCRController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/OCRController.java
@@ -373,6 +373,9 @@ public class OCRController {
                         } catch (OutOfMemoryError e) {
                             throw ExceptionUtils.createOutOfMemoryDpiException(
                                     pageNum + 1, renderDpi, e);
+                        } catch (NegativeArraySizeException e) {
+                            throw ExceptionUtils.createOutOfMemoryDpiException(
+                                    pageNum + 1, renderDpi, e);
                         }
                         File imagePath =
                                 new File(tempImagesDir, String.format("page_%d.png", pageNum));

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ScannerEffectController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ScannerEffectController.java
@@ -142,6 +142,8 @@ public class ScannerEffectController {
                     image = pdfRenderer.renderImageWithDPI(i, safeResolution);
                 } catch (OutOfMemoryError e) {
                     throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, safeResolution, e);
+                } catch (NegativeArraySizeException e) {
+                    throw ExceptionUtils.createOutOfMemoryDpiException(i + 1, safeResolution, e);
                 }
 
                 log.debug(


### PR DESCRIPTION
# Description of Changes

### How to reproduce:

1. Download: 
[sensors-21-04255.pdf_20.pdf](https://github.com/user-attachments/files/22052791/sensors-21-04255.pdf_20.pdf)
2. Choose any controller that relies on unchecked renderImageWithDPI (e.g., invert colour or flatten)
3. Wait (might take few minutes depending on your heap size)
4. Get (more example logs below):
> 22:04:29.456 [qtp956791394-43] WARN  o.e.j.ee10.servlet.ServletChannel - /api/v1/misc/flatten
> jakarta.servlet.ServletException: Handler dispatch failed: java.lang.OutOfMemoryError: Java heap space

Related issue on PDFBox JIRA: https://issues.apache.org/jira/browse/PDFBOX-5956

Examples logs:
1. Flatten:
[OOM.txt](https://github.com/user-attachments/files/22052862/OOM.txt)
2. invert colour:
[OOM.txt](https://github.com/user-attachments/files/22052929/OOM.txt)

### New fix:
- Use the custom ExceptionUtils to throw an error

### Example:
<img width="1916" height="174" alt="image" src="https://github.com/user-attachments/assets/a1bb528f-becf-44a6-9edd-dbac9e89e66f" />


### Improvements
- Now controllers respect max DPI
- Use said max DPI when possible
- Default to reasonable values

### Follow up to the discussion in: #4329
- Sadly, I concluded that finding alternative methods to process images are not really easy/or feasible solution to this.
- As requested in https://github.com/Stirling-Tools/Stirling-PDF/pull/4329#issuecomment-3238552472 now all relevant controller throw an informative OOM error, to avoid user confusion

### Update:
- included NegativeArraySizeException to the mix. As a follow-up to:  #4436

### Example of NegativeArraySizeException
<img width="1914" height="167" alt="image" src="https://github.com/user-attachments/assets/84e1439a-be09-4507-8e77-4a98608a4601" />


Closes #4329 
Closes #4436

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
