### PR TITLE
Get rid of bad description for file association on Windows

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -50,7 +50,6 @@
                     "pdf"
                 ],
                 "name": "PDF Document",
-                "description": "Open PDF files with Stirling-PDF",
                 "role": "Editor",
                 "mimeType": "application/pdf"
             }


### PR DESCRIPTION
# Description of Changes
Explorer currently shows this on Windows:

<img width="380" height="43" alt="image" src="https://github.com/user-attachments/assets/a892d827-8e0a-4f85-a035-52a454eaadd8" />

This PR just removes the description for the file association so we use the default behaviour. This string is only used on Windows according to the [Tauri docs](https://v2.tauri.app/reference/config/#description-1).