### PR TITLE
feat(viewer): add unified PDF loading via `usePdfLoaderSource` with buffer & URL support, error handling, and better export filenames

### DIFF
--- a/frontend/src/hooks/usePdfLoaderSource.ts
+++ b/frontend/src/hooks/usePdfLoaderSource.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+
+export type PdfLoaderSource =
+  | { type: 'url'; id: string; name?: string; url: string }
+  | { type: 'buffer'; id: string; name?: string; content: ArrayBuffer };
+
+interface UsePdfLoaderSourceOptions {
+  file?: File | Blob;
+  url?: string | null;
+  fallbackId: string;
+}
+
+function hasFileName(value: File | Blob): value is File {
+  return 'name' in value && typeof value.name === 'string';
+}
+
+function isPdfFile(file: File | Blob): boolean {
+  if ('type' in file && file.type) {
+    return file.type === 'application/pdf';
+  }
+  if (hasFileName(file)) {
+    return file.name.toLowerCase().endsWith('.pdf');
+  }
+  return false;
+}
+
+function isPdfUrl(url: string): boolean {
+  return url.toLowerCase().includes('.pdf');
+}
+
+export function usePdfLoaderSource({ file, url, fallbackId }: UsePdfLoaderSourceOptions) {
+  const [source, setSource] = useState<PdfLoaderSource | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const prepare = async () => {
+      setError(null);
+
+      if (file) {
+        if (!isPdfFile(file)) {
+          setError('Datei ist kein PDF.');
+          setSource(null);
+          return;
+        }
+
+        setIsLoading(true);
+        setSource(null);
+
+        const name = hasFileName(file) && file.name.trim().length > 0 ? file.name : undefined;
+        const id = name ?? fallbackId;
+
+        try {
+          const content = await file.arrayBuffer();
+          if (cancelled) return;
+
+          setSource({
+            type: 'buffer',
+            id,
+            name,
+            content,
+          });
+        } catch (err) {
+          if (cancelled) return;
+
+          setError(err instanceof Error ? err.message : String(err));
+          setSource(null);
+        } finally {
+          if (!cancelled) {
+            setIsLoading(false);
+          }
+        }
+
+        return;
+      }
+
+      setIsLoading(false);
+
+      if (typeof url === 'string' && url.length > 0) {
+        if (!isPdfUrl(url)) {
+          setError('URL zeigt nicht auf ein PDF.');
+          setSource(null);
+          return;
+        }
+
+        const id = url || fallbackId;
+
+        if (!cancelled) {
+          setSource({
+            type: 'url',
+            id,
+            url,
+          });
+        }
+      } else {
+        if (!cancelled) {
+          setSource(null);
+        }
+      }
+    };
+
+    void prepare();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [file, url, fallbackId]);
+
+  return { source, isLoading, error };
+}


### PR DESCRIPTION
# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
