### PR TITLE
feat(i18n): add missing compare placeholder and stamp label translations

### DIFF
--- a/frontend/public/locales/en-GB/translation.toml
+++ b/frontend/public/locales/en-GB/translation.toml
@@ -2642,6 +2642,7 @@ label = "Original PDF"
 
 [compare.edited]
 label = "Edited PDF"
+placeholder = "Select the edited PDF"
 
 [compare.swap]
 confirmTitle = "Re-run comparison?"
@@ -3595,6 +3596,11 @@ europeanDate = "European Date"
 timestamp = "Timestamp"
 draftWatermark = "Draft Watermark"
 custom = "Custom"
+page-numbers = "Page Numbers"
+draft = "Draft Watermark"
+doc-info = "Document Info"
+legal-footer = "Legal Footer"
+european-date = "European Date (DD/MM/YYYY)"
 
 [AddStampRequest.error]
 failed = "An error occurred while adding stamp to the PDF."


### PR DESCRIPTION
# Description of Changes

This pull request updates the English (UK) translation file to add new labels and placeholders for PDF comparison and stamping features.

Improvements to PDF comparison UI:

* Added a placeholder text `Select the edited PDF` for the edited PDF selection field to improve user guidance.

Enhancements to PDF stamping options:

* Added new labels for stamp types including `Page Numbers`, `Draft Watermark`, `Document Info`, `Legal Footer`, and clarified the format for `European Date` as `European Date (DD/MM/YYYY)`.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
