### PR TITLE
refactor(tests,common): encapsulate strategy assertions and remove unnecessary GC hook

### DIFF
--- a/app/common/src/test/java/stirling/software/common/service/CustomPDFDocumentFactoryTest.java
+++ b/app/common/src/test/java/stirling/software/common/service/CustomPDFDocumentFactoryTest.java
@@ -71,7 +71,7 @@ class CustomPDFDocumentFactoryTest {
     void testStrategy_FileInput(int sizeMB, StrategyType expected) throws IOException {
         File file = writeTempFile(inflatePdf(basePdfBytes, sizeMB));
         factory.load(file);
-        Assertions.assertEquals(expected, factory.lastStrategyUsed);
+        Assertions.assertEquals(expected, factory.getLastStrategyUsed());
     }
 
     @ParameterizedTest
@@ -79,7 +79,7 @@ class CustomPDFDocumentFactoryTest {
     void testStrategy_ByteArray(int sizeMB, StrategyType expected) throws IOException {
         byte[] inflated = inflatePdf(basePdfBytes, sizeMB);
         factory.load(inflated);
-        Assertions.assertEquals(expected, factory.lastStrategyUsed);
+        Assertions.assertEquals(expected, factory.getLastStrategyUsed());
     }
 
     @ParameterizedTest
@@ -87,7 +87,7 @@ class CustomPDFDocumentFactoryTest {
     void testStrategy_InputStream(int sizeMB, StrategyType expected) throws IOException {
         byte[] inflated = inflatePdf(basePdfBytes, sizeMB);
         factory.load(new ByteArrayInputStream(inflated));
-        Assertions.assertEquals(expected, factory.lastStrategyUsed);
+        Assertions.assertEquals(expected, factory.getLastStrategyUsed());
     }
 
     @ParameterizedTest
@@ -97,7 +97,7 @@ class CustomPDFDocumentFactoryTest {
         MockMultipartFile multipart =
                 new MockMultipartFile("file", "doc.pdf", MediaType.APPLICATION_PDF_VALUE, inflated);
         factory.load(multipart);
-        Assertions.assertEquals(expected, factory.lastStrategyUsed);
+        Assertions.assertEquals(expected, factory.getLastStrategyUsed());
     }
 
     @Test
@@ -208,11 +208,6 @@ class CustomPDFDocumentFactoryTest {
         PDFFile pdfFile = new PDFFile();
         pdfFile.setFileInput(multipart);
         factory.load(pdfFile);
-        Assertions.assertEquals(expected, factory.lastStrategyUsed);
-    }
-
-    @BeforeEach
-    void cleanup() {
-        System.gc();
+        Assertions.assertEquals(expected, factory.getLastStrategyUsed());
     }
 }

--- a/app/common/src/test/java/stirling/software/common/service/SpyPDFDocumentFactory.java
+++ b/app/common/src/test/java/stirling/software/common/service/SpyPDFDocumentFactory.java
@@ -9,10 +9,14 @@ class SpyPDFDocumentFactory extends CustomPDFDocumentFactory {
         TEMP_FILE
     }
 
-    public StrategyType lastStrategyUsed;
+    private StrategyType lastStrategyUsed;
 
     public SpyPDFDocumentFactory(PdfMetadataService service) {
         super(service);
+    }
+
+    public StrategyType getLastStrategyUsed() {
+        return lastStrategyUsed;
     }
 
     @Override


### PR DESCRIPTION
# Description of Changes

This pull request refactors the way the `lastStrategyUsed` field is accessed in the `SpyPDFDocumentFactory` class and updates related test assertions to use the new getter method. The main goal is to improve encapsulation by making `lastStrategyUsed` private and providing controlled access through a public getter.

Encapsulation improvements:

* Changed the visibility of the `lastStrategyUsed` field in `SpyPDFDocumentFactory` from public to private, and added a public getter method `getLastStrategyUsed()`. (`app/common/src/test/java/stirling/software/common/service/SpyPDFDocumentFactory.java`)

Test updates for encapsulation:

* Updated all test assertions in `CustomPDFDocumentFactoryTest.java` to use `factory.getLastStrategyUsed()` instead of directly accessing the field. (`app/common/src/test/java/stirling/software/common/service/CustomPDFDocumentFactoryTest.java`) [[1]](diffhunk://#diff-3c0e8dc94117a93c0dfb6fb969fcf557eabe3c9b60863b4e802544833e863d7eL74-R90) [[2]](diffhunk://#diff-3c0e8dc94117a93c0dfb6fb969fcf557eabe3c9b60863b4e802544833e863d7eL100-R100) [[3]](diffhunk://#diff-3c0e8dc94117a93c0dfb6fb969fcf557eabe3c9b60863b4e802544833e863d7eL211-R211)

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
