### PR TITLE
[V2] fix(tooltip): adjust close button position

### DIFF
--- a/frontend/src/core/components/shared/tooltip/Tooltip.module.css
+++ b/frontend/src/core/components/shared/tooltip/Tooltip.module.css
@@ -33,7 +33,7 @@
 /* Close button */
 .tooltip-pin-button {
   position: absolute;
-  top: -0.5rem;
+  top: 0.5rem;
   right: 0.5rem;
   font-size: 0.875rem;
   background: var(--bg-raised);


### PR DESCRIPTION
# Description of Changes

- Updated the `top` property of `.tooltip-pin-button` from `-0.5rem` to `0.5rem` for proper alignment.

### Pictures:

Before:
<img width="903" height="838" alt="image" src="https://github.com/user-attachments/assets/df2dfab0-9a5d-4d45-9b7b-16a30124af87" />
After:
<img width="903" height="838" alt="image" src="https://github.com/user-attachments/assets/d88f3fad-b281-4dfa-96e1-e56e2639aaf5" />
Before:
<img width="903" height="838" alt="image" src="https://github.com/user-attachments/assets/6406b9f4-8d03-4703-b680-9f70007ecced" />
After:
<img width="903" height="838" alt="image" src="https://github.com/user-attachments/assets/7c548149-ab5d-4364-bee7-9acd55662216" />



<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
