### PR TITLE
fix split cuased by defaultParameters breaking dynamic endpoint tools

### DIFF
--- a/app/core/src/main/resources/settings.yml.template
+++ b/app/core/src/main/resources/settings.yml.template
@@ -173,7 +173,7 @@ system:
   corsAllowedOrigins: [] # List of allowed origins for CORS (e.g. ['http://localhost:5173', 'https://app.example.com']). Leave empty to disable CORS. For local development with frontend on port 5173, add 'http://localhost:5173'
   backendUrl: "" # Backend base URL for SAML/OAuth/API callbacks (e.g. 'http://localhost:8080' for dev, 'https://api.example.com' for production). REQUIRED for SSO authentication to work correctly. This is where your IdP will send SAML responses and OAuth callbacks. Leave empty to default to 'http://localhost:8080' in development.
   frontendUrl: "" # Frontend URL for invite email links (e.g. 'https://app.example.com'). Optional - if not set, will use backendUrl. This is the URL users click in invite emails.
-  enableMobileScanner: false # Enable mobile phone QR code upload feature. Requires frontendUrl to be configured.
+  enableMobileScanner: true # Enable mobile phone QR code upload feature. Requires frontendUrl to be configured.
   mobileScannerSettings:
     convertToPdf: true # Automatically convert uploaded images to PDF format. If false, images are kept as-is.
     imageResolution: full # Image resolution for mobile uploads: 'full' (original size) or 'reduced' (max 1200px on longest side). Only applies when convertToPdf is true.

--- a/frontend/src/core/hooks/tools/split/useSplitOperation.ts
+++ b/frontend/src/core/hooks/tools/split/useSplitOperation.ts
@@ -12,7 +12,10 @@ export const buildSplitFormData = (parameters: SplitParameters, file: File): For
 
   formData.append("fileInput", file);
 
-  switch (parameters.method) {
+  // Use BY_PAGES as default if no method is selected
+  const method = parameters.method || SPLIT_METHODS.BY_PAGES;
+
+  switch (method) {
     case SPLIT_METHODS.BY_PAGES:
       formData.append("pageNumbers", parameters.pages);
       break;
@@ -52,13 +55,18 @@ export const buildSplitFormData = (parameters: SplitParameters, file: File): For
       formData.append("rightToLeft", (parameters.rightToLeft ?? false).toString());
       break;
     default:
-      throw new Error(`Unknown split method: ${parameters.method}`);
+      throw new Error(`Unknown split method: ${method}`);
   }
 
   return formData;
 };
 
 export const getSplitEndpoint = (parameters: SplitParameters): string => {
+  // Default to BY_PAGES endpoint if no method selected yet
+  if (!parameters.method) {
+    return "/api/v1/general/split-pages";
+  }
+
   switch (parameters.method) {
     case SPLIT_METHODS.BY_PAGES:
       return "/api/v1/general/split-pages";


### PR DESCRIPTION
# Description of Changes

## Root Cause 
  Introduced in commit 5c39acecd8 (2026-02-25) which added cloud usage checking that calls dynamic endpoint functions with defaultParameters.
  The Split tool has a function-based endpoint and defaultParameters with `method: ''`, causing the crash.
  
also make QR mode true by default :)

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
