### PR TITLE
Fix CORS issues in desktop app

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/config/WebMvcConfig.java
+++ b/app/core/src/main/java/stirling/software/SPDF/config/WebMvcConfig.java
@@ -42,7 +42,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
             // Tauri v1 uses tauri://localhost, v2 uses http(s)://tauri.localhost
             logger.info("Tauri mode detected - enabling CORS for Tauri protocols (v1 and v2)");
             registry.addMapping("/**")
-                    .allowedOrigins(
+                    .allowedOriginPatterns(
                             "tauri://localhost",
                             "http://tauri.localhost",
                             "https://tauri.localhost")


### PR DESCRIPTION
# Description of Changes
In the 2.0.0 release version, the frontend can't connect to the backend on my machine because all the network requests 403. I think this is because of CORS issues, and supposedly these will be fixed by using a different Spring function, which is more lenient on URL schemes (needs to allow `tauri://localhost` here, which isn't a standard URL)