### PR TITLE
feat(frontend): add mobile sliding layout

### DIFF
--- a/frontend/src/components/layout/MobileNavigationBar.module.css
+++ b/frontend/src/components/layout/MobileNavigationBar.module.css
@@ -1,0 +1,63 @@
+.container {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem calc(env(safe-area-inset-bottom) + 0.5rem);
+  background: var(--bg-toolbar);
+  border-top: 1px solid var(--border-subtle);
+  box-shadow: 0 -6px 24px rgba(12, 18, 28, 0.08);
+  z-index: 30;
+}
+
+.button {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0;
+  border-radius: 0.75rem;
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.button:focus-visible {
+  outline: 2px solid rgba(88, 101, 242, 0.6);
+  outline-offset: 2px;
+}
+
+.button:hover:not(.disabled) {
+  background-color: rgba(88, 101, 242, 0.08);
+}
+
+.active {
+  color: var(--text-primary, #f8fafc);
+}
+
+.active .mantine-ActionIcon-root {
+  background-color: rgba(88, 101, 242, 0.22);
+}
+
+.disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.label {
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+@supports (backdrop-filter: blur(12px)) {
+  .container {
+    background: rgba(18, 20, 28, 0.72);
+    backdrop-filter: blur(18px);
+  }
+}

--- a/frontend/src/components/layout/MobileNavigationBar.tsx
+++ b/frontend/src/components/layout/MobileNavigationBar.tsx
@@ -1,0 +1,139 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { ActionIcon, Tooltip } from "@mantine/core";
+import LocalIcon from "../shared/LocalIcon";
+import { useToolWorkflow } from "../../contexts/ToolWorkflowContext";
+import { useFilesModalContext } from "../../contexts/FilesModalContext";
+import useIsMobile from "../../hooks/useIsMobile";
+import styles from "./MobileNavigationBar.module.css";
+
+interface MobileNavigationBarProps {
+  activePane: "tools" | "workbench";
+  onPaneChange: (pane: "tools" | "workbench") => void;
+}
+
+export default function MobileNavigationBar({
+  activePane,
+  onPaneChange,
+}: MobileNavigationBarProps) {
+  const isMobile = useIsMobile();
+  const { t } = useTranslation();
+  const {
+    handleBackToTools,
+    handleReaderToggle,
+    handleToolSelect,
+    resetTool,
+    selectedToolKey,
+    readerMode,
+    isPanelVisible,
+  } = useToolWorkflow();
+  const { openFilesModal, isFilesModalOpen } = useFilesModalContext();
+
+  const items = useMemo(
+    () => [
+      {
+        id: "tools" as const,
+        label: t("mobileNav.tools", "Tools"),
+        icon: "handyman-rounded",
+        isActive: activePane === "tools" && isPanelVisible,
+        onClick: () => {
+          if (!isPanelVisible) {
+            return;
+          }
+          handleBackToTools();
+          onPaneChange("tools");
+        },
+        disabled: !isPanelVisible,
+      },
+      {
+        id: "workbench" as const,
+        label: t("mobileNav.document", "Document"),
+        icon: "description-rounded",
+        isActive: activePane === "workbench",
+        onClick: () => {
+          onPaneChange("workbench");
+        },
+      },
+      {
+        id: "read" as const,
+        label: t("quickAccess.read", "Read"),
+        icon: "menu-book-rounded",
+        isActive: readerMode,
+        onClick: () => {
+          handleBackToTools();
+          handleReaderToggle();
+          onPaneChange("workbench");
+        },
+      },
+      {
+        id: "automate" as const,
+        label: t("quickAccess.automate", "Automate"),
+        icon: "automation-outline",
+        isActive: selectedToolKey === "automate",
+        onClick: () => {
+          if (selectedToolKey === "automate") {
+            resetTool("automate");
+          } else {
+            handleToolSelect("automate");
+          }
+          onPaneChange("tools");
+        },
+      },
+      {
+        id: "files" as const,
+        label: t("quickAccess.files", "Files"),
+        icon: "folder-rounded",
+        isActive: isFilesModalOpen,
+        onClick: () => {
+          openFilesModal();
+        },
+      },
+    ],
+    [
+      activePane,
+      handleBackToTools,
+      handleReaderToggle,
+      handleToolSelect,
+      isFilesModalOpen,
+      isPanelVisible,
+      onPaneChange,
+      openFilesModal,
+      readerMode,
+      resetTool,
+      selectedToolKey,
+      t,
+    ]
+  );
+
+  if (!isMobile) {
+    return null;
+  }
+
+  return (
+    <nav className={styles.container} aria-label={t("mobileNav.navigation", "Primary navigation")!}>
+      {items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          className={`${styles.button} ${item.isActive ? styles.active : ""} ${
+            item.disabled ? styles.disabled : ""
+          }`}
+          onClick={item.onClick}
+          disabled={item.disabled}
+        >
+          <Tooltip label={item.label} position="top" withinPortal>
+            <ActionIcon
+              variant="subtle"
+              size="lg"
+              radius="xl"
+              aria-pressed={item.isActive}
+            >
+              <LocalIcon icon={item.icon} width="1.6rem" height="1.6rem" />
+            </ActionIcon>
+          </Tooltip>
+          <span className={styles.label}>{item.label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/tools/ToolPanel.tsx
+++ b/frontend/src/components/tools/ToolPanel.tsx
@@ -1,13 +1,14 @@
-import { useRainbowThemeContext } from '../shared/RainbowThemeProvider';
-import { useToolWorkflow } from '../../contexts/ToolWorkflowContext';
-import ToolPicker from './ToolPicker';
-import SearchResults from './SearchResults';
-import ToolRenderer from './ToolRenderer';
-import ToolSearch from './toolPicker/ToolSearch';
+import { useRainbowThemeContext } from "../shared/RainbowThemeProvider";
+import { useToolWorkflow } from "../../contexts/ToolWorkflowContext";
+import ToolPicker from "./ToolPicker";
+import SearchResults from "./SearchResults";
+import ToolRenderer from "./ToolRenderer";
+import ToolSearch from "./toolPicker/ToolSearch";
 import { useSidebarContext } from "../../contexts/SidebarContext";
-import rainbowStyles from '../../styles/rainbow.module.css';
-import { ScrollArea } from '@mantine/core';
-import { ToolId } from '../../types/toolId';
+import rainbowStyles from "../../styles/rainbow.module.css";
+import { ScrollArea } from "@mantine/core";
+import { ToolId } from "../../types/toolId";
+import { useIsMobile } from "../../hooks/useIsMobile";
 
 // No props needed - component uses context
 
@@ -15,6 +16,7 @@ export default function ToolPanel() {
   const { isRainbowMode } = useRainbowThemeContext();
   const { sidebarRefs } = useSidebarContext();
   const { toolPanelRef } = sidebarRefs;
+  const isMobile = useIsMobile();
 
 
   // Use context-based hooks to eliminate prop drilling
@@ -34,12 +36,13 @@ export default function ToolPanel() {
     <div
       ref={toolPanelRef}
       data-sidebar="tool-panel"
-      className={`h-screen flex flex-col overflow-hidden bg-[var(--bg-toolbar)] border-r border-[var(--border-subtle)] transition-all duration-300 ease-out ${
+      className={`${isMobile ? "h-full" : "h-screen"} flex flex-col overflow-hidden bg-[var(--bg-toolbar)] border-r border-[var(--border-subtle)] transition-all duration-300 ease-out ${
         isRainbowMode ? rainbowStyles.rainbowPaper : ''
       }`}
       style={{
-        width: isPanelVisible ? '18.5rem' : '0',
-        padding: '0'
+        width: isMobile ? (isPanelVisible ? "100%" : "0") : isPanelVisible ? "18.5rem" : "0",
+        padding: "0",
+        borderRight: isMobile ? "none" : undefined,
       }}
     >
       <div

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Small responsive helper for determining when the UI should switch to the
+ * mobile layout. Uses a matchMedia listener so it stays in sync with viewport
+ * changes without forcing re-renders on every resize event.
+ */
+export function useIsMobile(maxWidth = 960): boolean {
+  const getMatches = () =>
+    typeof window !== "undefined"
+      ? window.matchMedia(`(max-width: ${maxWidth}px)`).matches
+      : false;
+
+  const [isMobile, setIsMobile] = useState<boolean>(getMatches());
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(`(max-width: ${maxWidth}px)`);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
+    };
+
+    // Initial sync in case the component mounted before React read the value
+    setIsMobile(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, [maxWidth]);
+
+  return isMobile;
+}
+
+export default useIsMobile;

--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -1,0 +1,117 @@
+.mobileWrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--bg-background);
+  color: var(--text-primary, inherit);
+}
+
+.mobileTabs {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem 0.5rem;
+}
+
+.mobileTabButton {
+  flex: 1 1 0;
+  max-width: 12rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  background: rgba(88, 101, 242, 0.12);
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.mobileTabButtonActive {
+  background: rgba(88, 101, 242, 0.22);
+  color: var(--text-primary, #f8fafc);
+  border-color: rgba(88, 101, 242, 0.45);
+}
+
+.mobileTabButton:focus-visible {
+  outline: 2px solid rgba(88, 101, 242, 0.6);
+  outline-offset: 3px;
+}
+
+.mobileSliderContainer {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  touch-action: pan-y;
+}
+
+.mobileSlider {
+  display: flex;
+  width: 200%;
+  height: 100%;
+  transition: transform 320ms cubic-bezier(0.33, 1, 0.68, 1);
+  will-change: transform;
+}
+
+.mobilePane {
+  flex: 0 0 50%;
+  min-width: 50%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-toolbar);
+  position: relative;
+}
+
+.mobilePaneInner {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mobileIndicator {
+  position: absolute;
+  top: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.4rem;
+  z-index: 10;
+}
+
+.mobileIndicatorDot {
+  width: 0.65rem;
+  height: 0.25rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.6);
+  transition: background 180ms ease, width 180ms ease;
+}
+
+.mobileIndicatorDotActive {
+  background: rgba(88, 101, 242, 0.85);
+  width: 1.2rem;
+}
+
+.mobileEdgeGlow {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -1px;
+  width: 1rem;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    rgba(15, 23, 42, 0) 0%,
+    rgba(15, 23, 42, 0.35) 100%
+  );
+}
+
+.mobileSliderDragging {
+  transition: none;
+}
+
+@supports (padding: max(0px)) {
+  .mobileWrapper {
+    padding-bottom: max(env(safe-area-inset-bottom), 0px);
+  }
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TouchEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useToolWorkflow } from "../contexts/ToolWorkflowContext";
 import { Group } from "@mantine/core";
@@ -10,6 +12,9 @@ import Workbench from "../components/layout/Workbench";
 import QuickAccessBar from "../components/shared/QuickAccessBar";
 import RightRail from "../components/shared/RightRail";
 import FileManager from "../components/FileManager";
+import MobileNavigationBar from "../components/layout/MobileNavigationBar";
+import useIsMobile from "../hooks/useIsMobile";
+import styles from "./HomePage.module.css";
 
 
 export default function HomePage() {
@@ -20,7 +25,102 @@ export default function HomePage() {
 
   const { quickAccessRef } = sidebarRefs;
 
-  const { selectedTool, selectedToolKey } = useToolWorkflow();
+  const {
+    selectedTool,
+    selectedToolKey,
+    isPanelVisible,
+  } = useToolWorkflow();
+
+  const isMobile = useIsMobile();
+  const [activePane, setActivePane] = useState<"tools" | "workbench">("tools");
+  const [touchStartX, setTouchStartX] = useState<number | null>(null);
+  const [dragDelta, setDragDelta] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const sliderContainerRef = useRef<HTMLDivElement>(null);
+
+  const handlePaneChange = useCallback(
+    (pane: "tools" | "workbench") => {
+      if (pane === "tools" && !isPanelVisible) {
+        return;
+      }
+      setActivePane(pane);
+    },
+    [isPanelVisible]
+  );
+
+  useEffect(() => {
+    if (!isMobile) {
+      setActivePane("tools");
+      setTouchStartX(null);
+      setDragDelta(0);
+      setIsDragging(false);
+    }
+  }, [isMobile]);
+
+  useEffect(() => {
+    if (isMobile && !isPanelVisible) {
+      setActivePane("workbench");
+    }
+  }, [isMobile, isPanelVisible]);
+
+  const handleTouchStart = useCallback(
+    (event: TouchEvent<HTMLDivElement>) => {
+      if (event.touches.length !== 1) {
+        return;
+      }
+      if (activePane === "workbench" && !isPanelVisible) {
+        return;
+      }
+      setTouchStartX(event.touches[0].clientX);
+      setDragDelta(0);
+      setIsDragging(true);
+    },
+    [activePane, isPanelVisible]
+  );
+
+  const handleTouchMove = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    if (!isDragging || touchStartX === null) {
+      return;
+    }
+    const current = event.touches[0]?.clientX ?? 0;
+    setDragDelta(current - touchStartX);
+  }, [isDragging, touchStartX]);
+
+  const handleTouchEnd = useCallback(() => {
+    if (!isDragging || !sliderContainerRef.current) {
+      setIsDragging(false);
+      setTouchStartX(null);
+      setDragDelta(0);
+      return;
+    }
+
+    const width = sliderContainerRef.current.offsetWidth || 1;
+    const threshold = width * 0.18;
+
+    if (activePane === "tools" && dragDelta < -threshold) {
+      setActivePane("workbench");
+    } else if (activePane === "workbench" && dragDelta > threshold && isPanelVisible) {
+      setActivePane("tools");
+    }
+
+    setIsDragging(false);
+    setTouchStartX(null);
+    setDragDelta(0);
+  }, [activePane, dragDelta, isDragging, isPanelVisible]);
+
+  let sliderTransform = activePane === "tools" ? "translateX(0%)" : "translateX(-50%)";
+  if (sliderContainerRef.current) {
+    const width = sliderContainerRef.current.offsetWidth || 1;
+    const percentOffset = isDragging ? (dragDelta / width) * 50 : 0;
+
+    if (activePane === "tools") {
+      const clamped = Math.max(Math.min(percentOffset, 0), -50);
+      sliderTransform = `translateX(${clamped}%)`;
+    } else if (isPanelVisible) {
+      const clamped = Math.max(Math.min(percentOffset, 50), 0);
+      sliderTransform = `translateX(${-50 + clamped}%)`;
+    }
+  }
 
   const baseUrl = getBaseUrl();
 
@@ -35,6 +135,73 @@ export default function HomePage() {
   });
 
   // Note: File selection limits are now handled directly by individual tools
+
+  if (isMobile) {
+    return (
+      <div className={styles.mobileWrapper}>
+        <div className={styles.mobileTabs}>
+          <button
+            type="button"
+            className={`${styles.mobileTabButton} ${
+              activePane === "tools" && isPanelVisible ? styles.mobileTabButtonActive : ""
+            }`}
+            onClick={() => handlePaneChange("tools")}
+            disabled={!isPanelVisible}
+          >
+            {t("mobileNav.tools", "Tools")}
+          </button>
+          <button
+            type="button"
+            className={`${styles.mobileTabButton} ${
+              activePane === "workbench" ? styles.mobileTabButtonActive : ""
+            }`}
+            onClick={() => handlePaneChange("workbench")}
+          >
+            {t("mobileNav.document", "Document")}
+          </button>
+        </div>
+        <div
+          ref={sliderContainerRef}
+          className={styles.mobileSliderContainer}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          onTouchCancel={handleTouchEnd}
+        >
+          <div className={styles.mobileIndicator} aria-hidden="true">
+            <span
+              className={`${styles.mobileIndicatorDot} ${
+                activePane === "tools" && isPanelVisible ? styles.mobileIndicatorDotActive : ""
+              }`}
+            />
+            <span
+              className={`${styles.mobileIndicatorDot} ${
+                activePane === "workbench" ? styles.mobileIndicatorDotActive : ""
+              }`}
+            />
+          </div>
+          <div
+            className={`${styles.mobileSlider} ${isDragging ? styles.mobileSliderDragging : ""}`}
+            style={{ transform: sliderTransform }}
+          >
+            <div className={styles.mobilePane}>
+              {isPanelVisible && <div className={styles.mobileEdgeGlow} aria-hidden="true" />}
+              <div className={styles.mobilePaneInner}>
+                <ToolPanel />
+              </div>
+            </div>
+            <div className={styles.mobilePane}>
+              <div className={styles.mobilePaneInner}>
+                <Workbench />
+              </div>
+            </div>
+          </div>
+        </div>
+        <MobileNavigationBar activePane={activePane} onPaneChange={handlePaneChange} />
+        <FileManager selectedTool={selectedTool as any /* FIX ME */} />
+      </div>
+    );
+  }
 
   return (
     <div className="h-screen overflow-hidden">


### PR DESCRIPTION
## Summary
- add a viewport-aware hook and mobile navigation bar to support handheld layouts
- rework the home page to provide swipeable tool and workbench panels with clear mobile affordances
- update the tool panel and new CSS modules to cooperate with the mobile slider layout

## Testing
- npm run build *(fails: 403 Forbidden when fetching @atlaskit/pragmatic-drag-and-drop)*

------
https://chatgpt.com/codex/tasks/task_b_68dba3409810832893902ff469d5bb48