### PR TITLE
fix(scale): Throw exceptions for invalid page size instead of returning null in getTargetSize method

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/ScalePagesController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/ScalePagesController.java
@@ -106,12 +106,19 @@ public class ScalePagesController {
     private PDRectangle getTargetSize(String targetPDRectangle, PDDocument sourceDocument) {
         if ("KEEP".equals(targetPDRectangle)) {
             if (sourceDocument.getNumberOfPages() == 0) {
-                return null;
+                // Do not return null here — throw a clear exception so callers don't get a nullable
+                // PDRectangle.
+                throw ExceptionUtils.createInvalidPageSizeException("KEEP");
             }
 
             // use the first page to determine the target page size
             PDPage sourcePage = sourceDocument.getPage(0);
             PDRectangle sourceSize = sourcePage.getMediaBox();
+
+            if (sourceSize == null) {
+                // If media box is unexpectedly null, treat it as invalid
+                throw ExceptionUtils.createInvalidPageSizeException("KEEP");
+            }
 
             return sourceSize;
         }


### PR DESCRIPTION
# Description of Changes

Fixed getTargetSize to never make an early null return, instead throw an appropriate customException when the submitted doc has 0 pages.

### Why this change was made:
- If getTargetSize returned null, the call targetSize.getWidth() would throw a NullPointerException immediately.
- PDDocument.getNumberOfPages() can be 0 e.g., new PDDocument() or a loader/factory that produced an empty document for a malformed or partial upload, or a custom pdfDocumentFactory that creates an empty document in some error paths.
- Replacing the null return with throw ExceptionUtils.createInvalidPageSizeException("KEEP"): it fails fast with a clear error instead of producing an NPE.

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
