### PR TITLE
Fix: Only block export when signatures are placed but not applied

### DIFF
--- a/frontend/src/core/components/viewer/SignatureAPIBridge.tsx
+++ b/frontend/src/core/components/viewer/SignatureAPIBridge.tsx
@@ -122,7 +122,7 @@ const createTextStampImage = (
 
 export const SignatureAPIBridge = forwardRef<SignatureAPI>(function SignatureAPIBridge(_, ref) {
   const { provides: annotationApi } = useAnnotationCapability();
-  const { signatureConfig, storeImageData, isPlacementMode, placementPreviewSize } = useSignature();
+  const { signatureConfig, storeImageData, isPlacementMode, placementPreviewSize, setSignaturesApplied } = useSignature();
   const { getZoomState, registerImmediateZoomUpdate } = useViewer();
   const [currentZoom, setCurrentZoom] = useState(() => getZoomState()?.currentZoom ?? 1);
   const lastStampImageRef = useRef<string | null>(null);
@@ -389,6 +389,11 @@ export const SignatureAPIBridge = forwardRef<SignatureAPI>(function SignatureAPI
         return;
       }
 
+      // Mark signatures as not applied when a new signature is placed
+      if (event.type === 'create') {
+        setSignaturesApplied(false);
+      }
+
       const directData =
         extractDataUrl(annotation.imageSrc) ||
         extractDataUrl(annotation.imageData) ||
@@ -408,7 +413,7 @@ export const SignatureAPIBridge = forwardRef<SignatureAPI>(function SignatureAPI
     return () => {
       unsubscribe?.();
     };
-  }, [annotationApi, storeImageData]);
+  }, [annotationApi, storeImageData, setSignaturesApplied]);
 
   useEffect(() => {
     if (!isPlacementMode) {
@@ -443,6 +448,11 @@ export const SignatureAPIBridge = forwardRef<SignatureAPI>(function SignatureAPI
         return;
       }
 
+      // Mark signatures as not applied when a new signature is placed
+      if (event.type === 'create') {
+        setSignaturesApplied(false);
+      }
+
       const directData =
         extractDataUrl(annotation.imageSrc) ||
         extractDataUrl(annotation.imageData) ||
@@ -462,7 +472,7 @@ export const SignatureAPIBridge = forwardRef<SignatureAPI>(function SignatureAPI
     return () => {
       unsubscribe?.();
     };
-  }, [annotationApi, storeImageData]);
+  }, [annotationApi, storeImageData, setSignaturesApplied]);
 
   useEffect(() => {
     if (!isPlacementMode) {

--- a/frontend/src/core/contexts/SignatureContext.tsx
+++ b/frontend/src/core/contexts/SignatureContext.tsx
@@ -74,8 +74,6 @@ export const SignatureProvider: React.FC<{ children: ReactNode }> = ({ children 
     if (signatureApiRef.current) {
       signatureApiRef.current.activateDrawMode();
       setPlacementMode(true);
-      // Mark signatures as not applied when entering draw mode
-      setState(prev => ({ ...prev, signaturesApplied: false }));
     }
   }, [setPlacementMode]);
 
@@ -90,8 +88,6 @@ export const SignatureProvider: React.FC<{ children: ReactNode }> = ({ children 
     if (signatureApiRef.current) {
       signatureApiRef.current.activateSignaturePlacementMode();
       setPlacementMode(true);
-      // Mark signatures as not applied when placing new signatures
-      setState(prev => ({ ...prev, signaturesApplied: false }));
     }
   }, [setPlacementMode]);
 


### PR DESCRIPTION
Previously, activating signature placement mode would immediately set signaturesApplied=false, blocking export even when no signatures were actually placed on the PDF. This caused the "unapplied signatures" warning to appear incorrectly after clicking "Apply Signatures".

Changes:
- Remove signaturesApplied=false from activateDrawMode and activateSignaturePlacementMode in SignatureContext
- Add signaturesApplied=false to onAnnotationEvent handler in SignatureAPIBridge when event.type === 'create'
- Now signatures are only marked as unapplied when actually placed

This ensures:
- Users can activate placement mode without triggering export warning
- Export is only blocked when signatures are actually placed but not applied
- After applying signatures, users can immediately export without warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
