### PR TITLE
Fix hook ordering for endpoint name resolution

### DIFF
--- a/frontend/src/core/hooks/tools/shared/useBaseParameters.ts
+++ b/frontend/src/core/hooks/tools/shared/useBaseParameters.ts
@@ -33,17 +33,13 @@ export function useBaseParameters<T>(config: BaseParametersConfig<T>): BaseParam
     return config.validateFn ? config.validateFn(parameters) : true;
   }, [parameters, config.validateFn]);
 
-  const endpointName = config.endpointName;
-  let getEndpointName: () => string;
-  if (typeof endpointName === "string") {
-    getEndpointName = useCallback(() => {
+  const getEndpointName = useCallback(() => {
+    const { endpointName } = config;
+    if (typeof endpointName === "string") {
       return endpointName;
-    }, []);
-  } else {
-    getEndpointName = useCallback(() => {
-      return endpointName(parameters);
-    }, [parameters]);
-  }
+    }
+    return endpointName(parameters);
+  }, [config.endpointName, parameters]);
 
   return {
     parameters,


### PR DESCRIPTION
### Motivation
- Prevent a React hook ordering issue by removing conditional `useCallback` usage in endpoint name resolution within the base parameters hook.

### Description
- Replace conditional creation of `getEndpointName` with a single unconditional `useCallback` that reads `config.endpointName` and returns either the static string or calls the function with `parameters`, updating `frontend/src/core/hooks/tools/shared/useBaseParameters.ts`.

### Testing
- No automated tests were executed in this change; please run `./gradlew build` (or confirm CI build) to verify the project compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ec2829624832898fb4a92192ed548)