### PR TITLE
Add desktop certificate store selection for PDF signing

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/CertStoreEntriesRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/CertStoreEntriesRequest.java
@@ -1,0 +1,23 @@
+package stirling.software.SPDF.model.api.security;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.Data;
+
+@Data
+public class CertStoreEntriesRequest {
+
+    @Schema(
+            description = "The type of certificate store to query",
+            allowableValues = {"WINDOWS_STORE", "MAC_KEYCHAIN", "PKCS11"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String certType;
+
+    @Schema(description = "PKCS11 configuration file for hardware-backed certificates")
+    private MultipartFile pkcs11ConfigFile;
+
+    @Schema(description = "The password or PIN for the certificate store", format = "password")
+    private String password;
+}

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
@@ -15,7 +15,16 @@ public class SignPDFWithCertRequest extends PDFFile {
 
     @Schema(
             description = "The type of the digital certificate",
-            allowableValues = {"PEM", "PKCS12", "PFX", "JKS", "SERVER"},
+            allowableValues = {
+                "PEM",
+                "PKCS12",
+                "PFX",
+                "JKS",
+                "SERVER",
+                "WINDOWS_STORE",
+                "MAC_KEYCHAIN",
+                "PKCS11"
+            },
             requiredMode = Schema.RequiredMode.REQUIRED)
     private String certType;
 
@@ -41,6 +50,15 @@ public class SignPDFWithCertRequest extends PDFFile {
 
     @Schema(description = "The password for the keystore or the private key", format = "password")
     private String password;
+
+    @Schema(
+            description =
+                    "The alias of the certificate to use when loading from OS keystores or"
+                            + " PKCS11 tokens")
+    private String certAlias;
+
+    @Schema(description = "PKCS11 configuration file for hardware-backed certificates")
+    private MultipartFile pkcs11ConfigFile;
 
     @Schema(
             description = "Whether to visually show the signature in the PDF file",

--- a/app/core/src/main/java/stirling/software/SPDF/util/DesktopModeUtils.java
+++ b/app/core/src/main/java/stirling/software/SPDF/util/DesktopModeUtils.java
@@ -1,0 +1,14 @@
+package stirling.software.SPDF.util;
+
+public final class DesktopModeUtils {
+
+    private DesktopModeUtils() {}
+
+    public static boolean isDesktopMode() {
+        return Boolean.parseBoolean(System.getProperty("STIRLING_PDF_TAURI_MODE", "false"))
+                || Boolean.parseBoolean(
+                        System.getenv().getOrDefault("STIRLING_PDF_TAURI_MODE", "false"))
+                || Boolean.parseBoolean(System.getenv().getOrDefault("STIRLING_DESKTOP", "false"))
+                || Boolean.parseBoolean(System.getenv().getOrDefault("VITE_DESKTOP", "false"));
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/util/Pkcs11ProviderLoader.java
+++ b/app/core/src/main/java/stirling/software/SPDF/util/Pkcs11ProviderLoader.java
@@ -1,0 +1,44 @@
+package stirling.software.SPDF.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.Provider;
+import java.security.Security;
+
+import org.apache.commons.io.FileUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import stirling.software.common.util.ExceptionUtils;
+
+public final class Pkcs11ProviderLoader {
+
+    private Pkcs11ProviderLoader() {}
+
+    public static Provider loadProvider(MultipartFile configFile) throws IOException {
+        Provider baseProvider = Security.getProvider("SunPKCS11");
+        if (baseProvider == null) {
+            throw ExceptionUtils.createIllegalArgumentException(
+                    "error.invalidArgument",
+                    "Invalid argument: {0}",
+                    "SunPKCS11 provider is not available in this JVM");
+        }
+
+        File tempFile = File.createTempFile("spdf-pkcs11", ".cfg");
+        tempFile.deleteOnExit();
+        try {
+            FileUtils.copyInputStreamToFile(configFile.getInputStream(), tempFile);
+            Provider provider = baseProvider.configure(tempFile.getAbsolutePath());
+            Provider existingProvider = Security.getProvider(provider.getName());
+            if (existingProvider != null) {
+                return existingProvider;
+            }
+            Security.addProvider(provider);
+            return provider;
+        } catch (IOException e) {
+            if (tempFile.exists()) {
+                tempFile.delete();
+            }
+            throw e;
+        }
+    }
+}

--- a/frontend/public/locales/en-GB/translation.toml
+++ b/frontend/public/locales/en-GB/translation.toml
@@ -2655,6 +2655,7 @@ chooseJksFile = "Choose JKS File"
 chooseP12File = "Choose PKCS12 File"
 choosePfxFile = "Choose PFX File"
 choosePrivateKey = "Choose Private Key File"
+choosePkcs11Config = "Choose PKCS#11 Config File"
 location = "Location"
 logoTitle = "Logo"
 name = "Name"
@@ -2663,8 +2664,18 @@ pageNumber = "Page Number"
 password = "Certificate Password"
 passwordOptional = "Leave empty if no password"
 reason = "Reason"
+refreshStoreCertificates = "Refresh"
+selectStoreCertificate = "Select a certificate"
 serverCertMessage = "Using server certificate - no files or password required"
 showLogo = "Show Logo"
+storeCertificateExpires = "Expires"
+storeCertificateIssuer = "Issuer"
+storeCertificateSubject = "Subject"
+storeCertificates = "Available Certificates"
+storeCertificatesError = "Failed to load certificates"
+loadingStoreCertificates = "Loading certificates..."
+pin = "Token PIN / Password"
+pinOptional = "Leave empty if not required"
 
 [certSign.signMode]
 stepTitle = "Sign Mode"
@@ -2692,6 +2703,11 @@ text = "Need recipient <b>Trusted</b> status? <b>Manual</b>. Need a fast, tamper
 
 [certSign.certTypeStep]
 stepTitle = "Certificate Format"
+
+[certSign.certType]
+windowsStore = "Windows Store"
+macKeychain = "macOS Keychain"
+pkcs11 = "PKCS#11"
 
 [certSign.certFiles]
 stepTitle = "Certificate Files"

--- a/frontend/src/core/components/tools/certSign/CertificateFilesSettings.tsx
+++ b/frontend/src/core/components/tools/certSign/CertificateFilesSettings.tsx
@@ -1,7 +1,10 @@
-import { Stack, Text, TextInput } from "@mantine/core";
+import { Button, Group, Loader, Stack, Text, TextInput } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { CertSignParameters } from "@app/hooks/tools/certSign/useCertSignParameters";
 import FileUploadButton from "@app/components/shared/FileUploadButton";
+import DropdownListWithFooter from "@app/components/shared/DropdownListWithFooter";
+import { isDesktopMode as checkDesktopMode } from "@app/utils/isDesktopMode";
+import { useCertStoreEntries } from "@app/hooks/tools/certSign/useCertStoreEntries";
 
 interface CertificateFilesSettingsProps {
   parameters: CertSignParameters;
@@ -11,6 +14,24 @@ interface CertificateFilesSettingsProps {
 
 const CertificateFilesSettings = ({ parameters, onParameterChange, disabled = false }: CertificateFilesSettingsProps) => {
   const { t } = useTranslation();
+  const isDesktopMode = checkDesktopMode();
+  const isStoreCertType = ['WINDOWS_STORE', 'MAC_KEYCHAIN', 'PKCS11'].includes(parameters.certType);
+  const autoFetchStoreEntries = parameters.certType === 'WINDOWS_STORE' || parameters.certType === 'MAC_KEYCHAIN';
+
+  const {
+    entries: storeEntries,
+    loading: storeLoading,
+    error: storeError,
+    fetchEntries: refreshStoreEntries,
+  } = useCertStoreEntries({
+    certType: parameters.certType,
+    password: parameters.password,
+    pkcs11ConfigFile: parameters.pkcs11ConfigFile,
+    enabled: isDesktopMode && isStoreCertType,
+    autoFetch: autoFetchStoreEntries,
+  });
+
+  const selectedStoreEntry = storeEntries.find((entry) => entry.alias === parameters.certAlias);
 
   return (
     <Stack gap="md">
@@ -64,6 +85,89 @@ const CertificateFilesSettings = ({ parameters, onParameterChange, disabled = fa
           disabled={disabled}
           placeholder={t('certSign.chooseJksFile', 'Choose JKS File')}
         />
+      )}
+
+      {isDesktopMode && parameters.certType === 'PKCS11' && (
+        <FileUploadButton
+          file={parameters.pkcs11ConfigFile}
+          onChange={(file) => onParameterChange('pkcs11ConfigFile', file || undefined)}
+          accept=".cfg,.conf,.txt"
+          disabled={disabled}
+          placeholder={t('certSign.choosePkcs11Config', 'Choose PKCS#11 Config File')}
+        />
+      )}
+
+      {isDesktopMode && isStoreCertType && (
+        <Stack gap="xs">
+          {(parameters.certType === 'PKCS11') && (
+            <TextInput
+              label={t('certSign.pin', 'Token PIN / Password')}
+              placeholder={t('certSign.pinOptional', 'Leave empty if not required')}
+              type="password"
+              value={parameters.password}
+              onChange={(event) => onParameterChange('password', event.currentTarget.value)}
+              disabled={disabled}
+            />
+          )}
+
+          <Group justify="space-between" align="center">
+            <Text size="sm" fw={500}>
+              {t('certSign.storeCertificates', 'Available Certificates')}
+            </Text>
+            <Button
+              variant="subtle"
+              size="xs"
+              onClick={() => refreshStoreEntries()}
+              disabled={disabled || (parameters.certType === 'PKCS11' && !parameters.pkcs11ConfigFile)}
+            >
+              {t('certSign.refreshStoreCertificates', 'Refresh')}
+            </Button>
+          </Group>
+
+          {storeLoading && (
+            <Group gap="xs">
+              <Loader size="xs" />
+              <Text size="sm">
+                {t('certSign.loadingStoreCertificates', 'Loading certificates...')}
+              </Text>
+            </Group>
+          )}
+
+          {!storeLoading && (
+            <DropdownListWithFooter
+              value={parameters.certAlias}
+              onChange={(value) => onParameterChange('certAlias', value as string)}
+              items={storeEntries.map((entry) => ({
+                value: entry.alias,
+                name: `${entry.displayName} (${entry.alias})`,
+              }))}
+              placeholder={t('certSign.selectStoreCertificate', 'Select a certificate')}
+              disabled={disabled || storeEntries.length === 0}
+              searchable={true}
+              maxHeight={260}
+            />
+          )}
+
+          {storeError && (
+            <Text size="sm" c="red">
+              {t('certSign.storeCertificatesError', 'Failed to load certificates')} ({storeError})
+            </Text>
+          )}
+
+          {selectedStoreEntry && (
+            <Stack gap={2}>
+              <Text size="xs" c="dimmed">
+                {t('certSign.storeCertificateSubject', 'Subject')}: {selectedStoreEntry.subject}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {t('certSign.storeCertificateIssuer', 'Issuer')}: {selectedStoreEntry.issuer}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {t('certSign.storeCertificateExpires', 'Expires')}: {new Date(selectedStoreEntry.notAfterEpochMs).toLocaleString()}
+              </Text>
+            </Stack>
+          )}
+        </Stack>
       )}
 
       {parameters.signMode === 'AUTO' && (

--- a/frontend/src/core/components/tools/certSign/CertificateFormatSettings.tsx
+++ b/frontend/src/core/components/tools/certSign/CertificateFormatSettings.tsx
@@ -1,5 +1,7 @@
 import { Stack, Button } from "@mantine/core";
+import { useTranslation } from "react-i18next";
 import { CertSignParameters } from "@app/hooks/tools/certSign/useCertSignParameters";
+import { isDesktopMode as checkDesktopMode } from "@app/utils/isDesktopMode";
 
 interface CertificateFormatSettingsProps {
   parameters: CertSignParameters;
@@ -8,6 +10,16 @@ interface CertificateFormatSettingsProps {
 }
 
 const CertificateFormatSettings = ({ parameters, onParameterChange, disabled = false }: CertificateFormatSettingsProps) => {
+  const { t } = useTranslation();
+  const isDesktopMode = checkDesktopMode();
+
+  const setCertType = (certType: CertSignParameters['certType']) => {
+    onParameterChange('certType', certType);
+    onParameterChange('certAlias', '');
+    if (certType !== 'PKCS11') {
+      onParameterChange('pkcs11ConfigFile', undefined);
+    }
+  };
 
   return (
     <Stack gap="md">
@@ -17,7 +29,7 @@ const CertificateFormatSettings = ({ parameters, onParameterChange, disabled = f
           <Button
             variant={parameters.certType === 'PKCS12' ? 'filled' : 'outline'}
             color={parameters.certType === 'PKCS12' ? 'blue' : 'var(--text-muted)'}
-            onClick={() => onParameterChange('certType', 'PKCS12')}
+            onClick={() => setCertType('PKCS12')}
             disabled={disabled}
             style={{ flex: 1, height: 'auto', minHeight: '40px', fontSize: '11px' }}
           >
@@ -28,7 +40,7 @@ const CertificateFormatSettings = ({ parameters, onParameterChange, disabled = f
           <Button
             variant={parameters.certType === 'PFX' ? 'filled' : 'outline'}
             color={parameters.certType === 'PFX' ? 'blue' : 'var(--text-muted)'}
-            onClick={() => onParameterChange('certType', 'PFX')}
+            onClick={() => setCertType('PFX')}
             disabled={disabled}
             style={{ flex: 1, height: 'auto', minHeight: '40px', fontSize: '11px' }}
           >
@@ -42,7 +54,7 @@ const CertificateFormatSettings = ({ parameters, onParameterChange, disabled = f
           <Button
             variant={parameters.certType === 'PEM' ? 'filled' : 'outline'}
             color={parameters.certType === 'PEM' ? 'blue' : 'var(--text-muted)'}
-            onClick={() => onParameterChange('certType', 'PEM')}
+            onClick={() => setCertType('PEM')}
             disabled={disabled}
             style={{ flex: 1, height: 'auto', minHeight: '40px', fontSize: '11px' }}
           >
@@ -53,7 +65,7 @@ const CertificateFormatSettings = ({ parameters, onParameterChange, disabled = f
           <Button
             variant={parameters.certType === 'JKS' ? 'filled' : 'outline'}
             color={parameters.certType === 'JKS' ? 'blue' : 'var(--text-muted)'}
-            onClick={() => onParameterChange('certType', 'JKS')}
+            onClick={() => setCertType('JKS')}
             disabled={disabled}
             style={{ flex: 1, height: 'auto', minHeight: '40px', fontSize: '11px' }}
           >
@@ -62,6 +74,43 @@ const CertificateFormatSettings = ({ parameters, onParameterChange, disabled = f
             </div>
           </Button>
         </div>
+        {isDesktopMode && (
+          <div style={{ display: 'flex', gap: '4px' }}>
+            <Button
+              variant={parameters.certType === 'WINDOWS_STORE' ? 'filled' : 'outline'}
+              color={parameters.certType === 'WINDOWS_STORE' ? 'blue' : 'var(--text-muted)'}
+              onClick={() => setCertType('WINDOWS_STORE')}
+              disabled={disabled}
+              style={{ flex: 1, height: 'auto', minHeight: '40px', fontSize: '11px' }}
+            >
+              <div style={{ textAlign: 'center', lineHeight: '1.1', fontSize: '11px' }}>
+                {t('certSign.certType.windowsStore', 'Windows Store')}
+              </div>
+            </Button>
+            <Button
+              variant={parameters.certType === 'MAC_KEYCHAIN' ? 'filled' : 'outline'}
+              color={parameters.certType === 'MAC_KEYCHAIN' ? 'blue' : 'var(--text-muted)'}
+              onClick={() => setCertType('MAC_KEYCHAIN')}
+              disabled={disabled}
+              style={{ flex: 1, height: 'auto', minHeight: '40px', fontSize: '11px' }}
+            >
+              <div style={{ textAlign: 'center', lineHeight: '1.1', fontSize: '11px' }}>
+                {t('certSign.certType.macKeychain', 'macOS Keychain')}
+              </div>
+            </Button>
+            <Button
+              variant={parameters.certType === 'PKCS11' ? 'filled' : 'outline'}
+              color={parameters.certType === 'PKCS11' ? 'blue' : 'var(--text-muted)'}
+              onClick={() => setCertType('PKCS11')}
+              disabled={disabled}
+              style={{ flex: 1, height: 'auto', minHeight: '40px', fontSize: '11px' }}
+            >
+              <div style={{ textAlign: 'center', lineHeight: '1.1', fontSize: '11px' }}>
+                {t('certSign.certType.pkcs11', 'PKCS#11')}
+              </div>
+            </Button>
+          </div>
+        )}
       </div>
     </Stack>
   );

--- a/frontend/src/core/hooks/tools/certSign/useCertSignOperation.ts
+++ b/frontend/src/core/hooks/tools/certSign/useCertSignOperation.ts
@@ -14,6 +14,9 @@ export const buildCertSignFormData = (parameters: CertSignParameters, file: File
   } else {
     formData.append('certType', parameters.certType);
     formData.append('password', parameters.password);
+    if (['WINDOWS_STORE', 'MAC_KEYCHAIN', 'PKCS11'].includes(parameters.certType) && parameters.certAlias) {
+      formData.append('certAlias', parameters.certAlias);
+    }
     
     // Add certificate files based on type (only for manual mode)
     switch (parameters.certType) {
@@ -30,9 +33,19 @@ export const buildCertSignFormData = (parameters: CertSignParameters, file: File
           formData.append('p12File', parameters.p12File);
         }
         break;
+      case 'PFX':
+        if (parameters.p12File) {
+          formData.append('p12File', parameters.p12File);
+        }
+        break;
       case 'JKS':
         if (parameters.jksFile) {
           formData.append('jksFile', parameters.jksFile);
+        }
+        break;
+      case 'PKCS11':
+        if (parameters.pkcs11ConfigFile) {
+          formData.append('pkcs11ConfigFile', parameters.pkcs11ConfigFile);
         }
         break;
     }

--- a/frontend/src/core/hooks/tools/certSign/useCertSignParameters.ts
+++ b/frontend/src/core/hooks/tools/certSign/useCertSignParameters.ts
@@ -5,12 +5,14 @@ export interface CertSignParameters extends BaseParameters {
   // Sign mode selection
   signMode: 'MANUAL' | 'AUTO';
   // Certificate signing options (only for manual mode)
-  certType: '' | 'PEM' | 'PKCS12' | 'PFX' | 'JKS';
+  certType: '' | 'PEM' | 'PKCS12' | 'PFX' | 'JKS' | 'WINDOWS_STORE' | 'MAC_KEYCHAIN' | 'PKCS11';
   privateKeyFile?: File;
   certFile?: File;
   p12File?: File;
   jksFile?: File;
   password: string;
+  certAlias: string;
+  pkcs11ConfigFile?: File;
   
   // Signature appearance options
   showSignature: boolean;
@@ -25,6 +27,7 @@ export const defaultParameters: CertSignParameters = {
   signMode: 'MANUAL',
   certType: '',
   password: '',
+  certAlias: '',
   showSignature: false,
   reason: '',
   location: '',
@@ -59,6 +62,11 @@ export const useCertSignParameters = (): CertSignParametersHook => {
           return !!params.p12File;
         case 'JKS':
           return !!params.jksFile;
+        case 'WINDOWS_STORE':
+        case 'MAC_KEYCHAIN':
+          return !!params.certAlias;
+        case 'PKCS11':
+          return !!(params.certAlias && params.pkcs11ConfigFile);
         default:
           return false;
       }

--- a/frontend/src/core/hooks/tools/certSign/useCertStoreEntries.ts
+++ b/frontend/src/core/hooks/tools/certSign/useCertStoreEntries.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from 'react';
+import apiClient from '@app/services/apiClient';
+
+export interface CertificateStoreEntry {
+  alias: string;
+  displayName: string;
+  subject: string;
+  issuer: string;
+  serialNumber: string;
+  notBefore: string;
+  notAfter: string;
+  notBeforeEpochMs: number;
+  notAfterEpochMs: number;
+}
+
+interface CertificateStoreEntriesResponse {
+  entries: CertificateStoreEntry[];
+}
+
+interface UseCertStoreEntriesOptions {
+  certType: string;
+  password: string;
+  pkcs11ConfigFile?: File;
+  enabled: boolean;
+  autoFetch?: boolean;
+}
+
+export const useCertStoreEntries = ({
+  certType,
+  password,
+  pkcs11ConfigFile,
+  enabled,
+  autoFetch = true,
+}: UseCertStoreEntriesOptions) => {
+  const [entries, setEntries] = useState<CertificateStoreEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEntries = useCallback(async () => {
+    if (!enabled) {
+      setEntries([]);
+      return;
+    }
+    if (!certType) {
+      setEntries([]);
+      return;
+    }
+    if (certType === 'PKCS11' && !pkcs11ConfigFile) {
+      setEntries([]);
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const formData = new FormData();
+      formData.append('certType', certType);
+      if (password) {
+        formData.append('password', password);
+      }
+      if (pkcs11ConfigFile) {
+        formData.append('pkcs11ConfigFile', pkcs11ConfigFile);
+      }
+
+      const response = await apiClient.post<CertificateStoreEntriesResponse>(
+        '/api/v1/ui-data/cert-store-entries',
+        formData
+      );
+      setEntries(response.data.entries ?? []);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  }, [certType, enabled, password, pkcs11ConfigFile]);
+
+  useEffect(() => {
+    if (!autoFetch) {
+      return;
+    }
+    void fetchEntries();
+  }, [autoFetch, fetchEntries]);
+
+  return {
+    entries,
+    loading,
+    error,
+    fetchEntries,
+  };
+};

--- a/frontend/src/core/utils/isDesktopMode.ts
+++ b/frontend/src/core/utils/isDesktopMode.ts
@@ -1,0 +1,4 @@
+export const isDesktopMode = (): boolean =>
+  import.meta.env.MODE === 'desktop'
+  || import.meta.env.VITE_DESKTOP === 'true'
+  || import.meta.env.STIRLING_DESKTOP === 'true';

--- a/frontend/src/core/utils/isDesktopMode.ts
+++ b/frontend/src/core/utils/isDesktopMode.ts
@@ -1,4 +1,5 @@
 export const isDesktopMode = (): boolean =>
   import.meta.env.MODE === 'desktop'
   || import.meta.env.VITE_DESKTOP === 'true'
-  || import.meta.env.STIRLING_DESKTOP === 'true';
+  || import.meta.env.STIRLING_DESKTOP === 'true'
+  || import.meta.env.STIRLING_PDF_TAURI_MODE === 'true';


### PR DESCRIPTION
### Motivation
- Allow users on desktop builds to sign PDFs with certificates stored in OS keystores or hardware tokens (Windows Certificate Store, macOS Keychain, PKCS#11) and to explicitly pick the intended certificate entry by alias.
- Prevent server/remote environments from attempting to access local OS keystores by restricting these flows to desktop mode.
- Provide a UI-driven list of available store certificates so users can choose from multiple entries on the device.

### Description
- Backend: added a new UI-data endpoint `POST /api/v1/ui-data/cert-store-entries` with request model `CertStoreEntriesRequest` to enumerate OS-backed certificates and a loader for `Windows-MY`, `KeychainStore`, and PKCS#11 providers; added `ensureDesktopMode(...)` guard to restrict store access to desktop mode.
- Signing flow: extended `SignPDFWithCertRequest` with `certAlias` and `pkcs11ConfigFile` and updated `CertSignController` to support `WINDOWS_STORE`, `MAC_KEYCHAIN`, and `PKCS11` certType values, including `selectKeyStoreEntry(...)` to validate alias, extract private key and chain, and build an in-memory keystore for signing.
- Frontend: added `useCertStoreEntries` hook and `isDesktopMode` helper, exposed desktop-only buttons in `CertificateFormatSettings`, and added certificate listing, refresh, PKCS#11 config upload and alias dropdown in `CertificateFilesSettings`; updated form builder `buildCertSignFormData` to include `certAlias` and `pkcs11ConfigFile` when applicable.
- Misc: PKCS#11 provider loading uses a temporary config file and checks for the `SunPKCS11` provider; certificate listing returns display-friendly metadata (subject, issuer, validity) for dropdown presentation.

### Testing
- Ran `./gradlew spotlessApply` which completed successfully and applied formatting changes.
- Attempted `./gradlew build` but the build failed during dependency resolution with Maven Central returning HTTP 403, preventing full compilation and test execution.
- Frontend UI wiring was exercised locally via code changes (hook + components) but no E2E or automated browser tests completed because the frontend was not reachable during Playwright capture (empty response).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c20b013fc8328b3d2ecc8429af9e0)