### PR TITLE
refactor(types): deduplicate `AutomateParameters` definition in automation types

### DIFF
--- a/frontend/src/types/automation.ts
+++ b/frontend/src/types/automation.ts
@@ -66,8 +66,3 @@ export interface SuggestedAutomation {
   updatedAt: string;
   icon: any; // MUI Icon component
 }
-
-// Export the AutomateParameters interface that was previously defined inline
-export interface AutomateParameters extends AutomationExecutionCallbacks {
-  automationConfig?: AutomationConfig;
-}


### PR DESCRIPTION
# Description of Changes

- Removed duplicate `AutomateParameters` interface from `frontend/src/types/automation.ts`
- The interface was already defined earlier in the same file, leading to redundancy
- Keeps type definitions consistent and avoids confusion

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
