### PR TITLE
fix the text color for the first time setup with default credentials

### DIFF
--- a/frontend/src/core/styles/theme.css
+++ b/frontend/src/core/styles/theme.css
@@ -164,6 +164,9 @@
   --text-primary: #111827;
   --text-secondary: #4b5563;
   --text-muted: #6b7280;
+  /* Always-dark text (for use on light backgrounds like alerts) - does not change in dark mode */
+  --text-always-dark: #1f2937;
+  --text-always-dark-muted: #6b7280;
   --border-subtle: #e5e7eb;
   --border-default: #E2E8F0;
   --border-strong: #9ca3af;
@@ -440,6 +443,9 @@
   --text-primary: #f9fafb;
   --text-secondary: #d1d5db;
   --text-muted: #9ca3af;
+  /* Always-dark text (for use on light backgrounds like alerts) - does not change in dark mode */
+  --text-always-dark: #1f2937;
+  --text-always-dark-muted: #6b7280;
   --border-subtle: #2A2F36;
   --border-default: #3A4047;
   --border-strong: #4b5563;

--- a/frontend/src/proprietary/routes/Login.tsx
+++ b/frontend/src/proprietary/routes/Login.tsx
@@ -362,16 +362,16 @@ export default function Login() {
           mt="xl"
         >
           <Stack gap="xs" align="center">
-            <Text size="sm" fw={600} ta="center">
+            <Text size="sm" fw={600} ta="center" style={{ color: 'var(--text-always-dark)' }}>
               {t('login.defaultCredentials', 'Default Login Credentials')}
             </Text>
-            <Text size="sm" ta="center">
-              <Text component="span" fw={600}>{t('login.username', 'Username')}:</Text> admin
+            <Text size="sm" ta="center" style={{ color: 'var(--text-always-dark)' }}>
+              <Text component="span" fw={600} style={{ color: 'var(--text-always-dark)' }}>{t('login.username', 'Username')}:</Text> admin
             </Text>
-            <Text size="sm" ta="center">
-              <Text component="span" fw={600}>{t('login.password', 'Password')}:</Text> stirling
+            <Text size="sm" ta="center" style={{ color: 'var(--text-always-dark)' }}>
+              <Text component="span" fw={600} style={{ color: 'var(--text-always-dark)' }}>{t('login.password', 'Password')}:</Text> stirling
             </Text>
-            <Text size="xs" c="dimmed" ta="center" mt="xs">
+            <Text size="xs" ta="center" mt="xs" style={{ color: 'var(--text-always-dark-muted)' }}>
               {t('login.changePasswordWarning', 'Please change your password after logging in for the first time')}
             </Text>
           </Stack>


### PR DESCRIPTION
# Description of Changes

Fix for this:
<img width="584" height="203" alt="Screenshot 2025-11-26 at 11 58 17 AM" src="https://github.com/user-attachments/assets/fb5ea4ae-e42a-407a-a890-933d9f6db829" />

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
