### PR TITLE
[V2] refactor(tooltips): Standardize tooltips for reorganize, merge, and signature features

### DIFF
--- a/frontend/public/locales/en-GB/translation.json
+++ b/frontend/public/locales/en-GB/translation.json
@@ -823,6 +823,11 @@
   "merge": {
     "tags": "merge,Page operations,Back end,server side",
     "title": "Merge",
+    "tooltip": {
+      "header": {
+        "title": "Merge Settings Overview"
+      }
+    },
     "removeDigitalSignature": {
       "label": "Remove digital signature in the merged file?",
       "tooltip": {
@@ -3118,7 +3123,24 @@
       "title": "Validation Settings"
     },
     "signatureDate": "Signature Date",
-    "totalSignatures": "Total Signatures"
+    "totalSignatures": "Total Signatures",
+    "tooltip": {
+      "header": {
+        "title": "Signature Validation Settings"
+      },
+      "overview": {
+        "title": "What is Signature Validation?",
+        "text": "Check if PDF signatures are valid, verify signer identity, and detect if documents have been modified since signing."
+      },
+      "certificates": {
+        "title": "Certificate Validation",
+        "text": "Signatures are validated using certificate chains. Upload a custom certificate if you need to validate against a specific trust source."
+      },
+      "results": {
+        "title": "Validation Results",
+        "text": "Get detailed reports showing signature status, signer information, signing time, and document integrity."
+      }
+    }
   },
   "replaceColor": {
     "tags": "Replace Colour,Page operations,Back end,server side",
@@ -4726,7 +4748,28 @@
     "settings": {
       "title": "Settings"
     },
-    "submit": "Reorganize Pages"
+    "submit": "Reorganize Pages",
+    "tooltip": {
+      "header": {
+        "title": "Page Reorganization Settings"
+      },
+      "description": {
+        "title": "How Page Reorganization Works",
+        "text": "Rearrange, duplicate, or remove pages from your PDF using flexible page selection and organization modes."
+      },
+      "modes": {
+        "title": "Organization Modes",
+        "text": "Choose how to reorganize your pages:",
+        "bullet1": "Custom Order: Specify exact page sequence",
+        "bullet2": "Duplicate Pages: Copy pages multiple times",
+        "bullet3": "Reverse Order: Flip page order completely",
+        "bullet4": "Remove Pages: Delete specific pages"
+      },
+      "pageSelection": {
+        "title": "Page Selection",
+        "text": "Use page numbers, ranges, or formulas to specify which pages to include in your reorganized PDF."
+      }
+    }
   },
   "replace-color": {
     "options": {

--- a/frontend/src/core/components/tooltips/useMergeTips.tsx
+++ b/frontend/src/core/components/tooltips/useMergeTips.tsx
@@ -5,6 +5,9 @@ export const useMergeTips = (): TooltipContent => {
   const { t } = useTranslation();
 
   return {
+    header: {
+      title: t('merge.tooltip.header.title', 'Merge Settings Overview')
+    },
     tips: [
       {
         title: t('merge.removeDigitalSignature.tooltip.title', 'Remove Digital Signature'),

--- a/frontend/src/core/components/tooltips/useReorganizePagesTips.ts
+++ b/frontend/src/core/components/tooltips/useReorganizePagesTips.ts
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next';
+import { TooltipContent } from '@app/types/tips';
+
+export const useReorganizePagesTips = (): TooltipContent => {
+  const { t } = useTranslation();
+
+  return {
+    header: {
+      title: t('reorganizePages.tooltip.header.title', 'Page Reorganization Settings')
+    },
+    tips: [
+      {
+        title: t('reorganizePages.tooltip.description.title', 'How Page Reorganization Works'),
+        description: t('reorganizePages.tooltip.description.text', 'Rearrange, duplicate, or remove pages from your PDF using flexible page selection and organization modes.')
+      },
+      {
+        title: t('reorganizePages.tooltip.modes.title', 'Organization Modes'),
+        description: t('reorganizePages.tooltip.modes.text', 'Choose how to reorganize your pages:'),
+        bullets: [
+          t('reorganizePages.tooltip.modes.bullet1', 'Custom Order: Specify exact page sequence'),
+          t('reorganizePages.tooltip.modes.bullet2', 'Duplicate Pages: Copy pages multiple times'),
+          t('reorganizePages.tooltip.modes.bullet3', 'Reverse Order: Flip page order completely'),
+          t('reorganizePages.tooltip.modes.bullet4', 'Remove Pages: Delete specific pages')
+        ]
+      },
+      {
+        title: t('reorganizePages.tooltip.pageSelection.title', 'Page Selection'),
+        description: t('reorganizePages.tooltip.pageSelection.text', 'Use page numbers, ranges, or formulas to specify which pages to include in your reorganized PDF.')
+      }
+    ]
+  };
+};

--- a/frontend/src/core/components/tooltips/useValidateSignatureTips.ts
+++ b/frontend/src/core/components/tooltips/useValidateSignatureTips.ts
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import { TooltipContent } from '@app/types/tips';
+
+export const useValidateSignatureTips = (): TooltipContent => {
+  const { t } = useTranslation();
+
+  return {
+    header: {
+      title: t('validateSignature.tooltip.header.title', 'Signature Validation Settings')
+    },
+    tips: [
+      {
+        title: t('validateSignature.tooltip.overview.title', 'What is Signature Validation?'),
+        description: t('validateSignature.tooltip.overview.text', 'Check if PDF signatures are valid, verify signer identity, and detect if documents have been modified since signing.')
+      },
+      {
+        title: t('validateSignature.tooltip.certificates.title', 'Certificate Validation'),
+        description: t('validateSignature.tooltip.certificates.text', 'Signatures are validated using certificate chains. Upload a custom certificate if you need to validate against a specific trust source.')
+      },
+      {
+        title: t('validateSignature.tooltip.results.title', 'Validation Results'),
+        description: t('validateSignature.tooltip.results.text', 'Get detailed reports showing signature status, signer information, signing time, and document integrity.')
+      }
+    ]
+  };
+};

--- a/frontend/src/core/tools/ReorganizePages.tsx
+++ b/frontend/src/core/tools/ReorganizePages.tsx
@@ -8,6 +8,7 @@ import { useAccordionSteps } from "@app/hooks/tools/shared/useAccordionSteps";
 import ReorganizePagesSettings from "@app/components/tools/reorganizePages/ReorganizePagesSettings";
 import { useReorganizePagesParameters } from "@app/hooks/tools/reorganizePages/useReorganizePagesParameters";
 import { useReorganizePagesOperation } from "@app/hooks/tools/reorganizePages/useReorganizePagesOperation";
+import { useReorganizePagesTips } from "@app/components/tooltips/useReorganizePagesTips";
 
 const ReorganizePages = ({ onPreviewFile, onComplete, onError }: BaseToolProps) => {
   const { t } = useTranslation();
@@ -15,6 +16,7 @@ const ReorganizePages = ({ onPreviewFile, onComplete, onError }: BaseToolProps) 
 
   const params = useReorganizePagesParameters();
   const operation = useReorganizePagesOperation();
+  const reorganizeTips = useReorganizePagesTips();
 
   const { enabled: endpointEnabled, loading: endpointLoading } = useEndpointEnabled("rearrange-pages");
 
@@ -61,6 +63,7 @@ const ReorganizePages = ({ onPreviewFile, onComplete, onError }: BaseToolProps) 
       isCollapsed: accordion.getCollapsedState(Step.SETTINGS),
       onCollapsedClick: () => accordion.handleStepToggle(Step.SETTINGS),
       isVisible: true,
+      tooltip: reorganizeTips,
       content: (
         <ReorganizePagesSettings
           parameters={params.parameters}

--- a/frontend/src/core/tools/ValidateSignature.tsx
+++ b/frontend/src/core/tools/ValidateSignature.tsx
@@ -12,6 +12,7 @@ import ValidateSignatureReportView from '@app/components/tools/validateSignature
 import { useToolWorkflow } from '@app/contexts/ToolWorkflowContext';
 import { useNavigationActions, useNavigationState } from '@app/contexts/NavigationContext';
 import type { SignatureValidationReportData } from '@app/types/validateSignature';
+import { useValidateSignatureTips } from '@app/components/tooltips/useValidateSignatureTips';
 
 const ValidateSignature = (props: BaseToolProps) => {
   const { t } = useTranslation();
@@ -38,6 +39,7 @@ const ValidateSignature = (props: BaseToolProps) => {
   const operation = base.operation as ValidateSignatureOperationHook;
   const hasResults = operation.results.length > 0;
   const showResultsStep = hasResults || base.operation.isLoading || !!base.operation.errorMessage;
+  const validateTips = useValidateSignatureTips();
 
 
 
@@ -115,6 +117,7 @@ const ValidateSignature = (props: BaseToolProps) => {
         title: t('validateSignature.settings.title', 'Validation Settings'),
         isCollapsed: base.settingsCollapsed,
         onCollapsedClick: base.settingsCollapsed ? base.handleSettingsReset : undefined,
+        tooltip: validateTips,
         content: (
           <ValidateSignatureSettings
             parameters={base.params.parameters}


### PR DESCRIPTION
# Description of Changes
TLDR
- Created `useReorganizePagesTips` for tooltips in the reorganize pages tool
- Created `useValidateSignatureTips` for tooltips in the signature validation tool
- Integrated tooltips into `ReorganizePages` and `ValidateSignature`
- Updated translation files with new tooltip content

This pull request enhances the user experience for several PDF tool workflows by adding detailed, localized tooltip content for "Merge", "Reorganize Pages", and "Validate Signature" features. It introduces new tooltip configuration files, updates translation strings, and integrates these tooltips into the relevant UI components.

**Localization and Tooltip Content Enhancements:**

* Added comprehensive tooltip entries for "Merge", "Reorganize Pages", and "Validate Signature" tools in the `translation.json` file, providing users with clear explanations and guidance for each tool's settings and operations.

**Tooltip Logic and Integration:**

* Introduced new React hooks: `useReorganizePagesTips` and `useValidateSignatureTips`, which generate structured tooltip content for their respective features.
* Updated the "Merge" tool's tooltip logic to include a header section, improving consistency with other tooltips.

**Component Integration:**

* Integrated the new tooltips into the "Reorganize Pages" and "Validate Signature" tool components, ensuring that the UI displays contextual help to users during workflow steps.

### Before:

#### (there is no tooltip here)
<img width="1858" height="995" alt="image" src="https://github.com/user-attachments/assets/8f854504-f026-4201-9325-fb1561137d80" />

#### (there is no tooltip here)
<img width="1858" height="995" alt="image" src="https://github.com/user-attachments/assets/b4977318-cab9-41c6-94ba-866bd8b92d6a" />

#### (tooltip is inconsistent with the rest)
<img width="1858" height="995" alt="image" src="https://github.com/user-attachments/assets/49d6d1d8-30bb-4914-8ae7-1a6e27e8ea2b" />



### After:

<img width="1858" height="995" alt="image" src="https://github.com/user-attachments/assets/d96455b0-f200-4026-9e94-0c018f93925e" />
<img width="1858" height="995" alt="image" src="https://github.com/user-attachments/assets/26403f0e-1cfd-497f-a549-27c96b810675" />
<img width="1858" height="995" alt="image" src="https://github.com/user-attachments/assets/400108fd-8d45-4cf4-90b6-5abf7985d84a" />


<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [X] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
