### PR TITLE
Update Italian localization for redaction features

### DIFF
--- a/app/core/src/main/resources/messages_it_IT.properties
+++ b/app/core/src/main/resources/messages_it_IT.properties
@@ -937,13 +937,13 @@ home.showJS.title=Mostra Javascript
 home.showJS.desc=Cerca e visualizza qualsiasi JS inserito in un PDF
 showJS.tags=JS
 
-home.autoRedact.title=Redazione automatica
-home.autoRedact.desc=Redige automaticamente (oscura) il testo in un PDF in base al testo immesso
-autoRedact.tags=Redigere,nascondere,oscurare,nero,pennarello,nascosto
+home.autoRedact.title=Censura automatica
+home.autoRedact.desc=Censura automaticamente il testo in un PDF in base al testo immesso
+autoRedact.tags=Censurare,nascondere,oscurare,nero,pennarello,nascosto
 
-home.redact.title=Redazione manuale
-home.redact.desc=Redige un PDF in base al testo selezionato, alle forme disegnate e/o alle pagina selezionata(e)
-redact.tags=Redigere,nascondere,oscurare,nero,pennarello,nascosto,manuale
+home.redact.title=Censura manuale
+home.redact.desc=Censura un PDF in base al testo selezionato, alle forme disegnate e/o alle pagina selezionata(e)
+redact.tags=Censurare,nascondere,oscurare,nero,pennarello,nascosto,manuale
 
 home.tableExtraxt.title=Da PDF a CSV
 home.tableExtraxt.desc=Estrae tabelle da un PDF convertendolo in CSV
@@ -1039,8 +1039,8 @@ login.logoutMessage=Sei stato disconnesso.
 login.invalidInResponseTo=La risposta SAML richiesta non è valida o è scaduta. Contattare l'amministratore.
 
 #auto-redact
-autoRedact.title=Redazione automatica
-autoRedact.header=Redazione automatica
+autoRedact.title=Censura automatica
+autoRedact.header=Censura automatica
 autoRedact.colorLabel=Colore
 autoRedact.textsToRedactLabel=Testo da oscurare (separato da righe)
 autoRedact.textsToRedactPlaceholder=per esempio. \nConfidenziale \nTop-Secret
@@ -1051,18 +1051,18 @@ autoRedact.convertPDFToImageLabel=Converti PDF in immagine PDF (utilizzato per r
 autoRedact.submitButton=Invia
 
 #redact
-redact.title=Redazione manuale
-redact.header=Redazione manuale
-redact.submit=Redazione
-redact.textBasedRedaction=Redazione basata sul testo
-redact.pageBasedRedaction=Redazione basata sulla pagina
+redact.title=Censura manuale
+redact.header=Censura manuale
+redact.submit=Censura
+redact.textBasedRedaction=Censura basata sul testo
+redact.pageBasedRedaction=Censura basata sulla pagina
 redact.convertPDFToImageLabel=Converti PDF in immagine PDF (utilizzato per rimuovere il testo dietro la casella)
 redact.pageRedactionNumbers.title=Pagine
 redact.pageRedactionNumbers.placeholder=(es. 1,2,8 o 4,7,12-16 o 2n-1)
-redact.redactionColor.title=Colore di redazione
+redact.redactionColor.title=Colore di censura
 redact.export=Esporta
 redact.upload=Caricamento
-redact.boxRedaction=Redazione del disegno della casella
+redact.boxRedaction=Censura disegnando un rettangolo
 redact.zoom=Zoom
 redact.zoomIn=Ingrandisci
 redact.zoomOut=Rimpicciolisci


### PR DESCRIPTION
Replaced the word "redazione" with the word "censura" because "redazione" in Italian is interpreted as "redaction" and not as "blackout".

example like is intended in italian "redazione":
The lawyer must redact the contract.
The lawyer "create" the contract and not blacking it out.

# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
