### PR TITLE
Don't block desktop app on backend starting up

### DIFF
--- a/frontend/src-tauri/src/commands/backend.rs
+++ b/frontend/src-tauri/src/commands/backend.rs
@@ -398,10 +398,6 @@ pub async fn start_backend(
         e
     })?;
 
-    // Wait for the backend to start
-    println!("⏳ Waiting for backend startup...");
-    tokio::time::sleep(std::time::Duration::from_millis(10000)).await;
-
     // Reset the starting flag since startup is complete
     reset_starting_flag();
     add_log("✅ Backend startup sequence completed, starting flag cleared".to_string());

--- a/frontend/src/desktop/components/SetupWizard/index.tsx
+++ b/frontend/src/desktop/components/SetupWizard/index.tsx
@@ -61,7 +61,7 @@ export const SetupWizard: React.FC<SetupWizardProps> = ({ onComplete }) => {
       }
 
       await connectionModeService.switchToSaaS(serverConfig.url);
-      await tauriBackendService.startBackend();
+      tauriBackendService.startBackend().catch(console.error);
       onComplete();
     } catch (err) {
       console.error('SaaS login failed:', err);


### PR DESCRIPTION
# Description of Changes
Start bundled backend instantly on startup of app and don't wait on it being fully up to spawn app. This is techincally wasteful curently on self-hosted mode where everything runs remotely, but in the future we'll probably route simple operations to the local machine regardless of connection, and it stops unnecessary waiting in the offline mode.