### PR TITLE
Dynamically choose port for backend to start on in desktop app

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/SPDFApplication.java
+++ b/app/core/src/main/java/stirling/software/SPDF/SPDFApplication.java
@@ -12,6 +12,8 @@ import java.util.Properties;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.context.WebServerInitializedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -51,6 +53,14 @@ public class SPDFApplication {
         this.appConfig = appConfig;
         this.env = env;
         this.applicationProperties = applicationProperties;
+    }
+
+    @EventListener
+    public void onWebServerInitialized(WebServerInitializedEvent event) {
+        int actualPort = event.getWebServer().getPort();
+        serverPortStatic = String.valueOf(actualPort);
+        // Log the actual runtime port so Tauri can parse it when port is chosen dynamically
+        log.info("Stirling-PDF running on port: {}", actualPort);
     }
 
     public static void main(String[] args) throws IOException, InterruptedException {

--- a/frontend/src-tauri/src/commands/backend.rs
+++ b/frontend/src-tauri/src/commands/backend.rs
@@ -7,11 +7,25 @@ use crate::utils::add_log;
 // Store backend process handle globally
 static BACKEND_PROCESS: Mutex<Option<tauri_plugin_shell::process::CommandChild>> = Mutex::new(None);
 static BACKEND_STARTING: Mutex<bool> = Mutex::new(false);
+static BACKEND_PORT: Mutex<Option<u16>> = Mutex::new(None);
 
 // Helper function to reset starting flag
 fn reset_starting_flag() {
     let mut starting_guard = BACKEND_STARTING.lock().unwrap();
     *starting_guard = false;
+}
+
+// Extract port number from "Stirling-PDF running on port: PORT" log line
+fn extract_port_from_running_log(log_line: &str) -> Option<u16> {
+    if let Some(start) = log_line.find("running on port: ") {
+        let after_prefix = &log_line[start + 17..];
+        let port_str: String = after_prefix
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        return port_str.parse::<u16>().ok();
+    }
+    None
 }
 
 // Check if backend is already running or starting
@@ -150,6 +164,7 @@ fn run_stirling_pdf_jar(app: &tauri::AppHandle, java_path: &PathBuf, jar_path: &
         "-DSTIRLING_PDF_TAURI_MODE=true",
         &log_path_option,
         "-Dlogging.file.name=stirling-pdf.log",
+        "-Dserver.port=0", // Allow OS to choose a free port
         "-jar",
         jar_path.to_str().unwrap()
     ];
@@ -238,16 +253,21 @@ fn monitor_backend_output(mut rx: tauri::async_runtime::Receiver<tauri_plugin_sh
                     let output_str = output_str.strip_suffix('\n').unwrap_or(&output_str);
                     add_log(format!("📤 Backend: {}", output_str));
                     
+                    // Look for actual runtime port information logged by the backend
+                    if output_str.contains("running on port:") {
+                        if let Some(port) = extract_port_from_running_log(&output_str) {
+                            let mut port_guard = BACKEND_PORT.lock().unwrap();
+                            *port_guard = Some(port);
+                            add_log(format!("🎉 Backend started on port: {}", port));
+                            add_log(format!("🔌 Navigate to: http://localhost:{}/", port));
+                        }
+                    }
+
                     // Look for startup indicators
                     if output_str.contains("Started SPDFApplication") || 
                        output_str.contains("Navigate to "){
                         _startup_detected = true;
                         add_log(format!("🎉 Backend startup detected: {}", output_str));
-                    }
-                    
-                    // Look for port binding
-                    if output_str.contains("8080") {
-                        add_log(format!("🔌 Port 8080 related output: {}", output_str));
                     }
                 }
                 tauri_plugin_shell::process::CommandEvent::Stderr(output) => {
@@ -293,6 +313,8 @@ fn monitor_backend_output(mut rx: tauri::async_runtime::Receiver<tauri_plugin_sh
                     // Clear the stored process handle
                     let mut process_guard = BACKEND_PROCESS.lock().unwrap();
                     *process_guard = None;
+                    let mut port_guard = BACKEND_PORT.lock().unwrap();
+                    *port_guard = None;
                 }
                 _ => {
                     println!("🔍 Unknown command event: {:?}", event);
@@ -310,6 +332,11 @@ fn monitor_backend_output(mut rx: tauri::async_runtime::Receiver<tauri_plugin_sh
 #[tauri::command]
 pub async fn start_backend(app: tauri::AppHandle) -> Result<String, String> {
     add_log("🚀 start_backend() called - Attempting to start backend with bundled JRE...".to_string());
+
+    {
+        let mut port_guard = BACKEND_PORT.lock().unwrap();
+        *port_guard = None;
+    }
     
     // Check if backend is already running or starting
     if let Err(msg) = check_backend_status() {
@@ -363,6 +390,13 @@ pub async fn start_backend(app: tauri::AppHandle) -> Result<String, String> {
     Ok("Backend startup initiated successfully with bundled JRE".to_string())
 }
 
+// Get the dynamically assigned backend port
+#[tauri::command]
+pub fn get_backend_port() -> Option<u16> {
+    let port_guard = BACKEND_PORT.lock().unwrap();
+    *port_guard
+}
+
 // Cleanup function to stop backend on app exit
 pub fn cleanup_backend() {
     let mut process_guard = BACKEND_PROCESS.lock().unwrap();
@@ -380,4 +414,7 @@ pub fn cleanup_backend() {
             }
         }
     }
+
+    let mut port_guard = BACKEND_PORT.lock().unwrap();
+    *port_guard = None;
 }

--- a/frontend/src-tauri/src/commands/health.rs
+++ b/frontend/src-tauri/src/commands/health.rs
@@ -1,36 +1,16 @@
-// Command to check if backend is healthy
+use reqwest;
+
 #[tauri::command]
-pub async fn check_backend_health() -> Result<bool, String> {
-    let client = reqwest::Client::builder()
+pub async fn check_backend_health(port: u16) -> Result<bool, String> {
+    let url = format!("http://localhost:{}/api/v1/info/status", port);
+
+    match reqwest::Client::new()
+        .get(&url)
         .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
-    
-    match client.get("http://localhost:8080/api/v1/info/status").send().await {
-        Ok(response) => {
-            let status = response.status();
-            if status.is_success() {
-                match response.text().await {
-                    Ok(_body) => {
-                        println!("✅ Backend health check successful");
-                        Ok(true)
-                    }
-                    Err(e) => {
-                        println!("⚠️ Failed to read health response: {}", e);
-                        Ok(false)
-                    }
-                }
-            } else {
-                println!("⚠️ Health check failed with status: {}", status);
-                Ok(false)
-            }
-        }
-        Err(e) => {
-            // Only log connection errors if they're not the common "connection refused" during startup
-            if !e.to_string().contains("connection refused") && !e.to_string().contains("No connection could be made") {
-                println!("❌ Health check error: {}", e);
-            }
-            Ok(false)
-        }
+        .send()
+        .await
+    {
+        Ok(response) => Ok(response.status().is_success()),
+        Err(_) => Ok(false),
     }
 }

--- a/frontend/src-tauri/src/commands/mod.rs
+++ b/frontend/src-tauri/src/commands/mod.rs
@@ -3,7 +3,7 @@ pub mod health;
 pub mod files;
 pub mod default_app;
 
-pub use backend::{start_backend, cleanup_backend};
+pub use backend::{start_backend, cleanup_backend, get_backend_port};
 pub use health::check_backend_health;
 pub use files::{get_opened_files, clear_opened_files, add_opened_file};
 pub use default_app::{is_default_pdf_handler, set_as_default_pdf_handler};

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use commands::{
     add_opened_file,
     is_default_pdf_handler,
     set_as_default_pdf_handler,
+    get_backend_port,
 };
 use utils::{add_log, get_tauri_logs};
 
@@ -61,6 +62,7 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       start_backend,
       check_backend_health,
+      get_backend_port,
       get_opened_files,
       clear_opened_files,
       get_tauri_logs,

--- a/frontend/src/desktop/hooks/useBackendInitializer.ts
+++ b/frontend/src/desktop/hooks/useBackendInitializer.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useBackendHealth } from '@app/hooks/useBackendHealth';
-import { useEndpointConfig } from '@app/hooks/useEndpointConfig';
 import { tauriBackendService } from '@app/services/tauriBackendService';
 
 /**
@@ -8,7 +7,6 @@ import { tauriBackendService } from '@app/services/tauriBackendService';
  */
 export function useBackendInitializer() {
   const { status, checkHealth } = useBackendHealth();
-  const { backendUrl } = useEndpointConfig();
 
   useEffect(() => {
     // Skip if backend already running
@@ -20,7 +18,7 @@ export function useBackendInitializer() {
     const initializeBackend = async () => {
       try {
         console.log('[BackendInitializer] Starting backend...');
-        await tauriBackendService.startBackend(backendUrl);
+        await tauriBackendService.startBackend();
         console.log('[BackendInitializer] Backend started successfully');
 
         // Begin health checks after a short delay
@@ -36,5 +34,5 @@ export function useBackendInitializer() {
     if (status !== 'healthy' && status !== 'starting') {
       void initializeBackend();
     }
-  }, [status, backendUrl, checkHealth]);
+  }, [status, checkHealth]);
 }

--- a/frontend/src/desktop/hooks/useEndpointConfig.ts
+++ b/frontend/src/desktop/hooks/useEndpointConfig.ts
@@ -245,7 +245,7 @@ export function useEndpointConfig(): EndpointConfig {
     return runtimeEnv?.STIRLING_BACKEND_URL
       || import.meta.env.VITE_DESKTOP_BACKEND_URL
       || import.meta.env.VITE_API_BASE_URL
-      || 'http://localhost:8080';
+      || '';
   }, []);
 
   return { backendUrl };

--- a/frontend/src/desktop/services/apiClientConfig.ts
+++ b/frontend/src/desktop/services/apiClientConfig.ts
@@ -13,5 +13,7 @@ export function getApiBaseUrl(): string {
     return '/';
   }
 
-  return import.meta.env.VITE_DESKTOP_BACKEND_URL || 'http://localhost:8080';
+  // In production builds the backend selects a free port dynamically.
+  // Requests will be rewritten to the discovered port by the desktop interceptors.
+  return '';
 }

--- a/frontend/src/desktop/services/apiClientSetup.ts
+++ b/frontend/src/desktop/services/apiClientSetup.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance } from 'axios';
+import { isTauri } from '@tauri-apps/api/core';
 import { alert } from '@app/components/toast';
 import { setupApiInterceptors as coreSetup } from '@core/services/apiClientSetup';
 import { tauriBackendService } from '@app/services/tauriBackendService';
@@ -17,28 +18,37 @@ let lastBackendToast = 0;
 export function setupApiInterceptors(client: AxiosInstance): void {
   coreSetup(client);
 
+  const shouldRewriteBaseUrl = isTauri();
+
   client.interceptors.request.use(
-    (config) => {
+    async (config) => {
       const skipCheck = config?.skipBackendReadyCheck === true;
-      if (skipCheck || tauriBackendService.isBackendHealthy()) {
-        return config;
+      if (!skipCheck && !tauriBackendService.isBackendHealthy()) {
+        const method = (config.method || 'get').toLowerCase();
+        if (method !== 'get') {
+          const now = Date.now();
+          if (now - lastBackendToast > BACKEND_TOAST_COOLDOWN_MS) {
+            lastBackendToast = now;
+            alert({
+              alertType: 'error',
+              title: i18n.t('backendHealth.offline', 'Backend Offline'),
+              body: i18n.t('backendHealth.wait', 'Please wait for the backend to finish launching and try again.'),
+              isPersistentPopup: false,
+            });
+          }
+        }
+        return Promise.reject(createBackendNotReadyError());
       }
 
-      const method = (config.method || 'get').toLowerCase();
-      if (method !== 'get') {
-        const now = Date.now();
-        if (now - lastBackendToast > BACKEND_TOAST_COOLDOWN_MS) {
-          lastBackendToast = now;
-          alert({
-            alertType: 'error',
-            title: i18n.t('backendHealth.offline', 'Backend Offline'),
-            body: i18n.t('backendHealth.wait', 'Please wait for the backend to finish launching and try again.'),
-            isPersistentPopup: false,
-          });
+      if (shouldRewriteBaseUrl) {
+        const backendUrl = await tauriBackendService.ensureBackendUrl();
+        // Only overwrite when request is relative (most client calls)
+        if (!config.url || !config.url.startsWith('http')) {
+          config.baseURL = backendUrl;
         }
       }
 
-      return Promise.reject(createBackendNotReadyError());
+      return config;
     }
   );
 }


### PR DESCRIPTION
# Description of Changes
Currently, the desktop always spins up the backend on `localhost:8080`, which means if the user's computer has anything else running on that port, the app will fail to spin up. This PR changes the backend to have the port chosen by the OS and then the app respond to the port that's in use and send all traffic to it. 