### PR TITLE
fix: update broken enterprise docs link from /Pro to /Paid-Offerings

### DIFF
--- a/frontend/src/core/data/useTranslatedToolRegistry.tsx
+++ b/frontend/src/core/data/useTranslatedToolRegistry.tsx
@@ -835,7 +835,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         description: t("home.devAirgapped.desc", "Link to air-gapped setup guide"),
         categoryId: ToolCategoryId.ADVANCED_TOOLS,
         subcategoryId: SubcategoryId.DEVELOPER_TOOLS,
-        link: "https://docs.stirlingpdf.com/Pro/#activation",
+        link: "https://docs.stirlingpdf.com/Paid-Offerings/#activating-your-license",
         synonyms: getSynonyms(t, "devAirgapped"),
         supportsAutomate: false,
         automationSettings: null


### PR DESCRIPTION
## Description
Fixed broken documentation link in the air-gapped setup guide that was pointing to a non-existent `/Pro/#activation` page (returning 404). Updated to the correct `/Paid-Offerings/#activating-your-license` URL which returns 200 OK.

## Changes Made
- Updated link in `frontend/src/core/data/useTranslatedToolRegistry.tsx` (line 838)
- Changed from `https://docs.stirlingpdf.com/Pro/#activation` to `https://docs.stirlingpdf.com/Paid-Offerings/#activating-your-license`

## Testing
- Verified old link returns 404
- Verified new link returns 200 and has activation section
- Link now correctly points to the "Activating Your License" section of the Paid Offerings documentation

## Related Issue
Resolves #5088

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are limited to fixing the broken link only (atomic commit)
- [x] Link has been manually tested and verified working