### PR TITLE
feat(replace-and-invert-colour): Add CMYK color space conversion with prepress preset for PDF processing

### DIFF
--- a/app/common/src/main/java/stirling/software/common/model/api/misc/ReplaceAndInvert.java
+++ b/app/common/src/main/java/stirling/software/common/model/api/misc/ReplaceAndInvert.java
@@ -4,4 +4,5 @@ public enum ReplaceAndInvert {
     HIGH_CONTRAST_COLOR,
     CUSTOM_COLOR,
     FULL_INVERSION,
+    COLOR_SPACE_CONVERSION,
 }

--- a/app/common/src/main/java/stirling/software/common/util/misc/ColorSpaceConversionStrategy.java
+++ b/app/common/src/main/java/stirling/software/common/util/misc/ColorSpaceConversionStrategy.java
@@ -1,0 +1,94 @@
+package stirling.software.common.util.misc;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.extern.slf4j.Slf4j;
+
+import stirling.software.common.model.api.misc.ReplaceAndInvert;
+import stirling.software.common.util.ProcessExecutor;
+import stirling.software.common.util.ProcessExecutor.ProcessExecutorResult;
+
+@Slf4j
+public class ColorSpaceConversionStrategy extends ReplaceAndInvertColorStrategy {
+
+    public ColorSpaceConversionStrategy(MultipartFile file, ReplaceAndInvert replaceAndInvert) {
+        super(file, replaceAndInvert);
+    }
+
+    @Override
+    public InputStreamResource replace() throws IOException {
+        Path tempInputFile = null;
+        Path tempOutputFile = null;
+
+        try {
+            tempInputFile = Files.createTempFile("colorspace_input_", ".pdf");
+            tempOutputFile = Files.createTempFile("colorspace_output_", ".pdf");
+
+            Files.write(tempInputFile, getFileInput().getBytes());
+
+            log.info("Starting CMYK color space conversion");
+
+            List<String> command = new ArrayList<>();
+            command.add("gs");
+            command.add("-sDEVICE=pdfwrite");
+            command.add("-dCompatibilityLevel=1.5");
+            command.add("-dPDFSETTINGS=/prepress");
+            command.add("-dNOPAUSE");
+            command.add("-dQUIET");
+            command.add("-dBATCH");
+            command.add("-sProcessColorModel=DeviceCMYK");
+            command.add("-sColorConversionStrategy=CMYK");
+            command.add("-sColorConversionStrategyForImages=CMYK");
+            command.add("-sOutputFile=" + tempOutputFile.toString());
+            command.add(tempInputFile.toString());
+
+            log.debug("Executing Ghostscript command for CMYK conversion: {}", command);
+
+            ProcessExecutorResult result =
+                    ProcessExecutor.getInstance(ProcessExecutor.Processes.GHOSTSCRIPT)
+                            .runCommandWithOutputHandling(command);
+
+            if (result.getRc() != 0) {
+                log.error(
+                        "Ghostscript CMYK conversion failed with return code: {}. Output: {}",
+                        result.getRc(),
+                        result.getMessages());
+                throw new IOException(
+                        "CMYK color space conversion failed: " + result.getMessages());
+            }
+
+            log.info("CMYK color space conversion completed successfully");
+
+            byte[] pdfBytes = Files.readAllBytes(tempOutputFile);
+            return new InputStreamResource(new ByteArrayInputStream(pdfBytes));
+
+        } catch (Exception e) {
+            log.warn("CMYK color space conversion failed", e);
+            throw new IOException(
+                    "Failed to convert PDF to CMYK color space: " + e.getMessage(), e);
+        } finally {
+            if (tempInputFile != null) {
+                try {
+                    Files.deleteIfExists(tempInputFile);
+                } catch (IOException e) {
+                    log.warn("Failed to delete temporary input file: {}", tempInputFile, e);
+                }
+            }
+            if (tempOutputFile != null) {
+                try {
+                    Files.deleteIfExists(tempOutputFile);
+                } catch (IOException e) {
+                    log.warn("Failed to delete temporary output file: {}", tempOutputFile, e);
+                }
+            }
+        }
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/Factories/ReplaceAndInvertColorFactory.java
+++ b/app/core/src/main/java/stirling/software/SPDF/Factories/ReplaceAndInvertColorFactory.java
@@ -5,6 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import stirling.software.common.model.api.misc.HighContrastColorCombination;
 import stirling.software.common.model.api.misc.ReplaceAndInvert;
+import stirling.software.common.util.misc.ColorSpaceConversionStrategy;
 import stirling.software.common.util.misc.CustomColorReplaceStrategy;
 import stirling.software.common.util.misc.InvertFullColorStrategy;
 import stirling.software.common.util.misc.ReplaceAndInvertColorStrategy;
@@ -19,21 +20,17 @@ public class ReplaceAndInvertColorFactory {
             String backGroundColor,
             String textColor) {
 
-        if (replaceAndInvertOption == ReplaceAndInvert.CUSTOM_COLOR
-                || replaceAndInvertOption == ReplaceAndInvert.HIGH_CONTRAST_COLOR) {
-
-            return new CustomColorReplaceStrategy(
-                    file,
-                    replaceAndInvertOption,
-                    textColor,
-                    backGroundColor,
-                    highContrastColorCombination);
-
-        } else if (replaceAndInvertOption == ReplaceAndInvert.FULL_INVERSION) {
-
-            return new InvertFullColorStrategy(file, replaceAndInvertOption);
-        }
-
-        return null;
+        return switch (replaceAndInvertOption) {
+            case CUSTOM_COLOR, HIGH_CONTRAST_COLOR ->
+                    new CustomColorReplaceStrategy(
+                            file,
+                            replaceAndInvertOption,
+                            textColor,
+                            backGroundColor,
+                            highContrastColorCombination);
+            case FULL_INVERSION -> new InvertFullColorStrategy(file, replaceAndInvertOption);
+            case COLOR_SPACE_CONVERSION ->
+                    new ColorSpaceConversionStrategy(file, replaceAndInvertOption);
+        };
     }
 }

--- a/app/core/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
+++ b/app/core/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
@@ -400,6 +400,7 @@ public class EndpointConfiguration {
         /* Ghostscript */
         addEndpointToGroup("Ghostscript", "repair");
         addEndpointToGroup("Ghostscript", "compress-pdf");
+        addEndpointToGroup("Ghostscript", "replace-invert-pdf");
 
         /* tesseract */
         addEndpointToGroup("tesseract", "ocr-pdf");

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ReplaceAndInvertColorController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ReplaceAndInvertColorController.java
@@ -31,8 +31,8 @@ public class ReplaceAndInvertColorController {
     @Operation(
             summary = "Replace-Invert Color PDF",
             description =
-                    "This endpoint accepts a PDF file and option of invert all colors or replace"
-                            + " text and background colors. Input:PDF Output:PDF Type:SISO")
+                    "This endpoint accepts a PDF file and provides options to invert all colors, replace"
+                            + " text and background colors, or convert to CMYK color space for printing. Input:PDF Output:PDF Type:SISO")
     public ResponseEntity<InputStreamResource> replaceAndInvertColor(
             @ModelAttribute ReplaceAndInvertColorRequest request) throws IOException {
 

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ReplaceAndInvertColorRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ReplaceAndInvertColorRequest.java
@@ -17,7 +17,12 @@ public class ReplaceAndInvertColorRequest extends PDFFile {
             description = "Replace and Invert color options of a pdf.",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "HIGH_CONTRAST_COLOR",
-            allowableValues = {"HIGH_CONTRAST_COLOR", "CUSTOM_COLOR", "FULL_INVERSION"})
+            allowableValues = {
+                "HIGH_CONTRAST_COLOR",
+                "CUSTOM_COLOR",
+                "FULL_INVERSION",
+                "COLOR_SPACE_CONVERSION"
+            })
     private ReplaceAndInvert replaceAndInvertOption;
 
     @Schema(

--- a/app/core/src/main/resources/messages_en_GB.properties
+++ b/app/core/src/main/resources/messages_en_GB.properties
@@ -878,6 +878,12 @@ replace-color.selectText.8=Yellow text on black background
 replace-color.selectText.9=Green text on black background
 replace-color.selectText.10=Choose text Colour
 replace-color.selectText.11=Choose background Colour
+replace-color.selectText.12=Colour Space Conversion (CMYK for Printing)
+replace-color.selectText.13=CMYK Colour Space Conversion
+replace-color.selectText.14=This option converts the PDF from RGB colour space to CMYK colour space, which is optimized for professional printing. This process:
+replace-color.selectText.15=Converts colours to CMYK (Cyan, Magenta, Yellow, Black) colour model used by professional printers
+replace-color.selectText.16=Optimizes the PDF for print production with prepress settings
+replace-color.selectText.17=May result in slight colour changes as CMYK has a smaller colour gamut than RGB
 replace-color.submit=Replace
 
 

--- a/app/core/src/main/resources/templates/misc/replace-color.html
+++ b/app/core/src/main/resources/templates/misc/replace-color.html
@@ -30,6 +30,7 @@
                                     <option value="HIGH_CONTRAST_COLOR" th:text="#{replace-color.selectText.2}" ></option>
                                     <option value="CUSTOM_COLOR" th:text="#{replace-color.selectText.3}"></option>
                                     <option value="FULL_INVERSION" th:text="#{replace-color.selectText.4}" selected></option>
+                                    <option th:text="#{replace-color.selectText.12}" value="COLOR_SPACE_CONVERSION"></option>
                                 </select>
                             </div>
                         </div>
@@ -56,6 +57,18 @@
                                 <input type="color" name="backGroundColor" id="bg-color" class="form-control">
                             </div>
                         </div>
+                        
+                        <div class="card mb-3" id="color-space-info" style="display: none">
+                            <div class="card-body">
+                                <h4 th:text="#{replace-color.selectText.13}"></h4>
+                                <p th:text="#{replace-color.selectText.14}"></p>
+                                <ul>
+                                    <li th:text="#{replace-color.selectText.15}"></li>
+                                    <li th:text="#{replace-color.selectText.16}"></li>
+                                    <li th:text="#{replace-color.selectText.17}"></li>
+                                </ul>
+                            </div>
+                        </div>
 
                         <button type="submit" id="submitBtn" class="btn btn-primary" th:text="#{replace-color.submit}"></button>
                     </form>
@@ -74,12 +87,15 @@
             $('#high-contrast-options').hide();
             $('#custom-color-1').hide();
             $('#custom-color-2').hide();
+            $('#color-space-info').hide();
 
             if (selectedOption === "HIGH_CONTRAST_COLOR") {
                 $('#high-contrast-options').show();
             } else if (selectedOption === "CUSTOM_COLOR") {
                 $('#custom-color-1').show();
                 $('#custom-color-2').show();
+            } else if (selectedOption === "COLOR_SPACE_CONVERSION") {
+                $('#color-space-info').show();
             }
         });
     });


### PR DESCRIPTION
# Description of Changes

This pull request introduces a new feature that allows users to convert PDF files from RGB to CMYK color space, optimizing them for professional printing.

### Backend

- Added a new enum value `COLOR_SPACE_CONVERSION` to `ReplaceAndInvert`, and created the `ColorSpaceConversionStrategy` class to handle the conversion using Ghostscript. This class manages temporary files, executes the conversion command, and handles errors.
- Updated the `ReplaceAndInvertColorFactory` to support the new strategy, using a switch expression to instantiate the correct color strategy based on the selected option.
- Extended the API request model (`ReplaceAndInvertColorRequest`) and controller documentation to include the new color space conversion option, making it selectable via the endpoint.
- Registered the new endpoint under the Ghostscript group in the application configuration for proper routing and grouping.

<img width="1492" height="915" alt="image" src="https://github.com/user-attachments/assets/86bf998a-2733-4b86-b0d8-008be355fbee" />


### UI
- Added UI elements and localized messages to present the CMYK conversion option in the color selection dropdown and display informative details about the process to the user. The frontend logic now shows/hides relevant info cards based on the selected option. 

<img width="668" height="674" alt="image" src="https://github.com/user-attachments/assets/1f379c29-21e2-43bc-b4ff-a3b5bd391ab5" />

### Sample file

[inverted-2.pdf](https://github.com/user-attachments/files/22537378/inverted-2.pdf)

### Verification

* gs provides script to check if PDF is actually CMYK;

> Output:
> mode: CMYK
> 0 bw: 
> 2 color: 1,2
> total: 2

(I think this means it works)


Closes #1249
<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
