### PR TITLE
Add plist file for Mac permissions

### DIFF
--- a/frontend/src-tauri/Info.plist
+++ b/frontend/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Stirling-PDF needs access to your local network to connect to self-hosted servers.</string>
+</dict>
+</plist>

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -76,7 +76,8 @@
             "minimumSystemVersion": "10.15",
             "signingIdentity": null,
             "entitlements": null,
-            "providerShortName": null
+            "providerShortName": null,
+            "infoPlist": "Info.plist"
         }
     },
     "plugins": {


### PR DESCRIPTION
# Description of Changes
There's speculation that the Mac app failing to connect to self-hosted servers (#5264) is because of missing OS-permissions [NSLocalNetworkUsageDescription](https://developer.apple.com/documentation/bundleresources/information-property-list/nslocalnetworkusagedescription). This PR adds it in a `Info.plist` file which ships with the Tauri app which should throw an OS permissions dialog if required.