### PR TITLE
refactor(common): use local variables in constructors before assigning fields to avoid partial initialization

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/FileMonitor.java
+++ b/app/common/src/main/java/stirling/software/common/util/FileMonitor.java
@@ -41,14 +41,22 @@ public class FileMonitor {
             @Qualifier("directoryFilter") Predicate<Path> pathFilter,
             RuntimePathConfig runtimePathConfig)
             throws IOException {
-        this.newlyDiscoveredFiles = new HashSet<>();
-        this.path2KeyMapping = new HashMap<>();
-        this.stagingFiles = new HashSet<>();
-        this.pathFilter = pathFilter;
-        this.readyForProcessingFiles = ConcurrentHashMap.newKeySet();
-        this.watchService = FileSystems.getDefault().newWatchService();
+        Set<Path> createdNewlyDiscoveredFiles = new HashSet<>();
+        Map<Path, WatchKey> createdPath2KeyMapping = new HashMap<>();
+        Set<Path> createdStagingFiles = new HashSet<>();
+        ConcurrentHashMap.KeySetView<Path, Boolean> createdReadyForProcessingFiles =
+                ConcurrentHashMap.newKeySet();
+        WatchService createdWatchService = FileSystems.getDefault().newWatchService();
+        Path resolvedRootDir = Path.of(runtimePathConfig.getPipelineWatchedFoldersPath());
         log.info("Monitoring directory: {}", runtimePathConfig.getPipelineWatchedFoldersPath());
-        this.rootDir = Path.of(runtimePathConfig.getPipelineWatchedFoldersPath());
+
+        this.newlyDiscoveredFiles = createdNewlyDiscoveredFiles;
+        this.path2KeyMapping = createdPath2KeyMapping;
+        this.stagingFiles = createdStagingFiles;
+        this.pathFilter = pathFilter;
+        this.readyForProcessingFiles = createdReadyForProcessingFiles;
+        this.watchService = createdWatchService;
+        this.rootDir = resolvedRootDir;
     }
 
     private boolean shouldNotProcess(Path path) {

--- a/app/common/src/main/java/stirling/software/common/util/TempDirectory.java
+++ b/app/common/src/main/java/stirling/software/common/util/TempDirectory.java
@@ -16,8 +16,9 @@ public class TempDirectory implements AutoCloseable {
     private final Path directory;
 
     public TempDirectory(TempFileManager manager) throws IOException {
+        Path createdDirectory = manager.createTempDirectory();
         this.manager = manager;
-        this.directory = manager.createTempDirectory();
+        this.directory = createdDirectory;
     }
 
     public Path getPath() {

--- a/app/common/src/main/java/stirling/software/common/util/TempFile.java
+++ b/app/common/src/main/java/stirling/software/common/util/TempFile.java
@@ -18,8 +18,9 @@ public class TempFile implements AutoCloseable {
     @Getter private final File file;
 
     public TempFile(TempFileManager manager, String suffix) throws IOException {
+        File createdFile = manager.createTempFile(suffix);
         this.manager = manager;
-        this.file = manager.createTempFile(suffix);
+        this.file = createdFile;
     }
 
     public Path getPath() {

--- a/app/common/src/main/java/stirling/software/common/util/YamlHelper.java
+++ b/app/common/src/main/java/stirling/software/common/util/YamlHelper.java
@@ -64,7 +64,8 @@ public class YamlHelper {
 
     // Constructor that reads YAML from a file path
     public YamlHelper(Path originalFilePath) throws IOException {
-        this.yamlContent = Files.readString(originalFilePath);
+        String readContent = Files.readString(originalFilePath);
+        this.yamlContent = readContent;
         this.originalFilePath = originalFilePath;
     }
 


### PR DESCRIPTION
# Description of Changes

This pull request refactors several constructors in utility classes to improve code clarity and maintainability. The main change is introducing intermediate variables for values that were previously assigned directly to fields, making the assignment process more explicit and easier to follow.

Constructor assignment refactoring:

* [`FileMonitor.java`](diffhunk://#diff-7ed80b3a28331a6a8ffa5d4b2015cc77abfe7ed8b6f29412cbb0859fb0b41b19L44-R59): Intermediate variables are used for all constructor-assigned fields, including collections and the `WatchService`, before assigning them to the class fields. This clarifies the initialization process and improves readability.
* [`TempDirectory.java`](diffhunk://#diff-d50b584bad4c41b3a7f01bd5c5e5c2d69a2a937b54db3ea55a02f5fbc2d904feR19-R21): The temporary directory is now created and assigned to an intermediate variable before being set as a field.
* [`TempFile.java`](diffhunk://#diff-4edc220b80d3c765ec806ba1fbd30c2fbf52da1be8ff48a09115d617e2eab3a4R21-R23): The temporary file is created and stored in an intermediate variable prior to field assignment.
* [`YamlHelper.java`](diffhunk://#diff-a17a38fbd90fb0816b2a2bef86d75ba1eea9b47655b786437de920c187d944aaL67-R68): The YAML content read from a file is first stored in a local variable before being assigned to the class field, making the assignment explicit.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
