### PR TITLE
Remove path aliases for the self folder from configs

### DIFF
--- a/frontend/tsconfig.core.json
+++ b/frontend/tsconfig.core.json
@@ -4,8 +4,7 @@
     "paths": {
       "@app/*": [
         "src/core/*"
-      ],
-      "@core/*": ["src/core/*"]
+      ]
     }
   },
   "exclude": [

--- a/frontend/tsconfig.proprietary.json
+++ b/frontend/tsconfig.proprietary.json
@@ -6,7 +6,6 @@
         "src/proprietary/*",
         "src/core/*"
       ],
-      "@proprietary/*": ["src/proprietary/*"],
       "@core/*": ["src/core/*"]
     }
   }


### PR DESCRIPTION
# Description of Changes
Remove path aliases from self folder (e.g. remove `@core` from `tsconfig.core.json`). It's not necessary and using it means that it's impossible for the other folders to override the behaviour. The only reason we should currently be using `@core` is in `proprietary` where we need to explicitly import the `core` version of the thing we're overriding so that we can re-expose or use the objects.