### PR TITLE
stop enabling english

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/service/LanguageService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/LanguageService.java
@@ -42,9 +42,10 @@ public class LanguageService {
                             languageCode -> {
                                 Set<String> allowedLanguages =
                                         new HashSet<>(applicationProperties.getUi().getLanguages());
+                                // Empty list means all languages are allowed (no filtering)
+                                // Non-empty list acts as a strict whitelist
                                 return allowedLanguages.isEmpty()
-                                        || allowedLanguages.contains(languageCode)
-                                        || "en_GB".equals(languageCode);
+                                        || allowedLanguages.contains(languageCode);
                             })
                     .collect(Collectors.toSet());
 

--- a/app/core/src/main/resources/settings.yml.template
+++ b/app/core/src/main/resources/settings.yml.template
@@ -232,7 +232,7 @@ system:
 ui:
   appNameNavbar: "" # name displayed on the navigation bar
   logoStyle: classic # Options: 'classic' (default - classic S icon) or 'modern' (minimalist logo)
-  languages: [] # If empty, all languages are enabled. To display only German and Polish ["de_DE", "pl_PL"]. British English is always enabled.
+  languages: [] # If empty, all languages are enabled. To restrict to specific languages, use a whitelist like ["de_DE", "pl_PL", "sv_SE"]. Empty list or not restricting any languages will enable all available languages.
   defaultHideUnavailableTools: false # Default user preference: hide disabled tools instead of greying them out
   defaultHideUnavailableConversions: false # Default user preference: hide disabled conversion options instead of greying them out
 

--- a/app/core/src/test/java/stirling/software/SPDF/service/LanguageServiceBasicTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/LanguageServiceBasicTest.java
@@ -93,7 +93,7 @@ class LanguageServiceBasicTest {
         // Configure the test service
         ((LanguageServiceForTest) languageService).setMockResources(mockResources);
 
-        // Allow only specific languages (en_GB is always included)
+        // Allow only specific languages - strict whitelist
         when(applicationProperties.getUi().getLanguages())
                 .thenReturn(Arrays.asList("en_US", "fr_FR"));
 
@@ -103,7 +103,7 @@ class LanguageServiceBasicTest {
         // Verify filtering by restrictions
         assertTrue(supportedLanguages.contains("en_US"), "Allowed language should be included");
         assertTrue(supportedLanguages.contains("fr_FR"), "Allowed language should be included");
-        assertTrue(supportedLanguages.contains("en_GB"), "en_GB should always be included");
+        assertFalse(supportedLanguages.contains("en_GB"), "en_GB should NOT be included when not in whitelist");
         assertFalse(supportedLanguages.contains("de_DE"), "Restricted language should be excluded");
     }
 

--- a/app/core/src/test/java/stirling/software/SPDF/service/LanguageServiceTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/LanguageServiceTest.java
@@ -69,15 +69,15 @@ class LanguageServiceTest {
         // Setup
         Set<String> expectedLanguages =
                 new HashSet<>(Arrays.asList("en_US", "fr_FR", "de_DE", "en_GB"));
-        Set<String> allowedLanguages = new HashSet<>(Arrays.asList("en_US", "fr_FR", "en_GB"));
+        Set<String> allowedLanguages = new HashSet<>(Arrays.asList("en_US", "fr_FR"));
 
         // Mock the resource resolver response
         Resource[] mockResources = createMockResources(expectedLanguages);
         ((LanguageServiceForTest) languageService).setMockResources(mockResources);
 
-        // Set language restrictions in properties
+        // Set language restrictions in properties - strict whitelist only
         when(applicationProperties.getUi().getLanguages())
-                .thenReturn(Arrays.asList("en_US", "fr_FR")); // en_GB is always allowed
+                .thenReturn(Arrays.asList("en_US", "fr_FR"));
 
         // Test
         Set<String> supportedLanguages = languageService.getSupportedLanguages();
@@ -86,8 +86,9 @@ class LanguageServiceTest {
         assertEquals(
                 allowedLanguages,
                 supportedLanguages,
-                "Should return only allowed languages, plus en_GB which is always allowed");
-        assertTrue(supportedLanguages.contains("en_GB"), "en_GB should always be included");
+                "Should return only whitelisted languages");
+        assertFalse(supportedLanguages.contains("en_GB"), "en_GB should NOT be included when not in whitelist");
+        assertFalse(supportedLanguages.contains("de_DE"), "de_DE should NOT be included when not in whitelist");
     }
 
     @Test

--- a/frontend/src/core/i18n.ts
+++ b/frontend/src/core/i18n.ts
@@ -240,10 +240,11 @@ export function updateSupportedLanguages(configLanguages?: string[] | null, defa
   i18n.options.supportedLngs = validLanguages;
   i18n.options.fallbackLng = fallback;
 
-  // If current language is not in the new supported list, switch to fallback
+  // If current language is not in the new supported list, switch to fallback with higher priority to override browser detection
   const currentLang = normalizeLanguageCode(i18n.language || '');
   if (currentLang && !validLanguages.includes(currentLang)) {
-    setLanguageWithPriority(fallback, LanguageSource.Fallback);
+    // Use ServerDefault priority to override browser detection when language not in whitelist
+    setLanguageWithPriority(fallback, LanguageSource.ServerDefault);
   } else if (validDefault) {
     // Apply server default (respects user choice if already set)
     setLanguageWithPriority(validDefault, LanguageSource.ServerDefault);


### PR DESCRIPTION
# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
