### PR TITLE
fix: pin 2 unpinned action(s),extract 50 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/PR-Auto-Deploy-V2.yml
+++ b/.github/workflows/PR-Auto-Deploy-V2.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Check if image exists
         id: check-image
         run: |
-          if docker manifest inspect ${{ secrets.DOCKER_HUB_USERNAME }}/test:v2-${{ steps.commit-hash.outputs.app_short }} >/dev/null 2>&1; then
+          if docker manifest inspect ${DOCKER_HUB_USERNAME}/test:v2-${{ steps.commit-hash.outputs.app_short }} >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "Image already exists, skipping build"
           else
@@ -224,6 +224,8 @@ jobs:
             echo "Image needs to be built"
           fi
 
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       - name: Build and push V2 image
         if: steps.check-image.outputs.exists == 'false'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -240,9 +242,11 @@ jobs:
       - name: Set up SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.NEW_VPS_SSH_KEY }}" > ../private.key
+          echo "${NEW_VPS_SSH_KEY}" > ../private.key
           sudo chmod 600 ../private.key
 
+        env:
+          NEW_VPS_SSH_KEY: ${{ secrets.NEW_VPS_SSH_KEY }}
       - name: Deploy V2 to VPS
         id: deploy
         run: |
@@ -255,7 +259,7 @@ jobs:
           services:
             stirling-pdf-v2:
               container_name: stirling-pdf-v2-pr-${{ needs.check-pr.outputs.pr_number }}
-              image: ${{ secrets.DOCKER_HUB_USERNAME }}/test:v2-${{ steps.commit-hash.outputs.app_short }}
+              image: ${DOCKER_HUB_USERNAME}/test:v2-${{ steps.commit-hash.outputs.app_short }}
               ports:
                 - "${V2_PORT}:8080"
               volumes:
@@ -265,8 +269,8 @@ jobs:
               environment:
                 DISABLE_ADDITIONAL_FEATURES: "false"
                 SECURITY_ENABLELOGIN: "true"
-                SECURITY_INITIALLOGIN_USERNAME: "${{ secrets.TEST_LOGIN_USERNAME }}"
-                SECURITY_INITIALLOGIN_PASSWORD: "${{ secrets.TEST_LOGIN_PASSWORD }}"
+                SECURITY_INITIALLOGIN_USERNAME: "${TEST_LOGIN_USERNAME}"
+                SECURITY_INITIALLOGIN_PASSWORD: "${TEST_LOGIN_PASSWORD}"
                 SYSTEM_DEFAULTLOCALE: en-GB
                 UI_APPNAME: "Stirling-PDF V2 PR#${{ needs.check-pr.outputs.pr_number }}"
                 UI_HOMEDESCRIPTION: "V2 PR#${{ needs.check-pr.outputs.pr_number }} - Embedded Architecture"
@@ -280,9 +284,9 @@ jobs:
           EOF
 
           # Deploy to VPS
-          scp -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker-compose.yml ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }}:/tmp/docker-compose-v2.yml
+          scp -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker-compose.yml ${NEW_VPS_USERNAME}@${NEW_VPS_HOST}:/tmp/docker-compose-v2.yml
 
-          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }} << ENDSSH
+          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${NEW_VPS_USERNAME}@${NEW_VPS_HOST} << ENDSSH
             # Create V2 PR-specific directories
             mkdir -p /stirling/V2-PR-${{ needs.check-pr.outputs.pr_number }}/{data,config,logs}
 
@@ -307,6 +311,12 @@ jobs:
           # Set port for output
           echo "v2_port=${V2_PORT}" >> $GITHUB_OUTPUT
 
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          TEST_LOGIN_USERNAME: ${{ secrets.TEST_LOGIN_USERNAME }}
+          TEST_LOGIN_PASSWORD: ${{ secrets.TEST_LOGIN_PASSWORD }}
+          NEW_VPS_USERNAME: ${{ secrets.NEW_VPS_USERNAME }}
+          NEW_VPS_HOST: ${{ secrets.NEW_VPS_HOST }}
       - name: Post V2 deployment URL to PR
         if: success()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -407,12 +417,14 @@ jobs:
       - name: Set up SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.NEW_VPS_SSH_KEY }}" > ../private.key
+          echo "${NEW_VPS_SSH_KEY}" > ../private.key
           sudo chmod 600 ../private.key
 
+        env:
+          NEW_VPS_SSH_KEY: ${{ secrets.NEW_VPS_SSH_KEY }}
       - name: Cleanup V2 deployment
         run: |
-          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }} << 'ENDSSH'
+          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${NEW_VPS_USERNAME}@${NEW_VPS_HOST} << 'ENDSSH'
             if [ -d "/stirling/V2-PR-${{ github.event.pull_request.number }}" ]; then
               echo "Found V2 PR directory, proceeding with cleanup..."
 
@@ -441,6 +453,9 @@ jobs:
             # Only remove PR-specific containers and directories
           ENDSSH
 
+        env:
+          NEW_VPS_USERNAME: ${{ secrets.NEW_VPS_USERNAME }}
+          NEW_VPS_HOST: ${{ secrets.NEW_VPS_HOST }}
       - name: Cleanup temporary files
         if: always()
         run: |

--- a/.github/workflows/PR-Demo-Comment-with-react.yml
+++ b/.github/workflows/PR-Demo-Comment-with-react.yml
@@ -199,9 +199,11 @@ jobs:
       - name: Set up SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.NEW_VPS_SSH_KEY }}" > ../private.key
+          echo "${NEW_VPS_SSH_KEY}" > ../private.key
           sudo chmod 600 ../private.key
 
+        env:
+          NEW_VPS_SSH_KEY: ${{ secrets.NEW_VPS_SSH_KEY }}
       - name: Deploy to VPS
         id: deploy
         run: |
@@ -219,11 +221,11 @@ jobs:
           # Set pro/enterprise settings (enterprise implies pro)
           if [ "${{ needs.check-comment.outputs.enable_enterprise }}" == "true" ]; then
             PREMIUM_ENABLED="true"
-            PREMIUM_KEY="${{ secrets.ENTERPRISE_KEY }}"
+            PREMIUM_KEY="${ENTERPRISE_KEY}"
             PREMIUM_PROFEATURES_AUDIT_ENABLED="true"
           elif [ "${{ needs.check-comment.outputs.enable_pro }}" == "true" ]; then
             PREMIUM_ENABLED="true"
-            PREMIUM_KEY="${{ secrets.PREMIUM_KEY }}"
+            PREMIUM_KEY="${PREMIUM_KEY}"
             PREMIUM_PROFEATURES_AUDIT_ENABLED="true"
           else
             PREMIUM_ENABLED="false"
@@ -237,7 +239,7 @@ jobs:
           services:
             stirling-pdf:
               container_name: stirling-pdf-pr-${{ needs.check-comment.outputs.pr_number }}
-              image: ${{ secrets.DOCKER_HUB_USERNAME }}/test:pr-${{ needs.check-comment.outputs.pr_number }}
+              image: ${DOCKER_HUB_USERNAME}/test:pr-${{ needs.check-comment.outputs.pr_number }}
               ports:
                 - "${{ needs.check-comment.outputs.pr_number }}:8080"
               volumes:
@@ -261,9 +263,9 @@ jobs:
           EOF
 
           # Then copy the file and execute commands
-          scp -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker-compose.yml ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }}:/tmp/docker-compose.yml
+          scp -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker-compose.yml ${NEW_VPS_USERNAME}@${NEW_VPS_HOST}:/tmp/docker-compose.yml
 
-          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }} << ENDSSH
+          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${NEW_VPS_USERNAME}@${NEW_VPS_HOST} << ENDSSH
             # Create PR-specific directories
             mkdir -p /stirling/PR-${{ needs.check-comment.outputs.pr_number }}/{data,config,logs}
 
@@ -279,6 +281,12 @@ jobs:
           # Set output for use in PR comment
           echo "security_status=${SECURITY_STATUS}" >> $GITHUB_ENV
 
+        env:
+          ENTERPRISE_KEY: ${{ secrets.ENTERPRISE_KEY }}
+          PREMIUM_KEY: ${{ secrets.PREMIUM_KEY }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          NEW_VPS_USERNAME: ${{ secrets.NEW_VPS_USERNAME }}
+          NEW_VPS_HOST: ${{ secrets.NEW_VPS_HOST }}
       - name: Add success reaction to comment
         if: success()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/PR-Demo-cleanup.yml
+++ b/.github/workflows/PR-Demo-cleanup.yml
@@ -100,14 +100,16 @@ jobs:
         if: steps.remove-label-comment.outputs.present == 'true'
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.NEW_VPS_SSH_KEY }}" > ../private.key
+          echo "${NEW_VPS_SSH_KEY}" > ../private.key
           sudo chmod 600 ../private.key
 
+        env:
+          NEW_VPS_SSH_KEY: ${{ secrets.NEW_VPS_SSH_KEY }}
       - name: Cleanup PR deployment
         if: steps.remove-label-comment.outputs.present == 'true'
         id: cleanup
         run: |
-          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }} << 'ENDSSH'
+          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T ${NEW_VPS_USERNAME}@${NEW_VPS_HOST} << 'ENDSSH'
             if [ -d "/stirling/PR-${{ github.event.pull_request.number }}" ]; then
               echo "Found PR directory, proceeding with cleanup..."
 
@@ -122,7 +124,7 @@ jobs:
               rm -rf /stirling/PR-${{ github.event.pull_request.number }}
 
               # Remove the Docker image
-              docker rmi --no-prune ${{ secrets.DOCKER_HUB_USERNAME }}/test:pr-${{ github.event.pull_request.number }} || true
+              docker rmi --no-prune ${DOCKER_HUB_USERNAME}/test:pr-${{ github.event.pull_request.number }} || true
 
               echo "PERFORMED_CLEANUP"
             else
@@ -131,6 +133,10 @@ jobs:
             fi
           ENDSSH
 
+        env:
+          NEW_VPS_USERNAME: ${{ secrets.NEW_VPS_USERNAME }}
+          NEW_VPS_HOST: ${{ secrets.NEW_VPS_HOST }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       - name: Cleanup temporary files
         if: always()
         run: |

--- a/.github/workflows/ai-engine.yml
+++ b/.github/workflows/ai-engine.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           enable-cache: true
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Post fixer suggestions
         if: steps.fixer_changes.outputs.changed == 'true' && github.event_name == 'pull_request'
-        uses: reviewdog/action-suggester@v1
+        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         continue-on-error: true
         with:
           tool_name: engine-make-fix

--- a/.github/workflows/deploy-on-v2-commit.yml
+++ b/.github/workflows/deploy-on-v2-commit.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Check if frontend image exists
         id: check-frontend
         run: |
-          if docker manifest inspect ${{ secrets.DOCKER_HUB_USERNAME }}/test:v2-frontend-${{ steps.commit-hashes.outputs.frontend_short }} >/dev/null 2>&1; then
+          if docker manifest inspect ${DOCKER_HUB_USERNAME}/test:v2-frontend-${{ steps.commit-hashes.outputs.frontend_short }} >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "Frontend image already exists, skipping build"
           else
@@ -73,10 +73,12 @@ jobs:
             echo "Frontend image needs to be built"
           fi
 
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       - name: Check if backend image exists
         id: check-backend
         run: |
-          if docker manifest inspect ${{ secrets.DOCKER_HUB_USERNAME }}/test:v2-backend-${{ steps.commit-hashes.outputs.backend_short }} >/dev/null 2>&1; then
+          if docker manifest inspect ${DOCKER_HUB_USERNAME}/test:v2-backend-${{ steps.commit-hashes.outputs.backend_short }} >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "Backend image already exists, skipping build"
           else
@@ -84,6 +86,8 @@ jobs:
             echo "Backend image needs to be built"
           fi
 
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -123,9 +127,11 @@ jobs:
       - name: Set up SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.NEW_VPS_SSH_KEY }}" > ../private.key
+          echo "${NEW_VPS_SSH_KEY}" > ../private.key
           chmod 600 ../private.key
 
+        env:
+          NEW_VPS_SSH_KEY: ${{ secrets.NEW_VPS_SSH_KEY }}
       - name: Deploy to VPS on port 3000
         run: |
           export UNIQUE_NAME=docker-compose-v2-$GITHUB_RUN_ID.yml
@@ -135,7 +141,7 @@ jobs:
           services:
             backend:
               container_name: stirling-v2-backend
-              image: ${{ secrets.DOCKER_HUB_USERNAME }}/test:v2-backend-${{ steps.commit-hashes.outputs.backend_short }}
+              image: ${DOCKER_HUB_USERNAME}/test:v2-backend-${{ steps.commit-hashes.outputs.backend_short }}
               ports:
                 - "13000:8080"
               volumes:
@@ -158,21 +164,21 @@ jobs:
 
             frontend:
               container_name: stirling-v2-frontend
-              image: ${{ secrets.DOCKER_HUB_USERNAME }}/test:v2-frontend-${{ steps.commit-hashes.outputs.frontend_short }}
+              image: ${DOCKER_HUB_USERNAME}/test:v2-frontend-${{ steps.commit-hashes.outputs.frontend_short }}
               ports:
                 - "3000:80"
               environment:
-                VITE_API_BASE_URL: "http://${{ secrets.NEW_VPS_HOST }}:13000"
+                VITE_API_BASE_URL: "http://${NEW_VPS_HOST}:13000"
               depends_on:
                 - backend
               restart: on-failure:5
           EOF
 
           # Copy to remote with unique name
-          scp -i ../private.key -o StrictHostKeyChecking=no $UNIQUE_NAME ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }}:/tmp/$UNIQUE_NAME
+          scp -i ../private.key -o StrictHostKeyChecking=no $UNIQUE_NAME ${NEW_VPS_USERNAME}@${NEW_VPS_HOST}:/tmp/$UNIQUE_NAME
 
           # SSH and rename/move atomically to avoid interference
-          ssh -i ../private.key -o StrictHostKeyChecking=no ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }} << ENDSSH
+          ssh -i ../private.key -o StrictHostKeyChecking=no ${NEW_VPS_USERNAME}@${NEW_VPS_HOST} << ENDSSH
             mkdir -p /stirling/V2/{data,config,logs}
             mv /tmp/$UNIQUE_NAME /stirling/V2/docker-compose.yml
             cd /stirling/V2
@@ -183,6 +189,10 @@ jobs:
             docker image prune -af --filter "until=336h" --filter "label!=keep=true" || true
           ENDSSH
 
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          NEW_VPS_HOST: ${{ secrets.NEW_VPS_HOST }}
+          NEW_VPS_USERNAME: ${{ secrets.NEW_VPS_USERNAME }}
       - name: Cleanup temporary files
         if: always()
         run: |

--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -80,7 +80,7 @@ jobs:
         id: set-matrix
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            case "${{ github.event.inputs.platform }}" in
+            case "${INPUT_PLATFORM}" in
               "windows")
                 echo 'matrix={"include":[{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","name":"windows-x86_64"}]}' >> $GITHUB_OUTPUT
                 ;;
@@ -99,6 +99,8 @@ jobs:
             echo 'matrix={"include":[{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","name":"windows-x86_64"},{"platform":"macos-15","args":"--target aarch64-apple-darwin","name":"macos-aarch64"},{"platform":"macos-15-intel","args":"--target x86_64-apple-darwin","name":"macos-x86_64"},{"platform":"ubuntu-22.04","args":"","name":"linux-x86_64"}]}' >> $GITHUB_OUTPUT
           fi
 
+        env:
+          INPUT_PLATFORM: ${{ github.event.inputs.platform }}
   build-jars:
     needs: determine-matrix
     runs-on: ubuntu-latest
@@ -317,16 +319,16 @@ jobs:
           Write-Host "Setting up DigiCert KeyLocker environment..."
 
           # Decode client certificate
-          $certBytes = [Convert]::FromBase64String("${{ secrets.SM_CLIENT_CERT_FILE_B64 }}")
+          $certBytes = [Convert]::FromBase64String("${SM_CLIENT_CERT_FILE_B64}")
           $certPath = "D:\Certificate_pkcs12.p12"
           [IO.File]::WriteAllBytes($certPath, $certBytes)
 
           # Set environment variables
           echo "SM_CLIENT_CERT_FILE=D:\Certificate_pkcs12.p12" >> $env:GITHUB_ENV
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> $env:GITHUB_ENV
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> $env:GITHUB_ENV
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> $env:GITHUB_ENV
-          echo "SM_KEYPAIR_ALIAS=${{ secrets.SM_KEYPAIR_ALIAS }}" >> $env:GITHUB_ENV
+          echo "SM_HOST=${SM_HOST}" >> $env:GITHUB_ENV
+          echo "SM_API_KEY=${SM_API_KEY}" >> $env:GITHUB_ENV
+          echo "SM_CLIENT_CERT_PASSWORD=${SM_CLIENT_CERT_PASSWORD}" >> $env:GITHUB_ENV
+          echo "SM_KEYPAIR_ALIAS=${SM_KEYPAIR_ALIAS}" >> $env:GITHUB_ENV
 
           # Get PKCS11 config path from DigiCert action
           $pkcs11Config = $env:PKCS11_CONFIG
@@ -344,6 +346,12 @@ jobs:
             }
           }
 
+        env:
+          SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KEYPAIR_ALIAS: ${{ secrets.SM_KEYPAIR_ALIAS }}
       # Traditional PFX Certificate Import (fallback if KeyLocker not configured)
       - name: Import Windows Code Signing Certificate
         if: ${{ matrix.platform == 'windows-latest' && env.SM_API_KEY == '' && (github.event_name == 'release' || github.ref == 'refs/heads/V2-master') }}
@@ -492,14 +500,14 @@ jobs:
             Write-Host "Using PKCS11 config: $pkcs11Config"
 
             # Try signing with certificate fingerprint first (if available)
-            $fingerprint = "${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}"
+            $fingerprint = "${SM_CODE_SIGNING_CERT_SHA1_HASH}"
             if ($fingerprint -and $fingerprint -ne "") {
               Write-Host "Attempting to sign with certificate fingerprint..."
               $output = & smctl sign --fingerprint "$fingerprint" --input "$($file.FullName)" --config-file "$pkcs11Config" --verbose 2>&1
               $exitCode = $LASTEXITCODE
             } else {
               Write-Host "No fingerprint provided, using keypair alias..."
-              $output = & smctl sign --keypair-alias "${{ secrets.SM_KEYPAIR_ALIAS }}" --input "$($file.FullName)" --config-file "$pkcs11Config" --verbose 2>&1
+              $output = & smctl sign --keypair-alias "${SM_KEYPAIR_ALIAS}" --input "$($file.FullName)" --config-file "$pkcs11Config" --verbose 2>&1
               $exitCode = $LASTEXITCODE
             }
 
@@ -526,6 +534,9 @@ jobs:
           Write-Host "=== Summary ==="
           Write-Host "[SUCCESS] Signed $signedCount/$($filesToSign.Count) files successfully"
 
+        env:
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+          SM_KEYPAIR_ALIAS: ${{ secrets.SM_KEYPAIR_ALIAS }}
       - name: Rename artifacts
         shell: bash
         run: |

--- a/.github/workflows/push-docker-base.yml
+++ b/.github/workflows/push-docker-base.yml
@@ -33,12 +33,14 @@ jobs:
         id: version
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+            VERSION="${INPUT_VERSION}"
           else
             VERSION="1.0.0"
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -45,6 +45,7 @@ jobs:
         id: set-matrix
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          INPUT_PLATFORM: ${{ github.event.inputs.platform }}
         run: |
           WINDOWS='{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","name":"windows-x86_64"}'
           MACOS_ARM='{"platform":"macos-15","args":"--target aarch64-apple-darwin","name":"macos-aarch64"}'
@@ -53,7 +54,7 @@ jobs:
 
           # Resolve requested platform (non-dispatch events always build all)
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PLATFORM="${{ github.event.inputs.platform }}"
+            PLATFORM="${INPUT_PLATFORM}"
           else
             PLATFORM="all"
           fi
@@ -227,16 +228,16 @@ jobs:
           Write-Host "Setting up DigiCert KeyLocker environment..."
 
           # Decode client certificate
-          $certBytes = [Convert]::FromBase64String("${{ secrets.SM_CLIENT_CERT_FILE_B64 }}")
+          $certBytes = [Convert]::FromBase64String("${SM_CLIENT_CERT_FILE_B64}")
           $certPath = "D:\Certificate_pkcs12.p12"
           [IO.File]::WriteAllBytes($certPath, $certBytes)
 
           # Set environment variables
           echo "SM_CLIENT_CERT_FILE=D:\Certificate_pkcs12.p12" >> $env:GITHUB_ENV
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> $env:GITHUB_ENV
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> $env:GITHUB_ENV
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> $env:GITHUB_ENV
-          echo "SM_KEYPAIR_ALIAS=${{ secrets.SM_KEYPAIR_ALIAS }}" >> $env:GITHUB_ENV
+          echo "SM_HOST=${SM_HOST}" >> $env:GITHUB_ENV
+          echo "SM_API_KEY=${SM_API_KEY}" >> $env:GITHUB_ENV
+          echo "SM_CLIENT_CERT_PASSWORD=${SM_CLIENT_CERT_PASSWORD}" >> $env:GITHUB_ENV
+          echo "SM_KEYPAIR_ALIAS=${SM_KEYPAIR_ALIAS}" >> $env:GITHUB_ENV
 
           # Get PKCS11 config path from DigiCert action
           $pkcs11Config = $env:PKCS11_CONFIG
@@ -254,6 +255,12 @@ jobs:
             }
           }
 
+        env:
+          SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KEYPAIR_ALIAS: ${{ secrets.SM_KEYPAIR_ALIAS }}
       # Traditional PFX Certificate Import (fallback if KeyLocker not configured)
       - name: Import Windows Code Signing Certificate
         if: ${{ matrix.platform == 'windows-latest' && env.SM_API_KEY == '' && github.ref == 'refs/heads/main' }}
@@ -392,7 +399,7 @@ jobs:
           $hasCertificate = $false
 
           foreach ($line in $lines) {
-            if ($line -match "${{ secrets.SM_KEYPAIR_ALIAS }}") {
+            if ($line -match "${SM_KEYPAIR_ALIAS}") {
               $foundKeypair = $true
               Write-Host "[SUCCESS] Found keypair in list"
 
@@ -406,7 +413,7 @@ jobs:
           }
 
           if (-not $foundKeypair) {
-            Write-Host "[ERROR] Keypair not found: ${{ secrets.SM_KEYPAIR_ALIAS }}"
+            Write-Host "[ERROR] Keypair not found: ${SM_KEYPAIR_ALIAS}"
             Write-Host "Available keypairs are listed above"
             Write-Host ""
             Write-Host "Please verify:"
@@ -465,7 +472,7 @@ jobs:
             Write-Host "Using PKCS11 config: $pkcs11Config"
 
             # Try signing with certificate fingerprint first (if available)
-            $fingerprint = "${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}"
+            $fingerprint = "${SM_CODE_SIGNING_CERT_SHA1_HASH}"
             if ($fingerprint -and $fingerprint -ne "") {
               Write-Host "Attempting to sign with certificate fingerprint..."
               $output = & smctl sign --fingerprint "$fingerprint" --input "$($file.FullName)" --config-file "$pkcs11Config" --verbose 2>&1
@@ -473,7 +480,7 @@ jobs:
             } else {
               Write-Host "No fingerprint provided, using keypair alias..."
               # Use smctl to sign with keypair alias
-              $output = & smctl sign --keypair-alias "${{ secrets.SM_KEYPAIR_ALIAS }}" --input "$($file.FullName)" --config-file "$pkcs11Config" --verbose 2>&1
+              $output = & smctl sign --keypair-alias "${SM_KEYPAIR_ALIAS}" --input "$($file.FullName)" --config-file "$pkcs11Config" --verbose 2>&1
               $exitCode = $LASTEXITCODE
             }
 
@@ -513,6 +520,9 @@ jobs:
           Write-Host "=== Summary ==="
           Write-Host "[SUCCESS] Signed $signedCount/$($filesToSign.Count) files successfully"
 
+        env:
+          SM_KEYPAIR_ALIAS: ${{ secrets.SM_KEYPAIR_ALIAS }}
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
       - name: Verify notarization (macOS only)
         if: matrix.platform == 'macos-15' || matrix.platform == 'macos-15-intel'
         run: |

--- a/.github/workflows/testdriver.yml
+++ b/.github/workflows/testdriver.yml
@@ -81,9 +81,11 @@ jobs:
       - name: Set up SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.NEW_VPS_SSH_KEY }}" > ../private.key
+          echo "${NEW_VPS_SSH_KEY}" > ../private.key
           sudo chmod 600 ../private.key
 
+        env:
+          NEW_VPS_SSH_KEY: ${{ secrets.NEW_VPS_SSH_KEY }}
       - name: Deploy to VPS
         run: |
           cat > docker-compose.yml << EOF
@@ -91,7 +93,7 @@ jobs:
           services:
             stirling-pdf:
               container_name: stirling-pdf-test-${{ github.sha }}
-              image: ${{ secrets.DOCKER_HUB_USERNAME }}/test:test-${{ github.sha }}
+              image: ${DOCKER_HUB_USERNAME}/test:test-${{ github.sha }}
               ports:
                 - "1337:8080"
               volumes:
@@ -112,9 +114,9 @@ jobs:
               restart: on-failure:5
           EOF
 
-          scp -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker-compose.yml ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }}:/tmp/docker-compose.yml
+          scp -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker-compose.yml ${NEW_VPS_USERNAME}@${NEW_VPS_HOST}:/tmp/docker-compose.yml
 
-          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }} << EOF
+          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${NEW_VPS_USERNAME}@${NEW_VPS_HOST} << EOF
             mkdir -p /stirling/test-${{ github.sha }}/{data,config,logs}
             mv /tmp/docker-compose.yml /stirling/test-${{ github.sha }}/docker-compose.yml
             cd /stirling/test-${{ github.sha }}
@@ -122,6 +124,10 @@ jobs:
             docker-compose up -d
           EOF
 
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          NEW_VPS_USERNAME: ${{ secrets.NEW_VPS_USERNAME }}
+          NEW_VPS_HOST: ${{ secrets.NEW_VPS_HOST }}
   files-changed:
     if: always()
     name: detect what files changed
@@ -193,16 +199,21 @@ jobs:
       - name: Set up SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "${{ secrets.NEW_VPS_SSH_KEY }}" > ../private.key
+          echo "${NEW_VPS_SSH_KEY}" > ../private.key
           sudo chmod 600 ../private.key
 
+        env:
+          NEW_VPS_SSH_KEY: ${{ secrets.NEW_VPS_SSH_KEY }}
       - name: Cleanup deployment
         if: always()
         run: |
-          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.NEW_VPS_USERNAME }}@${{ secrets.NEW_VPS_HOST }} << EOF
+          ssh -i ../private.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${NEW_VPS_USERNAME}@${NEW_VPS_HOST} << EOF
             cd /stirling/test-${{ github.sha }}
             docker-compose down
             cd /stirling
             rm -rf test-${{ github.sha }}
           EOF
+        env:
+          NEW_VPS_USERNAME: ${{ secrets.NEW_VPS_USERNAME }}
+          NEW_VPS_HOST: ${{ secrets.NEW_VPS_HOST }}
         continue-on-error: true # Ensure cleanup runs even if previous steps fail


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/PR-Auto-Deploy-V2.yml` | Extracted 10 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/PR-Demo-Comment-with-react.yml` | Extracted 6 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/PR-Demo-cleanup.yml` | Extracted 4 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/ai-engine.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/deploy-on-v2-commit.yml` | Extracted 6 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/multiOSReleases.yml` | Extracted 8 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/push-docker-base.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/tauri-build.yml` | Extracted 8 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/testdriver.yml` | Extracted 7 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/PR-Demo-Comment-with-react.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/PR-Demo-Comment-with-react.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/PR-Demo-Comment-with-react.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/PR-Demo-Comment-with-react.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-003 | high | `.github/workflows/ai_pr_title_review.yml` | Filename Injection via Git Diff or File Listing |
| RGS-012 | high | `.github/workflows/swagger.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-005 | medium | `.github/workflows/PR-Demo-Comment-with-react.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/PR-Demo-Comment-with-react.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/PR-Demo-cleanup.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/auto-labelerV2.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/check_toml.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.