### PR TITLE
fix text editor not appearing

### DIFF
--- a/frontend/src/core/tools/pdfTextEditor/PdfTextEditor.tsx
+++ b/frontend/src/core/tools/pdfTextEditor/PdfTextEditor.tsx
@@ -207,7 +207,6 @@ const PdfTextEditor = ({ onComplete, onError }: BaseToolProps) => {
     unregisterCustomWorkbenchView,
     setCustomWorkbenchViewData,
     clearCustomWorkbenchViewData,
-    setLeftPanelView,
   } = useToolWorkflow();
   const { actions: navigationActions } = useNavigationActions();
   const navigationState = useNavigationState();

--- a/frontend/src/core/tools/pdfTextEditor/PdfTextEditor.tsx
+++ b/frontend/src/core/tools/pdfTextEditor/PdfTextEditor.tsx
@@ -1702,7 +1702,7 @@ const PdfTextEditor = ({ onComplete, onError }: BaseToolProps) => {
     viewLabel,
   ]);
 
-  // Cleanup ONLY on component unmount (not on re-renders)
+  // Cleanup backend cache on component unmount
   useEffect(() => {
     return () => {
       // Clear backend cache when leaving the tool
@@ -1713,9 +1713,6 @@ const PdfTextEditor = ({ onComplete, onError }: BaseToolProps) => {
           console.warn('[PdfTextEditor] Failed to clear cache on unmount:', error);
         });
       }
-      clearCustomWorkbenchViewData(WORKBENCH_VIEW_ID);
-      unregisterCustomWorkbenchView(WORKBENCH_VIEW_ID);
-      setLeftPanelView('toolPicker');
     };
   }, []); // Empty deps = cleanup only on unmount
 


### PR DESCRIPTION
use state-based tracking for custom workbench registration

Changes:
- Add `pendingWorkbenches` state to track workbenches with registration in progress
- `registerCustomWorkbenchView`: marks workbench as pending before adding to registry
- `setCustomWorkbenchViewData`: clears pending state when data is set (registration complete)
- `unregisterCustomWorkbenchView`: clears pending state on cleanup
- Validation effect now skips reset for pending workbenches instead of using timeouts

This fixes PDF Text Editor (and other custom workbench tools) failing to open
due to a race condition where the validation effect would reset the workbench
before the view finished registering.