### PR TITLE
Add linting to ensure correct imports style is used

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -27,6 +27,15 @@ export default defineConfig(
   tseslint.configs.recommended,
   {
     rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            ".*", // Disallow any relative imports (they should be '@app/x/y/z' or similar)
+            "src/*", // Disallow any absolute imports (they should be '@app/x/y/z' or similar)
+          ],
+        },
+      ],
       '@typescript-eslint/no-empty-object-type': [
         'error',
         {

--- a/frontend/src/core/components/shared/LocalIcon.tsx
+++ b/frontend/src/core/components/shared/LocalIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { addCollection, Icon } from '@iconify/react';
-import iconSet from '../../../assets/material-symbols-icons.json';
+import iconSet from '../../../assets/material-symbols-icons.json'; // eslint-disable-line no-restricted-imports -- Outside app paths
 
 // Load icons synchronously at import time - guaranteed to be ready on first render
 let iconsLoaded = false;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,6 @@
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
-import '../vite-env.d.ts';
+import '../vite-env.d.ts'; // eslint-disable-line no-restricted-imports -- Outside app paths
 import '@app/styles/index.css'; // Import global styles
 import React from 'react';
 import ReactDOM from 'react-dom/client';


### PR DESCRIPTION
# Description of Changes
Add linting to ensure correct imports style is used.

I've disabled the linting for two imports which use relative paths because the files they're importing are siblings to core and proprietary. They could probs be imported by `@app/../assets/xxx` but it seems silly. The other thing we could do is add an explicit `@assets` path alias or something, but it seemed more complex than just disabling the lint for those two imports at this stage. We could always do it in the future if we want to import stuff up there a lot in the future.