### PR TITLE
refactor(api): adjust default values and extend schema for stamp and watermark requests

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfByChaptersRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfByChaptersRequest.java
@@ -12,20 +12,20 @@ import stirling.software.common.model.api.PDFFile;
 public class SplitPdfByChaptersRequest extends PDFFile {
     @Schema(
             description = "Whether to include Metadata or not",
-            defaultValue = "true",
+            defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean includeMetadata;
 
     @Schema(
             description = "Whether to allow duplicates or not",
-            defaultValue = "true",
+            defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean allowDuplicates;
 
     @Schema(
             description = "Maximum bookmark level required",
             minimum = "0",
-            defaultValue = "2",
+            defaultValue = "0",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer bookmarkLevel;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/SplitPdfBySectionsRequest.java
@@ -26,7 +26,7 @@ public class SplitPdfBySectionsRequest extends PDFFile {
 
     @Schema(
             description = "Merge the split documents into a single PDF",
-            defaultValue = "true",
+            defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean merge;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/AddStampRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/AddStampRequest.java
@@ -27,7 +27,7 @@ public class AddStampRequest extends PDFWithPageNums {
 
     @Schema(
             description = "The selected alphabet of the stamp text",
-            allowableValues = {"roman", "arabic", "japanese", "korean", "chinese"},
+            allowableValues = {"roman", "arabic", "japanese", "korean", "chinese", "thai"},
             defaultValue = "roman")
     private String alphabet = "roman";
 
@@ -55,7 +55,7 @@ public class AddStampRequest extends PDFWithPageNums {
                             + " 3: bottom-right, 4: middle-left, 5: middle-center, 6: middle-right,"
                             + " 7: top-left, 8: top-center, 9: top-right)",
             allowableValues = {"1", "2", "3", "4", "5", "6", "7", "8", "9"},
-            defaultValue = "5",
+            defaultValue = "8",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private int position;
 

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
@@ -27,7 +27,7 @@ public class AddWatermarkRequest extends PDFFile {
 
     @Schema(
             description = "The selected alphabet",
-            allowableValues = {"roman", "arabic", "japanese", "korean", "chinese"},
+            allowableValues = {"roman", "arabic", "japanese", "korean", "chinese", "thai"},
             defaultValue = "roman")
     private String alphabet;
 


### PR DESCRIPTION
# Description of Changes

This refactor updates several API request models to better align with expected defaults and extend supported options:

- **SplitPdfByChaptersRequest**
  - `includeMetadata`: default changed from `true` → `false`
  - `allowDuplicates`: default changed from `true` → `false`
  - `bookmarkLevel`: default changed from `2` → `0`

- **SplitPdfBySectionsRequest**
  - `merge`: default changed from `true` → `false`

- **AddStampRequest**
  - Added `"thai"` to `allowableValues` for the `alphabet` field
  - Updated default `position` from `5` (middle-center) → `8` (top-center)

- **AddWatermarkRequest**
  - Added `"thai"` to `allowableValues` for the `alphabet` field

**Reason for change:**
These modifications bring the API defaults in line with real-world usage expectations and improve multilingual support (adding Thai alphabet).


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
