### PR TITLE
fix(security): reset attempt counter when window elapsed (treat equality as elapsed)

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/model/AttemptCounter.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/model/AttemptCounter.java
@@ -18,7 +18,8 @@ public class AttemptCounter {
     }
 
     public boolean shouldReset(long attemptIncrementTime) {
-        return System.currentTimeMillis() - lastAttemptTime > attemptIncrementTime;
+        long elapsed = System.currentTimeMillis() - lastAttemptTime;
+        return elapsed >= attemptIncrementTime;
     }
 
     public void reset() {

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/model/AttemptCounterTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/model/AttemptCounterTest.java
@@ -124,10 +124,8 @@ class AttemptCounterTest {
         }
 
         @Test
-        @DisplayName(
-                "returns FALSE when time difference is exactly equal to window (implementation uses"
-                        + " '>')")
-        void shouldReturnFalseWhenExactlyWindow() {
+        @DisplayName("returns TRUE when time difference is exactly equal to window")
+        void shouldReturnTrueWhenExactlyWindow() {
             AttemptCounter counter = new AttemptCounter();
             long window = 200L;
             long now = System.currentTimeMillis();
@@ -135,10 +133,10 @@ class AttemptCounterTest {
             // Simulate: last action was exactly 'window' ms ago
             setPrivateLong(counter, "lastAttemptTime", now - window);
 
-            // Purpose: Equality -> no reset, because implementation uses '>'
-            assertFalse(
+            // Purpose: Equality -> reset should occur because the window has fully elapsed
+            assertTrue(
                     counter.shouldReset(window),
-                    "With exactly equal difference, no reset should occur");
+                    "With exactly equal difference, the reset window has elapsed");
         }
 
         @Test


### PR DESCRIPTION
Updated shouldReset to use '>=' instead of '>' so that the counter resets when the elapsed time is exactly equal to the window. Adjusted the corresponding test to expect a reset in this case.

# Description of Changes

- **What was changed**
  - Updated `AttemptCounter.shouldReset(long attemptIncrementTime)` to treat the boundary as elapsed by switching from a strict `>` comparison to `>=` and introducing a local `elapsed` variable for clarity.
  - Adjusted unit tests in `AttemptCounterTest` to reflect the corrected behavior:
    - Renamed the equality-boundary test to communicate the new expectation.
    - Changed the assertion for the "exactly equal to window" case from `assertFalse` to `assertTrue`.

- **Why the change was made**
  - Fixes an off-by-one boundary issue where resets did **not** occur when the elapsed time was **exactly** equal to the configured window. This could permit one extra attempt beyond the intended rate-limit window.
  - Aligns logic with common rate-limiting semantics: once the window has fully elapsed, a reset should occur.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
