### PR TITLE
refactor(api): use boolean primitives where default values exist

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
@@ -242,7 +242,7 @@ public class MergeController {
         List<File> filesToDelete = new ArrayList<>(); // List of temporary files to delete
         TempFile outputTempFile = null;
 
-        boolean removeCertSign = Boolean.TRUE.equals(request.getRemoveCertSign());
+        boolean removeCertSign = request.isRemoveCertSign();
         boolean generateToc = request.isGenerateToc();
 
         MultipartFile[] files = request.getFileInput();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/MultiPageLayoutController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/MultiPageLayoutController.java
@@ -51,7 +51,7 @@ public class MultiPageLayoutController {
 
         int pagesPerSheet = request.getPagesPerSheet();
         MultipartFile file = request.getFileInput();
-        boolean addBorder = Boolean.TRUE.equals(request.getAddBorder());
+        boolean addBorder = request.isAddBorder();
 
         if (pagesPerSheet != 2
                 && pagesPerSheet != 3

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/SplitPdfByChaptersController.java
@@ -128,7 +128,7 @@ public class SplitPdfByChaptersController {
         Path zipFile = null;
 
         try {
-            boolean includeMetadata = Boolean.TRUE.equals(request.getIncludeMetadata());
+            boolean includeMetadata = request.isIncludeMetadata();
             Integer bookmarkLevel =
                     request.getBookmarkLevel(); // levels start from 0 (top most bookmarks)
             if (bookmarkLevel < 0) {
@@ -164,7 +164,7 @@ public class SplitPdfByChaptersController {
                         .body("Unable to extract outline items".getBytes());
             }
 
-            boolean allowDuplicates = Boolean.TRUE.equals(request.getAllowDuplicates());
+            boolean allowDuplicates = request.isAllowDuplicates();
             if (!allowDuplicates) {
                 /*
                 duplicates are generated when multiple bookmarks correspond to the same page,

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/SplitPdfBySectionsController.java
@@ -66,7 +66,7 @@ public class SplitPdfBySectionsController {
         // Process the PDF based on split parameters
         int horiz = request.getHorizontalDivisions() + 1;
         int verti = request.getVerticalDivisions() + 1;
-        boolean merge = Boolean.TRUE.equals(request.getMerge());
+        boolean merge = request.isMerge();
         List<PDDocument> splitDocuments = splitPdfPages(sourceDocument, verti, horiz);
 
         String filename = GeneralUtils.generateFilename(file.getOriginalFilename(), "_split.pdf");

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
@@ -88,7 +88,7 @@ public class ConvertImgPDFController {
         String colorType = request.getColorType();
         int dpi = request.getDpi();
         String pageNumbers = request.getPageNumbers();
-        boolean includeAnnotations = Boolean.TRUE.equals(request.getIncludeAnnotations());
+        boolean includeAnnotations = request.isIncludeAnnotations();
         Path tempFile = null;
         Path tempOutputDir = null;
         Path tempPdfPath = null;
@@ -246,7 +246,7 @@ public class ConvertImgPDFController {
         MultipartFile[] file = request.getFileInput();
         String fitOption = request.getFitOption();
         String colorType = request.getColorType();
-        boolean autoRotate = Boolean.TRUE.equals(request.getAutoRotate());
+        boolean autoRotate = request.isAutoRotate();
         // Handle Null entries for formdata
         if (colorType == null || colorType.isBlank()) {
             colorType = "color";

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoRenameController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoRenameController.java
@@ -49,7 +49,7 @@ public class AutoRenameController {
     public ResponseEntity<byte[]> extractHeader(@ModelAttribute ExtractHeaderRequest request)
             throws Exception {
         MultipartFile file = request.getFileInput();
-        boolean useFirstTextAsFallback = Boolean.TRUE.equals(request.getUseFirstTextAsFallback());
+        boolean useFirstTextAsFallback = request.isUseFirstTextAsFallback();
 
         PDDocument document = pdfDocumentFactory.load(file);
         PDFTextStripper reader =

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
@@ -119,7 +119,7 @@ public class AutoSplitPdfController {
     public ResponseEntity<byte[]> autoSplitPdf(@ModelAttribute AutoSplitPdfRequest request)
             throws IOException {
         MultipartFile file = request.getFileInput();
-        boolean duplexMode = Boolean.TRUE.equals(request.getDuplexMode());
+        boolean duplexMode = request.isDuplexMode();
 
         PDDocument document = null;
         List<PDDocument> splitDocuments = new ArrayList<>();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/CompressController.java
@@ -661,7 +661,7 @@ public class CompressController {
         MultipartFile inputFile = request.getFileInput();
         Integer optimizeLevel = request.getOptimizeLevel();
         String expectedOutputSizeString = request.getExpectedOutputSize();
-        Boolean convertToGrayscale = request.getGrayscale();
+        boolean convertToGrayscale = request.isGrayscale();
         if (expectedOutputSizeString == null && optimizeLevel == null) {
             throw new Exception("Both expected output size and optimize level are not specified");
         }
@@ -736,8 +736,7 @@ public class CompressController {
                 }
 
                 // Apply image compression for levels 4+ only if Ghostscript didn't run
-                if ((optimizeLevel >= 4 || Boolean.TRUE.equals(convertToGrayscale))
-                        && !imageCompressionApplied) {
+                if ((optimizeLevel >= 4 || convertToGrayscale) && !imageCompressionApplied) {
                     // Use different scale factors based on level
                     double scaleFactor =
                             switch (optimizeLevel) {
@@ -756,7 +755,7 @@ public class CompressController {
                                     currentFile,
                                     scaleFactor,
                                     0.7f, // Default JPEG quality
-                                    Boolean.TRUE.equals(convertToGrayscale));
+                                    convertToGrayscale);
 
                     tempFiles.add(compressedImageFile);
                     currentFile = compressedImageFile;
@@ -927,10 +926,10 @@ public class CompressController {
         // Build QPDF command
         List<String> command = new ArrayList<>();
         command.add("qpdf");
-        if (request.getNormalize()) {
+        if (request.isNormalize()) {
             command.add("--normalize-content=y");
         }
-        if (request.getLinearize()) {
+        if (request.isLinearize()) {
             command.add("--linearize");
         }
         command.add("--recompress-flate");

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImagesController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ExtractImagesController.java
@@ -65,7 +65,7 @@ public class ExtractImagesController {
             throws IOException, InterruptedException, ExecutionException {
         MultipartFile file = request.getFileInput();
         String format = request.getFormat();
-        boolean allowDuplicates = Boolean.TRUE.equals(request.getAllowDuplicates());
+        boolean allowDuplicates = request.isAllowDuplicates();
         PDDocument document = pdfDocumentFactory.load(file);
 
         // Determine if multithreading should be used based on PDF size or number of pages

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/FlattenController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/FlattenController.java
@@ -52,9 +52,9 @@ public class FlattenController {
         MultipartFile file = request.getFileInput();
 
         PDDocument document = pdfDocumentFactory.load(file);
-        Boolean flattenOnlyForms = request.getFlattenOnlyForms();
+        boolean flattenOnlyForms = request.isFlattenOnlyForms();
 
-        if (Boolean.TRUE.equals(flattenOnlyForms)) {
+        if (flattenOnlyForms) {
             PDAcroForm acroForm = document.getDocumentCatalog().getAcroForm();
             if (acroForm != null) {
                 acroForm.flatten();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/MetadataController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/MetadataController.java
@@ -67,7 +67,7 @@ public class MetadataController {
         MultipartFile pdfFile = request.getFileInput();
 
         // Extract metadata information
-        boolean deleteAll = Boolean.TRUE.equals(request.getDeleteAll());
+        boolean deleteAll = request.isDeleteAll();
         String author = request.getAuthor();
         String creationDate = request.getCreationDate();
         String creator = request.getCreator();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/OverlayImageController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/OverlayImageController.java
@@ -44,7 +44,7 @@ public class OverlayImageController {
         MultipartFile imageFile = request.getImageFile();
         float x = request.getX();
         float y = request.getY();
-        boolean everyPage = Boolean.TRUE.equals(request.getEveryPage());
+        boolean everyPage = request.isEveryPage();
         try {
             byte[] pdfBytes = pdfFile.getBytes();
             byte[] imageBytes = imageFile.getBytes();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
@@ -103,12 +103,12 @@ public class CertSignController {
             MultipartFile input,
             OutputStream output,
             CreateSignature instance,
-            Boolean showSignature,
+            boolean showSignature,
             Integer pageNumber,
             String name,
             String location,
             String reason,
-            Boolean showLogo) {
+            boolean showLogo) {
         try (PDDocument doc = pdfDocumentFactory.load(input)) {
             PDSignature signature = new PDSignature();
             signature.setFilter(PDSignature.FILTER_ADOBE_PPKLITE);
@@ -117,7 +117,7 @@ public class CertSignController {
             signature.setLocation(location);
             signature.setReason(reason);
             signature.setSignDate(Calendar.getInstance()); // PDFBox requires Calendar
-            if (Boolean.TRUE.equals(showSignature)) {
+            if (showSignature) {
                 SignatureOptions signatureOptions = new SignatureOptions();
                 signatureOptions.setVisualSignature(
                         instance.createVisibleSignature(doc, signature, pageNumber, showLogo));
@@ -155,13 +155,13 @@ public class CertSignController {
         MultipartFile p12File = request.getP12File();
         MultipartFile jksfile = request.getJksFile();
         String password = request.getPassword();
-        Boolean showSignature = request.getShowSignature();
+        boolean showSignature = request.isShowSignature();
         String reason = request.getReason();
         String location = request.getLocation();
         String name = request.getName();
         // Convert 1-indexed page number (user input) to 0-indexed page number (API requirement)
         Integer pageNumber = request.getPageNumber() != null ? (request.getPageNumber() - 1) : null;
-        Boolean showLogo = request.getShowLogo();
+        boolean showLogo = request.isShowLogo();
 
         if (StringUtils.isBlank(certType)) {
             throw ExceptionUtils.createIllegalArgumentException(

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/PasswordController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/PasswordController.java
@@ -71,16 +71,14 @@ public class PasswordController {
         String ownerPassword = request.getOwnerPassword();
         String password = request.getPassword();
         int keyLength = request.getKeyLength();
-        boolean preventAssembly = Boolean.TRUE.equals(request.getPreventAssembly());
-        boolean preventExtractContent = Boolean.TRUE.equals(request.getPreventExtractContent());
-        boolean preventExtractForAccessibility =
-                Boolean.TRUE.equals(request.getPreventExtractForAccessibility());
-        boolean preventFillInForm = Boolean.TRUE.equals(request.getPreventFillInForm());
-        boolean preventModify = Boolean.TRUE.equals(request.getPreventModify());
-        boolean preventModifyAnnotations =
-                Boolean.TRUE.equals(request.getPreventModifyAnnotations());
-        boolean preventPrinting = Boolean.TRUE.equals(request.getPreventPrinting());
-        boolean preventPrintingFaithful = Boolean.TRUE.equals(request.getPreventPrintingFaithful());
+        boolean preventAssembly = request.isPreventAssembly();
+        boolean preventExtractContent = request.isPreventExtractContent();
+        boolean preventExtractForAccessibility = request.isPreventExtractForAccessibility();
+        boolean preventFillInForm = request.isPreventFillInForm();
+        boolean preventModify = request.isPreventModify();
+        boolean preventModifyAnnotations = request.isPreventModifyAnnotations();
+        boolean preventPrinting = request.isPreventPrinting();
+        boolean preventPrintingFaithful = request.isPreventPrintingFaithful();
 
         PDDocument document = pdfDocumentFactory.load(fileInput);
         AccessPermission ap = new AccessPermission();

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/SanitizeController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/SanitizeController.java
@@ -57,12 +57,12 @@ public class SanitizeController {
     public ResponseEntity<byte[]> sanitizePDF(@ModelAttribute SanitizePdfRequest request)
             throws IOException {
         MultipartFile inputFile = request.getFileInput();
-        boolean removeJavaScript = Boolean.TRUE.equals(request.getRemoveJavaScript());
-        boolean removeEmbeddedFiles = Boolean.TRUE.equals(request.getRemoveEmbeddedFiles());
-        boolean removeXMPMetadata = Boolean.TRUE.equals(request.getRemoveXMPMetadata());
-        boolean removeMetadata = Boolean.TRUE.equals(request.getRemoveMetadata());
-        boolean removeLinks = Boolean.TRUE.equals(request.getRemoveLinks());
-        boolean removeFonts = Boolean.TRUE.equals(request.getRemoveFonts());
+        boolean removeJavaScript = request.isRemoveJavaScript();
+        boolean removeEmbeddedFiles = request.isRemoveEmbeddedFiles();
+        boolean removeXMPMetadata = request.isRemoveXMPMetadata();
+        boolean removeMetadata = request.isRemoveMetadata();
+        boolean removeLinks = request.isRemoveLinks();
+        boolean removeFonts = request.isRemoveFonts();
 
         PDDocument document = pdfDocumentFactory.load(inputFile, true);
         if (removeJavaScript) {

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -98,7 +98,7 @@ public class WatermarkController {
         int widthSpacer = request.getWidthSpacer();
         int heightSpacer = request.getHeightSpacer();
         String customColor = request.getCustomColor();
-        boolean convertPdfToImage = Boolean.TRUE.equals(request.getConvertPDFToImage());
+        boolean convertPdfToImage = request.isConvertPDFToImage();
 
         // Load the input PDF
         PDDocument document = pdfDocumentFactory.load(pdfFile);

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/EditTableOfContentsRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/EditTableOfContentsRequest.java
@@ -20,5 +20,5 @@ public class EditTableOfContentsRequest extends PDFFile {
     @Schema(
             description = "Whether to replace existing bookmarks or append to them",
             example = "true")
-    private Boolean replaceExisting;
+    private boolean replaceExisting;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/PDFExtractImagesRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/PDFExtractImagesRequest.java
@@ -14,5 +14,5 @@ public class PDFExtractImagesRequest extends PDFWithImageFormatRequest {
                     "Boolean to enable/disable the saving of duplicate images, true to enable"
                             + " duplicates",
             defaultValue = "false")
-    private Boolean allowDuplicates;
+    private boolean allowDuplicates;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfByChaptersRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfByChaptersRequest.java
@@ -14,13 +14,13 @@ public class SplitPdfByChaptersRequest extends PDFFile {
             description = "Whether to include Metadata or not",
             defaultValue = "true",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean includeMetadata;
+    private boolean includeMetadata;
 
     @Schema(
             description = "Whether to allow duplicates or not",
             defaultValue = "true",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean allowDuplicates;
+    private boolean allowDuplicates;
 
     @Schema(
             description = "Maximum bookmark level required",

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
@@ -28,5 +28,5 @@ public class SplitPdfBySectionsRequest extends PDFFile {
             description = "Merge the split documents into a single PDF",
             defaultValue = "true",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean merge;
+    private boolean merge;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequest.java
@@ -43,5 +43,5 @@ public class ConvertToImageRequest extends PDFWithPageNums {
     @Schema(
             description = "Include annotations such as comments in the output image(s)",
             defaultValue = "false")
-    private Boolean includeAnnotations;
+    private boolean includeAnnotations;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToPdfRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToPdfRequest.java
@@ -34,5 +34,5 @@ public class ConvertToPdfRequest {
             description = "Whether to automatically rotate the images to better fit the PDF page",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "false")
-    private Boolean autoRotate;
+    private boolean autoRotate;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/general/MergeMultiplePagesRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/general/MergeMultiplePagesRequest.java
@@ -20,5 +20,5 @@ public class MergeMultiplePagesRequest extends PDFFile {
     private int pagesPerSheet;
 
     @Schema(description = "Boolean for if you wish to add border around the pages")
-    private Boolean addBorder;
+    private boolean addBorder;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/general/MergePdfsRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/general/MergePdfsRequest.java
@@ -31,7 +31,7 @@ public class MergePdfsRequest extends MultiplePDFFiles {
                             + " final merged document.",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "true")
-    private Boolean removeCertSign;
+    private boolean removeCertSign;
 
     @Schema(
             description =

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/AutoSplitPdfRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/AutoSplitPdfRequest.java
@@ -16,5 +16,5 @@ public class AutoSplitPdfRequest extends PDFFile {
                     "Flag indicating if the duplex mode is active, where the page after the divider also gets removed.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED,
             defaultValue = "false")
-    private Boolean duplexMode;
+    private boolean duplexMode;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ExtractHeaderRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ExtractHeaderRequest.java
@@ -16,5 +16,5 @@ public class ExtractHeaderRequest extends PDFFile {
                     "Flag indicating whether to use the first text as a fallback if no suitable title is found. Defaults to false.",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED,
             defaultValue = "false")
-    private Boolean useFirstTextAsFallback;
+    private boolean useFirstTextAsFallback;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/FlattenRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/FlattenRequest.java
@@ -17,5 +17,5 @@ public class FlattenRequest extends PDFFile {
                             + " image)",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "false")
-    private Boolean flattenOnlyForms;
+    private boolean flattenOnlyForms;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/MetadataRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/MetadataRequest.java
@@ -17,7 +17,7 @@ public class MetadataRequest extends PDFFile {
             description = "Delete all metadata if set to true",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean deleteAll;
+    private boolean deleteAll;
 
     @Schema(
             description = "The author of the document",

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/OptimizePdfRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/OptimizePdfRequest.java
@@ -30,7 +30,7 @@ public class OptimizePdfRequest extends PDFFile {
             description = "Whether to linearize the PDF for faster web viewing. Default is false.",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "false")
-    private Boolean linearize = false;
+    private boolean linearize = false;
 
     @Schema(
             description =
@@ -38,11 +38,11 @@ public class OptimizePdfRequest extends PDFFile {
                             + " false.",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "false")
-    private Boolean normalize = false;
+    private boolean normalize = false;
 
     @Schema(
             description = "Whether to convert the PDF to grayscale. Default is false.",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "false")
-    private Boolean grayscale = false;
+    private boolean grayscale = false;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/OverlayImageRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/OverlayImageRequest.java
@@ -35,5 +35,5 @@ public class OverlayImageRequest extends PDFFile {
             description = "Whether to overlay the image onto every page of the PDF.",
             requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "false")
-    private Boolean everyPage;
+    private boolean everyPage;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddPasswordRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddPasswordRequest.java
@@ -33,30 +33,30 @@ public class AddPasswordRequest extends PDFFile {
     private int keyLength = 256;
 
     @Schema(description = "Whether document assembly is prevented", defaultValue = "false")
-    private Boolean preventAssembly;
+    private boolean preventAssembly;
 
     @Schema(description = "Whether content extraction is prevented", defaultValue = "false")
-    private Boolean preventExtractContent;
+    private boolean preventExtractContent;
 
     @Schema(
             description = "Whether content extraction for accessibility is prevented",
             defaultValue = "false")
-    private Boolean preventExtractForAccessibility;
+    private boolean preventExtractForAccessibility;
 
     @Schema(description = "Whether form filling is prevented", defaultValue = "false")
-    private Boolean preventFillInForm;
+    private boolean preventFillInForm;
 
     @Schema(description = "Whether document modification is prevented", defaultValue = "false")
-    private Boolean preventModify;
+    private boolean preventModify;
 
     @Schema(
             description = "Whether modification of annotations is prevented",
             defaultValue = "false")
-    private Boolean preventModifyAnnotations;
+    private boolean preventModifyAnnotations;
 
     @Schema(description = "Whether printing of the document is prevented", defaultValue = "false")
-    private Boolean preventPrinting;
+    private boolean preventPrinting;
 
     @Schema(description = "Whether faithful printing is prevented", defaultValue = "false")
-    private Boolean preventPrintingFaithful;
+    private boolean preventPrintingFaithful;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
@@ -53,5 +53,5 @@ public class AddWatermarkRequest extends PDFFile {
             description = "Convert the redacted PDF to an image",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean convertPDFToImage;
+    private boolean convertPDFToImage;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/SanitizePdfRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/SanitizePdfRequest.java
@@ -15,35 +15,35 @@ public class SanitizePdfRequest extends PDFFile {
             description = "Remove JavaScript actions from the PDF",
             defaultValue = "true",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean removeJavaScript;
+    private boolean removeJavaScript;
 
     @Schema(
             description = "Remove embedded files from the PDF",
             defaultValue = "true",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean removeEmbeddedFiles;
+    private boolean removeEmbeddedFiles;
 
     @Schema(
             description = "Remove XMP metadata from the PDF",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean removeXMPMetadata;
+    private boolean removeXMPMetadata;
 
     @Schema(
             description = "Remove document info metadata from the PDF",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean removeMetadata;
+    private boolean removeMetadata;
 
     @Schema(
             description = "Remove links from the PDF",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean removeLinks;
+    private boolean removeLinks;
 
     @Schema(
             description = "Remove fonts from the PDF",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean removeFonts;
+    private boolean removeFonts;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
@@ -46,7 +46,7 @@ public class SignPDFWithCertRequest extends PDFFile {
             description = "Whether to visually show the signature in the PDF file",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean showSignature;
+    private boolean showSignature;
 
     @Schema(description = "The reason for signing the PDF", defaultValue = "Signed by SPDF")
     private String reason;
@@ -68,5 +68,5 @@ public class SignPDFWithCertRequest extends PDFFile {
             description = "Whether to visually show a signature logo along with the signature",
             defaultValue = "true",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean showLogo;
+    private boolean showLogo;
 }


### PR DESCRIPTION
# Description of Changes

This PR converts `Boolean` wrapper types to `boolean` primitives across API request/response models and controllers for fields that have default non-null values defined.

### Motivation

When using `@Schema(defaultValue = "false")` or similar annotations with non-null defaults, the `Boolean` wrapper type is unnecessary and can lead to potential issues:

- Null Safety: `Boolean` objects can be null, which can cause NullPointerException during auto-unboxing operations
- Type Safety: Primitives cannot be null, making the API contract clearer and more predictable
- Semantic Correctness: When a field is marked as required with a default value, null is not a valid state, using a primitive enforces this constraint at the type level
- Performance: Primitives avoid the overhead of object allocation and potential unboxing operations

### Changes

- Converted `Boolean` fields to `boolean` primitives in API DTOs where:
  - A defaultValue is provided (that is non-null)
  - The field logically never needs to represent a null/unset state



<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
