### PR TITLE
fix: PDF Text Editor file open

### DIFF
--- a/scripts/convert_cff_to_ttf.py
+++ b/scripts/convert_cff_to_ttf.py
@@ -496,16 +496,48 @@ def wrap_cff_as_otf(input_path, output_path, tounicode_path=None):
 
 
 def main():
-    if len(sys.argv) < 3:
-        print(
-            "Usage: convert_cff_to_ttf.py <input.cff> <output.otf> [tounicode.cmap]",
-            file=sys.stderr,
-        )
+    import argparse
+
+    # Create argument parser that supports both named and positional arguments
+    parser = argparse.ArgumentParser(
+        description="Convert CFF font data to OpenType-CFF format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Named arguments (used by Java code):
+  convert_cff_to_ttf.py --input font.cff --output font.otf --to-unicode mapping.tounicode
+
+  # Positional arguments (backward compatibility):
+  convert_cff_to_ttf.py font.cff font.otf mapping.tounicode
+        """
+    )
+
+    # Add named arguments
+    parser.add_argument('--input', dest='input_file', help='Input CFF file path')
+    parser.add_argument('--output', dest='output_file', help='Output OTF file path')
+    parser.add_argument('--to-unicode', dest='tounicode_file', help='ToUnicode mapping file path')
+
+    # Add positional arguments for backward compatibility
+    parser.add_argument('input_pos', nargs='?', help='Input CFF file (positional)')
+    parser.add_argument('output_pos', nargs='?', help='Output OTF file (positional)')
+    parser.add_argument('tounicode_pos', nargs='?', help='ToUnicode file (positional)')
+
+    args = parser.parse_args()
+
+    # Determine which arguments to use (named take precedence over positional)
+    input_path = args.input_file or args.input_pos
+    output_path = args.output_file or args.output_pos
+    tounicode_path = args.tounicode_file or args.tounicode_pos
+
+    # Validate required arguments
+    if not input_path or not output_path:
+        parser.print_help(file=sys.stderr)
+        print("\nERROR: Both input and output files are required", file=sys.stderr)
         sys.exit(1)
 
-    input_path = Path(sys.argv[1])
-    output_path = Path(sys.argv[2])
-    tounicode_path = Path(sys.argv[3]) if len(sys.argv) > 3 else None
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+    tounicode_path = Path(tounicode_path) if tounicode_path else None
 
     if not input_path.exists():
         print(f"ERROR: Input file not found: {input_path}", file=sys.stderr)


### PR DESCRIPTION
# Description of Changes

## Content
This pull requests fix the problem when opening the file in the ALPHA feature PDF Text Editor.

## Page Where the Problem Occurred
http://localhost/pdf-text-editor

## Problem
convert_cff_to_ttf.py does not support named CLI arguments.

But Java is calling it like this:
convert_cff_to_ttf.py --input file.cff --output file.otf --to-unicode file.tounicode 

## Solved
convert_cff_to_ttf.py support named CLI arguments.

Closes #5518
---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
