### PR TITLE
fix(desktop): auto-select opened file in workbench when using "Open with"

### DIFF
--- a/frontend/src/core/components/AppProviders.tsx
+++ b/frontend/src/core/components/AppProviders.tsx
@@ -105,11 +105,11 @@ export function AppProviders({ children, appConfigRetryOptions, appConfigProvide
                 <ScarfTrackingInitializer />
                 <AppConfigLoader />
                 <ServerDefaultsSync />
-                <FileContextProvider enableUrlSync={true} enablePersistence={true}>
-                  <AppInitializer />
+                <FileContextProvider enableUrlSync={true} enablePersistence={true}> 
                   <BrandingAssetManager />
                   <ToolRegistryProvider>
                       <NavigationProvider>
+                        <AppInitializer />
                         <FilesModalProvider>
                           <ToolWorkflowProvider>
                             <HotkeyProvider>

--- a/frontend/src/desktop/hooks/useAppInitialization.ts
+++ b/frontend/src/desktop/hooks/useAppInitialization.ts
@@ -3,6 +3,7 @@ import { useOpenedFile } from '@app/hooks/useOpenedFile';
 import { fileOpenService } from '@app/services/fileOpenService';
 import { useFileManagement } from '@app/contexts/file/fileHooks';
 import { createQuickKey } from '@app/types/fileContext';
+import { useNavigationActions } from '@app/contexts/NavigationContext';
 
 /**
  * App initialization hook
@@ -16,6 +17,7 @@ export function useAppInitialization(): void {
 
   // Handle files opened with app (Tauri mode)
   const { openedFilePaths, loading: openedFileLoading, consumeOpenedFilePaths } = useOpenedFile();
+  const navActions = useNavigationActions();
 
   // Load opened files and add directly to FileContext
   useEffect(() => {
@@ -67,6 +69,8 @@ export function useAppInitialization(): void {
             }
           });
 
+          navActions.actions.setWorkbench('viewer');
+
           console.log(`[Desktop] ${loadedFiles.length} opened file(s) added to FileContext`);
         }
       } catch (error) {
@@ -75,7 +79,7 @@ export function useAppInitialization(): void {
     };
 
     loadOpenedFiles();
-  }, [openedFilePaths, openedFileLoading, addFiles, updateStirlingFileStub, consumeOpenedFilePaths]);
+  }, [openedFilePaths, openedFileLoading, addFiles, updateStirlingFileStub, consumeOpenedFilePaths, navActions]);
 }
 
 export function useSetupCompletion(): (completed: boolean) => void {


### PR DESCRIPTION
## Problem
Fixes #6029

When opening a PDF via "Open with Stirling PDF" on Windows, the file
displays correctly in the viewer but is not automatically selected in
the workbench. The user has to manually select the file a second time
before using any tools.

## Root Cause
`AppInitializer` was rendered before `NavigationProvider` in the
component tree, so `useNavigationActions` threw an error and navigation
to the viewer never happened after files were added to FileContext.

## Fix
Two changes:
1. Moved `<AppInitializer />` inside `<NavigationProvider>` in
   `AppProviders.tsx` so navigation context is available.
2. Added `navActions.setWorkbench('viewer')` in `useAppInitialization.ts`
   after files are added to FileContext, so the workbench automatically
   shows the opened file.

## Testing
- Open a PDF via right-click → "Open with" → Stirling PDF
- File now appears automatically selected in the workbench
- All tools are immediately usable without re-selecting the file