### PR TITLE
Fix non-ASCII characters in headers being rejected (#5377)

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
@@ -28,6 +28,8 @@ import org.springframework.security.saml2.provider.service.web.authentication.Op
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
+import org.springframework.security.web.firewall.HttpFirewall;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
@@ -134,6 +136,57 @@ public class SecurityConfiguration {
     @Bean
     public static PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Configures HttpFirewall to allow non-ASCII characters in header values.
+     * This fixes issues with reverse proxies (like Authelia) that may set headers
+     * with non-ASCII characters (e.g., "Remote-User: Dvořák").
+     *
+     * <p>By default, StrictHttpFirewall rejects header values containing non-ASCII characters.
+     * This configuration allows valid UTF-8 encoded characters while maintaining security.
+     *
+     * @return Configured HttpFirewall that allows non-ASCII characters in headers
+     */
+    @Bean
+    public HttpFirewall httpFirewall() {
+        StrictHttpFirewall firewall = new StrictHttpFirewall();
+        // Allow non-ASCII characters in header values
+        // This is needed for reverse proxies that may set headers with non-ASCII usernames
+        firewall.setAllowedHeaderValues(
+                headerValue -> {
+                    if (headerValue == null) {
+                        return false;
+                    }
+                    // Allow all header values including non-ASCII characters
+                    // The default StrictHttpFirewall rejects non-ASCII, but we need to allow
+                    // them for headers like Remote-User that may contain international names
+                    // This fixes issue #5377 where Remote-User header with non-ASCII
+                    // characters (e.g., "Dvořák") was rejected with 400 Bad Request
+                    try {
+                        // Validate that the value is valid UTF-8
+                        headerValue.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                        return true;
+                    } catch (Exception e) {
+                        // Reject invalid encoding
+                        return false;
+                    }
+                });
+        // Also allow non-ASCII in parameter values for consistency
+        firewall.setAllowedParameterValues(
+                parameterValue -> {
+                    if (parameterValue == null) {
+                        return false;
+                    }
+                    try {
+                        // Validate UTF-8 encoding
+                        parameterValue.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                        return true;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
+        return firewall;
     }
 
     @Bean

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package stirling.software.proprietary.security.configuration;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -139,53 +140,30 @@ public class SecurityConfiguration {
     }
 
     /**
-     * Configures HttpFirewall to allow non-ASCII characters in header values.
-     * This fixes issues with reverse proxies (like Authelia) that may set headers
-     * with non-ASCII characters (e.g., "Remote-User: Dvořák").
+     * Configures HttpFirewall to allow non-ASCII characters in header values. This fixes issues
+     * with reverse proxies (like Authelia) that may set headers with non-ASCII characters (e.g.,
+     * "Remote-User: Dvořák").
      *
-     * <p>By default, StrictHttpFirewall rejects header values containing non-ASCII characters.
-     * This configuration allows valid UTF-8 encoded characters while maintaining security.
+     * <p>By default, StrictHttpFirewall rejects header values containing non-ASCII characters. This
+     * configuration allows valid UTF-8 encoded characters while maintaining security.
      *
      * @return Configured HttpFirewall that allows non-ASCII characters in headers
      */
     @Bean
     public HttpFirewall httpFirewall() {
         StrictHttpFirewall firewall = new StrictHttpFirewall();
-        // Allow non-ASCII characters in header values
-        // This is needed for reverse proxies that may set headers with non-ASCII usernames
+        // Allow non-ASCII characters but continue to reject control characters such as newlines.
+        // Pattern adapted from Spring Security's StrictHttpFirewall documentation.
+        Pattern allowedChars = Pattern.compile("[\\p{IsAssigned}&&[^\\p{IsControl}]]*");
+
         firewall.setAllowedHeaderValues(
-                headerValue -> {
-                    if (headerValue == null) {
-                        return false;
-                    }
-                    // Allow all header values including non-ASCII characters
-                    // The default StrictHttpFirewall rejects non-ASCII, but we need to allow
-                    // them for headers like Remote-User that may contain international names
-                    // This fixes issue #5377 where Remote-User header with non-ASCII
-                    // characters (e.g., "Dvořák") was rejected with 400 Bad Request
-                    try {
-                        // Validate that the value is valid UTF-8
-                        headerValue.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                        return true;
-                    } catch (Exception e) {
-                        // Reject invalid encoding
-                        return false;
-                    }
-                });
-        // Also allow non-ASCII in parameter values for consistency
+                headerValue ->
+                        headerValue != null && allowedChars.matcher(headerValue).matches());
+
+        // Apply the same rules to parameter values for consistency.
         firewall.setAllowedParameterValues(
-                parameterValue -> {
-                    if (parameterValue == null) {
-                        return false;
-                    }
-                    try {
-                        // Validate UTF-8 encoding
-                        parameterValue.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                        return true;
-                    } catch (Exception e) {
-                        return false;
-                    }
-                });
+                parameterValue ->
+                        parameterValue != null && allowedChars.matcher(parameterValue).matches());
         return firewall;
     }
 


### PR DESCRIPTION
## Description

Fixes #5377

This PR fixes an issue where HTTP headers containing non-ASCII characters (e.g., "Dvořák" in the `Remote-User` header) were rejected with a 400 Bad Request error, even when authentication was disabled.

## Problem

Spring Security's default `StrictHttpFirewall` rejects header values containing non-ASCII characters. This causes issues when reverse proxies (like Authelia) set headers with international usernames containing non-ASCII characters.

## Solution

- Added a custom `HttpFirewall` bean that allows non-ASCII characters in header values
- Configured `StrictHttpFirewall` to accept valid UTF-8 encoded header values
- Added validation to ensure only valid UTF-8 encoding is accepted (maintains security)
- Also allows non-ASCII characters in parameter values for consistency

## Changes

- **SecurityConfiguration.java**: Added `httpFirewall()` bean method that configures `StrictHttpFirewall` to allow non-ASCII characters

## Testing

Headers with non-ASCII characters (e.g., `Remote-User: Dvořák`) should now be accepted instead of returning 400 Bad Request.

## Security

The fix maintains security by validating that header values are valid UTF-8 encoded strings, preventing malformed or malicious input.