### PR TITLE
feat(pdf-a): switch PDF/A conversion from LibreOffice to Ghostscript, support PDF/A-3b and preflight validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All documentation available at [https://docs.stirlingpdf.com/](https://docs.stir
 - Add page numbers
 - Auto-rename files by detecting PDF header text
 - OCR on PDF (using Tesseract OCR)
-- PDF/A conversion (using LibreOffice)
+- PDF/A conversion (using Ghostscript pdfwrite)
 - Edit metadata
 - Flatten PDFs
 - Get all information on a PDF to view or export as JSON

--- a/app/common/src/main/java/stirling/software/common/util/ExceptionUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/ExceptionUtils.java
@@ -190,6 +190,11 @@ public class ExceptionUtils {
                 "error.conversionFailed", "{0} conversion failed", null, "PDF/A");
     }
 
+    public static RuntimeException createPdfaConversionFailedException(Exception cause) {
+        return createRuntimeException(
+                "error.conversionFailed", "{0} conversion failed", cause, "PDF/A");
+    }
+
     public static IllegalArgumentException createInvalidComparatorException() {
         return createIllegalArgumentException(
                 "error.invalidFormat",

--- a/app/core/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
+++ b/app/core/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
@@ -400,6 +400,7 @@ public class EndpointConfiguration {
         /* Ghostscript */
         addEndpointToGroup("Ghostscript", "repair");
         addEndpointToGroup("Ghostscript", "compress-pdf");
+        addEndpointToGroup("Ghostscript", "pdf-to-pdfa");
 
         /* tesseract */
         addEndpointToGroup("tesseract", "ocr-pdf");

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertPDFToPDFA.java
@@ -1,57 +1,28 @@
 package stirling.software.SPDF.controller.api.converters;
 
-import java.awt.Color;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
+import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TimeZone;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.cos.COSArray;
-import org.apache.pdfbox.cos.COSBase;
-import org.apache.pdfbox.cos.COSDictionary;
-import org.apache.pdfbox.cos.COSName;
-import org.apache.pdfbox.pdfwriter.compress.CompressParameters;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
-import org.apache.pdfbox.pdmodel.PDDocumentInformation;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
-import org.apache.pdfbox.pdmodel.PDResources;
-import org.apache.pdfbox.pdmodel.common.PDMetadata;
-import org.apache.pdfbox.pdmodel.common.PDStream;
-import org.apache.pdfbox.pdmodel.font.PDFont;
-import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
-import org.apache.pdfbox.pdmodel.font.PDTrueTypeFont;
-import org.apache.pdfbox.pdmodel.font.PDType0Font;
-import org.apache.pdfbox.pdmodel.graphics.PDXObject;
-import org.apache.pdfbox.pdmodel.graphics.color.PDOutputIntent;
-import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
-import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationTextMarkup;
-import org.apache.pdfbox.pdmodel.interactive.viewerpreferences.PDViewerPreferences;
-import org.apache.xmpbox.XMPMetadata;
-import org.apache.xmpbox.schema.AdobePDFSchema;
-import org.apache.xmpbox.schema.DublinCoreSchema;
-import org.apache.xmpbox.schema.PDFAIdentificationSchema;
-import org.apache.xmpbox.schema.XMPBasicSchema;
-import org.apache.xmpbox.xml.DomXmpParser;
-import org.apache.xmpbox.xml.XmpSerializer;
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
+import org.apache.pdfbox.preflight.Format;
+import org.apache.pdfbox.preflight.PreflightConfiguration;
+import org.apache.pdfbox.preflight.PreflightDocument;
+import org.apache.pdfbox.preflight.ValidationResult;
+import org.apache.pdfbox.preflight.ValidationResult.ValidationError;
+import org.apache.pdfbox.preflight.exception.SyntaxValidationException;
+import org.apache.pdfbox.preflight.exception.ValidationException;
+import org.apache.pdfbox.preflight.parser.PreflightParser;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -78,623 +49,278 @@ import stirling.software.common.util.WebResponseUtils;
 @Tag(name = "Convert", description = "Convert APIs")
 public class ConvertPDFToPDFA {
 
+    private static final String ICC_RESOURCE_PATH = "/icc/sRGB2014.icc";
+    private static final int PDFA_COMPATIBILITY_POLICY = 1;
+
+    private static List<String> buildGhostscriptCommand(
+            Path inputPdf, Path outputPdf, Path iccProfile, Path workingDir, PdfaProfile profile) {
+
+        List<String> command = new ArrayList<>();
+        command.add("gs");
+        command.add("--permit-file-read=" + workingDir.toAbsolutePath());
+        command.add("--permit-file-read=" + iccProfile.toAbsolutePath());
+        command.add("--permit-file-read=" + inputPdf.toAbsolutePath());
+        command.add("--permit-file-write=" + workingDir.toAbsolutePath());
+        command.add("-sDEVICE=pdfwrite");
+        command.add("-dPDFA=" + profile.part());
+        command.add("-dPDFACompatibilityPolicy=" + PDFA_COMPATIBILITY_POLICY);
+        command.add("-dCompatibilityLevel=" + profile.compatibilityLevel());
+        command.add("-sColorConversionStrategy=RGB");
+        command.add("-sProcessColorModel=DeviceRGB");
+        command.add("-sOutputICCProfile=" + iccProfile.toAbsolutePath());
+        command.add("-dEmbedAllFonts=true");
+        command.add("-dSubsetFonts=true");
+        command.add("-dCompressFonts=true");
+        command.add("-dNOPAUSE");
+        command.add("-dBATCH");
+        command.add("-sOutputFile=" + outputPdf.toAbsolutePath());
+        command.add(inputPdf.toAbsolutePath().toString());
+
+        return command;
+    }
+
+    private static void validatePdfaOutput(Path pdfPath, PdfaProfile profile) throws IOException {
+        Optional<Format> format = profile.preflightFormat();
+        if (format.isEmpty()) {
+            log.debug("Skipping PDFBox preflight validation for {}", profile.displayName());
+            return;
+        }
+
+        try (RandomAccessRead rar = new RandomAccessReadBufferedFile(pdfPath.toFile())) {
+            PreflightParser parser = new PreflightParser(rar);
+            PreflightDocument document;
+            try {
+                document =
+                        (PreflightDocument)
+                                parser.parse(
+                                        format.get(),
+                                        PreflightConfiguration.createPdfA1BConfiguration());
+            } catch (SyntaxValidationException e) {
+                throw new IOException(buildPreflightErrorMessage(e.getResult(), profile), e);
+            } catch (ClassCastException e) {
+                throw new IOException(
+                        "PDF/A preflight did not produce a PreflightDocument for "
+                                + profile.displayName(),
+                        e);
+            }
+
+            if (document == null) {
+                throw new IOException(
+                        "PDF/A preflight returned no document for " + profile.displayName());
+            }
+
+            try (PreflightDocument closeableDocument = document) {
+                ValidationResult result = closeableDocument.validate();
+                if (result == null || !result.isValid()) {
+                    throw new IOException(buildPreflightErrorMessage(result, profile));
+                }
+            }
+        } catch (SyntaxValidationException e) {
+            throw new IOException(buildPreflightErrorMessage(e.getResult(), profile), e);
+        } catch (ValidationException e) {
+            throw new IOException(
+                    "PDF/A preflight validation failed for " + profile.displayName(), e);
+        }
+    }
+
+    private static String buildPreflightErrorMessage(ValidationResult result, PdfaProfile profile) {
+        String baseMessage = "PDF/A preflight validation failed for " + profile.displayName();
+        if (result == null) {
+            return baseMessage + ": no detailed validation result available";
+        }
+
+        List<ValidationError> errors = result.getErrorsList();
+        if (errors == null || errors.isEmpty()) {
+            return baseMessage + ": unknown validation error";
+        }
+
+        String summarizedErrors =
+                errors.stream()
+                        .limit(5)
+                        .map(
+                                error -> {
+                                    StringBuilder sb =
+                                            new StringBuilder(
+                                                    Optional.ofNullable(error.getErrorCode())
+                                                            .orElse("UNKNOWN"));
+                                    String details = error.getDetails();
+                                    if (details != null && !details.isBlank()) {
+                                        sb.append(": ").append(details.trim());
+                                    }
+                                    if (error.isWarning()) {
+                                        sb.append(" (warning)");
+                                    }
+                                    return sb.toString();
+                                })
+                        .collect(Collectors.joining("; "));
+
+        if (errors.size() > 5) {
+            summarizedErrors += " (" + (errors.size() - 5) + " more)";
+        }
+
+        return baseMessage + ": " + summarizedErrors;
+    }
+
+    private static void deleteQuietly(Path directory) {
+        if (directory == null) {
+            return;
+        }
+        try (Stream<Path> stream = Files.walk(directory)) {
+            stream.sorted(Comparator.reverseOrder())
+                    .forEach(
+                            path -> {
+                                try {
+                                    Files.deleteIfExists(path);
+                                } catch (IOException e) {
+                                    log.warn("Failed to delete temporary file: {}", path, e);
+                                }
+                            });
+        } catch (IOException e) {
+            log.warn("Failed to clean temporary directory: {}", directory, e);
+        }
+    }
+
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, value = "/pdf/pdfa")
     @Operation(
             summary = "Convert a PDF to a PDF/A",
             description =
-                    "This endpoint converts a PDF file to a PDF/A file using LibreOffice. PDF/A is a format designed for long-term archiving of digital documents. Input:PDF Output:PDF Type:SISO")
+                    "This endpoint converts a PDF file to a PDF/A file using Ghostscript. PDF/A is a format designed for long-term archiving of digital documents. Input:PDF Output:PDF Type:SISO")
     public ResponseEntity<byte[]> pdfToPdfA(@ModelAttribute PdfToPdfARequest request)
             throws Exception {
         MultipartFile inputFile = request.getFileInput();
         String outputFormat = request.getOutputFormat();
 
-        // Validate input file type
         if (!MediaType.APPLICATION_PDF_VALUE.equals(inputFile.getContentType())) {
             log.error("Invalid input file type: {}", inputFile.getContentType());
             throw ExceptionUtils.createPdfFileRequiredException();
         }
 
-        // Get the original filename without extension
+        PdfaProfile profile = PdfaProfile.fromRequest(outputFormat);
+
         String originalFileName = Filenames.toSimpleFileName(inputFile.getOriginalFilename());
         if (originalFileName == null || originalFileName.trim().isEmpty()) {
             originalFileName = "output.pdf";
         }
+
         String baseFileName =
                 originalFileName.contains(".")
                         ? originalFileName.substring(0, originalFileName.lastIndexOf('.'))
                         : originalFileName;
 
-        Path tempInputFile = null;
-        byte[] fileBytes;
-        Path loPdfPath = null; // Used for LibreOffice conversion output
-        File preProcessedFile = null;
-        int pdfaPart = 2;
+        Path workingDir = Files.createTempDirectory("pdfa_gs_");
+        Path inputPath = workingDir.resolve("input.pdf");
+        inputFile.transferTo(inputPath);
 
         try {
-            // Save uploaded file to temp location
-            tempInputFile = Files.createTempFile("input_", ".pdf");
-            inputFile.transferTo(tempInputFile);
-
-            // Branch conversion based on desired output PDF/A format
-            if ("pdfa".equals(outputFormat)) {
-                preProcessedFile = tempInputFile.toFile();
-            } else {
-                pdfaPart = 1;
-                preProcessedFile = preProcessHighlights(tempInputFile.toFile());
-            }
-            Set<String> missingFonts = new HashSet<>();
-            boolean needImgs = false;
-            try (PDDocument doc = Loader.loadPDF(preProcessedFile)) {
-                missingFonts = findUnembeddedFontNames(doc);
-                needImgs = (pdfaPart == 1) && hasTransparentImages(doc);
-                if (!missingFonts.isEmpty() || needImgs) {
-                    // Run LibreOffice conversion to get flattened images and embedded fonts
-                    loPdfPath = runLibreOfficeConversion(preProcessedFile.toPath(), pdfaPart);
-                }
-            }
-            fileBytes =
-                    convertToPdfA(
-                            preProcessedFile.toPath(), loPdfPath, pdfaPart, missingFonts, needImgs);
-
-            String outputFilename = baseFileName + "_PDFA.pdf";
-
+            byte[] converted = convertWithGhostscript(inputPath, workingDir, profile);
+            String outputFilename = baseFileName + profile.outputSuffix();
             return WebResponseUtils.bytesToWebResponse(
-                    fileBytes, outputFilename, MediaType.APPLICATION_PDF);
-
+                    converted, outputFilename, MediaType.APPLICATION_PDF);
+        } catch (IOException | InterruptedException e) {
+            log.error("Ghostscript PDF/A conversion failed", e);
+            throw ExceptionUtils.createPdfaConversionFailedException(e);
         } finally {
-            // Clean up temporary files
-            if (tempInputFile != null) {
-                Files.deleteIfExists(tempInputFile);
-            }
-            if (loPdfPath != null && loPdfPath.getParent() != null) {
-                FileUtils.deleteDirectory(loPdfPath.getParent().toFile());
-            }
-            if (preProcessedFile != null) {
-                Files.deleteIfExists(preProcessedFile.toPath());
-            }
+            deleteQuietly(workingDir);
         }
     }
 
-    /**
-     * Merge fonts & flattened images from loPdfPath into basePdfPath, then run the standard
-     * PDFBox/A pipeline.
-     *
-     * @param basePdfPath Path to the original (or highlight‐preprocessed) PDF
-     * @param loPdfPath Path to the LibreOffice–flattened PDF/A, or null if not used
-     * @param pdfaPart 1 (PDF/A-1B) or 2 (PDF/A-2B)
-     * @return the final PDF/A bytes
-     */
-    private byte[] convertToPdfA(
-            Path basePdfPath,
-            Path loPdfPath,
-            int pdfaPart,
-            Set<String> missingFonts,
-            boolean importImages)
-            throws Exception {
-        try (PDDocument baseDoc = Loader.loadPDF(basePdfPath.toFile())) {
-
-            if (loPdfPath != null) {
-                try (PDDocument loDoc = Loader.loadPDF(loPdfPath.toFile())) {
-                    if (!missingFonts.isEmpty()) {
-                        embedMissingFonts(loDoc, baseDoc, missingFonts);
-                    }
-                    if (importImages) {
-                        importFlattenedImages(loDoc, baseDoc);
-                    }
-                }
-            }
-            return processWithPDFBox(baseDoc, pdfaPart);
-        }
-    }
-
-    private byte[] processWithPDFBox(PDDocument document, int pdfaPart) throws Exception {
-
-        removeElementsForPdfA(document, pdfaPart);
-
-        mergeAndAddXmpMetadata(document, pdfaPart);
-
-        addICCProfileIfNotPresent(document);
-
-        // Mark the document as PDF/A
-        PDDocumentCatalog catalog = document.getDocumentCatalog();
-        catalog.setMetadata(
-                document.getDocumentCatalog().getMetadata()); // Ensure metadata is linked
-        catalog.setViewerPreferences(
-                new PDViewerPreferences(catalog.getCOSObject())); // PDF/A best practice
-        document.getDocument().setVersion(pdfaPart == 1 ? 1.4f : 1.7f);
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        if (pdfaPart == 1) {
-            document.save(baos, CompressParameters.NO_COMPRESSION);
-        } else {
-            document.save(baos);
-        }
-
-        return baos.toByteArray();
-    }
-
-    private Path runLibreOfficeConversion(Path tempInputFile, int pdfaPart) throws Exception {
-        // Create temp output directory
-        Path tempOutputDir = Files.createTempDirectory("output_");
-
-        // Determine PDF/A filter based on requested format
-        String pdfFilter =
-                pdfaPart == 2
-                        ? "pdf:writer_pdf_Export:{\"SelectPdfVersion\":{\"type\":\"long\",\"value\":\"2\"}}"
-                        : "pdf:writer_pdf_Export:{\"SelectPdfVersion\":{\"type\":\"long\",\"value\":\"1\"}}";
-
-        // Prepare LibreOffice command
+    private byte[] convertWithGhostscript(Path inputPdf, Path workingDir, PdfaProfile profile)
+            throws IOException, InterruptedException {
+        Path outputPdf = workingDir.resolve("output.pdf");
+        Path iccProfile = copyIccProfile(workingDir);
         List<String> command =
-                new ArrayList<>(
-                        Arrays.asList(
-                                "soffice",
-                                "--headless",
-                                "--nologo",
-                                "--convert-to",
-                                pdfFilter,
-                                "--outdir",
-                                tempOutputDir.toString(),
-                                tempInputFile.toString()));
+                buildGhostscriptCommand(inputPdf, outputPdf, iccProfile, workingDir, profile);
 
-        ProcessExecutorResult returnCode =
-                ProcessExecutor.getInstance(ProcessExecutor.Processes.LIBRE_OFFICE)
+        ProcessExecutorResult result =
+                ProcessExecutor.getInstance(ProcessExecutor.Processes.GHOSTSCRIPT)
                         .runCommandWithOutputHandling(command);
 
-        if (returnCode.getRc() != 0) {
-            log.error("PDF/A conversion failed with return code: {}", returnCode.getRc());
-            throw ExceptionUtils.createPdfaConversionFailedException();
+        if (result.getRc() != 0) {
+            throw new IOException("Ghostscript exited with code " + result.getRc());
         }
 
-        // Get the output file
-        File[] outputFiles = tempOutputDir.toFile().listFiles();
-        if (outputFiles == null || outputFiles.length != 1) {
-            throw ExceptionUtils.createPdfaConversionFailedException();
+        if (!Files.exists(outputPdf)) {
+            throw new IOException("Ghostscript did not produce an output file");
         }
-        return outputFiles[0].toPath();
+
+        validatePdfaOutput(outputPdf, profile);
+
+        return Files.readAllBytes(outputPdf);
     }
 
-    private void embedMissingFonts(PDDocument loDoc, PDDocument baseDoc, Set<String> missingFonts)
-            throws IOException {
-        List<PDPage> loPages = new ArrayList<>();
-        loDoc.getPages().forEach(loPages::add);
-        List<PDPage> basePages = new ArrayList<>();
-        baseDoc.getPages().forEach(basePages::add);
-
-        for (int i = 0; i < loPages.size(); i++) {
-            PDResources loRes = loPages.get(i).getResources();
-            PDResources baseRes = basePages.get(i).getResources();
-
-            for (COSName fontKey : loRes.getFontNames()) {
-                PDFont loFont = loRes.getFont(fontKey);
-                if (loFont == null) continue;
-
-                String psName = loFont.getName();
-                if (!missingFonts.contains(psName)) continue;
-
-                PDFontDescriptor desc = loFont.getFontDescriptor();
-                if (desc == null) continue;
-
-                PDStream fontStream = null;
-                if (desc.getFontFile() != null) {
-                    fontStream = desc.getFontFile();
-                } else if (desc.getFontFile2() != null) {
-                    fontStream = desc.getFontFile2();
-                } else if (desc.getFontFile3() != null) {
-                    fontStream = desc.getFontFile3();
-                }
-                if (fontStream == null) continue;
-
-                try (InputStream in = fontStream.createInputStream()) {
-                    PDFont newFont = null;
-                    try {
-                        newFont = PDType0Font.load(baseDoc, in, false);
-                    } catch (IOException e1) {
-                        try {
-                            newFont = PDTrueTypeFont.load(baseDoc, in, null);
-                        } catch (IOException | IllegalArgumentException e2) {
-                            log.error("Could not embed font {}: {}", psName, e2.getMessage());
-                            continue;
-                        }
-                    }
-                    if (newFont != null) {
-                        baseRes.put(fontKey, newFont);
-                    }
-                }
+    private Path copyIccProfile(Path workingDir) throws IOException {
+        Path iccTarget = workingDir.resolve("sRGB.icc");
+        try (InputStream in = getClass().getResourceAsStream(ICC_RESOURCE_PATH)) {
+            if (in == null) {
+                throw new IOException("ICC profile resource not found: " + ICC_RESOURCE_PATH);
             }
+            Files.copy(in, iccTarget);
         }
+        return iccTarget;
     }
 
-    private Set<String> findUnembeddedFontNames(PDDocument doc) throws IOException {
-        Set<String> missing = new HashSet<>();
-        for (PDPage page : doc.getPages()) {
-            PDResources res = page.getResources();
-            for (COSName name : res.getFontNames()) {
-                PDFont font = res.getFont(name);
-                if (font != null && !font.isEmbedded()) {
-                    missing.add(font.getName());
-                }
+    private enum PdfaProfile {
+        PDF_A_1B(1, "PDF/A-1b", "_PDFA-1b.pdf", "1.4", Format.PDF_A1B, "pdfa-1"),
+        PDF_A_2B(2, "PDF/A-2b", "_PDFA-2b.pdf", "1.7", null, "pdfa", "pdfa-2", "pdfa-2b"),
+        PDF_A_3B(3, "PDF/A-3b", "_PDFA-3b.pdf", "1.7", null, "pdfa-3", "pdfa-3b");
+
+        private final int part;
+        private final String displayName;
+        private final String suffix;
+        private final String compatibilityLevel;
+        private final Format preflightFormat;
+        private final List<String> requestTokens;
+
+        PdfaProfile(
+                int part,
+                String displayName,
+                String suffix,
+                String compatibilityLevel,
+                Format preflightFormat,
+                String... requestTokens) {
+            this.part = part;
+            this.displayName = displayName;
+            this.suffix = suffix;
+            this.compatibilityLevel = compatibilityLevel;
+            this.preflightFormat = preflightFormat;
+            this.requestTokens = Arrays.asList(requestTokens);
+        }
+
+        static PdfaProfile fromRequest(String requestToken) {
+            if (requestToken == null) {
+                return PDF_A_2B;
             }
-        }
-        return missing;
-    }
+            String normalized = requestToken.trim().toLowerCase(Locale.ROOT);
+            Optional<PdfaProfile> match =
+                    Arrays.stream(values())
+                            .filter(
+                                    profile ->
+                                            profile.requestTokens.stream()
+                                                    .map(token -> token.toLowerCase(Locale.ROOT))
+                                                    .anyMatch(token -> token.equals(normalized)))
+                            .findFirst();
 
-    private void importFlattenedImages(PDDocument loDoc, PDDocument baseDoc) throws IOException {
-        List<PDPage> loPages = new ArrayList<>();
-        loDoc.getPages().forEach(loPages::add);
-        List<PDPage> basePages = new ArrayList<>();
-        baseDoc.getPages().forEach(basePages::add);
-
-        for (int i = 0; i < loPages.size(); i++) {
-            PDPage loPage = loPages.get(i);
-            PDPage basePage = basePages.get(i);
-
-            PDResources loRes = loPage.getResources();
-            PDResources baseRes = basePage.getResources();
-            Set<COSName> toReplace = detectTransparentXObjects(basePage);
-
-            for (COSName name : toReplace) {
-                PDXObject loXo = loRes.getXObject(name);
-                if (!(loXo instanceof PDImageXObject img)) continue;
-
-                PDImageXObject newImg = LosslessFactory.createFromImage(baseDoc, img.getImage());
-
-                // replace the resource under the same name
-                baseRes.put(name, newImg);
-            }
-        }
-    }
-
-    private Set<COSName> detectTransparentXObjects(PDPage page) {
-        Set<COSName> transparentObjects = new HashSet<>();
-        PDResources res = page.getResources();
-        if (res == null) return transparentObjects;
-
-        for (COSName name : res.getXObjectNames()) {
-            try {
-                PDXObject xo = res.getXObject(name);
-                if (xo instanceof PDImageXObject img) {
-                    COSDictionary d = img.getCOSObject();
-                    if (d.containsKey(COSName.SMASK)
-                            || isTransparencyGroup(d)
-                            || d.getBoolean(COSName.INTERPOLATE, false)) {
-                        transparentObjects.add(name);
-                    }
-                }
-            } catch (IOException ioe) {
-                log.error("Error processing XObject {}: {}", name.getName(), ioe.getMessage());
-            }
-        }
-        return transparentObjects;
-    }
-
-    private boolean isTransparencyGroup(COSDictionary dict) {
-        COSBase g = dict.getDictionaryObject(COSName.GROUP);
-        return g instanceof COSDictionary gd
-                && COSName.TRANSPARENCY.equals(gd.getCOSName(COSName.S));
-    }
-
-    private boolean hasTransparentImages(PDDocument doc) {
-        for (PDPage page : doc.getPages()) {
-            PDResources res = page.getResources();
-            if (res == null) continue;
-            for (COSName name : res.getXObjectNames()) {
-                try {
-                    PDXObject xo = res.getXObject(name);
-                    if (xo instanceof PDImageXObject img) {
-                        COSDictionary dict = img.getCOSObject();
-                        if (dict.containsKey(COSName.SMASK)) return true;
-                        COSBase g = dict.getDictionaryObject(COSName.GROUP);
-                        if (g instanceof COSDictionary gd
-                                && COSName.TRANSPARENCY.equals(gd.getCOSName(COSName.S))) {
-                            return true;
-                        }
-                        if (dict.getBoolean(COSName.INTERPOLATE, false)) return true;
-                    }
-                } catch (IOException ioe) {
-                    log.error("Error processing XObject {}: {}", name.getName(), ioe.getMessage());
-                }
-            }
-        }
-        return false;
-    }
-
-    private void sanitizePdfA(COSBase base, PDResources resources, int pdfaPart) {
-        if (base instanceof COSDictionary dict) {
-            if (pdfaPart == 1) {
-                // Remove transparency-related elements
-                COSBase group = dict.getDictionaryObject(COSName.GROUP);
-                if (group instanceof COSDictionary gDict
-                        && COSName.TRANSPARENCY.equals(gDict.getCOSName(COSName.S))) {
-                    dict.removeItem(COSName.GROUP);
-                }
-
-                dict.removeItem(COSName.SMASK);
-                // Transparency blending constants (/CA, /ca) — disallowed in PDF/A-1
-                dict.removeItem(COSName.CA);
-                dict.removeItem(COSName.getPDFName("ca"));
-            }
-
-            // Interpolation (non-deterministic image scaling) — required to be false
-            if (dict.containsKey(COSName.INTERPOLATE)
-                    && dict.getBoolean(COSName.INTERPOLATE, true)) {
-                dict.setBoolean(COSName.INTERPOLATE, false);
-            }
-
-            // Remove common forbidden features (for PDF/A 1 and 2)
-            dict.removeItem(COSName.JAVA_SCRIPT);
-            dict.removeItem(COSName.getPDFName("JS"));
-            dict.removeItem(COSName.getPDFName("RichMedia"));
-            dict.removeItem(COSName.getPDFName("Movie"));
-            dict.removeItem(COSName.getPDFName("Sound"));
-            dict.removeItem(COSName.getPDFName("Launch"));
-            dict.removeItem(COSName.URI);
-            dict.removeItem(COSName.getPDFName("GoToR"));
-            dict.removeItem(COSName.EMBEDDED_FILES);
-            dict.removeItem(COSName.FILESPEC);
-
-            // Recurse through all entries in the dictionary
-            for (Map.Entry<COSName, COSBase> entry : dict.entrySet()) {
-                sanitizePdfA(entry.getValue(), resources, pdfaPart);
-            }
-
-        } else if (base instanceof COSArray arr) {
-            // Recursively sanitize each item in the array
-            for (COSBase item : arr) {
-                sanitizePdfA(item, resources, pdfaPart);
-            }
-        }
-    }
-
-    private void removeElementsForPdfA(PDDocument doc, int pdfaPart) {
-
-        if (pdfaPart == 1) {
-            // Remove Optional Content (Layers) - not allowed in PDF/A-1
-            doc.getDocumentCatalog().getCOSObject().removeItem(COSName.getPDFName("OCProperties"));
+            return match.orElse(PDF_A_2B);
         }
 
-        for (PDPage page : doc.getPages()) {
-            if (pdfaPart == 1) {
-                page.setAnnotations(Collections.emptyList());
-            }
-            PDResources res = page.getResources();
-            // Clean page-level dictionary
-            sanitizePdfA(page.getCOSObject(), res, pdfaPart);
-
-            // sanitize each Form XObject
-            if (res != null) {
-                for (COSName name : res.getXObjectNames()) {
-                    try {
-                        PDXObject xo = res.getXObject(name);
-                        if (xo instanceof PDFormXObject form) {
-                            sanitizePdfA(form.getCOSObject(), res, pdfaPart);
-                        } else if (xo instanceof PDImageXObject img) {
-                            sanitizePdfA(img.getCOSObject(), res, pdfaPart);
-                        }
-                    } catch (IOException ioe) {
-                        log.error("Cannot load XObject {}: {}", name.getName(), ioe.getMessage());
-                    }
-                }
-            }
-        }
-    }
-
-    /** Embbeds the XMP metadata required for PDF/A compliance. */
-    private void mergeAndAddXmpMetadata(PDDocument document, int pdfaPart) throws Exception {
-        PDMetadata existingMetadata = document.getDocumentCatalog().getMetadata();
-        XMPMetadata xmp;
-
-        // Load existing XMP if available
-        if (existingMetadata != null) {
-            try (InputStream xmpStream = existingMetadata.createInputStream()) {
-                DomXmpParser parser = new DomXmpParser();
-                parser.setStrictParsing(false);
-                xmp = parser.parse(xmpStream);
-            } catch (Exception e) {
-                xmp = XMPMetadata.createXMPMetadata();
-            }
-        } else {
-            xmp = XMPMetadata.createXMPMetadata();
+        int part() {
+            return part;
         }
 
-        PDDocumentInformation docInfo = document.getDocumentInformation();
-        if (docInfo == null) {
-            docInfo = new PDDocumentInformation();
+        String displayName() {
+            return displayName;
         }
 
-        String originalCreator = Optional.ofNullable(docInfo.getCreator()).orElse("Unknown");
-        String originalProducer = Optional.ofNullable(docInfo.getProducer()).orElse("Unknown");
-
-        // Only keep the original creator so it can match xmp creator tool for compliance
-        DublinCoreSchema dcSchema = xmp.getDublinCoreSchema();
-        if (dcSchema != null) {
-            List<String> existingCreators = dcSchema.getCreators();
-            if (existingCreators != null) {
-                for (String creator : new ArrayList<>(existingCreators)) {
-                    dcSchema.removeCreator(creator);
-                }
-            }
-        } else {
-            dcSchema = xmp.createAndAddDublinCoreSchema();
-        }
-        dcSchema.addCreator(originalCreator);
-
-        PDFAIdentificationSchema pdfaSchema =
-                (PDFAIdentificationSchema) xmp.getSchema(PDFAIdentificationSchema.class);
-        if (pdfaSchema == null) {
-            pdfaSchema = xmp.createAndAddPDFAIdentificationSchema();
-        }
-        pdfaSchema.setPart(pdfaPart);
-        pdfaSchema.setConformance("B");
-
-        XMPBasicSchema xmpBasicSchema = xmp.getXMPBasicSchema();
-        if (xmpBasicSchema == null) {
-            xmpBasicSchema = xmp.createAndAddXMPBasicSchema();
+        String outputSuffix() {
+            return suffix;
         }
 
-        AdobePDFSchema adobePdfSchema = xmp.getAdobePDFSchema();
-        if (adobePdfSchema == null) {
-            adobePdfSchema = xmp.createAndAddAdobePDFSchema();
+        String compatibilityLevel() {
+            return compatibilityLevel;
         }
 
-        docInfo.setCreator(originalCreator);
-        xmpBasicSchema.setCreatorTool(originalCreator);
-
-        docInfo.setProducer(originalProducer);
-        adobePdfSchema.setProducer(originalProducer);
-
-        String originalAuthor = docInfo.getAuthor();
-        if (originalAuthor != null && !originalAuthor.isBlank()) {
-            docInfo.setAuthor(null);
-            // If the author is set, we keep it in the XMP metadata
-            if (!originalCreator.equals(originalAuthor)) {
-                dcSchema.addCreator(originalAuthor);
-            }
-        }
-
-        String title = docInfo.getTitle();
-        if (title != null && !title.isBlank()) {
-            dcSchema.setTitle(title);
-        }
-        String subject = docInfo.getSubject();
-        if (subject != null && !subject.isBlank()) {
-            dcSchema.addSubject(subject);
-        }
-        String keywords = docInfo.getKeywords();
-        if (keywords != null && !keywords.isBlank()) {
-            adobePdfSchema.setKeywords(keywords);
-        }
-
-        // Set creation and modification dates
-        Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        Calendar originalCreationDate = docInfo.getCreationDate();
-        if (originalCreationDate == null) {
-            originalCreationDate = now;
-        }
-        docInfo.setCreationDate(originalCreationDate);
-        xmpBasicSchema.setCreateDate(originalCreationDate);
-
-        docInfo.setModificationDate(now);
-        xmpBasicSchema.setModifyDate(now);
-        xmpBasicSchema.setMetadataDate(now);
-
-        // Serialize the created metadata so it can be attached to the existent metadata
-        ByteArrayOutputStream xmpOut = new ByteArrayOutputStream();
-        new XmpSerializer().serialize(xmp, xmpOut, true);
-
-        PDMetadata newMetadata = new PDMetadata(document);
-        newMetadata.importXMPMetadata(xmpOut.toByteArray());
-        document.getDocumentCatalog().setMetadata(newMetadata);
-    }
-
-    private void addICCProfileIfNotPresent(PDDocument document) throws Exception {
-        if (document.getDocumentCatalog().getOutputIntents().isEmpty()) {
-            try (InputStream colorProfile = getClass().getResourceAsStream("/icc/sRGB2014.icc")) {
-                PDOutputIntent outputIntent = new PDOutputIntent(document, colorProfile);
-                outputIntent.setInfo("sRGB IEC61966-2.1");
-                outputIntent.setOutputCondition("sRGB IEC61966-2.1");
-                outputIntent.setOutputConditionIdentifier("sRGB IEC61966-2.1");
-                outputIntent.setRegistryName("http://www.color.org");
-                document.getDocumentCatalog().addOutputIntent(outputIntent);
-            } catch (Exception e) {
-                log.error("Failed to load ICC profile: {}", e.getMessage());
-            }
-        }
-    }
-
-    private File preProcessHighlights(File inputPdf) throws Exception {
-
-        try (PDDocument document = Loader.loadPDF(inputPdf)) {
-
-            for (PDPage page : document.getPages()) {
-                // Retrieve the annotations on the page.
-                List<PDAnnotation> annotations = page.getAnnotations();
-                for (PDAnnotation annot : annotations) {
-                    // Process only highlight annotations.
-                    if ("Highlight".equals(annot.getSubtype())
-                            && annot instanceof PDAnnotationTextMarkup highlight) {
-                        // Create a new appearance stream with the same bounding box.
-                        float[] colorComponents =
-                                highlight.getColor() != null
-                                        ? highlight.getColor().getComponents()
-                                        : new float[] {1f, 1f, 0f};
-                        Color highlightColor =
-                                new Color(
-                                        colorComponents[0], colorComponents[1], colorComponents[2]);
-
-                        float[] quadPoints = highlight.getQuadPoints();
-                        if (quadPoints != null) {
-                            try (PDPageContentStream cs =
-                                    new PDPageContentStream(
-                                            document,
-                                            page,
-                                            PDPageContentStream.AppendMode.PREPEND,
-                                            true,
-                                            true)) {
-
-                                cs.setStrokingColor(highlightColor);
-                                cs.setLineWidth(0.05f);
-                                float spacing = 2f;
-                                // Draw diagonal lines across the highlight area to simulate
-                                // transparency.
-                                for (int i = 0; i < quadPoints.length; i += 8) {
-                                    float minX =
-                                            Math.min(
-                                                    Math.min(quadPoints[i], quadPoints[i + 2]),
-                                                    Math.min(quadPoints[i + 4], quadPoints[i + 6]));
-                                    float maxX =
-                                            Math.max(
-                                                    Math.max(quadPoints[i], quadPoints[i + 2]),
-                                                    Math.max(quadPoints[i + 4], quadPoints[i + 6]));
-                                    float minY =
-                                            Math.min(
-                                                    Math.min(quadPoints[i + 1], quadPoints[i + 3]),
-                                                    Math.min(quadPoints[i + 5], quadPoints[i + 7]));
-                                    float maxY =
-                                            Math.max(
-                                                    Math.max(quadPoints[i + 1], quadPoints[i + 3]),
-                                                    Math.max(quadPoints[i + 5], quadPoints[i + 7]));
-
-                                    float width = maxX - minX;
-                                    float height = maxY - minY;
-
-                                    for (float y = minY; y <= maxY; y += spacing) {
-                                        float len = Math.min(width, maxY - y);
-                                        cs.moveTo(minX, y);
-                                        cs.lineTo(minX + len, y + len);
-                                    }
-                                    for (float x = minX + spacing; x <= maxX; x += spacing) {
-                                        float len = Math.min(maxX - x, height);
-                                        cs.moveTo(x, minY);
-                                        cs.lineTo(x + len, minY + len);
-                                    }
-                                }
-
-                                cs.stroke();
-                            }
-                        }
-
-                        page.getAnnotations().remove(highlight);
-                        COSDictionary pageDict = page.getCOSObject();
-
-                        if (pageDict.containsKey(COSName.GROUP)) {
-                            COSDictionary groupDict =
-                                    (COSDictionary) pageDict.getDictionaryObject(COSName.GROUP);
-
-                            if (groupDict != null) {
-                                if (COSName.TRANSPARENCY
-                                        .getName()
-                                        .equalsIgnoreCase(groupDict.getNameAsString(COSName.S))) {
-                                    pageDict.removeItem(COSName.GROUP);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            // Save the modified document to a temporary file.
-            File preProcessedFile = Files.createTempFile("preprocessed_", ".pdf").toFile();
-            document.save(preProcessedFile);
-            return preProcessedFile;
+        Optional<Format> preflightFormat() {
+            return Optional.ofNullable(preflightFormat);
         }
     }
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPdfARequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/converters/PdfToPdfARequest.java
@@ -14,6 +14,6 @@ public class PdfToPdfARequest extends PDFFile {
     @Schema(
             description = "The output PDF/A type",
             requiredMode = Schema.RequiredMode.REQUIRED,
-            allowableValues = {"pdfa", "pdfa-1"})
+            allowableValues = {"pdfa", "pdfa-1", "pdfa-2", "pdfa-3"})
     private String outputFormat;
 }

--- a/app/core/src/main/resources/messages_en_GB.properties
+++ b/app/core/src/main/resources/messages_en_GB.properties
@@ -1536,7 +1536,7 @@ unlockPDFForms.submit=Remove
 #pdfToPDFA
 pdfToPDFA.title=PDF To PDF/A
 pdfToPDFA.header=PDF To PDF/A
-pdfToPDFA.credit=This service uses libreoffice for PDF/A conversion
+pdfToPDFA.credit=This service uses Ghostscript for PDF/A conversion
 pdfToPDFA.submit=Convert
 pdfToPDFA.tip=Currently does not work for multiple inputs at once
 pdfToPDFA.outputFormat=Output format

--- a/app/core/src/main/resources/templates/convert/pdf-to-pdfa.html
+++ b/app/core/src/main/resources/templates/convert/pdf-to-pdfa.html
@@ -24,7 +24,8 @@
                   <label for="outputFormat" th:text="#{pdfToPDFA.outputFormat}"></label>
                   <select class="form-control" name="outputFormat" id="outputFormat">
                     <option value="pdfa-1">PDF/A-1b</option>
-                    <option value="pdfa">PDF/A-2b</option>
+                    <option selected value="pdfa-2">PDF/A-2b</option>
+                    <option value="pdfa-3">PDF/A-3b</option>
                   </select>
                 </div>
                 <div id="result" class="alert-warning"></div>


### PR DESCRIPTION
# Description of Changes

This pull request updates the PDF/A conversion functionality to use Ghostscript instead of LibreOffice, expands support for additional PDF/A output formats

### PDF/A Conversion:

- Switched the backend for PDF/A conversion from LibreOffice to Ghostscript in both the documentation (`README.md`) and user-facing credit message (`messages_en_GB.properties`).
- Registered the new `pdf-to-pdfa` endpoint under the Ghostscript group in the endpoint configuration (`EndpointConfiguration.java`).

### PDF/A Output:

- Expanded allowable output formats for PDF/A conversion requests to include `pdfa-2` and `pdfa-3` in addition to existing options (`PdfToPdfARequest.java`).
- Updated the conversion form to default to `pdfa-2` and added an option for `pdfa-3` (`pdf-to-pdfa.html`).

### Error Handling Improvements:

- Added a new exception utility method to allow passing a cause when PDF/A conversion fails (`ExceptionUtils.java`)

### Prefligh validation with PDFBox

- `validatePdfaOutput` to validate output


### Why this is better;

- Ghostscript, generally the preferred library for PDF/A conversion, I have "no smoking gun" proving it is better or not from Libreoffice but it is much more used; and anecdotally seem to have better visual quality (at least this is what I gathered from forums)
- Ghostscript being more PDF focused library, it is more error tolerant and is able "repair" some less problematic PDFs meanwhile Libreoffice would just fail
- Ghostscript has better PDF/A-3b support
- Ghostscript can offer several long-term improvement possibilities such as; XML/XML invoice (e.g., Factur-X, XRechnung) PDF conversions;
- GS does offer optionally: device/ICC/metadata and attachment scripting (PDF/A-3b support attachments)
- GS does **some** compression so the output files should be more consistent in size
- It is also less code generally

Closes: #3059
<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
