### PR TITLE
[V2] feat(ocr): add option to invalidate digital signatures with warning tooltip

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ProcessPdfWithOcrRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ProcessPdfWithOcrRequest.java
@@ -46,5 +46,4 @@ public class ProcessPdfWithOcrRequest extends PDFFile {
 
     @Schema(description = "Remove images from the output PDF if set to true")
     private boolean removeImagesAfter;
-
 }

--- a/frontend/src/core/components/tools/ocr/AdvancedOCRSettings.tsx
+++ b/frontend/src/core/components/tools/ocr/AdvancedOCRSettings.tsx
@@ -34,7 +34,7 @@ const AdvancedOCRSettings: React.FC<AdvancedOCRSettingsProps> = ({
     { value: 'sidecar', label: t('ocr.settings.advancedOptions.sidecar', 'Create a text file'), isSpecial: false },
     { value: 'deskew', label: t('ocr.settings.advancedOptions.deskew', 'Deskew pages'), isSpecial: false },
     { value: 'clean', label: t('ocr.settings.advancedOptions.clean', 'Clean input file'), isSpecial: false },
-    { value: 'cleanFinal', label: t('ocr.settings.advancedOptions.cleanFinal', 'Clean final output'), isSpecial: false }
+    { value: 'cleanFinal', label: t('ocr.settings.advancedOptions.cleanFinal', 'Clean final output'), isSpecial: false },
   ];
 
   // Handle individual checkbox changes


### PR DESCRIPTION
# Description of Changes
This pull request adds support for invalidating digital signatures during the OCR process, allowing users to process signed PDFs with OCR at the cost of breaking their digital signatures. The feature is integrated across the backend, frontend, and user interface, including appropriate warnings to inform users of the consequences.

**Backend support for digital signature invalidation:**

- Added a new `invalidateDigitalSignatures` boolean field to the `ProcessPdfWithOcrRequest` model, and updated the `OCRController` to accept, pass, and handle this parameter. If enabled, the backend adds the `--invalidate-digital-signatures` flag to the OCR command, invalidating any digital signatures present in the PDF. 

**Frontend and UI integration:**

- Added an "Invalidate digital signatures" option to the advanced OCR settings in the UI, including a warning tooltip to inform users that enabling this option will make the document's digital signatures invalid. 
- Updated the OCR form data builder to include the `invalidateDigitalSignatures` parameter when submitting OCR requests.

**Localization and tooltips:**

- Added new translation strings and warning messages for the "Invalidate digital signatures" option and its tooltip, ensuring users are clearly informed about the consequences of enabling this feature. 

<img width="649" height="994" alt="image" src="https://github.com/user-attachments/assets/8d7f42cb-fc9e-4864-ad09-09ccb56347a1" />

Closes: #5142
<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
