### PR TITLE
Use Tauri shell for external links

### DIFF
--- a/frontend/src/core/components/onboarding/slides/AnalyticsChoiceSlide.tsx
+++ b/frontend/src/core/components/onboarding/slides/AnalyticsChoiceSlide.tsx
@@ -5,6 +5,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import i18n from '@app/i18n';
 import { SlideConfig } from '@app/types/types';
 import { UNIFIED_CIRCLE_CONFIG } from '@app/components/onboarding/slides/unifiedBackgroundConfig';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 import styles from '@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css';
 
 interface AnalyticsChoiceSlideProps {
@@ -33,7 +34,7 @@ export default function AnalyticsChoiceSlide({ analyticsError }: AnalyticsChoice
           <Button
             variant="default"
             size="sm"
-            onClick={() => window.open('https://docs.stirlingpdf.com/analytics-telemetry/', '_blank')}
+            onClick={() => void openExternalUrl('https://docs.stirlingpdf.com/analytics-telemetry/')}
             rightSection={<OpenInNewIcon style={{ fontSize: 16 }} />}
           >
             {i18n.t('analytics.learnMore', 'Learn more about our analytics')}
@@ -52,4 +53,3 @@ export default function AnalyticsChoiceSlide({ analyticsError }: AnalyticsChoice
     },
   };
 }
-

--- a/frontend/src/core/components/onboarding/useOnboardingDownload.ts
+++ b/frontend/src/core/components/onboarding/useOnboardingDownload.ts
@@ -7,6 +7,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useOs } from '@app/hooks/useOs';
 import { DOWNLOAD_URLS } from '@app/constants/downloads';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 
 interface OsInfo {
   label: string;
@@ -64,7 +65,7 @@ export function useOnboardingDownload(): UseOnboardingDownloadResult {
   const handleDownloadSelected = useCallback(() => {
     const downloadUrl = selectedDownloadUrl || osInfo.url;
     if (downloadUrl) {
-      window.open(downloadUrl, '_blank', 'noopener');
+      void openExternalUrl(downloadUrl, { features: 'noopener' });
     }
   }, [selectedDownloadUrl, osInfo.url]);
 
@@ -76,4 +77,3 @@ export function useOnboardingDownload(): UseOnboardingDownloadResult {
     handleDownloadSelected,
   };
 }
-

--- a/frontend/src/core/components/tools/FullscreenToolList.tsx
+++ b/frontend/src/core/components/tools/FullscreenToolList.tsx
@@ -9,6 +9,7 @@ import { useToolWorkflow } from '@app/contexts/ToolWorkflowContext';
 import StarRoundedIcon from '@mui/icons-material/StarRounded';
 import ThumbUpRoundedIcon from '@mui/icons-material/ThumbUpRounded';
 import Badge from '@app/components/shared/Badge';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 import '@app/components/tools/ToolPanel.css';
 import DetailedToolItem from '@app/components/tools/fullscreen/DetailedToolItem';
 import CompactToolItem from '@app/components/tools/fullscreen/CompactToolItem';
@@ -82,7 +83,7 @@ const FullscreenToolList = ({
     const handleClick = () => {
       if (!tool.component && !tool.link && id !== 'read' && id !== 'multiTool') return;
       if (tool.link) {
-        window.open(tool.link, '_blank', 'noopener,noreferrer');
+        void openExternalUrl(tool.link);
         return;
       }
       onSelect(id as ToolId);
@@ -249,5 +250,4 @@ const FullscreenToolList = ({
 };
 
 export default FullscreenToolList;
-
 

--- a/frontend/src/core/components/tools/ocr/LanguagePicker.tsx
+++ b/frontend/src/core/components/tools/ocr/LanguagePicker.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { getAutoOcrLanguage, getBrowserLanguagesForOcr, getOcrDisplayName } from '@app/utils/languageMapping';
 import apiClient from '@app/services/apiClient';
 import DropdownListWithFooter, { DropdownItem } from '@app/components/shared/DropdownListWithFooter';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 
 export interface LanguageOption {
   value: string;
@@ -134,7 +135,7 @@ const LanguagePicker: React.FC<LanguagePickerProps> = ({
           textDecoration: 'underline',
           textAlign: 'center'
         }}
-        onClick={() => window.open('https://docs.stirlingpdf.com/Configuration/OCR', '_blank')}
+        onClick={() => void openExternalUrl('https://docs.stirlingpdf.com/Configuration/OCR')}
       >
         {t('ocr.languagePicker.viewSetupGuide', 'View setup guide →')}
       </Text>

--- a/frontend/src/core/components/tools/toolPicker/ToolButton.tsx
+++ b/frontend/src/core/components/tools/toolPicker/ToolButton.tsx
@@ -14,6 +14,7 @@ import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
 import { ToolId } from "@app/types/toolId";
 import { getToolDisabledReason, getDisabledLabel } from "@app/components/tools/fullscreen/shared";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
+import { openExternalUrl } from "@app/utils/openExternalUrl";
 
 interface ToolButtonProps {
   id: ToolId;
@@ -42,7 +43,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({ id, tool, isSelected, onSelect,
     if (isUnavailable) return;
     if (tool.link) {
       // Open external link in new tab
-      window.open(tool.link, '_blank', 'noopener,noreferrer');
+      void openExternalUrl(tool.link);
       return;
     }
     // Normal tool selection

--- a/frontend/src/core/components/viewer/BookmarkSidebar.tsx
+++ b/frontend/src/core/components/viewer/BookmarkSidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { Box, ScrollArea, Text, ActionIcon, Loader, Stack, TextInput, Button } from '@mantine/core';
 import LocalIcon from '@app/components/shared/LocalIcon';
 import { useViewer } from '@app/contexts/ViewerContext';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 import { PdfBookmarkObject, PdfActionType } from '@embedpdf/models';
 import BookmarksIcon from '@mui/icons-material/BookmarksRounded';
 import '@app/components/viewer/BookmarkSidebar.css';
@@ -288,12 +289,12 @@ export const BookmarkSidebar = ({ visible, thumbnailVisible, documentCacheKey, p
       const action = target.action;
       if (action.type === PdfActionType.URI && action.uri) {
         event.preventDefault();
-        window.open(action.uri, '_blank', 'noopener');
+        void openExternalUrl(action.uri, { features: 'noopener' });
         return;
       }
       if (action.type === PdfActionType.LaunchAppOrOpenFile && action.path) {
         event.preventDefault();
-        window.open(action.path, '_blank', 'noopener');
+        void openExternalUrl(action.path, { features: 'noopener' });
         return;
       }
     }

--- a/frontend/src/core/components/viewer/LinkLayer.tsx
+++ b/frontend/src/core/components/viewer/LinkLayer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useAnnotationCapability } from '@embedpdf/plugin-annotation/react';
 import { useScroll } from '@embedpdf/plugin-scroll/react';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 
 enum PDFActionType {
   GoTo = 0,
@@ -202,7 +203,7 @@ export const LinkLayer: React.FC<LinkLayerProps> = ({
       } else if (isExternalLink(link)) {
         const uri = link.target?.uri ?? link.target?.action?.uri;
         if (uri) {
-          window.open(uri, '_blank', 'noopener,noreferrer');
+          await openExternalUrl(uri);
         }
       } else {
         throw new Error(`Unsupported link type: ${link.target?.type}`);

--- a/frontend/src/core/hooks/useToolNavigation.ts
+++ b/frontend/src/core/hooks/useToolNavigation.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { ToolRegistryEntry, getToolUrlPath } from '@app/data/toolsTaxonomy';
 import { useToolWorkflow } from '@app/contexts/ToolWorkflowContext';
 import { handleUnlessSpecialClick } from '@app/utils/clickHandlers';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 import { ToolId } from '@app/types/toolId';
 
 export interface ToolNavigationProps {
@@ -30,7 +31,7 @@ export function useToolNavigation(): {
       handleUnlessSpecialClick(e, () => {
         // Handle external links normally
         if (tool.link) {
-          window.open(tool.link, '_blank', 'noopener,noreferrer');
+          void openExternalUrl(tool.link);
           return;
         }
 

--- a/frontend/src/core/tools/SwaggerUI.tsx
+++ b/frontend/src/core/tools/SwaggerUI.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from "react";
 import { BaseToolProps } from "@app/types/tool";
 import { withBasePath } from "@app/constants/app";
+import { openExternalUrl } from "@app/utils/openExternalUrl";
 
 const SwaggerUI: React.FC<BaseToolProps> = () => {
   useEffect(() => {
     // Redirect to Swagger UI
-    window.open(withBasePath("/swagger-ui/5.21.0/index.html"), "_blank");
+    void openExternalUrl(withBasePath("/swagger-ui/5.21.0/index.html"));
   }, []);
 
   return (

--- a/frontend/src/core/utils/openExternalUrl.ts
+++ b/frontend/src/core/utils/openExternalUrl.ts
@@ -1,0 +1,23 @@
+import { isTauri } from '@tauri-apps/api/core';
+
+type OpenExternalOptions = {
+  target?: string;
+  features?: string;
+};
+
+export const openExternalUrl = async (url: string, options: OpenExternalOptions = {}): Promise<boolean> => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (isTauri()) {
+    const { open } = await import('@tauri-apps/plugin-shell');
+    await open(url);
+    return true;
+  }
+
+  const target = options.target ?? '_blank';
+  const features = options.features ?? 'noopener,noreferrer';
+  const opened = window.open(url, target, features);
+  return Boolean(opened);
+};

--- a/frontend/src/proprietary/components/shared/ManageBillingButton.tsx
+++ b/frontend/src/proprietary/components/shared/ManageBillingButton.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mantine/core';
 import { useTranslation } from 'react-i18next';
 import licenseService from '@app/services/licenseService';
 import { alert } from '@app/components/toast';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 
 interface ManageBillingButtonProps {
   returnUrl?: string;
@@ -32,7 +33,7 @@ export const ManageBillingButton: React.FC<ManageBillingButtonProps> = ({
       );
 
       // Open billing portal in new tab
-      window.open(response.url, '_blank');
+      await openExternalUrl(response.url);
       setLoading(false);
     } catch (error: any) {
       console.error('Failed to open billing portal:', error);

--- a/frontend/src/proprietary/components/shared/config/configSections/AdminPlanSection.tsx
+++ b/frontend/src/proprietary/components/shared/config/configSections/AdminPlanSection.tsx
@@ -15,6 +15,7 @@ import { getPreferredCurrency, setCachedCurrency } from '@app/utils/currencyDete
 import { useLoginRequired } from '@app/hooks/useLoginRequired';
 import LoginRequiredBanner from '@core/components/shared/config/LoginRequiredBanner';
 import { isSupabaseConfigured } from '@app/services/supabaseClient';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 
 const AdminPlanSection: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -71,7 +72,7 @@ const AdminPlanSection: React.FC = () => {
       );
 
       // Open billing portal in new tab
-      window.open(response.url, '_blank');
+      await openExternalUrl(response.url);
     } catch (error: any) {
       console.error('Failed to open billing portal:', error);
       alert({

--- a/frontend/src/proprietary/components/shared/config/configSections/plan/StaticCheckoutModal.tsx
+++ b/frontend/src/proprietary/components/shared/config/configSections/plan/StaticCheckoutModal.tsx
@@ -11,6 +11,7 @@ import { Z_INDEX_OVER_CONFIG_MODAL } from '@app/styles/zIndex';
 import { useIsMobile } from '@app/hooks/useIsMobile';
 import licenseService from '@app/services/licenseService';
 import { useLicense } from '@app/contexts/LicenseContext';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 
 interface StaticCheckoutModalProps {
   opened: boolean;
@@ -57,7 +58,7 @@ const StaticCheckoutModal: React.FC<StaticCheckoutModalProps> = ({
     const urlWithEmail = buildStripeUrlWithEmail(baseUrl, email);
 
     // Open Stripe checkout in new tab
-    window.open(urlWithEmail, '_blank');
+    void openExternalUrl(urlWithEmail);
 
     // Transition to license activation stage
     setStageHistory([...stageHistory, 'period-selection']);

--- a/frontend/src/proprietary/components/shared/config/configSections/plan/StaticPlanSection.tsx
+++ b/frontend/src/proprietary/components/shared/config/configSections/plan/StaticPlanSection.tsx
@@ -11,6 +11,7 @@ import { STATIC_STRIPE_LINKS } from '@app/constants/staticStripeLinks';
 import { PricingBadge } from '@app/components/shared/stripeCheckout/components/PricingBadge';
 import { getBaseCardStyle } from '@app/components/shared/stripeCheckout/utils/cardStyles';
 import { isCurrentTier as checkIsCurrentTier, isDowngrade as checkIsDowngrade, isEnterpriseBlockedForFree } from '@app/utils/planTierUtils';
+import { openExternalUrl } from '@app/utils/openExternalUrl';
 
 interface StaticPlanSectionProps {
   currentLicenseInfo?: LicenseInfo;
@@ -56,7 +57,7 @@ const StaticPlanSection: React.FC<StaticPlanSectionProps> = ({ currentLicenseInf
       ),
     });
 
-    window.open(STATIC_STRIPE_LINKS.billingPortal, '_blank');
+    void openExternalUrl(STATIC_STRIPE_LINKS.billingPortal);
   };
 
   const staticPlans = [


### PR DESCRIPTION
### Motivation

- Ensure external links in the desktop app open using the native Tauri shell plugin to avoid web popup restrictions and provide consistent native behavior.
- Centralize external link handling with a single helper that falls back to `window.open` for non-desktop (web) contexts.

### Description

- Add `openExternalUrl(url, options)` in `frontend/src/core/utils/openExternalUrl.ts` which uses `isTauri()` and a dynamic import of `@tauri-apps/plugin-shell` when running inside Tauri, and otherwise calls `window.open` with supplied options.
- Replace direct `window.open` calls across core and proprietary UI surfaces to use the new helper (examples: `useToolNavigation.ts`, `LinkLayer.tsx`, `BookmarkSidebar.tsx`, `ToolButton.tsx`, `FullscreenToolList.tsx`, `SwaggerUI.tsx`, onboarding components, OCR `LanguagePicker`, billing/plan components and checkout modal).
- Keep the same behavior and options (`target` / `features`) when falling back to the browser method and use `await`/`void` where the call is async.

### Testing

- Ran `./gradlew build` which completed successfully (`BUILD SUCCESSFUL`).
- Gradle tasks including formatting checks and build lifecycle ran without errors and no automated tests failed during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962aed705f883258af752bfc787df2f)