### PR TITLE
fix jumping cursor bug

### DIFF
--- a/frontend/src/core/components/tools/editTableOfContents/BookmarkEditor.tsx
+++ b/frontend/src/core/components/tools/editTableOfContents/BookmarkEditor.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ActionIcon,
@@ -115,9 +115,19 @@ const addSiblingInTree = (
 export default function BookmarkEditor({ bookmarks, onChange, disabled }: BookmarkEditorProps) {
   const { t } = useTranslation();
 
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [currentTitleInput, setCurrentTitleInput] = useState<string>('');
+
+  const getLatestTree = () => {
+    if (editingId) {
+      return updateTree(bookmarks, editingId, bookmark => ({ ...bookmark, title: currentTitleInput }));
+    }
+    return bookmarks;
+  };
+
   const handleAddTopLevel = () => {
     const newBookmark = createBookmarkNode({ title: t('editTableOfContents.editor.defaultTitle', 'New bookmark') });
-    onChange([...bookmarks, newBookmark]);
+    onChange([...getLatestTree(), newBookmark]);
   };
 
   const handleTitleChange = (id: string, value: string) => {
@@ -126,11 +136,11 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
 
   const handlePageChange = (id: string, value: number | string) => {
     const page = typeof value === 'number' ? value : parseInt(value, 10);
-    onChange(updateTree(bookmarks, id, bookmark => ({ ...bookmark, pageNumber: Number.isFinite(page) && page > 0 ? page : 1 })));
+    onChange(updateTree(getLatestTree(), id, bookmark => ({ ...bookmark, pageNumber: Number.isFinite(page) && page > 0 ? page : 1 })));
   };
 
   const handleToggle = (id: string) => {
-    onChange(updateTree(bookmarks, id, bookmark => ({ ...bookmark, expanded: !bookmark.expanded })));
+    onChange(updateTree(getLatestTree(), id, bookmark => ({ ...bookmark, expanded: !bookmark.expanded })));
   };
 
   const handleRemove = (id: string) => {
@@ -139,20 +149,20 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
       'Remove this bookmark and all of its children?'
     );
     if (window.confirm(confirmation)) {
-      onChange(removeFromTree(bookmarks, id));
+      onChange(removeFromTree(getLatestTree(), id));
     }
   };
 
   const handleAddChild = (parentId: string) => {
     const child = createBookmarkNode({ title: t('editTableOfContents.editor.defaultChildTitle', 'Child bookmark') });
-    const { nodes, added } = addChildToTree(bookmarks, parentId, child);
-    onChange(added ? nodes : [...bookmarks, child]);
+    const { nodes, added } = addChildToTree(getLatestTree(), parentId, child);
+    onChange(added ? nodes : [...getLatestTree(), child]);
   };
 
   const handleAddSibling = (targetId: string) => {
     const sibling = createBookmarkNode({ title: t('editTableOfContents.editor.defaultSiblingTitle', 'New bookmark') });
-    const { nodes, added } = addSiblingInTree(bookmarks, targetId, sibling);
-    onChange(added ? nodes : [...bookmarks, sibling]);
+    const { nodes, added } = addSiblingInTree(getLatestTree(), targetId, sibling);
+    onChange(added ? nodes : [...getLatestTree(), sibling]);
   };
 
   const renderBookmark = (bookmark: BookmarkNode, level = 0) => {
@@ -176,7 +186,10 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
               <ActionIcon
                 variant="subtle"
                 color="gray"
-                onClick={() => hasChildren && handleToggle(bookmark.id)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  if (hasChildren) handleToggle(bookmark.id);
+                }}
                 disabled={disabled || !hasChildren}
                 aria-label={t('editTableOfContents.editor.actions.toggle', 'Toggle children')}
                 style={{ marginTop: 4 }}
@@ -202,7 +215,10 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
                 <ActionIcon
                   variant="subtle"
                   color="green"
-                  onClick={() => handleAddChild(bookmark.id)}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    handleAddChild(bookmark.id)
+                  }}
                   disabled={disabled}
                 >
                   <LocalIcon icon="subdirectory-arrow-right-rounded" />
@@ -212,7 +228,10 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
                 <ActionIcon
                   variant="subtle"
                   color="blue"
-                  onClick={() => handleAddSibling(bookmark.id)}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    handleAddSibling(bookmark.id)
+                  }}
                   disabled={disabled}
                 >
                   <LocalIcon icon="add-rounded" />
@@ -222,7 +241,10 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
                 <ActionIcon
                   variant="subtle"
                   color="red"
-                  onClick={() => handleRemove(bookmark.id)}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    handleRemove(bookmark.id)
+                  }}
                   disabled={disabled}
                 >
                   <LocalIcon icon="delete-rounded" />
@@ -236,8 +258,18 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
               <TextInput
                 size="sm"
                 label={t('editTableOfContents.editor.field.title', 'Bookmark title')}
-                value={bookmark.title}
-                onChange={event => handleTitleChange(bookmark.id, event.currentTarget.value)}
+                value={editingId === bookmark.id ? currentTitleInput : bookmark.title}
+                onFocus={() => {
+                  setEditingId(bookmark.id);
+                  setCurrentTitleInput(bookmark.title);
+                }}
+                onBlur={() => {
+                  if (editingId === bookmark.id && currentTitleInput !== bookmark.title) {
+                    handleTitleChange(bookmark.id, currentTitleInput);
+                  }
+                  setEditingId(null);
+                }}
+                onChange={event => setCurrentTitleInput(event.currentTarget.value)}
                 disabled={disabled}
               />
               <NumberInput
@@ -277,7 +309,10 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
           variant="default"
           color="blue"
           leftSection={<LocalIcon icon="bookmark-add-rounded" />}
-          onClick={handleAddTopLevel}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            handleAddTopLevel();
+          }}
           disabled={disabled}
         >
           {t('editTableOfContents.editor.addTopLevel', 'Add top-level bookmark')}
@@ -296,7 +331,10 @@ export default function BookmarkEditor({ bookmarks, onChange, disabled }: Bookma
               variant="subtle"
               color="blue"
               leftSection={<LocalIcon icon="add-rounded" />}
-              onClick={handleAddTopLevel}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleAddTopLevel();
+              }}
               disabled={disabled}
             >
               {t('editTableOfContents.editor.empty.action', 'Add first bookmark')}


### PR DESCRIPTION
# Description

Fixes #5870 

Fixed an issue in the Table of Contents editor where the cursor would jump to the end of the input field on every keystroke. I modified the following file:

* frontend/src/core/components/tools/editTableOfContents/BookmarkEditor.tsx

## Changes

1. Introduced a local state (currentTitleInput) and editingId to decouple text input from the tree re-renders;

2. Implemented a getLatestTree method to synchronize the current title input with the tree state before any changes on the tree (adding/removing/expanding/collapsing nodes or changing target page number);

3. Changed onClick button events to onMouseDown events with preventDefault() to ensure that tree updates trigger before the input focus is lost.

The change (1) was already enough to fix the main bug, but I realized it introduced another bug while I was testing: if the user typed the title input (without clicking outside the text input box) and immediately after clicked on the up and down arrows to change the target page number or clicked on a button (add child/sibling, delete, expand/collapse), then the title input would be restored to its previous state. Hence why I did changes (2) and (3) aswell.

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
