### PR TITLE
chore(vscode): replace deprecated Copilot extension with Copilot Chat

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,7 +13,7 @@
     "vscjava.vscode-spring-boot-dashboard", // Spring Boot dashboard for managing and visualizing Spring Boot applications
     "EditorConfig.EditorConfig", // EditorConfig support for maintaining consistent coding styles
     "ms-azuretools.vscode-docker", // Docker extension for Visual Studio Code
-    "GitHub.copilot", // GitHub Copilot AI pair programmer for Visual Studio Code
+    "GitHub.copilot-chat", // GitHub Copilot AI pair programmer for Visual Studio Code
     "GitHub.vscode-pull-request-github", // GitHub Pull Requests extension for Visual Studio Code
     "charliermarsh.ruff", // Ruff code formatter for Python to follow the Ruff Style Guide
     "yzhang.markdown-all-in-one", // Markdown All-in-One extension for enhanced Markdown editing


### PR DESCRIPTION
# Description of Changes

- **What was changed**  
  Updated `.vscode/extensions.json` to replace the deprecated `GitHub.copilot` extension with `GitHub.copilot-chat`.

- **Why the change was made**  
  The original GitHub Copilot extension is deprecated. Using the Copilot Chat extension ensures continued support, compatibility with current GitHub tooling, and access to the recommended Copilot experience in VS Code.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
