### PR TITLE
Add tool hotkey support and settings customization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { ToolWorkflowProvider } from "./contexts/ToolWorkflowContext";
 import { SidebarProvider } from "./contexts/SidebarContext";
 import ErrorBoundary from "./components/shared/ErrorBoundary";
 import HomePage from "./pages/HomePage";
+import { HotkeysProvider } from "./contexts/HotkeysContext";
 
 // Import global styles
 import "./styles/tailwind.css";
@@ -44,15 +45,17 @@ export default function App() {
             <NavigationProvider>
               <FilesModalProvider>
                 <ToolWorkflowProvider>
-                  <SidebarProvider>
-                    <ViewerProvider>
-                      <SignatureProvider>
-                      <RightRailProvider>
-                            <HomePage />
-                          </RightRailProvider>
-                      </SignatureProvider>
-                    </ViewerProvider>
-                  </SidebarProvider>
+                  <HotkeysProvider>
+                    <SidebarProvider>
+                      <ViewerProvider>
+                        <SignatureProvider>
+                        <RightRailProvider>
+                              <HomePage />
+                            </RightRailProvider>
+                        </SignatureProvider>
+                      </ViewerProvider>
+                    </SidebarProvider>
+                  </HotkeysProvider>
                 </ToolWorkflowProvider>
               </FilesModalProvider>
             </NavigationProvider>

--- a/frontend/src/components/shared/AppConfigModal.tsx
+++ b/frontend/src/components/shared/AppConfigModal.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Modal, Button, Stack, Text, Code, ScrollArea, Group, Badge, Alert, Loader } from '@mantine/core';
+import React, { useEffect, useState } from 'react';
+import { Modal, Button, Stack, Text, Code, ScrollArea, Group, Badge, Alert, Loader, Tabs } from '@mantine/core';
 import { useAppConfig } from '../../hooks/useAppConfig';
+import HotkeySettings from './settings/HotkeySettings';
 
 interface AppConfigModalProps {
   opened: boolean;
@@ -9,6 +10,13 @@ interface AppConfigModalProps {
 
 const AppConfigModal: React.FC<AppConfigModalProps> = ({ opened, onClose }) => {
   const { config, loading, error, refetch } = useAppConfig();
+  const [activeTab, setActiveTab] = useState<string>('configuration');
+
+  useEffect(() => {
+    if (!opened) {
+      setActiveTab('configuration');
+    }
+  }, [opened]);
 
   const renderConfigSection = (title: string, data: any) => {
     if (!data || typeof data !== 'object') return null;
@@ -22,15 +30,15 @@ const AppConfigModal: React.FC<AppConfigModalProps> = ({ opened, onClose }) => {
               <Text size="sm" w={150} style={{ flexShrink: 0 }} c="dimmed">
                 {key}:
               </Text>
-                {typeof value === 'boolean' ? (
-                  <Badge color={value ? 'green' : 'red'} size="sm">
-                    {value ? 'true' : 'false'}
-                  </Badge>
-                ) : typeof value === 'object' ? (
-                  <Code block>{JSON.stringify(value, null, 2)}</Code>
-                ) : (
-                  String(value) || 'null'
-                )}
+              {typeof value === 'boolean' ? (
+                <Badge color={value ? 'green' : 'red'} size="sm">
+                  {value ? 'true' : 'false'}
+                </Badge>
+              ) : typeof value === 'object' ? (
+                <Code block>{JSON.stringify(value, null, 2)}</Code>
+              ) : (
+                String(value) || 'null'
+              )}
             </Group>
           ))}
         </Stack>
@@ -80,59 +88,78 @@ const AppConfigModal: React.FC<AppConfigModalProps> = ({ opened, onClose }) => {
     <Modal
       opened={opened}
       onClose={onClose}
-      title="App Configuration (Testing)"
+      title="Settings"
       size="lg"
       style={{ zIndex: 1000 }}
     >
-      <Stack>
-        <Group justify="space-between">
-          <Text size="sm" c="dimmed">
-            This modal shows the current application configuration for testing purposes only.
-          </Text>
-          <Button size="xs" variant="light" onClick={refetch}>
-            Refresh
-          </Button>
-        </Group>
+      <Tabs value={activeTab} onChange={value => value && setActiveTab(value)}>
+        <Tabs.List>
+          <Tabs.Tab value="configuration">Configuration</Tabs.Tab>
+          <Tabs.Tab value="hotkeys">Hotkeys</Tabs.Tab>
+        </Tabs.List>
 
-        {loading && (
-          <Stack align="center" py="md">
-            <Loader size="sm" />
-            <Text size="sm" c="dimmed">Loading configuration...</Text>
-          </Stack>
-        )}
+        <Tabs.Panel value="configuration" pt="md">
+          <Stack>
+            <Group justify="space-between">
+              <Text size="sm" c="dimmed">
+                Review the current application configuration pulled from the server.
+              </Text>
+              <Button size="xs" variant="light" onClick={refetch}>
+                Refresh
+              </Button>
+            </Group>
 
-        {error && (
-          <Alert color="red" title="Error">
-            {error}
-          </Alert>
-        )}
-
-        {config && (
-          <ScrollArea h={400}>
-            <Stack gap="lg">
-              {renderConfigSection('Basic Configuration', basicConfig)}
-              {renderConfigSection('Security Configuration', securityConfig)}
-              {renderConfigSection('System Configuration', systemConfig)}
-              {renderConfigSection('Premium/Enterprise Configuration', premiumConfig)}
-              {renderConfigSection('Integration Configuration', integrationConfig)}
-              {renderConfigSection('Legal Configuration', legalConfig)}
-              
-              {config.error && (
-                <Alert color="yellow" title="Configuration Warning">
-                  {config.error}
-                </Alert>
-              )}
-
-              <Stack gap="xs">
-                <Text fw={600} size="md" c="blue">Raw Configuration</Text>
-                <Code block style={{ fontSize: '11px' }}>
-                  {JSON.stringify(config, null, 2)}
-                </Code>
+            {loading && (
+              <Stack align="center" py="md">
+                <Loader size="sm" />
+                <Text size="sm" c="dimmed">Loading configuration...</Text>
               </Stack>
-            </Stack>
-          </ScrollArea>
-        )}
-      </Stack>
+            )}
+
+            {error && (
+              <Alert color="red" title="Error">
+                {error}
+              </Alert>
+            )}
+
+            {!loading && !error && !config && (
+              <Alert color="yellow" title="Configuration unavailable">
+                The application configuration could not be loaded.
+              </Alert>
+            )}
+
+            {config && (
+              <ScrollArea h={400}>
+                <Stack gap="lg">
+                  {renderConfigSection('Basic Configuration', basicConfig)}
+                  {renderConfigSection('Security Configuration', securityConfig)}
+                  {renderConfigSection('System Configuration', systemConfig)}
+                  {renderConfigSection('Premium/Enterprise Configuration', premiumConfig)}
+                  {renderConfigSection('Integration Configuration', integrationConfig)}
+                  {renderConfigSection('Legal Configuration', legalConfig)}
+
+                  {config.error && (
+                    <Alert color="yellow" title="Configuration Warning">
+                      {config.error}
+                    </Alert>
+                  )}
+
+                  <Stack gap="xs">
+                    <Text fw={600} size="md" c="blue">Raw Configuration</Text>
+                    <Code block style={{ fontSize: '11px' }}>
+                      {JSON.stringify(config, null, 2)}
+                    </Code>
+                  </Stack>
+                </Stack>
+              </ScrollArea>
+            )}
+          </Stack>
+        </Tabs.Panel>
+
+        <Tabs.Panel value="hotkeys" pt="md">
+          <HotkeySettings />
+        </Tabs.Panel>
+      </Tabs>
     </Modal>
   );
 };

--- a/frontend/src/components/shared/QuickAccessBar.tsx
+++ b/frontend/src/components/shared/QuickAccessBar.tsx
@@ -12,6 +12,7 @@ import { ButtonConfig } from '../../types/sidebar';
 import './quickAccessBar/QuickAccessBar.css';
 import AllToolsNavButton from './AllToolsNavButton';
 import ActiveToolButton from "./quickAccessBar/ActiveToolButton";
+import AppConfigModal from './AppConfigModal';
 import {
   isNavButtonActive,
   getNavButtonStyle,
@@ -241,10 +242,10 @@ const QuickAccessBar = forwardRef<HTMLDivElement>((_, ref) => {
         </div>
       </div>
 
-      {/* <AppConfigModal
+      <AppConfigModal
         opened={configModalOpen}
         onClose={() => setConfigModalOpen(false)}
-      /> */}
+      />
     </div>
   );
 });

--- a/frontend/src/components/shared/settings/HotkeySettings.tsx
+++ b/frontend/src/components/shared/settings/HotkeySettings.tsx
@@ -1,0 +1,210 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Badge, Button, Group, ScrollArea, Stack, Table, Text } from '@mantine/core';
+import { useHotkeysContext, Hotkey } from '../../../contexts/HotkeysContext';
+import { useToolWorkflow } from '../../../contexts/ToolWorkflowContext';
+
+const areHotkeysEqual = (a?: Hotkey, b?: Hotkey): boolean => {
+  if (!a || !b) return false;
+  return (
+    a.code === b.code &&
+    a.altKey === b.altKey &&
+    a.ctrlKey === b.ctrlKey &&
+    a.metaKey === b.metaKey &&
+    a.shiftKey === b.shiftKey
+  );
+};
+
+const HotkeySettings: React.FC = () => {
+  const {
+    hotkeys,
+    defaultHotkeys,
+    formatHotkeyParts,
+    setHotkey,
+    resetHotkey,
+    resetAllHotkeys,
+    isHotkeyInUse,
+    suspendHotkeys,
+    createHotkeyFromEvent,
+  } = useHotkeysContext();
+
+  const { toolRegistry } = useToolWorkflow();
+  const [editingToolId, setEditingToolId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const sortedTools = useMemo(
+    () => Object.entries(toolRegistry || {})
+      .sort((a, b) => a[1].name.localeCompare(b[1].name, undefined, { sensitivity: 'base' })),
+    [toolRegistry]
+  );
+
+  const toolNameMap = useMemo(() => Object.fromEntries(sortedTools), [sortedTools]);
+
+  const stopEditing = useCallback(() => {
+    setEditingToolId(null);
+    setErrorMessage(null);
+  }, []);
+
+  useEffect(() => {
+    if (!editingToolId) return;
+
+    suspendHotkeys(true);
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (event.key === 'Escape') {
+        stopEditing();
+        return;
+      }
+
+      const nextHotkey = createHotkeyFromEvent(event);
+
+      if (!nextHotkey.altKey && !nextHotkey.ctrlKey && !nextHotkey.metaKey) {
+        setErrorMessage('Please include at least one modifier key (Ctrl, Command, Alt, etc.).');
+        return;
+      }
+
+      if (isHotkeyInUse(nextHotkey, editingToolId)) {
+        setErrorMessage('That shortcut is already assigned to another tool.');
+        return;
+      }
+
+      setHotkey(editingToolId, nextHotkey);
+      setEditingToolId(null);
+      setErrorMessage(null);
+    };
+
+    window.addEventListener('keydown', handleKeydown, true);
+
+    return () => {
+      suspendHotkeys(false);
+      window.removeEventListener('keydown', handleKeydown, true);
+    };
+  }, [editingToolId, suspendHotkeys, createHotkeyFromEvent, isHotkeyInUse, setHotkey, stopEditing]);
+
+  const renderHotkeyBadges = useCallback((hotkey: Hotkey | undefined, keyPrefix: string) => {
+    const parts = formatHotkeyParts(hotkey);
+    if (parts.length === 0) {
+      return <Text size="sm" c="dimmed">Not assigned</Text>;
+    }
+
+    return (
+      <Group gap={4} wrap="wrap">
+        {parts.map((part, index) => (
+          <Badge key={`${keyPrefix}-${part}-${index}`} variant="light" color="gray" radius="sm">
+            {part}
+          </Badge>
+        ))}
+      </Group>
+    );
+  }, [formatHotkeyParts]);
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" align="flex-start">
+        <div>
+          <Text fw={600}>Tool hotkeys</Text>
+          <Text size="sm" c="dimmed">
+            Use keyboard shortcuts to launch tools instantly. Click "Change" and press a new key combination to customise.
+          </Text>
+        </div>
+        <Button
+          size="xs"
+          variant="light"
+          onClick={() => resetAllHotkeys()}
+        >
+          Reset all
+        </Button>
+      </Group>
+
+      {editingToolId && (
+        <Alert color="blue" title="Assign a shortcut">
+          Press the desired key combination for <strong>{toolNameMap[editingToolId]?.name || editingToolId}</strong>, or press
+          {' '}Escape to cancel.
+        </Alert>
+      )}
+
+      {errorMessage && (
+        <Alert color="red" title="Shortcut unavailable">
+          {errorMessage}
+        </Alert>
+      )}
+
+      <ScrollArea h={360} type="auto" offsetScrollbars>
+        <Table highlightOnHover verticalSpacing="sm" striped>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Tool</Table.Th>
+              <Table.Th>Shortcut</Table.Th>
+              <Table.Th style={{ width: '14rem' }}>Actions</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {sortedTools.map(([toolId, tool]) => {
+              const current = hotkeys[toolId];
+              const defaultHotkey = defaultHotkeys[toolId];
+              const isEditing = editingToolId === toolId;
+
+              return (
+                <Table.Tr key={toolId}>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <Text fw={500}>{tool.name}</Text>
+                      {tool.description && (
+                        <Text size="xs" c="dimmed" lineClamp={2}>
+                          {tool.description}
+                        </Text>
+                      )}
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>
+                    <Stack gap={6}>
+                      {isEditing ? (
+                        <Badge color="blue" variant="light">Listening...</Badge>
+                      ) : (
+                        renderHotkeyBadges(current, `${toolId}-current`)
+                      )}
+                      {defaultHotkey && !isEditing && !areHotkeysEqual(current, defaultHotkey) && (
+                        <Group gap={6} wrap="wrap">
+                          <Text size="xs" c="dimmed">Default:</Text>
+                          {renderHotkeyBadges(defaultHotkey, `${toolId}-default`)}
+                        </Group>
+                      )}
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap="xs">
+                      {isEditing ? (
+                        <Button size="xs" variant="subtle" onClick={stopEditing}>
+                          Cancel
+                        </Button>
+                      ) : (
+                        <Button size="xs" variant="light" onClick={() => {
+                          setEditingToolId(toolId);
+                          setErrorMessage(null);
+                        }}>
+                          Change
+                        </Button>
+                      )}
+                      <Button
+                        size="xs"
+                        variant="subtle"
+                        onClick={() => resetHotkey(toolId)}
+                        disabled={!defaultHotkey || areHotkeysEqual(current, defaultHotkey)}
+                      >
+                        Reset
+                      </Button>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      </ScrollArea>
+    </Stack>
+  );
+};
+
+export default HotkeySettings;

--- a/frontend/src/components/tools/toolPicker/ToolButton.tsx
+++ b/frontend/src/components/tools/toolPicker/ToolButton.tsx
@@ -5,6 +5,7 @@ import { ToolRegistryEntry } from "../../../data/toolsTaxonomy";
 import { useToolNavigation } from "../../../hooks/useToolNavigation";
 import { handleUnlessSpecialClick } from "../../../utils/clickHandlers";
 import FitText from "../../shared/FitText";
+import { useHotkeysContext } from "../../../contexts/HotkeysContext";
 
 interface ToolButtonProps {
   id: string;
@@ -20,6 +21,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({ id, tool, isSelected, onSelect,
   // Special case: read and multiTool are navigational tools that are always available
   const isUnavailable = !tool.component && !tool.link && id !== 'read' && id !== 'multiTool';
   const { getToolNavigation } = useToolNavigation();
+  const { getHotkey, formatHotkeyParts } = useHotkeysContext();
 
   const handleClick = (id: string) => {
     if (isUnavailable) return;
@@ -35,9 +37,39 @@ const ToolButton: React.FC<ToolButtonProps> = ({ id, tool, isSelected, onSelect,
   // Get navigation props for URL support (only if navigation is not disabled)
   const navProps = !isUnavailable && !tool.link && !disableNavigation ? getToolNavigation(id, tool) : null;
 
-  const tooltipContent = isUnavailable
+  const assignedHotkey = getHotkey(id);
+  const hotkeyParts = formatHotkeyParts(assignedHotkey);
+
+  const descriptionNode = isUnavailable
     ? (<span><strong>Coming soon:</strong> {tool.description}</span>)
     : tool.description;
+
+  const tooltipContent = hotkeyParts.length > 0
+    ? (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+        <span>{descriptionNode}</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', flexWrap: 'wrap' }}>
+          <span style={{ fontSize: '0.75rem', color: 'var(--mantine-color-dimmed)' }}>Shortcut:</span>
+          {hotkeyParts.map((part, index) => (
+            <span
+              key={`${id}-hotkey-${part}-${index}`}
+              style={{
+                backgroundColor: 'var(--mantine-color-gray-2, rgba(0,0,0,0.08))',
+                color: 'var(--mantine-color-dark-6, #1A1B1E)',
+                borderRadius: '0.4rem',
+                padding: '0.1rem 0.45rem',
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                letterSpacing: '0.01em'
+              }}
+            >
+              {part}
+            </span>
+          ))}
+        </div>
+      </div>
+    )
+    : descriptionNode;
 
   const buttonContent = (
     <>

--- a/frontend/src/contexts/HotkeysContext.tsx
+++ b/frontend/src/contexts/HotkeysContext.tsx
@@ -1,0 +1,482 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+import { useToolWorkflow } from './ToolWorkflowContext';
+import { ToolId, isValidToolId } from '../types/toolId';
+import { ToolRegistryEntry } from '../data/toolsTaxonomy';
+
+type HotkeyMap = Record<string, Hotkey>;
+
+export interface Hotkey {
+  code: string;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+interface HotkeysContextValue {
+  hotkeys: HotkeyMap;
+  defaultHotkeys: HotkeyMap;
+  getHotkey: (toolId: string) => Hotkey | undefined;
+  formatHotkey: (hotkey?: Hotkey) => string;
+  formatHotkeyParts: (hotkey?: Hotkey) => string[];
+  setHotkey: (toolId: string, hotkey: Hotkey) => void;
+  resetHotkey: (toolId: string) => void;
+  resetAllHotkeys: () => void;
+  isHotkeyInUse: (hotkey: Hotkey, excludeToolId?: string) => boolean;
+  suspendHotkeys: (suspended: boolean) => void;
+  isSuspended: boolean;
+  isMac: boolean;
+  createHotkeyFromEvent: (event: KeyboardEvent) => Hotkey;
+}
+
+const HotkeysContext = createContext<HotkeysContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'stirling-pdf.hotkeys';
+
+const FALLBACK_CODE_POOL: string[] = [
+  ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('').map(letter => `Key${letter}`),
+  ...'0123456789'.split('').map(num => `Digit${num}`),
+  'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12', 'F13', 'F14', 'F15', 'F16', 'F17', 'F18', 'F19', 'F20', 'F21', 'F22', 'F23', 'F24',
+  'Backquote', 'Minus', 'Equal', 'BracketLeft', 'BracketRight', 'Backslash', 'Semicolon', 'Quote', 'Comma', 'Period', 'Slash'
+];
+
+const SPECIAL_CHAR_TO_CODE: Record<string, string> = {
+  '-': 'Minus',
+  '=': 'Equal',
+  '[': 'BracketLeft',
+  ']': 'BracketRight',
+  '\\': 'Backslash',
+  ';': 'Semicolon',
+  "'": 'Quote',
+  ',': 'Comma',
+  '.': 'Period',
+  '/': 'Slash',
+  '`': 'Backquote',
+};
+
+const CODE_TO_LABEL: Record<string, string> = {
+  Space: 'Space',
+  Escape: 'Esc',
+  Tab: 'Tab',
+  Enter: 'Enter',
+  Backspace: 'Backspace',
+  Delete: 'Del',
+  ArrowUp: '↑',
+  ArrowDown: '↓',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+  Home: 'Home',
+  End: 'End',
+  PageUp: 'PgUp',
+  PageDown: 'PgDn',
+  Backquote: '`',
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backslash: '\\',
+  Semicolon: ';',
+  Quote: "'",
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  IntlBackslash: '\\',
+};
+
+const isMacPlatform = () => {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac|iPhone|iPad/.test(navigator.platform);
+};
+
+const serializeHotkey = (hotkey: Hotkey): string => {
+  const parts: string[] = [];
+  if (hotkey.metaKey) parts.push('Meta');
+  if (hotkey.ctrlKey) parts.push('Ctrl');
+  if (hotkey.altKey) parts.push('Alt');
+  if (hotkey.shiftKey) parts.push('Shift');
+  parts.push(hotkey.code);
+  return parts.join('+');
+};
+
+const charToCode = (char: string): string | null => {
+  if (!char) return null;
+  if (/^[A-Z]$/.test(char)) return `Key${char}`;
+  if (/^[0-9]$/.test(char)) return `Digit${char}`;
+  return SPECIAL_CHAR_TO_CODE[char] || null;
+};
+
+const getKeyLabelFromCode = (code: string): string => {
+  if (code.startsWith('Key')) {
+    return code.slice(3);
+  }
+  if (code.startsWith('Digit')) {
+    return code.slice(5);
+  }
+  if (/^F\d{1,2}$/.test(code)) {
+    return code;
+  }
+  return CODE_TO_LABEL[code] || code;
+};
+
+const buildHotkey = (code: string, isMac: boolean, withShift = false): Hotkey => ({
+  code,
+  altKey: true,
+  ctrlKey: !isMac,
+  metaKey: isMac,
+  shiftKey: withShift,
+});
+
+const generateCandidateCodes = (toolId: string, tool: ToolRegistryEntry): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const add = (code: string | null | undefined) => {
+    if (!code) return;
+    if (seen.has(code)) return;
+    seen.add(code);
+    result.push(code);
+  };
+
+  const addFromText = (text: string | undefined | null) => {
+    if (!text) return;
+    text
+      .split(/[^A-Za-z0-9]+/)
+      .map(token => token.trim())
+      .filter(Boolean)
+      .forEach(token => add(charToCode(token[0]!.toUpperCase())));
+  };
+
+  addFromText(tool.name);
+  addFromText(toolId.replace(/([a-z0-9])([A-Z])/g, '$1 $2'));
+
+  if (tool.synonyms) {
+    tool.synonyms.forEach(synonym => addFromText(synonym));
+  }
+
+  toolId
+    .replace(/[^A-Za-z0-9\-_=\[\]\\;',\.\/`]/g, '')
+    .toUpperCase()
+    .split('')
+    .forEach(character => add(charToCode(character)));
+
+  FALLBACK_CODE_POOL.forEach(code => add(code));
+
+  return result;
+};
+
+const allocateHotkey = (
+  toolId: string,
+  tool: ToolRegistryEntry,
+  used: Set<string>,
+  isMac: boolean,
+  preferred?: Hotkey
+): Hotkey => {
+  if (preferred) {
+    const serialized = serializeHotkey(preferred);
+    if (!used.has(serialized)) {
+      return preferred;
+    }
+  }
+
+  const candidateCodes = generateCandidateCodes(toolId, tool);
+
+  for (const code of candidateCodes) {
+    const candidate = buildHotkey(code, isMac, false);
+    if (!used.has(serializeHotkey(candidate))) {
+      return candidate;
+    }
+  }
+
+  for (const code of candidateCodes) {
+    const candidate = buildHotkey(code, isMac, true);
+    if (!used.has(serializeHotkey(candidate))) {
+      return candidate;
+    }
+  }
+
+  // Final fallback - generate synthetic function keys beyond F24 if somehow needed
+  let counter = 25;
+  while (true) {
+    const code = `F${counter}`;
+    const candidate = buildHotkey(code, isMac, true);
+    const serialized = serializeHotkey(candidate);
+    if (!used.has(serialized)) {
+      return candidate;
+    }
+    counter += 1;
+    if (counter > 64) {
+      // Hard stop to prevent infinite loop
+      return buildHotkey('F64', isMac, true);
+    }
+  }
+};
+
+const computeDefaultHotkeys = (
+  toolEntries: Array<[string, ToolRegistryEntry]>,
+  isMac: boolean
+): HotkeyMap => {
+  const used = new Set<string>();
+  const defaults: HotkeyMap = {};
+  const sortedEntries = [...toolEntries].sort((a, b) => a[1].name.localeCompare(b[1].name, undefined, { sensitivity: 'base' }));
+
+  sortedEntries.forEach(([toolId, tool]) => {
+    const hotkey = allocateHotkey(toolId, tool, used, isMac);
+    defaults[toolId] = hotkey;
+    used.add(serializeHotkey(hotkey));
+  });
+
+  return defaults;
+};
+
+const loadStoredHotkeys = (): HotkeyMap => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    const entries = Object.entries(parsed) as Array<[string, Hotkey]>;
+    const sanitized: HotkeyMap = {};
+    entries.forEach(([toolId, combo]) => {
+      if (
+        combo &&
+        typeof combo.code === 'string' &&
+        typeof combo.altKey === 'boolean' &&
+        typeof combo.ctrlKey === 'boolean' &&
+        typeof combo.metaKey === 'boolean' &&
+        typeof combo.shiftKey === 'boolean'
+      ) {
+        sanitized[toolId] = combo;
+      }
+    });
+    return sanitized;
+  } catch (err) {
+    console.warn('Failed to parse stored hotkeys:', err);
+    return {};
+  }
+};
+
+const saveHotkeysToStorage = (hotkeys: HotkeyMap) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(hotkeys));
+  } catch (err) {
+    console.warn('Failed to persist hotkeys:', err);
+  }
+};
+
+const matchesEvent = (event: KeyboardEvent, hotkey: Hotkey): boolean => {
+  return (
+    event.code === hotkey.code &&
+    event.altKey === hotkey.altKey &&
+    event.ctrlKey === hotkey.ctrlKey &&
+    event.metaKey === hotkey.metaKey &&
+    event.shiftKey === hotkey.shiftKey
+  );
+};
+
+const shouldIgnoreEventTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName;
+  const editableTags = ['INPUT', 'TEXTAREA', 'SELECT'];
+  if (editableTags.includes(tagName)) return true;
+  if (target.isContentEditable) return true;
+  return false;
+};
+
+export const HotkeysProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { toolRegistry, handleToolSelect } = useToolWorkflow();
+  const isMac = useMemo(() => isMacPlatform(), []);
+  const toolEntries = useMemo(() => Object.entries(toolRegistry || {}) as Array<[string, ToolRegistryEntry]>, [toolRegistry]);
+  const toolMap = useMemo(() => Object.fromEntries(toolEntries), [toolEntries]);
+
+  const [storedHotkeys] = useState<HotkeyMap>(() => loadStoredHotkeys());
+  const [hotkeys, setHotkeys] = useState<HotkeyMap>(storedHotkeys);
+  const [isSuspended, setIsSuspended] = useState(false);
+
+  const defaultHotkeys = useMemo(() => computeDefaultHotkeys(toolEntries, isMac), [toolEntries, isMac]);
+
+  // Ensure every tool has a hotkey and remove those that no longer exist
+  useEffect(() => {
+    if (toolEntries.length === 0) return;
+
+    setHotkeys(prev => {
+      const used = new Set<string>();
+      const next: HotkeyMap = {};
+      let changed = false;
+
+      Object.entries(prev).forEach(([toolId, combo]) => {
+        if (defaultHotkeys[toolId]) {
+          next[toolId] = combo;
+          used.add(serializeHotkey(combo));
+        } else {
+          changed = true;
+        }
+      });
+
+      toolEntries.forEach(([toolId, tool]) => {
+        if (!next[toolId]) {
+          const preferred = defaultHotkeys[toolId];
+          const resolved = allocateHotkey(toolId, tool, used, isMac, preferred);
+          next[toolId] = resolved;
+          used.add(serializeHotkey(resolved));
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [toolEntries, defaultHotkeys, isMac]);
+
+  // Persist hotkeys when they change and tools are loaded
+  useEffect(() => {
+    if (toolEntries.length === 0) return;
+    saveHotkeysToStorage(hotkeys);
+  }, [hotkeys, toolEntries.length]);
+
+  const getHotkey = useCallback((toolId: string) => hotkeys[toolId], [hotkeys]);
+
+  const formatHotkeyParts = useCallback((hotkey?: Hotkey) => {
+    if (!hotkey) return [];
+    const parts: string[] = [];
+    if (hotkey.metaKey) parts.push(isMac ? '⌘' : 'Win');
+    if (hotkey.ctrlKey) parts.push(isMac ? '⌃' : 'Ctrl');
+    if (hotkey.altKey) parts.push(isMac ? '⌥' : 'Alt');
+    if (hotkey.shiftKey) parts.push(isMac ? '⇧' : 'Shift');
+    parts.push(getKeyLabelFromCode(hotkey.code));
+    return parts;
+  }, [isMac]);
+
+  const formatHotkey = useCallback((hotkey?: Hotkey) => formatHotkeyParts(hotkey).join(' + '), [formatHotkeyParts]);
+
+  const cloneHotkey = useCallback((hotkey: Hotkey): Hotkey => ({
+    code: hotkey.code,
+    altKey: hotkey.altKey,
+    ctrlKey: hotkey.ctrlKey,
+    metaKey: hotkey.metaKey,
+    shiftKey: hotkey.shiftKey,
+  }), []);
+
+  const setHotkey = useCallback((toolId: string, hotkey: Hotkey) => {
+    setHotkeys(prev => ({ ...prev, [toolId]: cloneHotkey(hotkey) }));
+  }, [cloneHotkey]);
+
+  const resetHotkey = useCallback((toolId: string) => {
+    const fallback = defaultHotkeys[toolId];
+    if (!fallback) return;
+    setHotkeys(prev => ({ ...prev, [toolId]: cloneHotkey(fallback) }));
+  }, [defaultHotkeys, cloneHotkey]);
+
+  const resetAllHotkeys = useCallback(() => {
+    setHotkeys(() => {
+      const next: HotkeyMap = {};
+      Object.entries(defaultHotkeys).forEach(([toolId, combo]) => {
+        next[toolId] = cloneHotkey(combo);
+      });
+      return next;
+    });
+  }, [defaultHotkeys, cloneHotkey]);
+
+  const isHotkeyInUse = useCallback((hotkey: Hotkey, excludeToolId?: string) => {
+    const serialized = serializeHotkey(hotkey);
+    return Object.entries(hotkeys).some(([toolId, combo]) => {
+      if (excludeToolId && toolId === excludeToolId) return false;
+      return serializeHotkey(combo) === serialized;
+    });
+  }, [hotkeys]);
+
+  const suspendHotkeys = useCallback((suspended: boolean) => {
+    setIsSuspended(suspended);
+  }, []);
+
+  const createHotkeyFromEvent = useCallback((event: KeyboardEvent): Hotkey => ({
+    code: event.code,
+    altKey: event.altKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    shiftKey: event.shiftKey,
+  }), []);
+
+  useEffect(() => {
+    if (toolEntries.length === 0) return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (isSuspended) return;
+      if (event.repeat) return;
+      if (shouldIgnoreEventTarget(event.target)) return;
+
+      const matchEntry = Object.entries(hotkeys).find(([, combo]) => matchesEvent(event, combo));
+      if (!matchEntry) return;
+
+      const [toolId] = matchEntry;
+      const tool = toolMap[toolId];
+      if (!tool) return;
+
+      const isUnavailable = !tool.component && !tool.link && toolId !== 'read' && toolId !== 'multiTool';
+      if (isUnavailable) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (tool.link) {
+        window.open(tool.link, '_blank', 'noopener,noreferrer');
+        return;
+      }
+
+      if (isValidToolId(toolId)) {
+        handleToolSelect(toolId as ToolId);
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [hotkeys, isSuspended, toolEntries.length, handleToolSelect, toolMap]);
+
+  const value = useMemo<HotkeysContextValue>(() => ({
+    hotkeys,
+    defaultHotkeys,
+    getHotkey,
+    formatHotkey,
+    formatHotkeyParts,
+    setHotkey,
+    resetHotkey,
+    resetAllHotkeys,
+    isHotkeyInUse,
+    suspendHotkeys,
+    isSuspended,
+    isMac,
+    createHotkeyFromEvent,
+  }), [
+    hotkeys,
+    defaultHotkeys,
+    getHotkey,
+    formatHotkey,
+    formatHotkeyParts,
+    setHotkey,
+    resetHotkey,
+    resetAllHotkeys,
+    isHotkeyInUse,
+    suspendHotkeys,
+    isSuspended,
+    isMac,
+    createHotkeyFromEvent,
+  ]);
+
+  return <HotkeysContext.Provider value={value}>{children}</HotkeysContext.Provider>;
+};
+
+export const useHotkeysContext = (): HotkeysContextValue => {
+  const context = useContext(HotkeysContext);
+  if (!context) {
+    throw new Error('useHotkeysContext must be used within a HotkeysProvider');
+  }
+  return context;
+};
+


### PR DESCRIPTION
## Summary
- add a global hotkeys context that assigns unique shortcuts to each tool, listens for key presses, and persists custom mappings
- expose shortcut customization controls through a new Hotkeys tab in the settings modal and wrap the app tree with the provider
- surface shortcut hints in tool button tooltips and connect the config quick-access button to the refreshed settings modal

## Testing
- npm run lint *(fails: eslint.config.mjs imports @eslint/js which is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d84f45b82c8328be41116da681888d