### PR TITLE
fixes for desktop SSO

### DIFF
--- a/frontend/src/desktop/components/SetupWizard/index.tsx
+++ b/frontend/src/desktop/components/SetupWizard/index.tsx
@@ -213,9 +213,30 @@ export const SetupWizard: React.FC<SetupWizardProps> = ({ onComplete }) => {
         const params = new URLSearchParams(hash);
         const accessToken = params.get('access_token');
         const type = params.get('type') || parsed.searchParams.get('type');
-        // Self-hosted SSO deep links are handled by authService.loginWithSelfHostedOAuth
-        // to avoid duplicate session completion/reload races in first-launch setup.
+        // Self-hosted SSO deep links are normally handled by authService.loginWithSelfHostedOAuth.
+        // Fallback here only if no in-flight auth listener exists (e.g. renderer reload mid-flow).
         if (type === 'sso' || type === 'sso-selfhosted') {
+          if (authService.isSelfHostedDeepLinkFlowActive()) {
+            return;
+          }
+
+          const accessTokenFromHash = params.get('access_token');
+          const accessTokenFromQuery = parsed.searchParams.get('access_token');
+          const serverFromQuery = parsed.searchParams.get('server');
+          const token = accessTokenFromHash || accessTokenFromQuery;
+          const serverUrl = serverFromQuery || serverConfig?.url || STIRLING_SAAS_URL;
+          if (!token || !serverUrl) {
+            console.error('[SetupWizard] Deep link missing token or server for SSO completion');
+            return;
+          }
+
+          setLoading(true);
+          setError(null);
+
+          await authService.completeSelfHostedSession(serverUrl, token);
+          await connectionModeService.switchToSelfHosted({ url: serverUrl });
+          await tauriBackendService.initializeExternalBackend();
+          onComplete();
           return;
         }
 


### PR DESCRIPTION
# Description of Changes



  Race condition: The browser was opened before the deep-link listener was registered. On slow first launches the OAuth
  callback could arrive before the listener was ready. Fixed by registering the listener first, then opening the browser
   inside .then() once the listener is confirmed active.

  Double-handling: Both SetupWizard and authService.waitForDeepLinkCompletion processed the same sso/sso-selfhosted deep
   links, calling completeSelfHostedSession and onComplete() independently. Fixed by moving all SSO completion into
  authService and having SetupWizard defer to it.

  Hardening: Removing SetupWizard's handler entirely left no fallback if the webview reloads while the auth listener's
  Promise is in flight. A selfHostedDeepLinkFlowActive flag tracks whether authService has an active listener.
  SetupWizard now acts as a fallback only when the flag is false (i.e. after a JS context reset), preventing duplicate
  handling in the normal path while preserving resilience on reload.
---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
