### PR TITLE
fix pause-rounded icon typos and comments

### DIFF
--- a/frontend/src/core/components/tools/sign/SignSettings.tsx
+++ b/frontend/src/core/components/tools/sign/SignSettings.tsx
@@ -488,7 +488,7 @@ const SignSettings = ({
   const handleCanvasSignatureChange = useCallback((data: string | null) => {
     const nextValue = data ?? undefined;
     setCanvasSignatureData(prevData => {
-      // Reset pause-rounded state and trigger placement for signature changes
+      // Reset pause state and trigger placement for signature changes
       // (onDrawingComplete handles initial activation)
       if (prevData && prevData !== nextValue && nextValue) {
         setPlacementManuallyPaused(false);
@@ -899,7 +899,7 @@ const SignSettings = ({
         color: isPlacementMode ? 'blue' : 'teal',
         title: isPlacementMode
           ? translate('instructions.title', 'How to add your signature')
-          : translate('instructions.pause-roundedd', 'Placement pause-roundedd'),
+          : translate('instructions.paused', 'Placement paused'),
         message: isPlacementMode
           ? placementInstructions()
           : translate('instructions.resumeHint', 'Resume placement to click and add your signature.'),
@@ -920,7 +920,7 @@ const SignSettings = ({
     onActivateSignaturePlacement?.();
   };
 
-  // Handle Escape key to toggle pause-rounded/resume
+  // Handle Escape key to toggle pause/resume
   useEffect(() => {
     if (!isCurrentTypeReady) return;
 
@@ -943,11 +943,11 @@ const SignSettings = ({
     onActivateSignaturePlacement || onDeactivateSignature
       ? isPlacementMode
         ? (
-            <Tooltip label={translate('mode.pause-rounded', 'Pause placement')}>
+            <Tooltip label={translate('mode.pause', 'Pause placement')}>
               <ActionIcon
                 variant="default"
                 size="lg"
-                aria-label={translate('mode.pause-rounded', 'Pause placement')}
+                aria-label={translate('mode.pause', 'Pause placement')}
                 onClick={handlePausePlacement}
                 disabled={disabled || !onDeactivateSignature}
                 style={{
@@ -960,7 +960,7 @@ const SignSettings = ({
               >
                 <LocalIcon icon="pause-rounded" width={20} height={20} />
                 <Text component="span" size="sm" fw={500}>
-                  {translate('mode.pause-rounded', 'Pause placement')}
+                  {translate('mode.pause', 'Pause placement')}
                 </Text>
               </ActionIcon>
             </Tooltip>


### PR DESCRIPTION
## Description

Fixed typos related to an icon named 'pause-rounded'. Now the translations work as expected on the add text, image and signature tools. The typos were likely caused by a find-and-replace attempt. I modified the following files:

* frontend/src/core/components/tools/sign/SignSettings.tsx

### Changes

* Reverted instructions.pause-roundedd to the correct key instructions.paused;

* Fixed the fallback English string from 'Placement pause-roundedd' to 'Placement paused';

* Reverted mode.pause-rounded to mode.pause;

* Fixed comments.

It looked like this before:
<img width="259" height="271" alt="print1-contribuicao2" src="https://github.com/user-attachments/assets/e5268f5d-30db-4919-9554-0281ebecf2ac" />

It now looks as expected and the translations are functioning correctly:
<img width="294" height="287" alt="print2-contribuicao2" src="https://github.com/user-attachments/assets/b8fb2cd2-c3e1-4efb-8e86-95914829986e" />


## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/DeveloperGuide.md#6-testing) for more details.
