### PR TITLE
refactor: remove redundant static modifiers from UtilityClass because lombok already makes them static

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/ChecksumUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/ChecksumUtils.java
@@ -22,10 +22,10 @@ import lombok.experimental.UtilityClass;
 public class ChecksumUtils {
 
     /** Shared buffer size for streaming I/O. */
-    private static final int BUFFER_SIZE = 8192;
+    private final int BUFFER_SIZE = 8192;
 
     /** Mask to extract the lower 32 bits of a long value (unsigned int). */
-    private static final long UNSIGNED_32_BIT_MASK = 0xFFFFFFFFL;
+    private final long UNSIGNED_32_BIT_MASK = 0xFFFFFFFFL;
 
     /**
      * Computes a checksum for the given file using the chosen algorithm and returns a lowercase hex
@@ -40,7 +40,7 @@ public class ChecksumUtils {
      * @return hex string of the checksum
      * @throws IOException if the file cannot be read
      */
-    public static String checksum(Path path, String algorithm) throws IOException {
+    public String checksum(Path path, String algorithm) throws IOException {
         try (InputStream is = Files.newInputStream(path)) {
             return checksum(is, algorithm);
         }
@@ -57,7 +57,7 @@ public class ChecksumUtils {
      * @return hex string of the checksum
      * @throws IOException if reading from the stream fails
      */
-    public static String checksum(InputStream is, String algorithm) throws IOException {
+    public String checksum(InputStream is, String algorithm) throws IOException {
         switch (algorithm.toUpperCase(Locale.ROOT)) {
             case "CRC32":
                 return checksumChecksum(is, new CRC32());
@@ -80,7 +80,7 @@ public class ChecksumUtils {
      * @return Base64-encoded checksum bytes
      * @throws IOException if the file cannot be read
      */
-    public static String checksumBase64(Path path, String algorithm) throws IOException {
+    public String checksumBase64(Path path, String algorithm) throws IOException {
         try (InputStream is = Files.newInputStream(path)) {
             return checksumBase64(is, algorithm);
         }
@@ -97,7 +97,7 @@ public class ChecksumUtils {
      * @return Base64-encoded checksum bytes
      * @throws IOException if reading from the stream fails
      */
-    public static String checksumBase64(InputStream is, String algorithm) throws IOException {
+    public String checksumBase64(InputStream is, String algorithm) throws IOException {
         switch (algorithm.toUpperCase(Locale.ROOT)) {
             case "CRC32":
                 return Base64.getEncoder().encodeToString(checksumChecksumBytes(is, new CRC32()));
@@ -119,7 +119,7 @@ public class ChecksumUtils {
      * @return map of algorithm → hex string
      * @throws IOException if the file cannot be read
      */
-    public static Map<String, String> checksums(Path path, String... algorithms)
+    public Map<String, String> checksums(Path path, String... algorithms)
             throws IOException {
         try (InputStream is = Files.newInputStream(path)) {
             return checksums(is, algorithms);
@@ -136,7 +136,7 @@ public class ChecksumUtils {
      * @return map of algorithm → hex string
      * @throws IOException if reading from the stream fails
      */
-    public static Map<String, String> checksums(InputStream is, String... algorithms)
+    public Map<String, String> checksums(InputStream is, String... algorithms)
             throws IOException {
         // Use LinkedHashMap to preserve the order of requested algorithms in the result.
         Map<String, MessageDigest> digests = new LinkedHashMap<>();
@@ -193,7 +193,7 @@ public class ChecksumUtils {
      * @return {@code true} if they match, otherwise {@code false}
      * @throws IOException if the file cannot be read
      */
-    public static boolean matches(Path path, String algorithm, String expected) throws IOException {
+    public boolean matches(Path path, String algorithm, String expected) throws IOException {
         try (InputStream is = Files.newInputStream(path)) {
             return matches(is, algorithm, expected);
         }
@@ -210,7 +210,7 @@ public class ChecksumUtils {
      * @return {@code true} if they match, otherwise {@code false}
      * @throws IOException if reading from the stream fails
      */
-    public static boolean matches(InputStream is, String algorithm, String expected)
+    public boolean matches(InputStream is, String algorithm, String expected)
             throws IOException {
         return checksum(is, algorithm).equalsIgnoreCase(expected);
     }
@@ -226,7 +226,7 @@ public class ChecksumUtils {
      * @throws IOException if reading fails
      * @throws IllegalStateException if the algorithm is unsupported
      */
-    private static byte[] checksumBytes(InputStream is, String algorithm) throws IOException {
+    private byte[] checksumBytes(InputStream is, String algorithm) throws IOException {
         try {
             MessageDigest digest = MessageDigest.getInstance(algorithm);
             byte[] buffer = new byte[BUFFER_SIZE];
@@ -250,7 +250,7 @@ public class ChecksumUtils {
      * @return 8-character lowercase hex (big-endian representation)
      * @throws IOException if reading fails
      */
-    private static String checksumChecksum(InputStream is, Checksum checksum) throws IOException {
+    private String checksumChecksum(InputStream is, Checksum checksum) throws IOException {
         byte[] buffer = new byte[BUFFER_SIZE];
         int read;
         while ((read = is.read(buffer)) != -1) {
@@ -273,7 +273,7 @@ public class ChecksumUtils {
      * @return 4 bytes (big-endian)
      * @throws IOException if reading fails
      */
-    private static byte[] checksumChecksumBytes(InputStream is, Checksum checksum)
+    private byte[] checksumChecksumBytes(InputStream is, Checksum checksum)
             throws IOException {
         byte[] buffer = new byte[BUFFER_SIZE];
         int read;
@@ -291,7 +291,7 @@ public class ChecksumUtils {
      * @param hash the byte array to convert
      * @return the lowercase hex string
      */
-    private static String toHex(byte[] hash) {
+    private String toHex(byte[] hash) {
         StringBuilder sb = new StringBuilder(hash.length * 2);
         for (byte b : hash) {
             sb.append(String.format("%02x", b));

--- a/app/common/src/main/java/stirling/software/common/util/ChecksumUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/ChecksumUtils.java
@@ -119,8 +119,7 @@ public class ChecksumUtils {
      * @return map of algorithm → hex string
      * @throws IOException if the file cannot be read
      */
-    public Map<String, String> checksums(Path path, String... algorithms)
-            throws IOException {
+    public Map<String, String> checksums(Path path, String... algorithms) throws IOException {
         try (InputStream is = Files.newInputStream(path)) {
             return checksums(is, algorithms);
         }
@@ -136,8 +135,7 @@ public class ChecksumUtils {
      * @return map of algorithm → hex string
      * @throws IOException if reading from the stream fails
      */
-    public Map<String, String> checksums(InputStream is, String... algorithms)
-            throws IOException {
+    public Map<String, String> checksums(InputStream is, String... algorithms) throws IOException {
         // Use LinkedHashMap to preserve the order of requested algorithms in the result.
         Map<String, MessageDigest> digests = new LinkedHashMap<>();
         Map<String, Checksum> checksums = new LinkedHashMap<>();
@@ -210,8 +208,7 @@ public class ChecksumUtils {
      * @return {@code true} if they match, otherwise {@code false}
      * @throws IOException if reading from the stream fails
      */
-    public boolean matches(InputStream is, String algorithm, String expected)
-            throws IOException {
+    public boolean matches(InputStream is, String algorithm, String expected) throws IOException {
         return checksum(is, algorithm).equalsIgnoreCase(expected);
     }
 
@@ -273,8 +270,7 @@ public class ChecksumUtils {
      * @return 4 bytes (big-endian)
      * @throws IOException if reading fails
      */
-    private byte[] checksumChecksumBytes(InputStream is, Checksum checksum)
-            throws IOException {
+    private byte[] checksumChecksumBytes(InputStream is, Checksum checksum) throws IOException {
         byte[] buffer = new byte[BUFFER_SIZE];
         int read;
         while ((read = is.read(buffer)) != -1) {

--- a/app/common/src/main/java/stirling/software/common/util/EmlParser.java
+++ b/app/common/src/main/java/stirling/software/common/util/EmlParser.java
@@ -61,7 +61,7 @@ public class EmlParser {
     }
 
     public EmailContent extractEmailContent(
-        byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer)
+            byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer)
             throws IOException {
         EmlProcessingUtils.validateEmlInput(emlBytes);
 
@@ -73,7 +73,7 @@ public class EmlParser {
     }
 
     private EmailContent extractEmailContentBasic(
-        byte[] emlBytes, CustomHtmlSanitizer customHtmlSanitizer) {
+            byte[] emlBytes, CustomHtmlSanitizer customHtmlSanitizer) {
         String emlContent = new String(emlBytes, StandardCharsets.UTF_8);
         EmailContent content = new EmailContent();
 
@@ -102,7 +102,7 @@ public class EmlParser {
     }
 
     private EmailContent extractEmailContentAdvanced(
-        byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
+            byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
         try {
             Class<?> sessionClass = Class.forName("jakarta.mail.Session");
             Class<?> mimeMessageClass = Class.forName("jakarta.mail.internet.MimeMessage");
@@ -125,7 +125,7 @@ public class EmlParser {
     }
 
     private EmailContent extractFromMimeMessage(
-        Object message, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
+            Object message, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
         EmailContent content = new EmailContent();
 
         try {
@@ -161,8 +161,7 @@ public class EmlParser {
         return content;
     }
 
-    private void extractRecipients(
-        Object message, Class<?> messageClass, EmailContent content) {
+    private void extractRecipients(Object message, Class<?> messageClass, EmailContent content) {
         try {
             Method getRecipients =
                     messageClass.getMethod(
@@ -210,11 +209,11 @@ public class EmlParser {
     }
 
     private void processMessageContent(
-        Object message,
-        Object messageContent,
-        EmailContent content,
-        EmlToPdfRequest request,
-        CustomHtmlSanitizer customHtmlSanitizer) {
+            Object message,
+            Object messageContent,
+            EmailContent content,
+            EmlToPdfRequest request,
+            CustomHtmlSanitizer customHtmlSanitizer) {
         try {
             if (messageContent instanceof String stringContent) {
                 Method getContentType = message.getClass().getMethod("getContentType");
@@ -237,11 +236,11 @@ public class EmlParser {
     }
 
     private void processMultipart(
-        Object multipart,
-        EmailContent content,
-        EmlToPdfRequest request,
-        CustomHtmlSanitizer customHtmlSanitizer,
-        int depth) {
+            Object multipart,
+            EmailContent content,
+            EmlToPdfRequest request,
+            CustomHtmlSanitizer customHtmlSanitizer,
+            int depth) {
 
         final int MAX_MULTIPART_DEPTH = 10;
         if (depth > MAX_MULTIPART_DEPTH) {
@@ -267,11 +266,11 @@ public class EmlParser {
     }
 
     private void processPart(
-        Object part,
-        EmailContent content,
-        EmlToPdfRequest request,
-        CustomHtmlSanitizer customHtmlSanitizer,
-        int depth) {
+            Object part,
+            EmailContent content,
+            EmlToPdfRequest request,
+            CustomHtmlSanitizer customHtmlSanitizer,
+            int depth) {
         try {
             Class<?> partClass = part.getClass();
 
@@ -327,13 +326,13 @@ public class EmlParser {
     }
 
     private void processAttachment(
-        Object part,
-        EmailContent content,
-        EmlToPdfRequest request,
-        Method getHeader,
-        Method getContent,
-        String filename,
-        String contentType) {
+            Object part,
+            EmailContent content,
+            EmlToPdfRequest request,
+            Method getHeader,
+            Method getContent,
+            String filename,
+            String contentType) {
 
         content.setAttachmentCount(content.getAttachmentCount() + 1);
 
@@ -366,7 +365,7 @@ public class EmlParser {
     }
 
     private void extractAttachmentData(
-        Object part, EmailAttachment attachment, Method getContent, EmlToPdfRequest request) {
+            Object part, EmailAttachment attachment, Method getContent, EmlToPdfRequest request) {
         try {
             Object attachmentContent = getContent.invoke(part);
             byte[] attachmentData = null;

--- a/app/common/src/main/java/stirling/software/common/util/EmlParser.java
+++ b/app/common/src/main/java/stirling/software/common/util/EmlParser.java
@@ -22,30 +22,27 @@ import stirling.software.common.model.api.converters.EmlToPdfRequest;
 @UtilityClass
 public class EmlParser {
 
-    private static volatile Boolean jakartaMailAvailable = null;
-    private static volatile Method mimeUtilityDecodeTextMethod = null;
-    private static volatile boolean mimeUtilityChecked = false;
-
-    private static final Pattern MIME_ENCODED_PATTERN =
+    private final Pattern MIME_ENCODED_PATTERN =
             Pattern.compile("=\\?([^?]+)\\?([BbQq])\\?([^?]*)\\?=");
+    private final String DISPOSITION_ATTACHMENT = "attachment";
+    private final String TEXT_PLAIN = MediaType.TEXT_PLAIN_VALUE;
+    private final String TEXT_HTML = MediaType.TEXT_HTML_VALUE;
+    private final String MULTIPART_PREFIX = "multipart/";
+    private final String HEADER_CONTENT_TYPE = "content-type:";
+    private final String HEADER_CONTENT_DISPOSITION = "content-disposition:";
+    private final String HEADER_CONTENT_TRANSFER_ENCODING = "content-transfer-encoding:";
+    private final String HEADER_CONTENT_ID = "Content-ID";
+    private final String HEADER_SUBJECT = "Subject:";
+    private final String HEADER_FROM = "From:";
+    private final String HEADER_TO = "To:";
+    private final String HEADER_CC = "Cc:";
+    private final String HEADER_BCC = "Bcc:";
+    private final String HEADER_DATE = "Date:";
+    private volatile Boolean jakartaMailAvailable = null;
+    private volatile Method mimeUtilityDecodeTextMethod = null;
+    private volatile boolean mimeUtilityChecked = false;
 
-    private static final String DISPOSITION_ATTACHMENT = "attachment";
-    private static final String TEXT_PLAIN = MediaType.TEXT_PLAIN_VALUE;
-    private static final String TEXT_HTML = MediaType.TEXT_HTML_VALUE;
-    private static final String MULTIPART_PREFIX = "multipart/";
-
-    private static final String HEADER_CONTENT_TYPE = "content-type:";
-    private static final String HEADER_CONTENT_DISPOSITION = "content-disposition:";
-    private static final String HEADER_CONTENT_TRANSFER_ENCODING = "content-transfer-encoding:";
-    private static final String HEADER_CONTENT_ID = "Content-ID";
-    private static final String HEADER_SUBJECT = "Subject:";
-    private static final String HEADER_FROM = "From:";
-    private static final String HEADER_TO = "To:";
-    private static final String HEADER_CC = "Cc:";
-    private static final String HEADER_BCC = "Bcc:";
-    private static final String HEADER_DATE = "Date:";
-
-    private static synchronized boolean isJakartaMailAvailable() {
+    private synchronized boolean isJakartaMailAvailable() {
         if (jakartaMailAvailable == null) {
             try {
                 Class.forName("jakarta.mail.internet.MimeMessage");
@@ -63,8 +60,8 @@ public class EmlParser {
         return jakartaMailAvailable;
     }
 
-    public static EmailContent extractEmailContent(
-            byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer)
+    public EmailContent extractEmailContent(
+        byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer)
             throws IOException {
         EmlProcessingUtils.validateEmlInput(emlBytes);
 
@@ -75,8 +72,8 @@ public class EmlParser {
         }
     }
 
-    private static EmailContent extractEmailContentBasic(
-            byte[] emlBytes, CustomHtmlSanitizer customHtmlSanitizer) {
+    private EmailContent extractEmailContentBasic(
+        byte[] emlBytes, CustomHtmlSanitizer customHtmlSanitizer) {
         String emlContent = new String(emlBytes, StandardCharsets.UTF_8);
         EmailContent content = new EmailContent();
 
@@ -104,8 +101,8 @@ public class EmlParser {
         return content;
     }
 
-    private static EmailContent extractEmailContentAdvanced(
-            byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
+    private EmailContent extractEmailContentAdvanced(
+        byte[] emlBytes, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
         try {
             Class<?> sessionClass = Class.forName("jakarta.mail.Session");
             Class<?> mimeMessageClass = Class.forName("jakarta.mail.internet.MimeMessage");
@@ -127,8 +124,8 @@ public class EmlParser {
         }
     }
 
-    private static EmailContent extractFromMimeMessage(
-            Object message, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
+    private EmailContent extractFromMimeMessage(
+        Object message, EmlToPdfRequest request, CustomHtmlSanitizer customHtmlSanitizer) {
         EmailContent content = new EmailContent();
 
         try {
@@ -164,8 +161,8 @@ public class EmlParser {
         return content;
     }
 
-    private static void extractRecipients(
-            Object message, Class<?> messageClass, EmailContent content) {
+    private void extractRecipients(
+        Object message, Class<?> messageClass, EmailContent content) {
         try {
             Method getRecipients =
                     messageClass.getMethod(
@@ -199,7 +196,7 @@ public class EmlParser {
         }
     }
 
-    private static String buildAddressString(Object[] addresses) {
+    private String buildAddressString(Object[] addresses) {
         if (addresses == null || addresses.length == 0) {
             return "";
         }
@@ -212,12 +209,12 @@ public class EmlParser {
         return builder.toString();
     }
 
-    private static void processMessageContent(
-            Object message,
-            Object messageContent,
-            EmailContent content,
-            EmlToPdfRequest request,
-            CustomHtmlSanitizer customHtmlSanitizer) {
+    private void processMessageContent(
+        Object message,
+        Object messageContent,
+        EmailContent content,
+        EmlToPdfRequest request,
+        CustomHtmlSanitizer customHtmlSanitizer) {
         try {
             if (messageContent instanceof String stringContent) {
                 Method getContentType = message.getClass().getMethod("getContentType");
@@ -239,12 +236,12 @@ public class EmlParser {
         }
     }
 
-    private static void processMultipart(
-            Object multipart,
-            EmailContent content,
-            EmlToPdfRequest request,
-            CustomHtmlSanitizer customHtmlSanitizer,
-            int depth) {
+    private void processMultipart(
+        Object multipart,
+        EmailContent content,
+        EmlToPdfRequest request,
+        CustomHtmlSanitizer customHtmlSanitizer,
+        int depth) {
 
         final int MAX_MULTIPART_DEPTH = 10;
         if (depth > MAX_MULTIPART_DEPTH) {
@@ -269,12 +266,12 @@ public class EmlParser {
         }
     }
 
-    private static void processPart(
-            Object part,
-            EmailContent content,
-            EmlToPdfRequest request,
-            CustomHtmlSanitizer customHtmlSanitizer,
-            int depth) {
+    private void processPart(
+        Object part,
+        EmailContent content,
+        EmlToPdfRequest request,
+        CustomHtmlSanitizer customHtmlSanitizer,
+        int depth) {
         try {
             Class<?> partClass = part.getClass();
 
@@ -329,14 +326,14 @@ public class EmlParser {
         }
     }
 
-    private static void processAttachment(
-            Object part,
-            EmailContent content,
-            EmlToPdfRequest request,
-            Method getHeader,
-            Method getContent,
-            String filename,
-            String contentType) {
+    private void processAttachment(
+        Object part,
+        EmailContent content,
+        EmlToPdfRequest request,
+        Method getHeader,
+        Method getContent,
+        String filename,
+        String contentType) {
 
         content.setAttachmentCount(content.getAttachmentCount() + 1);
 
@@ -368,8 +365,8 @@ public class EmlParser {
         }
     }
 
-    private static void extractAttachmentData(
-            Object part, EmailAttachment attachment, Method getContent, EmlToPdfRequest request) {
+    private void extractAttachmentData(
+        Object part, EmailAttachment attachment, Method getContent, EmlToPdfRequest request) {
         try {
             Object attachmentContent = getContent.invoke(part);
             byte[] attachmentData = null;
@@ -406,7 +403,7 @@ public class EmlParser {
         }
     }
 
-    private static String extractBasicHeader(String emlContent, String headerName) {
+    private String extractBasicHeader(String emlContent, String headerName) {
         try {
             String[] lines = emlContent.split("\r?\n");
             for (int i = 0; i < lines.length; i++) {
@@ -431,7 +428,7 @@ public class EmlParser {
         return "";
     }
 
-    private static String extractHtmlBody(String emlContent) {
+    private String extractHtmlBody(String emlContent) {
         try {
             String lowerContent = emlContent.toLowerCase();
             int htmlStart = lowerContent.indexOf(HEADER_CONTENT_TYPE + " " + TEXT_HTML);
@@ -450,7 +447,7 @@ public class EmlParser {
         }
     }
 
-    private static String extractTextBody(String emlContent) {
+    private String extractTextBody(String emlContent) {
         try {
             String lowerContent = emlContent.toLowerCase();
             int textStart = lowerContent.indexOf(HEADER_CONTENT_TYPE + " " + TEXT_PLAIN);
@@ -478,7 +475,7 @@ public class EmlParser {
         }
     }
 
-    private static int findPartEnd(String content, int start) {
+    private int findPartEnd(String content, int start) {
         String[] lines = content.substring(start).split("\r?\n");
         StringBuilder result = new StringBuilder();
 
@@ -490,7 +487,7 @@ public class EmlParser {
         return start + result.length();
     }
 
-    private static List<EmailAttachment> extractAttachmentsBasic(String emlContent) {
+    private List<EmailAttachment> extractAttachmentsBasic(String emlContent) {
         List<EmailAttachment> attachments = new ArrayList<>();
         try {
             String[] lines = emlContent.split("\r?\n");
@@ -538,13 +535,13 @@ public class EmlParser {
         return attachments;
     }
 
-    private static boolean isAttachment(String disposition, String filename, String contentType) {
+    private boolean isAttachment(String disposition, String filename, String contentType) {
         return (disposition.toLowerCase().contains(DISPOSITION_ATTACHMENT) && !filename.isEmpty())
                 || (!filename.isEmpty() && !contentType.toLowerCase().startsWith("text/"))
                 || (contentType.toLowerCase().contains("application/") && !filename.isEmpty());
     }
 
-    private static String extractFilenameFromDisposition(String disposition) {
+    private String extractFilenameFromDisposition(String disposition) {
         if (disposition == null || !disposition.contains("filename=")) {
             return "";
         }
@@ -575,7 +572,7 @@ public class EmlParser {
         return safeMimeDecode(filename);
     }
 
-    public static String safeMimeDecode(String headerValue) {
+    public String safeMimeDecode(String headerValue) {
         if (headerValue == null || headerValue.trim().isEmpty()) {
             return "";
         }
@@ -599,7 +596,7 @@ public class EmlParser {
         return EmlProcessingUtils.decodeMimeHeader(headerValue.trim());
     }
 
-    private static void initializeMimeUtilityDecoding() {
+    private void initializeMimeUtilityDecoding() {
         try {
             Class<?> mimeUtilityClass = Class.forName("jakarta.mail.internet.MimeUtility");
             mimeUtilityDecodeTextMethod = mimeUtilityClass.getMethod("decodeText", String.class);
@@ -610,7 +607,7 @@ public class EmlParser {
     }
 
     @Data
-    public static class EmailContent {
+    public class EmailContent {
         private String subject;
         private String from;
         private String to;
@@ -633,7 +630,7 @@ public class EmlParser {
     }
 
     @Data
-    public static class EmailAttachment {
+    public class EmailAttachment {
         private String filename;
         private String contentType;
         private byte[] data;

--- a/app/common/src/main/java/stirling/software/common/util/EmlProcessingUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/EmlProcessingUtils.java
@@ -102,9 +102,9 @@ public class EmlProcessingUtils {
     }
 
     public String generateEnhancedEmailHtml(
-        EmlParser.EmailContent content,
-        EmlToPdfRequest request,
-        CustomHtmlSanitizer customHtmlSanitizer) {
+            EmlParser.EmailContent content,
+            EmlToPdfRequest request,
+            CustomHtmlSanitizer customHtmlSanitizer) {
         StringBuilder html = new StringBuilder();
 
         html.append(
@@ -191,9 +191,9 @@ public class EmlProcessingUtils {
     }
 
     public String processEmailHtmlBody(
-        String htmlBody,
-        EmlParser.EmailContent emailContent,
-        CustomHtmlSanitizer customHtmlSanitizer) {
+            String htmlBody,
+            EmlParser.EmailContent emailContent,
+            CustomHtmlSanitizer customHtmlSanitizer) {
         if (htmlBody == null) return "";
 
         String processed =
@@ -209,8 +209,7 @@ public class EmlProcessingUtils {
         return processed;
     }
 
-    public String convertTextToHtml(
-        String textBody, CustomHtmlSanitizer customHtmlSanitizer) {
+    public String convertTextToHtml(String textBody, CustomHtmlSanitizer customHtmlSanitizer) {
         if (textBody == null) return "";
 
         String html =
@@ -377,10 +376,10 @@ public class EmlProcessingUtils {
     }
 
     private void appendAttachmentsSection(
-        StringBuilder html,
-        EmlParser.EmailContent content,
-        EmlToPdfRequest request,
-        CustomHtmlSanitizer customHtmlSanitizer) {
+            StringBuilder html,
+            EmlParser.EmailContent content,
+            EmlToPdfRequest request,
+            CustomHtmlSanitizer customHtmlSanitizer) {
         html.append("<div class=\"attachment-section\">\n");
         int displayedAttachmentCount =
                 content.getAttachmentCount() > 0

--- a/app/common/src/main/java/stirling/software/common/util/EmlProcessingUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/EmlProcessingUtils.java
@@ -19,21 +19,21 @@ import stirling.software.common.model.api.converters.HTMLToPdfRequest;
 public class EmlProcessingUtils {
 
     // Style constants
-    private static final int DEFAULT_FONT_SIZE = 12;
-    private static final String DEFAULT_FONT_FAMILY = "Helvetica, sans-serif";
-    private static final float DEFAULT_LINE_HEIGHT = 1.4f;
-    private static final String DEFAULT_ZOOM = "1.0";
-    private static final String DEFAULT_TEXT_COLOR = "#202124";
-    private static final String DEFAULT_BACKGROUND_COLOR = "#ffffff";
-    private static final String DEFAULT_BORDER_COLOR = "#e8eaed";
-    private static final String ATTACHMENT_BACKGROUND_COLOR = "#f9f9f9";
-    private static final String ATTACHMENT_BORDER_COLOR = "#eeeeee";
+    private final int DEFAULT_FONT_SIZE = 12;
+    private final String DEFAULT_FONT_FAMILY = "Helvetica, sans-serif";
+    private final float DEFAULT_LINE_HEIGHT = 1.4f;
+    private final String DEFAULT_ZOOM = "1.0";
+    private final String DEFAULT_TEXT_COLOR = "#202124";
+    private final String DEFAULT_BACKGROUND_COLOR = "#ffffff";
+    private final String DEFAULT_BORDER_COLOR = "#e8eaed";
+    private final String ATTACHMENT_BACKGROUND_COLOR = "#f9f9f9";
+    private final String ATTACHMENT_BORDER_COLOR = "#eeeeee";
 
-    private static final int EML_CHECK_LENGTH = 8192;
-    private static final int MIN_HEADER_COUNT_FOR_VALID_EML = 2;
+    private final int EML_CHECK_LENGTH = 8192;
+    private final int MIN_HEADER_COUNT_FOR_VALID_EML = 2;
 
     // MIME type detection
-    private static final Map<String, String> EXTENSION_TO_MIME_TYPE =
+    private final Map<String, String> EXTENSION_TO_MIME_TYPE =
             Map.of(
                     ".png", MediaType.IMAGE_PNG_VALUE,
                     ".jpg", MediaType.IMAGE_JPEG_VALUE,
@@ -46,7 +46,7 @@ public class EmlProcessingUtils {
                     ".tiff", "image/tiff",
                     ".tif", "image/tiff");
 
-    public static void validateEmlInput(byte[] emlBytes) {
+    public void validateEmlInput(byte[] emlBytes) {
         if (emlBytes == null || emlBytes.length == 0) {
             throw new IllegalArgumentException("EML file is empty or null");
         }
@@ -56,7 +56,7 @@ public class EmlProcessingUtils {
         }
     }
 
-    private static boolean isInvalidEmlFormat(byte[] emlBytes) {
+    private boolean isInvalidEmlFormat(byte[] emlBytes) {
         try {
             int checkLength = Math.min(emlBytes.length, EML_CHECK_LENGTH);
             String content;
@@ -101,10 +101,10 @@ public class EmlProcessingUtils {
         }
     }
 
-    public static String generateEnhancedEmailHtml(
-            EmlParser.EmailContent content,
-            EmlToPdfRequest request,
-            CustomHtmlSanitizer customHtmlSanitizer) {
+    public String generateEnhancedEmailHtml(
+        EmlParser.EmailContent content,
+        EmlToPdfRequest request,
+        CustomHtmlSanitizer customHtmlSanitizer) {
         StringBuilder html = new StringBuilder();
 
         html.append(
@@ -190,10 +190,10 @@ public class EmlProcessingUtils {
         return html.toString();
     }
 
-    public static String processEmailHtmlBody(
-            String htmlBody,
-            EmlParser.EmailContent emailContent,
-            CustomHtmlSanitizer customHtmlSanitizer) {
+    public String processEmailHtmlBody(
+        String htmlBody,
+        EmlParser.EmailContent emailContent,
+        CustomHtmlSanitizer customHtmlSanitizer) {
         if (htmlBody == null) return "";
 
         String processed =
@@ -209,8 +209,8 @@ public class EmlProcessingUtils {
         return processed;
     }
 
-    public static String convertTextToHtml(
-            String textBody, CustomHtmlSanitizer customHtmlSanitizer) {
+    public String convertTextToHtml(
+        String textBody, CustomHtmlSanitizer customHtmlSanitizer) {
         if (textBody == null) return "";
 
         String html =
@@ -234,7 +234,7 @@ public class EmlProcessingUtils {
         return html;
     }
 
-    private static void appendEnhancedStyles(StringBuilder html) {
+    private void appendEnhancedStyles(StringBuilder html) {
         String css =
                 String.format(
                         """
@@ -376,11 +376,11 @@ public class EmlProcessingUtils {
         html.append(css);
     }
 
-    private static void appendAttachmentsSection(
-            StringBuilder html,
-            EmlParser.EmailContent content,
-            EmlToPdfRequest request,
-            CustomHtmlSanitizer customHtmlSanitizer) {
+    private void appendAttachmentsSection(
+        StringBuilder html,
+        EmlParser.EmailContent content,
+        EmlToPdfRequest request,
+        CustomHtmlSanitizer customHtmlSanitizer) {
         html.append("<div class=\"attachment-section\">\n");
         int displayedAttachmentCount =
                 content.getAttachmentCount() > 0
@@ -441,7 +441,7 @@ public class EmlProcessingUtils {
         html.append("</div>\n");
     }
 
-    public static HTMLToPdfRequest createHtmlRequest(EmlToPdfRequest request) {
+    public HTMLToPdfRequest createHtmlRequest(EmlToPdfRequest request) {
         HTMLToPdfRequest htmlRequest = new HTMLToPdfRequest();
 
         if (request != null) {
@@ -452,7 +452,7 @@ public class EmlProcessingUtils {
         return htmlRequest;
     }
 
-    public static String detectMimeType(String filename, String existingMimeType) {
+    public String detectMimeType(String filename, String existingMimeType) {
         if (existingMimeType != null && !existingMimeType.isEmpty()) {
             return existingMimeType;
         }
@@ -469,7 +469,7 @@ public class EmlProcessingUtils {
         return MediaType.IMAGE_PNG_VALUE; // Default MIME type
     }
 
-    public static String decodeUrlEncoded(String encoded) {
+    public String decodeUrlEncoded(String encoded) {
         try {
             return java.net.URLDecoder.decode(encoded, StandardCharsets.UTF_8);
         } catch (Exception e) {
@@ -477,7 +477,7 @@ public class EmlProcessingUtils {
         }
     }
 
-    public static String decodeMimeHeader(String encodedText) {
+    public String decodeMimeHeader(String encodedText) {
         if (encodedText == null || encodedText.trim().isEmpty()) {
             return encodedText;
         }
@@ -535,7 +535,7 @@ public class EmlProcessingUtils {
         }
     }
 
-    private static String decodeQuotedPrintable(String encodedText, String charset) {
+    private String decodeQuotedPrintable(String encodedText, String charset) {
         StringBuilder result = new StringBuilder();
         for (int i = 0; i < encodedText.length(); i++) {
             char c = encodedText.charAt(i);
@@ -578,7 +578,7 @@ public class EmlProcessingUtils {
         }
     }
 
-    public static String escapeHtml(String text) {
+    public String escapeHtml(String text) {
         if (text == null) return "";
         return text.replace("&", "&amp;")
                 .replace("<", "&lt;")
@@ -587,7 +587,7 @@ public class EmlProcessingUtils {
                 .replace("'", "&#39;");
     }
 
-    public static String sanitizeText(String text, CustomHtmlSanitizer customHtmlSanitizer) {
+    public String sanitizeText(String text, CustomHtmlSanitizer customHtmlSanitizer) {
         if (customHtmlSanitizer != null) {
             return customHtmlSanitizer.sanitize(text);
         } else {
@@ -595,7 +595,7 @@ public class EmlProcessingUtils {
         }
     }
 
-    public static String simplifyHtmlContent(String htmlContent) {
+    public String simplifyHtmlContent(String htmlContent) {
         String simplified = htmlContent.replaceAll("(?i)<script[^>]*>.*?</script>", "");
         simplified = simplified.replaceAll("(?i)<style[^>]*>.*?</style>", "");
         return simplified;

--- a/app/common/src/main/java/stirling/software/common/util/EmlToPdf.java
+++ b/app/common/src/main/java/stirling/software/common/util/EmlToPdf.java
@@ -11,7 +11,7 @@ import stirling.software.common.service.CustomPDFDocumentFactory;
 @UtilityClass
 public class EmlToPdf {
 
-    public static String convertEmlToHtml(byte[] emlBytes, EmlToPdfRequest request)
+    public String convertEmlToHtml(byte[] emlBytes, EmlToPdfRequest request)
             throws IOException {
         EmlProcessingUtils.validateEmlInput(emlBytes);
 
@@ -20,14 +20,14 @@ public class EmlToPdf {
         return EmlProcessingUtils.generateEnhancedEmailHtml(emailContent, request, null);
     }
 
-    public static byte[] convertEmlToPdf(
-            String weasyprintPath,
-            EmlToPdfRequest request,
-            byte[] emlBytes,
-            String fileName,
-            CustomPDFDocumentFactory pdfDocumentFactory,
-            TempFileManager tempFileManager,
-            CustomHtmlSanitizer customHtmlSanitizer)
+    public byte[] convertEmlToPdf(
+        String weasyprintPath,
+        EmlToPdfRequest request,
+        byte[] emlBytes,
+        String fileName,
+        CustomPDFDocumentFactory pdfDocumentFactory,
+        TempFileManager tempFileManager,
+        CustomHtmlSanitizer customHtmlSanitizer)
             throws IOException, InterruptedException {
 
         EmlProcessingUtils.validateEmlInput(emlBytes);
@@ -63,20 +63,20 @@ public class EmlToPdf {
         }
     }
 
-    private static boolean shouldAttachFiles(
-            EmlParser.EmailContent emailContent, EmlToPdfRequest request) {
+    private boolean shouldAttachFiles(
+        EmlParser.EmailContent emailContent, EmlToPdfRequest request) {
         return emailContent != null
                 && request != null
                 && request.isIncludeAttachments()
                 && !emailContent.getAttachments().isEmpty();
     }
 
-    private static byte[] convertHtmlToPdf(
-            String weasyprintPath,
-            EmlToPdfRequest request,
-            String htmlContent,
-            TempFileManager tempFileManager,
-            CustomHtmlSanitizer customHtmlSanitizer)
+    private byte[] convertHtmlToPdf(
+        String weasyprintPath,
+        EmlToPdfRequest request,
+        String htmlContent,
+        TempFileManager tempFileManager,
+        CustomHtmlSanitizer customHtmlSanitizer)
             throws IOException, InterruptedException {
 
         var htmlRequest = EmlProcessingUtils.createHtmlRequest(request);

--- a/app/common/src/main/java/stirling/software/common/util/EmlToPdf.java
+++ b/app/common/src/main/java/stirling/software/common/util/EmlToPdf.java
@@ -11,8 +11,7 @@ import stirling.software.common.service.CustomPDFDocumentFactory;
 @UtilityClass
 public class EmlToPdf {
 
-    public String convertEmlToHtml(byte[] emlBytes, EmlToPdfRequest request)
-            throws IOException {
+    public String convertEmlToHtml(byte[] emlBytes, EmlToPdfRequest request) throws IOException {
         EmlProcessingUtils.validateEmlInput(emlBytes);
 
         EmlParser.EmailContent emailContent =
@@ -21,13 +20,13 @@ public class EmlToPdf {
     }
 
     public byte[] convertEmlToPdf(
-        String weasyprintPath,
-        EmlToPdfRequest request,
-        byte[] emlBytes,
-        String fileName,
-        CustomPDFDocumentFactory pdfDocumentFactory,
-        TempFileManager tempFileManager,
-        CustomHtmlSanitizer customHtmlSanitizer)
+            String weasyprintPath,
+            EmlToPdfRequest request,
+            byte[] emlBytes,
+            String fileName,
+            CustomPDFDocumentFactory pdfDocumentFactory,
+            TempFileManager tempFileManager,
+            CustomHtmlSanitizer customHtmlSanitizer)
             throws IOException, InterruptedException {
 
         EmlProcessingUtils.validateEmlInput(emlBytes);
@@ -64,7 +63,7 @@ public class EmlToPdf {
     }
 
     private boolean shouldAttachFiles(
-        EmlParser.EmailContent emailContent, EmlToPdfRequest request) {
+            EmlParser.EmailContent emailContent, EmlToPdfRequest request) {
         return emailContent != null
                 && request != null
                 && request.isIncludeAttachments()
@@ -72,11 +71,11 @@ public class EmlToPdf {
     }
 
     private byte[] convertHtmlToPdf(
-        String weasyprintPath,
-        EmlToPdfRequest request,
-        String htmlContent,
-        TempFileManager tempFileManager,
-        CustomHtmlSanitizer customHtmlSanitizer)
+            String weasyprintPath,
+            EmlToPdfRequest request,
+            String htmlContent,
+            TempFileManager tempFileManager,
+            CustomHtmlSanitizer customHtmlSanitizer)
             throws IOException, InterruptedException {
 
         var htmlRequest = EmlProcessingUtils.createHtmlRequest(request);

--- a/app/common/src/main/java/stirling/software/common/util/PdfAttachmentHandler.java
+++ b/app/common/src/main/java/stirling/software/common/util/PdfAttachmentHandler.java
@@ -57,9 +57,9 @@ public class PdfAttachmentHandler {
     private final float ANNOTATION_Y_OFFSET = 10f;
 
     public byte[] attachFilesToPdf(
-        byte[] pdfBytes,
-        List<EmlParser.EmailAttachment> attachments,
-        CustomPDFDocumentFactory pdfDocumentFactory)
+            byte[] pdfBytes,
+            List<EmlParser.EmailAttachment> attachments,
+            CustomPDFDocumentFactory pdfDocumentFactory)
             throws IOException {
 
         if (attachments == null || attachments.isEmpty()) {
@@ -180,8 +180,7 @@ public class PdfAttachmentHandler {
         return uniqueName;
     }
 
-    private @NotNull PDRectangle calculateAnnotationRectangle(
-        PDPage page, float x, float y) {
+    private @NotNull PDRectangle calculateAnnotationRectangle(PDPage page, float x, float y) {
         PDRectangle cropBox = page.getCropBox();
 
         // ISO 32000-1:2008 Section 8.3: PDF coordinate system transforms
@@ -242,8 +241,7 @@ public class PdfAttachmentHandler {
         return rect;
     }
 
-    public String processInlineImages(
-        String htmlContent, EmlParser.EmailContent emailContent) {
+    public String processInlineImages(String htmlContent, EmlParser.EmailContent emailContent) {
         if (htmlContent == null || emailContent == null) return htmlContent;
 
         Map<String, EmlParser.EmailAttachment> contentIdMap = new HashMap<>();
@@ -298,9 +296,9 @@ public class PdfAttachmentHandler {
     }
 
     private Map<Integer, String> addAttachmentsToDocumentWithMapping(
-        PDDocument document,
-        List<MultipartFile> attachments,
-        List<EmlParser.EmailAttachment> originalAttachments)
+            PDDocument document,
+            List<MultipartFile> attachments,
+            List<EmlParser.EmailAttachment> originalAttachments)
             throws IOException {
 
         PDDocumentCatalog catalog = document.getDocumentCatalog();
@@ -374,9 +372,9 @@ public class PdfAttachmentHandler {
     }
 
     private void addAttachmentAnnotationsToDocumentWithMapping(
-        PDDocument document,
-        List<EmlParser.EmailAttachment> attachments,
-        Map<Integer, String> indexToFilenameMap)
+            PDDocument document,
+            List<EmlParser.EmailAttachment> attachments,
+            Map<Integer, String> indexToFilenameMap)
             throws IOException {
 
         if (document.getNumberOfPages() == 0 || attachments == null || attachments.isEmpty()) {
@@ -422,7 +420,7 @@ public class PdfAttachmentHandler {
     }
 
     private EmlParser.EmailAttachment findAttachmentByFilename(
-        List<EmlParser.EmailAttachment> attachments, String targetFilename) {
+            List<EmlParser.EmailAttachment> attachments, String targetFilename) {
         if (targetFilename == null || targetFilename.trim().isEmpty()) {
             return null;
         }
@@ -454,7 +452,7 @@ public class PdfAttachmentHandler {
     }
 
     private String findEmbeddedFilenameForAttachment(
-        EmlParser.EmailAttachment attachment, Map<Integer, String> indexToFilenameMap) {
+            EmlParser.EmailAttachment attachment, Map<Integer, String> indexToFilenameMap) {
 
         String attachmentFilename = attachment.getFilename();
         if (attachmentFilename == null) {
@@ -483,13 +481,13 @@ public class PdfAttachmentHandler {
     }
 
     private void addAttachmentAnnotationToPageWithMapping(
-        PDDocument document,
-        PDPage page,
-        EmlParser.EmailAttachment attachment,
-        String embeddedFilename,
-        float x,
-        float y,
-        int attachmentIndex)
+            PDDocument document,
+            PDPage page,
+            EmlParser.EmailAttachment attachment,
+            String embeddedFilename,
+            float x,
+            float y,
+            int attachmentIndex)
             throws IOException {
 
         PDAnnotationFileAttachment fileAnnotation = new PDAnnotationFileAttachment();


### PR DESCRIPTION
# Description of Changes

Lombok marks all members of a utility class automatically as static, including fields and inner classes.[1]

Declaring member as static inside UtilityClass leads to less readable code (it might imply to people who are inexperienced with lombok that there are differences between static vs non-static code in lombok UtilityClasses when in fact there is none)  and more boilerplate (Lombok goals is to reduce boilerplate; unnecessary keywords go against that benefit), and according to the lombok docs [1], it is expected that these modifiers are not present (going against intended usage of Lombok might break with future updates.).


Source:
[1] https://projectlombok.org/features/experimental/UtilityClass

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
