### PR TITLE
fix(scanner-effect): lower default DPI in ScannerEffectRequest

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ScannerEffectRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ScannerEffectRequest.java
@@ -101,7 +101,7 @@ public class ScannerEffectRequest {
         this.noise = 1.0f;
         this.brightness = 1.02f;
         this.contrast = 1.05f;
-        this.resolution = 600;
+        this.resolution = 300;
     }
 
     public void applyMediumQualityPreset() {


### PR DESCRIPTION
# Description of Changes

On High preset the Scanner-effect request was blocked on default since max DPI is 500. This meant if users **tried** to use Scannereffect on default DPI limit, and default ScannerEffect setting  then they would get error. This update lowers default high preset's DPI to 300 so that is under the default limit.

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
