### PR TITLE
Continue on error if CI comments fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,19 @@ jobs:
 
       - name: Fail if Java formatting issues found
         if: steps.spotless-check.outcome == 'failure'
-        run: exit 1
+        run: |
+          echo "============================================"
+          echo "  Java Formatting Check Failed"
+          echo "============================================"
+          echo ""
+          echo "Your code has formatting issues."
+          echo "Run the following command to fix them:"
+          echo ""
+          echo "  ./gradlew spotlessApply"
+          echo ""
+          echo "Then commit and push the changes."
+          echo "============================================"
+          exit 1
 
       - name: Build with Gradle and spring security ${{ matrix.spring-security }}
         run: ./gradlew build -PnoSpotless
@@ -307,7 +319,19 @@ jobs:
             }
       - name: Fail if TypeScript formatting issues found
         if: steps.prettier-check.outcome == 'failure'
-        run: exit 1
+        run: |
+          echo "============================================"
+          echo "  TypeScript Formatting Check Failed"
+          echo "============================================"
+          echo ""
+          echo "Your code has formatting issues."
+          echo "Run the following command to fix them:"
+          echo ""
+          echo "  cd frontend && npm run fix"
+          echo ""
+          echo "Then commit and push the changes."
+          echo "============================================"
+          exit 1
       - name: Type-check frontend
         run: cd frontend && npm run prep && npm run typecheck:all
       - name: Lint frontend

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: Comment on Java formatting failure
         if: steps.spotless-check.outcome == 'failure'
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -266,6 +267,7 @@ jobs:
         continue-on-error: true
       - name: Comment on TypeScript formatting failure
         if: steps.prettier-check.outcome == 'failure'
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |


### PR DESCRIPTION
# Description of Changes
As seen in [this pipeline](https://github.com/Stirling-Tools/Stirling-PDF/actions/runs/24348584788/job/71175211289?pr=6097), the new PR comments from #6052 which tell the user how to fix their formatting don't work on PRs from forks because of permission issues with the GitHub token. 

This PR makes the CI ignore failed PR comments because it is expected to happen on OSS PRs, but also prints the comment to the console since that should always be visible to the user (if slightly less obvious to find than the PR comments were).