### PR TITLE
fix(security): sanitize uploaded filenames before temp file creation and email attachments

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/misc/CustomColorReplaceStrategy.java
+++ b/app/common/src/main/java/stirling/software/common/util/misc/CustomColorReplaceStrategy.java
@@ -22,6 +22,8 @@ import org.apache.pdfbox.text.TextPosition;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.github.pixee.security.Filenames;
+
 import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.common.model.api.misc.HighContrastColorCombination;
@@ -60,7 +62,11 @@ public class CustomColorReplaceStrategy extends ReplaceAndInvertColorStrategy {
         }
 
         // Create a temporary file, with the original filename from the multipart file
-        File file = Files.createTempFile("temp", getFileInput().getOriginalFilename()).toFile();
+        String safeSuffix = Filenames.toSimpleFileName(getFileInput().getOriginalFilename());
+        if (safeSuffix == null || safeSuffix.isBlank()) {
+            safeSuffix = ".tmp";
+        }
+        File file = Files.createTempFile("temp", safeSuffix).toFile();
 
         // Transfer the content of the multipart file to the file
         getFileInput().transferTo(file);

--- a/app/common/src/main/java/stirling/software/common/util/misc/InvertFullColorStrategy.java
+++ b/app/common/src/main/java/stirling/software/common/util/misc/InvertFullColorStrategy.java
@@ -19,6 +19,8 @@ import org.apache.pdfbox.rendering.PDFRenderer;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.github.pixee.security.Filenames;
+
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.api.misc.ReplaceAndInvert;
 import stirling.software.common.util.ApplicationContextProvider;
@@ -32,10 +34,11 @@ public class InvertFullColorStrategy extends ReplaceAndInvertColorStrategy {
 
     @Override
     public InputStreamResource replace() throws IOException {
-        try (TempFile tempFile =
-                new TempFile(
-                        Files.createTempFile("temp", getFileInput().getOriginalFilename())
-                                .toFile())) {
+        String safeSuffix = Filenames.toSimpleFileName(getFileInput().getOriginalFilename());
+        if (safeSuffix == null || safeSuffix.isBlank()) {
+            safeSuffix = ".tmp";
+        }
+        try (TempFile tempFile = new TempFile(Files.createTempFile("temp", safeSuffix).toFile())) {
             // Transfer the content of the multipart file to the file
             getFileInput().transferTo(tempFile.getFile());
 

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/service/EmailService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/service/EmailService.java
@@ -7,6 +7,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.github.pixee.security.Filenames;
+
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 
@@ -52,6 +54,10 @@ public class EmailService {
                 || file.getOriginalFilename().isEmpty()) {
             throw new MessagingException("An attachment is required to send the email.");
         }
+        String safeFilename = Filenames.toSimpleFileName(file.getOriginalFilename());
+        if (safeFilename == null || safeFilename.isBlank()) {
+            throw new MessagingException("An attachment is required to send the email.");
+        }
 
         ApplicationProperties.Mail mailProperties = applicationProperties.getMail();
 
@@ -70,7 +76,7 @@ public class EmailService {
         helper.setFrom(mailProperties.getFrom());
 
         // Adds the attachment to the email
-        helper.addAttachment(file.getOriginalFilename(), file);
+        helper.addAttachment(safeFilename, file);
 
         // Sends the email via the configured mail sender
         mailSender.send(message);


### PR DESCRIPTION
# Description of Changes

This pull request introduces important security improvements by sanitizing filenames used in temporary file creation and email attachments. The changes ensure that only safe filenames are used, reducing the risk of vulnerabilities related to file handling. The main updates are grouped below:

**Security: Filename Sanitization**

* Integrated the `Filenames.toSimpleFileName` utility to sanitize filenames before creating temporary files in both `CustomColorReplaceStrategy` and `InvertFullColorStrategy`, preventing unsafe or malformed filenames from being used. [[1]](diffhunk://#diff-fc65c0000b1b50c66eecb9153c07a97f0ddb3229de0fbf028d7c00977e12e530R25-R26) [[2]](diffhunk://#diff-8068a0e167084f26f726d9f49a0f3a19a6dbd91009d690ec76935e6acc69219eR22-R23)
* Updated logic in `CustomColorReplaceStrategy.replace()` and `InvertFullColorStrategy.replace()` to use the sanitized filename as the suffix for temp files, defaulting to `.tmp` if the sanitized result is blank or null. [[1]](diffhunk://#diff-fc65c0000b1b50c66eecb9153c07a97f0ddb3229de0fbf028d7c00977e12e530L63-R69) [[2]](diffhunk://#diff-8068a0e167084f26f726d9f49a0f3a19a6dbd91009d690ec76935e6acc69219eL35-R41)

**Email Attachment Handling**

* In `EmailService.sendEmailWithAttachment`, added a check to ensure the sanitized filename is not blank or null, throwing a `MessagingException` if it fails, to prevent unsafe attachments.
* Changed email attachment logic to use the sanitized filename instead of the original filename when adding attachments, ensuring only safe filenames are used.
* Imported the `Filenames` utility in `EmailService` for consistent filename sanitization.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
