### PR TITLE
Fix: SSO Login Page

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/config/OpenApiConfig.java
+++ b/app/core/src/main/java/stirling/software/SPDF/config/OpenApiConfig.java
@@ -66,7 +66,8 @@ public class OpenApiConfig {
         if (swaggerServerUrl != null && !swaggerServerUrl.trim().isEmpty()) {
             server = new Server().url(swaggerServerUrl).description("API Server");
         } else {
-            // Use relative path so Swagger uses the current browser origin to avoid CORS issues when accessing via different ports
+            // Use relative path so Swagger uses the current browser origin to avoid CORS issues
+            // when accessing via different ports
             server = new Server().url("/").description("Current Server");
         }
         openAPI.addServersItem(server);

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
@@ -197,7 +197,6 @@ public class SecurityConfiguration {
         http.csrf(CsrfConfigurer::disable);
 
         if (loginEnabledValue) {
-            boolean v2Enabled = appConfig.v2Enabled();
 
             http.addFilterBefore(
                             userAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -205,19 +204,9 @@ public class SecurityConfiguration {
                     .addFilterBefore(jwtAuthenticationFilter, UserAuthenticationFilter.class);
 
             http.sessionManagement(
-                    sessionManagement -> {
-                        if (v2Enabled) {
+                    sessionManagement ->
                             sessionManagement.sessionCreationPolicy(
-                                    SessionCreationPolicy.STATELESS);
-                        } else {
-                            sessionManagement
-                                    .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-                                    .maximumSessions(10)
-                                    .maxSessionsPreventsLogin(false)
-                                    .sessionRegistry(sessionRegistry)
-                                    .expiredUrl("/login?logout=true");
-                        }
-                    });
+                                    SessionCreationPolicy.STATELESS));
             http.authenticationProvider(daoAuthenticationProvider());
             http.requestCache(requestCache -> requestCache.requestCache(new NullRequestCache()));
 
@@ -300,18 +289,7 @@ public class SecurityConfiguration {
             if (securityProperties.isOauth2Active()) {
                 http.oauth2Login(
                         oauth2 -> {
-                            // v1: Use /oauth2 as login page for Thymeleaf templates
-                            if (!v2Enabled) {
-                                oauth2.loginPage("/oauth2");
-                            }
-
-                            // v2: Don't set loginPage, let default OAuth2 flow handle it
-                            oauth2
-                                    /*
-                                       This Custom handler is used to check if the OAUTH2 user trying to log in, already exists in the database.
-                                       If user exists, login proceeds as usual. If user does not exist, then it is auto-created but only if 'OAUTH2AutoCreateUser'
-                                       is set as true, else login fails with an error message advising the same.
-                                    */
+                            oauth2.loginPage("/login")
                                     .successHandler(
                                             new CustomOAuth2AuthenticationSuccessHandler(
                                                     loginAttemptService,
@@ -345,12 +323,8 @@ public class SecurityConfiguration {
                         .saml2Login(
                                 saml2 -> {
                                     try {
-                                        // Only set login page for v1/Thymeleaf mode
-                                        if (!v2Enabled) {
-                                            saml2.loginPage("/saml2");
-                                        }
-
-                                        saml2.relyingPartyRegistrationRepository(
+                                        saml2.loginPage("/login")
+                                                .relyingPartyRegistrationRepository(
                                                         saml2RelyingPartyRegistrations)
                                                 .authenticationManager(
                                                         new ProviderManager(authenticationProvider))

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/service/EmailService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/service/EmailService.java
@@ -226,7 +226,8 @@ public class EmailService {
 
     @Async
     public void sendPasswordChangedNotification(
-            String to, String username, String newPassword, String loginUrl) throws MessagingException {
+            String to, String username, String newPassword, String loginUrl)
+            throws MessagingException {
         String subject = "Your Stirling PDF password has been updated";
 
         String passwordSection =


### PR DESCRIPTION
Users logging in via OAuth2 were redirected to Spring's default login form instead of the React frontend login page. This happened because the OAuth2 configuration used `.loginPage("/oauth2")` which pointed to the old Thymeleaf template.

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
