### PR TITLE
[V2] feat(compress): add linearize option for fast web viewing

### DIFF
--- a/frontend/public/locales/en-GB/translation.toml
+++ b/frontend/public/locales/en-GB/translation.toml
@@ -3736,6 +3736,9 @@ filesize = "File Size"
 [compress.grayscale]
 label = "Apply Grayscale for Compression"
 
+[compress.linearize]
+label = "Linearize PDF for fast web viewing"
+
 [compress.lineArt]
 label = "Convert images to line art"
 description = "Uses ImageMagick to reduce pages to high-contrast black and white for maximum size reduction."

--- a/frontend/src/core/components/tools/compress/CompressSettings.tsx
+++ b/frontend/src/core/components/tools/compress/CompressSettings.tsx
@@ -144,6 +144,17 @@ const CompressSettings = ({ parameters, onParameterChange, disabled = false }: C
           disabled={disabled}
           label={t("compress.grayscale.label", "Apply Grayscale for compression")}
         />
+
+        {/* Linearize Option */}
+        <Stack gap="sm">
+          <Checkbox
+            checked={parameters.linearize}
+            onChange={(event) => onParameterChange('linearize', event.currentTarget.checked)}
+            disabled={disabled}
+            label={t("compress.linearize.label", "Linearize PDF for fast web viewing")}
+          />
+        </Stack>
+
         <Checkbox
           checked={parameters.lineArt}
           onChange={(event) => onParameterChange('lineArt', event.currentTarget.checked)}

--- a/frontend/src/core/hooks/tools/compress/useCompressOperation.ts
+++ b/frontend/src/core/hooks/tools/compress/useCompressOperation.ts
@@ -20,6 +20,7 @@ export const buildCompressFormData = (parameters: CompressParameters, file: File
 
   formData.append("grayscale", parameters.grayscale.toString());
   formData.append("lineArt", parameters.lineArt.toString());
+  formData.append("linearize", parameters.linearize.toString());
   if (parameters.lineArt) {
     formData.append("lineArtThreshold", parameters.lineArtThreshold.toString());
     formData.append("lineArtEdgeLevel", parameters.lineArtEdgeLevel.toString());

--- a/frontend/src/core/hooks/tools/compress/useCompressParameters.ts
+++ b/frontend/src/core/hooks/tools/compress/useCompressParameters.ts
@@ -11,6 +11,7 @@ export interface CompressParameters extends BaseParameters {
   compressionMethod: 'quality' | 'filesize';
   fileSizeValue: string;
   fileSizeUnit: 'KB' | 'MB';
+  linearize: boolean;
 }
 
 export const defaultParameters: CompressParameters = {
@@ -23,6 +24,7 @@ export const defaultParameters: CompressParameters = {
   compressionMethod: 'quality',
   fileSizeValue: '',
   fileSizeUnit: 'MB',
+  linearize: false,
 };
 
 export type CompressParametersHook = BaseParametersHook<CompressParameters>;


### PR DESCRIPTION
# Description of Changes

This pull request adds a new "Linearize PDF" option to the PDF compression tool, enabling users to optimize PDFs for fast web viewing. The change includes updates to the user interface, parameters, and form data handling to support this feature.

**User Interface Updates:**
- Added a new checkbox labeled "Linearize PDF for fast web viewing" to the compression settings UI, allowing users to enable or disable PDF linearization.

**Localization:**
- Introduced a new localization string for the "Linearize PDF for fast web viewing" label in the English (UK) translation file.

**Parameter Handling:**
- Updated the `CompressParameters` interface and default parameters to include a `linearize` boolean flag. 
- Modified the form data builder to append the `linearize` parameter when submitting compression requests.

<img width="366" height="998" alt="image" src="https://github.com/user-attachments/assets/f1efcdd5-fb91-4232-94f7-0a72de86739f" />


<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [X] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
