### PR TITLE
Remove cmd-r override for rotation because it interferes with refresh

### DIFF
--- a/frontend/src/core/components/viewer/EmbedPdfViewer.tsx
+++ b/frontend/src/core/components/viewer/EmbedPdfViewer.tsx
@@ -397,16 +397,6 @@ const EmbedPdfViewerContent = ({
               event.preventDefault();
               printActions.print();
               return;
-            case 'r':
-            case 'R':
-              // Ctrl+R: Rotate forward; Ctrl+Shift+R: Rotate backward
-              event.preventDefault();
-              if (event.shiftKey) {
-                rotationActions.rotateBackward();
-              } else {
-                rotationActions.rotateForward();
-              }
-              return;
           }
         }
       }


### PR DESCRIPTION
# Description of Changes
Currently, cmd-r is set to rotate the PDF in the viewer instead of perform refresh in the browser. This is unintuitive and confusing for Mac users, and for Windows users (who are less used to doing ctrl-r for refresh) it only works some of the time, if the Viewer is active, so removing the override is no great loss.