### PR TITLE
ci: provide default desktop env vars in tauri GitHub Actions builds

### DIFF
--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -419,8 +419,9 @@ jobs:
           APPIMAGETOOL_SIGN_PASSPHRASE: ${{ secrets.APPIMAGETOOL_SIGN_PASSPHRASE }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
-          VITE_SAAS_SERVER_URL: ${{ secrets.VITE_SAAS_SERVER_URL }}
+          VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY || 'sb_publishable_UHz2SVRF5mvdrPHWkRteyA_yNlZTkYb' }}
+          VITE_SAAS_SERVER_URL: ${{ secrets.VITE_SAAS_SERVER_URL || 'https://app.stirlingpdf.com' }}
+          VITE_SAAS_BACKEND_API_URL: ${{ secrets.VITE_SAAS_BACKEND_API_URL || 'https://api.stirlingpdf.com' }}
           # Only enable Windows signing in Tauri when on release or V2-master
           SIGN: ${{ (github.event_name == 'release' || github.ref == 'refs/heads/V2-master') && (env.SM_API_KEY == '' && env.WINDOWS_CERTIFICATE != '') && '1' || '0' }}
           CI: true

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -327,9 +327,9 @@ jobs:
           APPIMAGETOOL_SIGN_PASSPHRASE: ${{ secrets.APPIMAGETOOL_SIGN_PASSPHRASE }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
-          VITE_SAAS_SERVER_URL: ${{ secrets.VITE_SAAS_SERVER_URL }}
-          VITE_SAAS_BACKEND_API_URL: ${{ secrets.VITE_SAAS_BACKEND_API_URL }}
+          VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY || 'sb_publishable_UHz2SVRF5mvdrPHWkRteyA_yNlZTkYb' }}
+          VITE_SAAS_SERVER_URL: ${{ secrets.VITE_SAAS_SERVER_URL || 'https://app.stirlingpdf.com' }}
+          VITE_SAAS_BACKEND_API_URL: ${{ secrets.VITE_SAAS_BACKEND_API_URL || 'https://api.stirlingpdf.com' }}
           # Only enable Windows signing in Tauri when on main
           SIGN: ${{ github.ref == 'refs/heads/main' && (env.SM_API_KEY == '' && env.WINDOWS_CERTIFICATE != '') && '1' || '0' }}
           CI: true


### PR DESCRIPTION
### Motivation
- Desktop Tauri builds in CI were failing when required Vite environment variables were not set as repository secrets, causing `vite.config.ts` to abort desktop builds for validation/test runs. 

### Description
- Add fallback environment values in `.github/workflows/tauri-build.yml` so `VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY`, `VITE_SAAS_SERVER_URL`, and `VITE_SAAS_BACKEND_API_URL` use `${{ secrets.<NAME> || '<fallback>' }}` when secrets are absent. 
- Apply the same fallback behavior to `.github/workflows/multiOSReleases.yml` and add the previously-missing `VITE_SAAS_BACKEND_API_URL` to that workflow's Tauri build env block. 
- Use the existing public Supabase publishable key `sb_publishable_UHz2SVRF5mvdrPHWkRteyA_yNlZTkYb` and reasonable SaaS endpoints `https://app.stirlingpdf.com` and `https://api.stirlingpdf.com` as defaults. 

### Testing
- Ran `git diff --check` to verify no patch/whitespace issues and it succeeded. 
- Inspected the resulting diffs with `git diff -- .github/workflows/tauri-build.yml .github/workflows/multiOSReleases.yml` and verified the inserted fallback lines. 
- Confirmed the workflow files contain the expected env lines using `nl`/`sed` output checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a0c6cc27ec83288be656b039326a32)