### PR TITLE
Ban lint warnings

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "predev": "npm run generate-icons",
     "dev": "npm run typecheck && vite",
     "prebuild": "npm run generate-icons",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings=0",
     "build": "npm run typecheck && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
# Description of Changes
[See my comment here on why I think we should never allow lint warnings to be merged into our source](https://github.com/Stirling-Tools/Stirling-PDF/pull/4738#issuecomment-3451053692).

This doesn't change how ESLint behaves at all other than if only warnings are reported, it'll report failure instead of success.