### PR TITLE
docs: add Spanish translation for HowToUseOCR

### DIFF
--- a/docs/es_ES/ComoUsarOCR.md
+++ b/docs/es_ES/ComoUsarOCR.md
@@ -1,0 +1,38 @@
+# Cómo usar la función OCR
+
+## Introducción
+La función OCR (Reconocimiento Óptico de Caracteres) permite convertir el texto de imágenes o archivos PDF escaneados en texto editable y seleccionable.  
+Esto resulta útil para digitalizar documentos impresos y facilitar su búsqueda o edición.
+
+## Requisitos previos
+Antes de usar OCR, asegúrate de tener lo siguiente:
+- Un archivo PDF o una imagen compatible (JPG, PNG, TIFF, etc.).
+- Conexión a Internet si utilizas el servicio OCR en línea.
+- Suficiente espacio en disco para guardar el nuevo archivo procesado.
+
+## Pasos para usar OCR
+
+1. **Abre Stirling-PDF** y selecciona la opción **“OCR”** en el menú principal.  
+2. **Carga tu archivo** haciendo clic en *Seleccionar archivo* o arrastrándolo a la zona de carga.  
+3. Elige el **idioma del texto** que deseas reconocer (por ejemplo, Español, Inglés, Francés, etc.).  
+4. Haz clic en **“Procesar”**.  
+5. Espera unos segundos mientras se analiza el archivo.  
+6. Una vez finalizado, podrás:
+   - Ver el texto extraído.
+   - Descargar un nuevo PDF con texto seleccionable.
+   - Copiar o exportar el resultado.
+
+## Consejos
+- Cuanto mejor sea la calidad de la imagen, más preciso será el reconocimiento.
+- Usa archivos en blanco y negro para reducir el tamaño y mejorar la detección de texto.
+- Si el texto está torcido, utiliza la opción de *Enderezar páginas* antes del OCR.
+
+## Problemas comunes
+| Problema | Causa posible | Solución |
+|-----------|----------------|-----------|
+| El texto reconocido no coincide | Mala calidad del escaneo | Usa un archivo con mayor resolución |
+| No se detecta el idioma | Idioma incorrecto seleccionado | Selecciona el idioma correcto en el menú OCR |
+| Error al procesar | Archivo demasiado grande o dañado | Divide el archivo antes de procesarlo |
+
+## Créditos
+Traducción al español realizada por **Miguel Antonio Rojas Sucarino** como contribución para **Hacktoberfest 2025** 🎃.


### PR DESCRIPTION
### What has been done
Added a complete Spanish translation of the "How To Use OCR" documentation file into `docs/es_ES/ComoUsarOCR.md`.

### Why this change
To make Stirling-PDF documentation accessible for Spanish-speaking users, expanding the usability and inclusivity of the project.

### How to review
1. Open the file `docs/es_ES/ComoUsarOCR.md`.
2. Verify that it mirrors the content of the original English version (`docs/HowToUseOCR.md`).
3. Ensure all sections and formatting are consistent.

---

Hacktoberfest contribution 🎃  
Translation made by Miguel Antonio Rojas Sucarino.
