### PR TITLE
quick Z index fix for file modal

### DIFF
--- a/frontend/src/components/fileManager/FileListItem.tsx
+++ b/frontend/src/components/fileManager/FileListItem.tsx
@@ -12,6 +12,7 @@ import { FileId, StirlingFileStub } from '../../types/fileContext';
 import { useFileManagerContext } from '../../contexts/FileManagerContext';
 import { zipFileService } from '../../services/zipFileService';
 import ToolChain from '../shared/ToolChain';
+import { Z_INDEX_OVER_FILE_MANAGER_MODAL } from '../../styles/zIndex';
 
 interface FileListItemProps {
   file: StirlingFileStub;
@@ -127,6 +128,7 @@ const FileListItem: React.FC<FileListItemProps> = ({
             withinPortal
             onOpen={() => setIsMenuOpen(true)}
             onClose={() => setIsMenuOpen(false)}
+            zIndex={Z_INDEX_OVER_FILE_MANAGER_MODAL}
           >
             <Menu.Target>
               <ActionIcon

--- a/frontend/src/styles/zIndex.ts
+++ b/frontend/src/styles/zIndex.ts
@@ -2,8 +2,12 @@
 // Keep values identical to their original inline usages.
 
 export const Z_INDEX_FULLSCREEN_SURFACE = 1000;
-export const Z_INDEX_AUTOMATE_MODAL = 1100;
-export const Z_INDEX_FILE_MANAGER_MODAL = 1200; 
 export const Z_INDEX_OVER_FULLSCREEN_SURFACE = 1300;
+
+export const Z_INDEX_FILE_MANAGER_MODAL = 1200; 
+export const Z_INDEX_OVER_FILE_MANAGER_MODAL = 1300;
+
+export const Z_INDEX_AUTOMATE_MODAL = 1100;
+
 
 


### PR DESCRIPTION
# Description of Changes

<img width="1540" height="788" alt="Screenshot 2025-10-15 at 3 38 45 PM" src="https://github.com/user-attachments/assets/8e2a486c-1955-4a7b-832f-148883611325" />

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
