### PR TITLE
fix(certSign): accept .pfx/.p12 uploads for PKCS12 and ensure PFX files are included in form data

### DIFF
--- a/frontend/src/core/components/tools/certSign/CertificateFilesSettings.tsx
+++ b/frontend/src/core/components/tools/certSign/CertificateFilesSettings.tsx
@@ -36,23 +36,17 @@ const CertificateFilesSettings = ({ parameters, onParameterChange, disabled = fa
         </Stack>
       )}
 
-      {parameters.certType === 'PKCS12' && (
+      {(parameters.certType === 'PKCS12' || parameters.certType === 'PFX') && (
         <FileUploadButton
           file={parameters.p12File}
           onChange={(file) => onParameterChange('p12File', file || undefined)}
-          accept=".p12"
+          accept=".p12,.pfx"
           disabled={disabled}
-          placeholder={t('certSign.chooseP12File', 'Choose PKCS12 File')}
-        />
-      )}
-
-      {parameters.certType === 'PFX' && (
-        <FileUploadButton
-          file={parameters.p12File}
-          onChange={(file) => onParameterChange('p12File', file || undefined)}
-          accept=".pfx"
-          disabled={disabled}
-          placeholder={t('certSign.choosePfxFile', 'Choose PFX File')}
+          placeholder={
+            parameters.certType === 'PFX'
+              ? t('certSign.choosePfxFile', 'Choose PFX File')
+              : t('certSign.chooseP12File', 'Choose PKCS12 File')
+          }
         />
       )}
 

--- a/frontend/src/core/hooks/tools/certSign/useCertSignOperation.ts
+++ b/frontend/src/core/hooks/tools/certSign/useCertSignOperation.ts
@@ -7,14 +7,14 @@ import { CertSignParameters, defaultParameters } from '@app/hooks/tools/certSign
 export const buildCertSignFormData = (parameters: CertSignParameters, file: File): FormData => {
   const formData = new FormData();
   formData.append('fileInput', file);
-  
+
   // Handle sign mode
   if (parameters.signMode === 'AUTO') {
     formData.append('certType', 'SERVER');
   } else {
     formData.append('certType', parameters.certType);
     formData.append('password', parameters.password);
-    
+
     // Add certificate files based on type (only for manual mode)
     switch (parameters.certType) {
       case 'PEM':
@@ -26,6 +26,7 @@ export const buildCertSignFormData = (parameters: CertSignParameters, file: File
         }
         break;
       case 'PKCS12':
+      case 'PFX':
         if (parameters.p12File) {
           formData.append('p12File', parameters.p12File);
         }
@@ -37,7 +38,7 @@ export const buildCertSignFormData = (parameters: CertSignParameters, file: File
         break;
     }
   }
-  
+
   // Add signature appearance options if enabled
   if (parameters.showSignature) {
     formData.append('showSignature', 'true');
@@ -47,7 +48,7 @@ export const buildCertSignFormData = (parameters: CertSignParameters, file: File
     formData.append('pageNumber', parameters.pageNumber.toString());
     formData.append('showLogo', parameters.showLogo.toString());
   }
-  
+
   return formData;
 };
 


### PR DESCRIPTION
# Description of Changes

This pull request improves the handling of PKCS12 and PFX certificate file types in the certificate signing tool. The main changes unify and simplify the logic for uploading and processing these file types, ensuring consistent behavior and reducing code duplication.

**Certificate file upload improvements:**

* Updated the `CertificateFilesSettings` component to handle both `PKCS12` and `PFX` certificate types in a single file upload input, allowing selection of either `.p12` or `.pfx` files and dynamically adjusting the placeholder text.

**Certificate signing logic updates:**

* Modified the `buildCertSignFormData` function to append the uploaded file for both `PKCS12` and `PFX` certificate types, ensuring both are supported during form data construction.

<img width="1916" height="463" alt="image" src="https://github.com/user-attachments/assets/51dbe130-c25b-4b77-aecd-f3d55d5c62ae" />


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
