### PR TITLE
fix: normalize path in ApplicationPropertiesLogicTest

### DIFF
--- a/app/common/src/test/java/stirling/software/common/model/ApplicationPropertiesLogicTest.java
+++ b/app/common/src/test/java/stirling/software/common/model/ApplicationPropertiesLogicTest.java
@@ -2,9 +2,11 @@ package stirling.software.common.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,22 +33,23 @@ class ApplicationPropertiesLogicTest {
 
     @Test
     void tempFileManagement_defaults_and_overrides() {
+        Function<String, String> normalize = s -> Paths.get(s).normalize().toString();
         ApplicationProperties.TempFileManagement tfm =
                 new ApplicationProperties.TempFileManagement();
 
         String expectedBase =
                 java.lang.System.getProperty("java.io.tmpdir").replaceAll("/+$", "")
                         + "/stirling-pdf";
-        assertEquals(expectedBase, tfm.getBaseTmpDir());
+        assertEquals(expectedBase, normalize.apply(tfm.getBaseTmpDir()));
 
         String expectedLibre = expectedBase + "/libreoffice";
-        assertEquals(expectedLibre, tfm.getLibreofficeDir());
+        assertEquals(expectedLibre, normalize.apply(tfm.getLibreofficeDir()));
 
         tfm.setBaseTmpDir("/custom/base");
-        assertEquals("/custom/base", tfm.getBaseTmpDir());
+        assertEquals("/custom/base", normalize.apply(tfm.getBaseTmpDir()));
 
         tfm.setLibreofficeDir("/opt/libre");
-        assertEquals("/opt/libre", tfm.getLibreofficeDir());
+        assertEquals("/opt/libre", normalize.apply(tfm.getLibreofficeDir()));
     }
 
     @Test


### PR DESCRIPTION
This fixes a failing unit test on macOS.

`ApplicationPropertiesLogicTest.tempFileManagement_defaults_and_overrides()` has 4 asserts that will fail with this error on macOS:

```
org.opentest4j.AssertionFailedError: expected: </var/folders/6d/12xt4b4m8xjf3t0059_w18bh0000gn/T/stirling-pdf> but was: </var/folders/6d/12xt4b4m8xjf3t0059_w18bh0000gn/T//stirling-pdf>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at app//stirling.software.common.model.ApplicationPropertiesLogicTest.tempFileManagement_defaults_and_overrides(ApplicationPropertiesLogicTest.java:40)
	at java.base@24.0.2/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base@24.0.2/java.util.ArrayList.forEach(ArrayList.java:1604)
	at java.base@24.0.2/java.util.ArrayList.forEach(ArrayList.java:1604)
```

Note the double `/` in the actual path here: `/T//stirling-pdf`.

# Description of Changes

The fix creates a lambda:

```
Function<String, String> normalize = s ->Paths.get(s).normalize().toString();
```
and applies it in all 4 broken tests.

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
