### PR TITLE
refactor(frontend): standardize array type annotations to `T[]` across UI and hooks

### DIFF
--- a/frontend/src/components/shared/FileGrid.tsx
+++ b/frontend/src/components/shared/FileGrid.tsx
@@ -8,7 +8,7 @@ import { StirlingFileStub } from "../../types/fileContext";
 import { FileId } from "../../types/file";
 
 interface FileGridProps {
-  files: Array<{ file: File; record?: StirlingFileStub }>;
+  files: { file: File; record?: StirlingFileStub }[];
   onRemove?: (index: number) => void;
   onDoubleClick?: (item: { file: File; record?: StirlingFileStub }) => void;
   onView?: (item: { file: File; record?: StirlingFileStub }) => void;

--- a/frontend/src/components/toast/index.ts
+++ b/frontend/src/components/toast/index.ts
@@ -8,7 +8,7 @@ export { useToast, ToastProvider, ToastRenderer };
 let _api: ReturnType<typeof createImperativeApi> | null = null;
 
 function createImperativeApi() {
-  const subscribers: Array<(fn: any) => void> = [];
+  const subscribers: ((fn: any) => void)[] = [];
   let api: any = null;
   return {
     provide(instance: any) {

--- a/frontend/src/components/tools/SearchResults.tsx
+++ b/frontend/src/components/tools/SearchResults.tsx
@@ -9,7 +9,7 @@ import NoToolsFound from './shared/NoToolsFound';
 import "./toolPicker/ToolPicker.css";
 
 interface SearchResultsProps {
-  filteredTools: Array<{ item: [string, ToolRegistryEntry]; matchedText?: string }>;
+  filteredTools: { item: [string, ToolRegistryEntry]; matchedText?: string }[];
   onSelect: (id: string) => void;
   searchQuery?: string;
 }

--- a/frontend/src/components/tools/ToolPicker.tsx
+++ b/frontend/src/components/tools/ToolPicker.tsx
@@ -10,7 +10,7 @@ import { renderToolButtons } from "./shared/renderToolButtons";
 interface ToolPickerProps {
   selectedToolKey: string | null;
   onSelect: (id: string) => void;
-  filteredTools: Array<{ item: [string, ToolRegistryEntry]; matchedText?: string }>;
+  filteredTools: { item: [string, ToolRegistryEntry]; matchedText?: string }[];
   isSearching?: boolean;
 }
 

--- a/frontend/src/components/tools/changePermissions/ChangePermissionsSettings.test.tsx
+++ b/frontend/src/components/tools/changePermissions/ChangePermissionsSettings.test.tsx
@@ -34,7 +34,7 @@ describe('ChangePermissionsSettings', () => {
     );
 
     // Should render checkboxes for all permission types
-    const permissionKeys = Object.keys(defaultParameters) as Array<keyof ChangePermissionsParameters>;
+    const permissionKeys = Object.keys(defaultParameters) as (keyof ChangePermissionsParameters)[];
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(permissionKeys.length);
 
@@ -55,7 +55,7 @@ describe('ChangePermissionsSettings', () => {
       </TestWrapper>
     );
 
-    const permissionKeys = Object.keys(defaultParameters) as Array<keyof ChangePermissionsParameters>;
+    const permissionKeys = Object.keys(defaultParameters) as (keyof ChangePermissionsParameters)[];
 
     permissionKeys.forEach(permission => {
       expect(screen.getByText(`mock-changePermissions.permissions.${permission}.label`)).toBeInTheDocument();
@@ -183,13 +183,13 @@ describe('ChangePermissionsSettings', () => {
       </TestWrapper>
     );
 
-    const permissionKeys = Object.keys(defaultParameters) as Array<keyof ChangePermissionsParameters>;
+    const permissionKeys = Object.keys(defaultParameters) as (keyof ChangePermissionsParameters)[];
     permissionKeys.forEach(permission => {
       expect(mockT).toHaveBeenCalledWith(`changePermissions.permissions.${permission}.label`, permission);
     });
   });
 
-  test.each(Object.keys(defaultParameters) as Array<keyof ChangePermissionsParameters>)('should handle %s permission type individually', (permission) => {
+  test.each(Object.keys(defaultParameters) as (keyof ChangePermissionsParameters)[])('should handle %s permission type individually', (permission) => {
     const testParameters: ChangePermissionsParameters = {
       ...defaultParameters,
       [permission]: true

--- a/frontend/src/components/tools/changePermissions/ChangePermissionsSettings.tsx
+++ b/frontend/src/components/tools/changePermissions/ChangePermissionsSettings.tsx
@@ -14,7 +14,7 @@ const ChangePermissionsSettings = ({ parameters, onParameterChange, disabled = f
   return (
     <Stack gap="sm">
       <Stack gap="xs">
-        {(Object.keys(parameters) as Array<keyof ChangePermissionsParameters>).map((key) => (
+        {(Object.keys(parameters) as (keyof ChangePermissionsParameters)[]).map((key) => (
           <Checkbox
             key={key}
             label={t(`changePermissions.permissions.${key}.label`, key)}

--- a/frontend/src/components/tools/convert/ConvertSettings.tsx
+++ b/frontend/src/components/tools/convert/ConvertSettings.tsx
@@ -27,7 +27,7 @@ import { StirlingFile } from "../../../types/fileContext";
 interface ConvertSettingsProps {
   parameters: ConvertParameters;
   onParameterChange: <K extends keyof ConvertParameters>(key: K, value: ConvertParameters[K]) => void;
-  getAvailableToExtensions: (fromExtension: string) => Array<{value: string, label: string, group: string}>;
+  getAvailableToExtensions: (fromExtension: string) => {value: string, label: string, group: string}[];
   selectedFiles: StirlingFile[];
   disabled?: boolean;
 }

--- a/frontend/src/components/tools/sanitize/SanitizeSettings.tsx
+++ b/frontend/src/components/tools/sanitize/SanitizeSettings.tsx
@@ -11,7 +11,7 @@ interface SanitizeSettingsProps {
 const SanitizeSettings = ({ parameters, onParameterChange, disabled = false }: SanitizeSettingsProps) => {
   const { t } = useTranslation();
 
-  const options = (Object.keys(defaultParameters) as Array<keyof SanitizeParameters>).map((key) => ({
+  const options = (Object.keys(defaultParameters) as (keyof SanitizeParameters)[]).map((key) => ({
     key: key,
     label: t(`sanitize.options.${key}`, key),
     description: t(`sanitize.options.${key}.desc`, `${key} from the PDF`),

--- a/frontend/src/components/tools/shared/renderToolButtons.tsx
+++ b/frontend/src/components/tools/shared/renderToolButtons.tsx
@@ -14,7 +14,7 @@ export const renderToolButtons = (
   onSelect: (id: string) => void,
   showSubcategoryHeader: boolean = true,
   disableNavigation: boolean = false,
-  searchResults?: Array<{ item: [string, any]; matchedText?: string }>
+  searchResults?: { item: [string, any]; matchedText?: string }[]
 ) => {
   // Create a map of matched text for quick lookup
   const matchedTextMap = new Map<string, string>();

--- a/frontend/src/components/viewer/CustomSearchLayer.tsx
+++ b/frontend/src/components/viewer/CustomSearchLayer.tsx
@@ -14,13 +14,13 @@ interface SearchLayerProps {
 }
 
 interface SearchResultState {
-  results: Array<{
+  results: {
     pageIndex: number;
-    rects: Array<{
+    rects: {
       origin: { x: number; y: number };
       size: { width: number; height: number };
-    }>;
-  }>;
+    }[];
+  }[];
   activeResultIndex?: number;
 }
 

--- a/frontend/src/components/viewer/LocalEmbedPDF.tsx
+++ b/frontend/src/components/viewer/LocalEmbedPDF.tsx
@@ -50,7 +50,7 @@ interface LocalEmbedPDFProps {
 
 export function LocalEmbedPDF({ file, url, enableSignature = false, onSignatureAdded, signatureApiRef, historyApiRef }: LocalEmbedPDFProps) {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
-  const [, setAnnotations] = useState<Array<{id: string, pageIndex: number, rect: any}>>([]);
+  const [, setAnnotations] = useState<{id: string, pageIndex: number, rect: any}[]>([]);
 
   // Convert File to URL if needed
   useEffect(() => {

--- a/frontend/src/components/viewer/SearchAPIBridge.tsx
+++ b/frontend/src/components/viewer/SearchAPIBridge.tsx
@@ -4,10 +4,10 @@ import { useViewer } from '../../contexts/ViewerContext';
 
 interface SearchResult {
   pageIndex: number;
-  rects: Array<{
+  rects: {
     origin: { x: number; y: number };
     size: { width: number; height: number };
-  }>;
+  }[];
 }
 
 /**

--- a/frontend/src/contexts/ToolWorkflowContext.tsx
+++ b/frontend/src/contexts/ToolWorkflowContext.tsx
@@ -101,7 +101,7 @@ interface ToolWorkflowContextValue extends ToolWorkflowState {
   handleReaderToggle: () => void;
 
   // Computed values
-  filteredTools: Array<{ item: [string, ToolRegistryEntry]; matchedText?: string }>; // Filtered by search
+  filteredTools: { item: [string, ToolRegistryEntry]; matchedText?: string }[]; // Filtered by search
   isPanelVisible: boolean;
 }
 

--- a/frontend/src/contexts/ViewerContext.tsx
+++ b/frontend/src/contexts/ViewerContext.tsx
@@ -88,10 +88,10 @@ interface RotationState {
 
 interface SearchResult {
   pageIndex: number;
-  rects: Array<{
+  rects: {
     origin: { x: number; y: number };
     size: { width: number; height: number };
-  }>;
+  }[];
 }
 
 interface SearchState {

--- a/frontend/src/contexts/file/fileActions.ts
+++ b/frontend/src/contexts/file/fileActions.ts
@@ -25,7 +25,7 @@ const DEBUG = process.env.NODE_ENV === 'development';
  */
 class SimpleMutex {
   private locked = false;
-  private queue: Array<() => void> = [];
+  private queue: (() => void)[] = [];
 
   async lock(): Promise<void> {
     if (!this.locked) {
@@ -151,7 +151,7 @@ interface AddFileOptions {
   files?: File[];
 
   // For 'processed' files
-  filesWithThumbnails?: Array<{ file: File; thumbnail?: string; pageCount?: number }>;
+  filesWithThumbnails?: { file: File; thumbnail?: string; pageCount?: number }[];
 
   // Insertion position
   insertAfterPageId?: string;
@@ -355,7 +355,7 @@ export async function consumeFiles(
  * Helper function to restore files to filesRef and manage IndexedDB cleanup
  */
 async function restoreFilesAndCleanup(
-  filesToRestore: Array<{ file: File; record: StirlingFileStub }>,
+  filesToRestore: { file: File; record: StirlingFileStub }[],
   fileIdsToRemove: FileId[],
   filesRef: React.MutableRefObject<Map<FileId, File>>,
   indexedDB?: { deleteFile: (fileId: FileId) => Promise<void> } | null

--- a/frontend/src/contexts/file/fileSelectors.ts
+++ b/frontend/src/contexts/file/fileSelectors.ts
@@ -111,7 +111,7 @@ export function buildQuickKeySet(stirlingFileStubs: Record<FileId, StirlingFileS
 /**
  * Helper for building quickKey sets from IndexedDB metadata
  */
-export function buildQuickKeySetFromMetadata(metadata: Array<{ name: string; size: number; lastModified: number }>): Set<string> {
+export function buildQuickKeySetFromMetadata(metadata: { name: string; size: number; lastModified: number }[]): Set<string> {
   const quickKeys = new Set<string>();
   metadata.forEach(meta => {
     // Format: name|size|lastModified (same as createQuickKey)

--- a/frontend/src/hooks/tools/addPassword/useAddPasswordParameters.test.ts
+++ b/frontend/src/hooks/tools/addPassword/useAddPasswordParameters.test.ts
@@ -125,7 +125,7 @@ describe('useAddPasswordParameters', () => {
     expect(result.current.validateParameters()).toBe(true);
   });
 
-  test.each(Object.keys(defaultChangePermissionsParameters) as Array<keyof ChangePermissionsParameters>)('should handle boolean restriction parameter %s', (param) => {
+  test.each(Object.keys(defaultChangePermissionsParameters) as (keyof ChangePermissionsParameters)[])('should handle boolean restriction parameter %s', (param) => {
     const { result } = renderHook(() => useAddPasswordParameters());
 
     act(() => {

--- a/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.test.ts
+++ b/frontend/src/hooks/tools/changePermissions/useChangePermissionsOperation.test.ts
@@ -96,7 +96,7 @@ describe('useChangePermissionsOperation', () => {
     // Verify the form data contains the file
     expect(formData.get('fileInput')).toBe(testFile);
 
-    (Object.keys(testParameters) as Array<keyof ChangePermissionsParameters>).forEach(key => {
+    (Object.keys(testParameters) as (keyof ChangePermissionsParameters)[]).forEach(key => {
       expect(formData.get(key), `Parameter ${key} should be set correctly`).toBe(testParameters[key].toString());
     });
   });

--- a/frontend/src/hooks/tools/changePermissions/useChangePermissionsParameters.test.ts
+++ b/frontend/src/hooks/tools/changePermissions/useChangePermissionsParameters.test.ts
@@ -30,7 +30,7 @@ describe('useChangePermissionsParameters', () => {
   test('should update all permission parameters', () => {
     const { result } = renderHook(() => useChangePermissionsParameters());
 
-    const permissionKeys = Object.keys(defaultParameters) as Array<keyof ChangePermissionsParameters>;
+    const permissionKeys = Object.keys(defaultParameters) as (keyof ChangePermissionsParameters)[];
 
     // Set all to true
     act(() => {
@@ -99,7 +99,7 @@ describe('useChangePermissionsParameters', () => {
 
     // Set all restrictions - should still be valid
     act(() => {
-      const permissionKeys = Object.keys(defaultParameters) as Array<keyof ChangePermissionsParameters>;
+      const permissionKeys = Object.keys(defaultParameters) as (keyof ChangePermissionsParameters)[];
       permissionKeys.forEach(key => {
         result.current.updateParameter(key, true);
       });

--- a/frontend/src/hooks/tools/convert/useConvertParameters.ts
+++ b/frontend/src/hooks/tools/convert/useConvertParameters.ts
@@ -42,8 +42,8 @@ export interface ConvertParameters extends BaseParameters {
 
 export interface ConvertParametersHook extends BaseParametersHook<ConvertParameters> {
   getEndpoint: () => string;
-  getAvailableToExtensions: (fromExtension: string) => Array<{value: string, label: string, group: string}>;
-  analyzeFileTypes: (files: Array<{name: string}>) => void;
+  getAvailableToExtensions: (fromExtension: string) => {value: string, label: string, group: string}[];
+  analyzeFileTypes: (files: {name: string}[]) => void;
 }
 
 export const defaultParameters: ConvertParameters = {
@@ -157,7 +157,7 @@ export const useConvertParameters = (): ConvertParametersHook => {
   const getAvailableToExtensions = getAvailableToExtensionsUtil;
 
 
-  const analyzeFileTypes = useCallback((files: Array<{name: string}>) => {
+  const analyzeFileTypes = useCallback((files: {name: string}[]) => {
     if (files.length === 0) {
       // No files - only reset smart detection, keep user's format choices
       baseHook.setParameters(prev => {

--- a/frontend/src/hooks/tools/convert/useConvertParametersAutoDetection.test.ts
+++ b/frontend/src/hooks/tools/convert/useConvertParametersAutoDetection.test.ts
@@ -345,7 +345,7 @@ describe('useConvertParameters - Auto Detection & Smart Conversion', () => {
     test('should handle malformed file objects', () => {
       const { result } = renderHook(() => useConvertParameters());
 
-      const malformedFiles: Array<{name: string}> = [
+      const malformedFiles: {name: string}[] = [
         { name: 'valid.pdf' },
         // @ts-expect-error - Testing runtime resilience
         { name: null },

--- a/frontend/src/hooks/useToolSections.ts
+++ b/frontend/src/hooks/useToolSections.ts
@@ -4,7 +4,7 @@ import { SUBCATEGORY_ORDER, SubcategoryId, ToolCategoryId, ToolRegistryEntry } f
 import { useTranslation } from 'react-i18next';
 
 type SubcategoryIdMap = {
-  [subcategoryId in SubcategoryId]: Array<{ id: string /* FIX ME: Should be ToolId */; tool: ToolRegistryEntry }>;
+  [subcategoryId in SubcategoryId]: { id: string /* FIX ME: Should be ToolId */; tool: ToolRegistryEntry }[];
 }
 
 type GroupedTools = {
@@ -28,7 +28,7 @@ export interface ToolSection {
 };
 
 export function useToolSections(
-  filteredTools: Array<{ item: [string /* FIX ME: Should be ToolId */, ToolRegistryEntry]; matchedText?: string }>,
+  filteredTools: { item: [string /* FIX ME: Should be ToolId */, ToolRegistryEntry]; matchedText?: string }[],
   searchQuery?: string
 ) {
   const { t } = useTranslation();

--- a/frontend/src/services/automationStorage.ts
+++ b/frontend/src/services/automationStorage.ts
@@ -6,10 +6,10 @@ export interface AutomationConfig {
   id: string;
   name: string;
   description?: string;
-  operations: Array<{
+  operations: {
     operation: string;
     parameters: any;
-  }>;
+  }[];
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/services/fileProcessingService.ts
+++ b/frontend/src/services/fileProcessingService.ts
@@ -10,12 +10,12 @@ import { FileId } from '../types/file';
 
 export interface ProcessedFileMetadata {
   totalPages: number;
-  pages: Array<{
+  pages: {
     pageNumber: number;
     thumbnail?: string;
     rotation: number;
     splitBefore: boolean;
-  }>;
+  }[];
   thumbnailUrl?: string; // Page 1 thumbnail for FileEditor
   lastProcessed: number;
 }

--- a/frontend/src/tests/utils/testFileHelpers.ts
+++ b/frontend/src/tests/utils/testFileHelpers.ts
@@ -20,7 +20,7 @@ export function createTestStirlingFile(
  * Create multiple StirlingFile objects for testing
  */
 export function createTestFilesWithId(
-  files: Array<{ name: string; content?: string; type?: string }>
+  files: { name: string; content?: string; type?: string }[]
 ): StirlingFile[] {
   return files.map(({ name, content = 'test content', type = 'application/pdf' }) =>
     createTestStirlingFile(name, content, type)

--- a/frontend/src/utils/convertUtils.ts
+++ b/frontend/src/utils/convertUtils.ts
@@ -64,7 +64,7 @@ export const isWebFormat = (extension: string): boolean => {
  * Gets available target extensions for a given source extension
  * Extracted from useConvertParameters to be reusable in automation settings
  */
-export const getAvailableToExtensions = (fromExtension: string): Array<{value: string, label: string, group: string}> => {
+export const getAvailableToExtensions = (fromExtension: string): {value: string, label: string, group: string}[] => {
   if (!fromExtension) return [];
 
   // Handle dynamic format identifiers (file-<extension>)

--- a/frontend/src/utils/fuzzySearch.ts
+++ b/frontend/src/utils/fuzzySearch.ts
@@ -82,8 +82,8 @@ export function isFuzzyMatch(query: string, target: string, minScore?: number): 
 }
 
 // Convenience: rank a list of items by best score across provided getters
-export function rankByFuzzy<T>(items: T[], query: string, getters: Array<(item: T) => string>, minScore?: number): Array<{ item: T; score: number; matchedText?: string }>{
-  const results: Array<{ item: T; score: number; matchedText?: string }> = [];
+export function rankByFuzzy<T>(items: T[], query: string, getters: ((item: T) => string)[], minScore?: number): { item: T; score: number; matchedText?: string }[]{
+  const results: { item: T; score: number; matchedText?: string }[] = [];
   const threshold = typeof minScore === 'number' ? minScore : minScoreForQuery(query);
   for (const item of items) {
     let best = 0;

--- a/frontend/src/utils/signatureFlattening.ts
+++ b/frontend/src/utils/signatureFlattening.ts
@@ -27,7 +27,7 @@ export async function flattenSignatures(options: SignatureFlatteningOptions): Pr
 
   try {
     // Step 1: Extract all annotations from EmbedPDF before export
-    const allAnnotations: Array<{pageIndex: number, annotations: any[]}> = [];
+    const allAnnotations: {pageIndex: number, annotations: any[]}[] = [];
 
     if (signatureApiRef?.current) {
 

--- a/frontend/src/utils/toolSearch.ts
+++ b/frontend/src/utils/toolSearch.ts
@@ -18,10 +18,10 @@ export function filterToolRegistryByQuery(
   const nq = normalizeForSearch(query);
   const threshold = minScoreForQuery(query);
 
-  const exactName: Array<{ id: string; tool: ToolRegistryEntry; pos: number }> = [];
-  const exactSyn: Array<{ id: string; tool: ToolRegistryEntry; text: string; pos: number }> = [];
-  const fuzzyName: Array<{ id: string; tool: ToolRegistryEntry; score: number; text: string }> = [];
-  const fuzzySyn: Array<{ id: string; tool: ToolRegistryEntry; score: number; text: string }> = [];
+  const exactName: { id: string; tool: ToolRegistryEntry; pos: number }[] = [];
+  const exactSyn: { id: string; tool: ToolRegistryEntry; text: string; pos: number }[] = [];
+  const fuzzyName: { id: string; tool: ToolRegistryEntry; score: number; text: string }[] = [];
+  const fuzzySyn: { id: string; tool: ToolRegistryEntry; score: number; text: string }[] = [];
 
   for (const [id, tool] of entries) {
     const nameNorm = normalizeForSearch(tool.name || '');


### PR DESCRIPTION
# Description of Changes

**What was changed**
- Replaced `Array<T>` with `T[]` in TypeScript code across the frontend to adopt a single, concise array type style.
  - Components (e.g., `FileGrid`, `SearchResults`, `ToolPicker`) now use `T[]` for props and state.
  - Contexts, hooks, utilities, services, and tests updated accordingly (e.g., `ViewerContext`, `useConvertParameters`, `fuzzySearch`, `fileActions`, `automationStorage`).
- Adjusted type assertions related to `Object.keys(...)` to use `(keyof X)[]` instead of `Array<keyof X>` for accuracy and readability in several modules and tests.

**Why the change was made**
- Improves readability and consistency by using the idiomatic `T[]` syntax.
- Reduces verbosity, especially in nested or higher-order generics.
- Aligns type assertions with current TypeScript best practices (e.g., `(keyof X)[]`), decreasing friction with inference and editor tooling.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
