### PR TITLE
fix(frontend): prevent unintended form submission in Add Password settings

### DIFF
--- a/frontend/src/core/components/tools/addPassword/AddPasswordSettings.tsx
+++ b/frontend/src/core/components/tools/addPassword/AddPasswordSettings.tsx
@@ -13,46 +13,47 @@ const AddPasswordSettings = ({ parameters, onParameterChange, disabled = false }
   const { t } = useTranslation();
 
   return (
-    <Stack gap="md">
-      {/* Password Settings */}
-      <Stack gap="sm">
-        <PasswordInput
-          label={t('addPassword.passwords.user.label', 'User Password')}
-          placeholder={t('addPassword.passwords.user.placeholder', 'Enter user password')}
-          value={parameters.password}
-          onChange={(e) => onParameterChange('password', e.target.value)}
-          disabled={disabled}
-        />
-        <PasswordInput
-          label={t('addPassword.passwords.owner.label', 'Owner Password')}
-          placeholder={t('addPassword.passwords.owner.placeholder', 'Enter owner password')}
-          value={parameters.ownerPassword}
-          onChange={(e) => onParameterChange('ownerPassword', e.target.value)}
-          disabled={disabled}
-        />
-      </Stack>
+    <form onSubmit={(e) => e.preventDefault()}>
+      <Stack gap="md">
+        {/* Password Settings */}
+        <Stack gap="sm">
+          <PasswordInput
+            label={t("addPassword.passwords.user.label", "User Password")}
+            placeholder={t("addPassword.passwords.user.placeholder", "Enter user password")}
+            value={parameters.password}
+            onChange={(e) => onParameterChange("password", e.target.value)}
+            disabled={disabled}
+          />
+          <PasswordInput
+            label={t("addPassword.passwords.owner.label", "Owner Password")}
+            placeholder={t("addPassword.passwords.owner.placeholder", "Enter owner password")}
+            value={parameters.ownerPassword}
+            onChange={(e) => onParameterChange("ownerPassword", e.target.value)}
+            disabled={disabled}
+          />
+        </Stack>
 
-      {/* Encryption Settings */}
-      <Stack gap="sm">
-        <Select
-          label={t('addPassword.encryption.keyLength.label', 'Encryption Key Length')}
-          value={parameters.keyLength.toString()}
-          onChange={(value) => {
-            if (value) {
-              onParameterChange('keyLength', parseInt(value));
-            }
-          }}
-          disabled={disabled}
-          data={[
-            { value: '40', label: t('addPassword.encryption.keyLength.40bit', '40-bit (Low)') },
-            { value: '128', label: t('addPassword.encryption.keyLength.128bit', '128-bit (Standard)') },
-            { value: '256', label: t('addPassword.encryption.keyLength.256bit', '256-bit (High)') }
-          ]}
-          comboboxProps={{ withinPortal: true, zIndex: Z_INDEX_AUTOMATE_DROPDOWN }}
-        />
+        {/* Encryption Settings */}
+        <Stack gap="sm">
+          <Select
+            label={t("addPassword.encryption.keyLength.label", "Encryption Key Length")}
+            value={parameters.keyLength.toString()}
+            onChange={(value) => {
+              if (value) {
+                onParameterChange("keyLength", parseInt(value));
+              }
+            }}
+            disabled={disabled}
+            data={[
+              { value: "40", label: t("addPassword.encryption.keyLength.40bit", "40-bit (Low)") },
+              { value: "128", label: t("addPassword.encryption.keyLength.128bit", "128-bit (Standard)") },
+              { value: "256", label: t("addPassword.encryption.keyLength.256bit", "256-bit (High)") },
+            ]}
+            comboboxProps={{ withinPortal: true, zIndex: Z_INDEX_AUTOMATE_DROPDOWN }}
+          />
+        </Stack>
       </Stack>
-
-    </Stack>
+    </form>
   );
 };
 


### PR DESCRIPTION
# Description of Changes

This pull request makes minor improvements to the `AddPasswordSettings` component by wrapping the settings UI in a form and standardizing the use of double quotes for translation keys and parameter names.

- UI and accessibility improvements:
  * Wrapped the settings elements in a `<form>` with `onSubmit` preventing default behavior, which improves accessibility and semantic structure.

- Code consistency:
  * Standardized translation key and parameter name usage to double quotes throughout the component for consistency.

<img width="598" height="167" alt="image" src="https://github.com/user-attachments/assets/526ce8ac-6f96-4037-8d01-144f1a5e7c42" />


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
