### PR TITLE
Limit PostHog cookie to Stirling PDF's subdomain only

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -18,6 +18,7 @@ posthog.init('phc_VOdeYnlevc2T63m3myFGjeBlRcIusRgmhfx6XL5a1iz', {
   capture_exceptions: true, // This enables capturing exceptions using Error Tracking, set to false if you don't want this
   debug: false,
   opt_out_capturing_by_default: true, // Opt-out by default, controlled by cookie consent
+  cross_subdomain_cookie: false,
 });
 
 function updatePosthogConsent(){


### PR DESCRIPTION
# Description of Changes

Currently, the PostHog cookie is set at the top-level domain, such as `.example.com`. This is not desirable if Stirling PDF is hosted on a subdomain such as `stirling-pdf.example.com`, as the cookie will be sent to every other subdomain (`other-site.example.com`) and the top-level domain (`example.com`) where it does not belong and may cause issues with sites hosted at those locations.

This PR contains a one-line change to set the `cross_subdomain_cookie` option in [PostHog's JavaScript SDK](https://posthog.com/docs/libraries/js/config) such that the PostHog cookie will be set on Stirling PDF's subdomain only.

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
