### PR TITLE
Have Task choose free ports for dev servers

### DIFF
--- a/.taskfiles/backend.yml
+++ b/.taskfiles/backend.yml
@@ -4,10 +4,15 @@ tasks:
   dev:
     desc: "Start backend dev server"
     ignore_error: true
+    vars:
+      PORT: '{{.PORT | default "8080"}}'
+      AIENGINE_URL: '{{.AIENGINE_URL | default ""}}'
+    env:
+      SERVER_PORT: '{{.PORT}}'
     cmds:
-      - cmd: cmd /c gradlew.bat :stirling-pdf:bootRun
+      - cmd: '{{if .AIENGINE_URL}}AIENGINE_URL="{{.AIENGINE_URL}}" AIENGINE_ENABLED=true {{end}}cmd /c gradlew.bat :stirling-pdf:bootRun'
         platforms: [windows]
-      - cmd: ./gradlew :stirling-pdf:bootRun
+      - cmd: '{{if .AIENGINE_URL}}AIENGINE_URL="{{.AIENGINE_URL}}" AIENGINE_ENABLED=true {{end}}./gradlew :stirling-pdf:bootRun'
         platforms: [linux, darwin]
 
   build:

--- a/.taskfiles/backend.yml
+++ b/.taskfiles/backend.yml
@@ -9,10 +9,12 @@ tasks:
       AIENGINE_URL: '{{.AIENGINE_URL | default ""}}'
     env:
       SERVER_PORT: '{{.PORT}}'
+      AIENGINE_URL: '{{.AIENGINE_URL}}'
+      AIENGINE_ENABLED: '{{if .AIENGINE_URL}}true{{end}}'
     cmds:
-      - cmd: '{{if .AIENGINE_URL}}AIENGINE_URL="{{.AIENGINE_URL}}" AIENGINE_ENABLED=true {{end}}cmd /c gradlew.bat :stirling-pdf:bootRun'
+      - cmd: cmd /c gradlew.bat :stirling-pdf:bootRun
         platforms: [windows]
-      - cmd: '{{if .AIENGINE_URL}}AIENGINE_URL="{{.AIENGINE_URL}}" AIENGINE_ENABLED=true {{end}}./gradlew :stirling-pdf:bootRun'
+      - cmd: ./gradlew :stirling-pdf:bootRun
         platforms: [linux, darwin]
 
   build:

--- a/.taskfiles/backend.yml
+++ b/.taskfiles/backend.yml
@@ -9,12 +9,10 @@ tasks:
       AIENGINE_URL: '{{.AIENGINE_URL | default ""}}'
     env:
       SERVER_PORT: '{{.PORT}}'
-      AIENGINE_URL: '{{.AIENGINE_URL}}'
-      AIENGINE_ENABLED: '{{if .AIENGINE_URL}}true{{end}}'
     cmds:
-      - cmd: cmd /c gradlew.bat :stirling-pdf:bootRun
+      - cmd: '{{if .AIENGINE_URL}}set "AIENGINE_URL={{.AIENGINE_URL}}" && set "AIENGINE_ENABLED=true" && {{end}}cmd /c gradlew.bat :stirling-pdf:bootRun'
         platforms: [windows]
-      - cmd: ./gradlew :stirling-pdf:bootRun
+      - cmd: '{{if .AIENGINE_URL}}AIENGINE_URL={{.AIENGINE_URL}} AIENGINE_ENABLED=true {{end}}./gradlew :stirling-pdf:bootRun'
         platforms: [linux, darwin]
 
   build:

--- a/.taskfiles/desktop.yml
+++ b/.taskfiles/desktop.yml
@@ -6,7 +6,11 @@ vars:
 tasks:
   prepare:
     desc: "Prepare desktop build dependencies"
-    deps: [jlink, ":frontend:prepare:desktop", provisioner]
+    deps:
+      - jlink
+      - task: ":frontend:prepare"
+        vars: { MODE: desktop }
+      - provisioner
 
   provisioner:
     desc: "Build installer provisioner"

--- a/.taskfiles/engine.yml
+++ b/.taskfiles/engine.yml
@@ -28,20 +28,24 @@ tasks:
     deps: [prepare]
     ignore_error: true
     dir: src
+    vars:
+      PORT: '{{.PORT | default "5001"}}'
     env:
       PYTHONUNBUFFERED: "1"
     cmds:
-      - uv run uvicorn stirling.api.app:app --host 0.0.0.0 --port 5001
+      - uv run uvicorn stirling.api.app:app --host 0.0.0.0 --port {{.PORT}}
 
   dev:
     desc: "Start engine dev server with hot reload"
     deps: [prepare]
     ignore_error: true
     dir: src
+    vars:
+      PORT: '{{.PORT | default "5001"}}'
     env:
       PYTHONUNBUFFERED: "1"
     cmds:
-      - uv run uvicorn stirling.api.app:app --host 0.0.0.0 --port 5001 --reload
+      - uv run uvicorn stirling.api.app:app --host 0.0.0.0 --port {{.PORT}} --reload
 
   lint:
     desc: "Run linting"

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -58,10 +58,9 @@ tasks:
       BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
       OPEN: '{{.OPEN | default ""}}'
     env:
-      VITE_DEV_PORT: '{{.PORT}}'
       BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode {{.MODE}}{{if .OPEN}} --open{{end}}
+      - npx vite --mode {{.MODE}} --port {{.PORT}}{{if .OPEN}} --open{{end}}
 
   dev:
     desc: "Start frontend dev server"

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -15,42 +15,21 @@ tasks:
       CI: '{{ .CI | default "false" }}'
 
   prepare:env:
-    desc: "Generate .env from example if missing"
-    run: once
+    internal: true
+    run: when_changed
     deps: [install]
+    vars:
+      MODE: '{{.MODE | default ""}}'
     cmds:
-      - npx tsx scripts/setup-env.ts
+      - npx tsx scripts/setup-env.ts{{if .MODE}} --{{.MODE}}{{end}}
     sources:
       - scripts/setup-env.ts
     generates:
       - .env.local
-
-  prepare:env:saas:
-    desc: "Generate .env and .env.saas from examples if missing"
-    run: once
-    deps: [install]
-    cmds:
-      - npx tsx scripts/setup-env.ts --saas
-    sources:
-      - scripts/setup-env.ts
-    generates:
-      - .env.local
-      - .env.saas.local
-
-  prepare:env:desktop:
-    desc: "Generate .env and .env.desktop from examples if missing"
-    run: once
-    deps: [install]
-    cmds:
-      - npx tsx scripts/setup-env.ts --desktop
-    sources:
-      - scripts/setup-env.ts
-    generates:
-      - .env.local
-      - .env.desktop.local
+      - .env{{if .MODE}}.{{.MODE}}{{end}}.local
 
   prepare:icons:
-    desc: "Generate icon bundle from source references"
+    internal: true
     run: once
     deps: [install]
     cmds:
@@ -58,28 +37,23 @@ tasks:
 
   prepare:
     desc: "Set up dev environment"
-    run: once
-    deps: [prepare:env, prepare:icons]
-
-  prepare:saas:
-    desc: "Prepare for SaaS mode"
-    run: once
-    deps: [prepare:env:saas, prepare:icons]
-
-  prepare:desktop:
-    desc: "Prepare for desktop mode"
-    run: once
-    deps: [prepare:env:desktop, prepare:icons]
+    run: when_changed
+    vars:
+      MODE: '{{.MODE | default ""}}'
+    deps:
+      - task: prepare:env
+        vars: { MODE: '{{.MODE}}' }
+      - prepare:icons
 
   # ============================================================
   # Development
   # ============================================================
 
-  dev:
-    desc: "Start frontend dev server"
-    deps: [prepare]
+  dev:_run:
+    internal: true
     ignore_error: true
     vars:
+      MODE: '{{.MODE}}'
       PORT: '{{.PORT | default "5173"}}'
       BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
       OPEN: '{{.OPEN | default ""}}'
@@ -87,70 +61,52 @@ tasks:
       VITE_DEV_PORT: '{{.PORT}}'
       BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite{{if .OPEN}} --open{{end}}
+      - npx vite --mode {{.MODE}}{{if .OPEN}} --open{{end}}
+
+  dev:
+    desc: "Start frontend dev server"
+    cmds:
+      - task: dev:proprietary
+        vars: { PORT: '{{.PORT}}', BACKEND_URL: '{{.BACKEND_URL}}', OPEN: '{{.OPEN}}' }
 
   dev:core:
     desc: "Start frontend dev server in core mode"
     deps: [prepare]
-    ignore_error: true
-    vars:
-      PORT: '{{.PORT | default "5173"}}'
-      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
-      OPEN: '{{.OPEN | default ""}}'
-    env:
-      VITE_DEV_PORT: '{{.PORT}}'
-      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode core{{if .OPEN}} --open{{end}}
+      - task: dev:_run
+        vars: { MODE: core, PORT: '{{.PORT}}', BACKEND_URL: '{{.BACKEND_URL}}', OPEN: '{{.OPEN}}' }
 
   dev:proprietary:
     desc: "Start frontend dev server in proprietary mode"
     deps: [prepare]
-    ignore_error: true
-    vars:
-      PORT: '{{.PORT | default "5173"}}'
-      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
-      OPEN: '{{.OPEN | default ""}}'
-    env:
-      VITE_DEV_PORT: '{{.PORT}}'
-      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode proprietary{{if .OPEN}} --open{{end}}
+      - task: dev:_run
+        vars: { MODE: proprietary, PORT: '{{.PORT}}', BACKEND_URL: '{{.BACKEND_URL}}', OPEN: '{{.OPEN}}' }
 
   dev:saas:
     desc: "Start frontend dev server in SaaS mode"
-    deps: [prepare:saas]
-    ignore_error: true
-    vars:
-      PORT: '{{.PORT | default "5173"}}'
-      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
-      OPEN: '{{.OPEN | default ""}}'
-    env:
-      VITE_DEV_PORT: '{{.PORT}}'
-      BACKEND_URL: '{{.BACKEND_URL}}'
+    deps:
+      - task: prepare
+        vars: { MODE: saas }
     cmds:
-      - npx vite --mode saas{{if .OPEN}} --open{{end}}
+      - task: dev:_run
+        vars: { MODE: saas, PORT: '{{.PORT}}', BACKEND_URL: '{{.BACKEND_URL}}', OPEN: '{{.OPEN}}' }
 
   dev:desktop:
     desc: "Start frontend dev server in desktop mode"
-    deps: [prepare:desktop]
-    ignore_error: true
+    deps:
+      - task: prepare
+        vars: { MODE: desktop }
     cmds:
-      - npx vite --mode desktop
+      - task: dev:_run
+        vars: { MODE: desktop, PORT: '{{.PORT}}', BACKEND_URL: '{{.BACKEND_URL}}', OPEN: '{{.OPEN}}' }
 
   dev:prototypes:
     desc: "Start frontend dev server in prototypes mode"
     deps: [prepare]
-    ignore_error: true
-    vars:
-      PORT: '{{.PORT | default "5173"}}'
-      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
-      OPEN: '{{.OPEN | default ""}}'
-    env:
-      VITE_DEV_PORT: '{{.PORT}}'
-      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode prototypes{{if .OPEN}} --open{{end}}
+      - task: dev:_run
+        vars: { MODE: prototypes, PORT: '{{.PORT}}', BACKEND_URL: '{{.BACKEND_URL}}', OPEN: '{{.OPEN}}' }
 
   # ============================================================
   # Build
@@ -176,13 +132,17 @@ tasks:
 
   build:saas:
     desc: "Build for SaaS mode"
-    deps: [prepare:saas]
+    deps:
+      - task: prepare
+        vars: { MODE: saas }
     cmds:
       - npx vite build --mode saas
 
   build:desktop:
     desc: "Build for desktop mode"
-    deps: [prepare:desktop]
+    deps:
+      - task: prepare
+        vars: { MODE: desktop }
     cmds:
       - npx vite build --mode desktop
 
@@ -246,13 +206,17 @@ tasks:
 
   typecheck:saas:
     desc: "Typecheck SaaS build variant"
-    deps: [prepare:saas]
+    deps:
+      - task: prepare
+        vars: { MODE: saas }
     cmds:
       - npx tsc --noEmit --project src/saas/tsconfig.json
 
   typecheck:desktop:
     desc: "Typecheck desktop build variant"
-    deps: [prepare:desktop]
+    deps:
+      - task: prepare
+        vars: { MODE: desktop }
     cmds:
       - npx tsc --noEmit --project src/desktop/tsconfig.json
 

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -79,6 +79,12 @@ tasks:
     desc: "Start frontend dev server"
     deps: [prepare]
     ignore_error: true
+    vars:
+      PORT: '{{.PORT | default "5173"}}'
+      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+    env:
+      VITE_DEV_PORT: '{{.PORT}}'
+      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
       - npx vite
 
@@ -86,6 +92,12 @@ tasks:
     desc: "Start frontend dev server in core mode"
     deps: [prepare]
     ignore_error: true
+    vars:
+      PORT: '{{.PORT | default "5173"}}'
+      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+    env:
+      VITE_DEV_PORT: '{{.PORT}}'
+      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
       - npx vite --mode core
 
@@ -93,6 +105,12 @@ tasks:
     desc: "Start frontend dev server in proprietary mode"
     deps: [prepare]
     ignore_error: true
+    vars:
+      PORT: '{{.PORT | default "5173"}}'
+      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+    env:
+      VITE_DEV_PORT: '{{.PORT}}'
+      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
       - npx vite --mode proprietary
 
@@ -100,6 +118,12 @@ tasks:
     desc: "Start frontend dev server in SaaS mode"
     deps: [prepare:saas]
     ignore_error: true
+    vars:
+      PORT: '{{.PORT | default "5173"}}'
+      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+    env:
+      VITE_DEV_PORT: '{{.PORT}}'
+      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
       - npx vite --mode saas
 
@@ -114,6 +138,12 @@ tasks:
     desc: "Start frontend dev server in prototypes mode"
     deps: [prepare]
     ignore_error: true
+    vars:
+      PORT: '{{.PORT | default "5173"}}'
+      BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+    env:
+      VITE_DEV_PORT: '{{.PORT}}'
+      BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
       - npx vite --mode prototypes
 

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -82,11 +82,12 @@ tasks:
     vars:
       PORT: '{{.PORT | default "5173"}}'
       BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+      OPEN: '{{.OPEN | default ""}}'
     env:
       VITE_DEV_PORT: '{{.PORT}}'
       BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite
+      - npx vite{{if .OPEN}} --open{{end}}
 
   dev:core:
     desc: "Start frontend dev server in core mode"
@@ -95,11 +96,12 @@ tasks:
     vars:
       PORT: '{{.PORT | default "5173"}}'
       BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+      OPEN: '{{.OPEN | default ""}}'
     env:
       VITE_DEV_PORT: '{{.PORT}}'
       BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode core
+      - npx vite --mode core{{if .OPEN}} --open{{end}}
 
   dev:proprietary:
     desc: "Start frontend dev server in proprietary mode"
@@ -108,11 +110,12 @@ tasks:
     vars:
       PORT: '{{.PORT | default "5173"}}'
       BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+      OPEN: '{{.OPEN | default ""}}'
     env:
       VITE_DEV_PORT: '{{.PORT}}'
       BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode proprietary
+      - npx vite --mode proprietary{{if .OPEN}} --open{{end}}
 
   dev:saas:
     desc: "Start frontend dev server in SaaS mode"
@@ -121,11 +124,12 @@ tasks:
     vars:
       PORT: '{{.PORT | default "5173"}}'
       BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+      OPEN: '{{.OPEN | default ""}}'
     env:
       VITE_DEV_PORT: '{{.PORT}}'
       BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode saas
+      - npx vite --mode saas{{if .OPEN}} --open{{end}}
 
   dev:desktop:
     desc: "Start frontend dev server in desktop mode"
@@ -141,11 +145,12 @@ tasks:
     vars:
       PORT: '{{.PORT | default "5173"}}'
       BACKEND_URL: '{{.BACKEND_URL | default "http://localhost:8080"}}'
+      OPEN: '{{.OPEN | default ""}}'
     env:
       VITE_DEV_PORT: '{{.PORT}}'
       BACKEND_URL: '{{.BACKEND_URL}}'
     cmds:
-      - npx vite --mode prototypes
+      - npx vite --mode prototypes{{if .OPEN}} --open{{end}}
 
   # ============================================================
   # Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This file provides guidance to AI Agents when working with code in this reposito
 
 This project uses [Task](https://taskfile.dev/) as a unified command runner. All build, dev, test, lint, and docker commands can be run from the repo root via `task <command>`. Run `task --list` to see all available commands.
 
+Task `desc:` fields should describe **what** the task does, not **how** it does it. Keep them generic and stable: don't reference implementation details like aliases, internal helpers, mode flags, or which other task delegates to which. The description is for users picking a command from `task --list`, not a changelog of refactors.
+
 ### Quick Reference
 - `task install` — install all dependencies
 - `task dev` — start backend + frontend concurrently
@@ -143,7 +145,7 @@ The project structure is defined in `engine/pyproject.toml`. Any new dependencie
 - These files are committed to Git and must not contain private keys
 - Local overrides (API keys, machine-specific settings) go in uncommitted sibling `.env.local` / `.env.saas.local` / `.env.desktop.local` files — Vite automatically layers them on top
 - Never use `|| 'hardcoded-fallback'` inline — put defaults in the committed env files
-- `task frontend:prepare` / `prepare:saas` / `prepare:desktop` create empty `.local` override files on first run
+- `task frontend:prepare` creates empty `.local` override files on first run; pass `MODE=saas` or `MODE=desktop` to also create the mode-specific `.local` file
 - Prepare runs automatically as a dependency of all `dev*`, `build*`, and `desktop*` tasks
 - See `frontend/README.md#environment-variables` for full documentation
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,17 +35,41 @@ tasks:
   # ============================================================
 
   dev:
-    desc: "Start backend + frontend concurrently"
+    desc: "Start backend + frontend concurrently on free ports"
+    vars:
+      PORTS:
+        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Count 2{{else}}bash scripts/find-free-port.sh 2{{end}}'
+      BACKEND_PORT: '{{index (splitList "\n" .PORTS) 0}}'
+      FRONTEND_PORT: '{{index (splitList "\n" .PORTS) 1}}'
     deps:
-      - backend:dev
-      - frontend:dev
+      - task: backend:dev
+        vars:
+          PORT: '{{.BACKEND_PORT}}'
+      - task: frontend:dev
+        vars:
+          PORT: '{{.FRONTEND_PORT}}'
+          BACKEND_URL: 'http://localhost:{{.BACKEND_PORT}}'
 
   dev:all:
-    desc: "Start backend + frontend + engine concurrently"
+    desc: "Start backend + frontend + engine concurrently on free ports"
+    vars:
+      PORTS:
+        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Count 3{{else}}bash scripts/find-free-port.sh 3{{end}}'
+      BACKEND_PORT: '{{index (splitList "\n" .PORTS) 0}}'
+      FRONTEND_PORT: '{{index (splitList "\n" .PORTS) 1}}'
+      ENGINE_PORT: '{{index (splitList "\n" .PORTS) 2}}'
     deps:
-      - backend:dev
-      - frontend:dev:prototypes
-      - engine:dev
+      - task: engine:dev
+        vars:
+          PORT: '{{.ENGINE_PORT}}'
+      - task: backend:dev
+        vars:
+          PORT: '{{.BACKEND_PORT}}'
+          AIENGINE_URL: 'http://localhost:{{.ENGINE_PORT}}'
+      - task: frontend:dev:prototypes
+        vars:
+          PORT: '{{.FRONTEND_PORT}}'
+          BACKEND_URL: 'http://localhost:{{.BACKEND_PORT}}'
 
   # ============================================================
   # Build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,6 +49,7 @@ tasks:
         vars:
           PORT: '{{.FRONTEND_PORT}}'
           BACKEND_URL: 'http://localhost:{{.BACKEND_PORT}}'
+          OPEN: "true"
 
   dev:all:
     desc: "Start backend + frontend + engine concurrently on free ports"
@@ -70,6 +71,7 @@ tasks:
         vars:
           PORT: '{{.FRONTEND_PORT}}'
           BACKEND_URL: 'http://localhost:{{.BACKEND_PORT}}'
+          OPEN: "true"
 
   # ============================================================
   # Build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
     desc: "Start backend + frontend concurrently on free ports"
     vars:
       PORTS:
-        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Count 2{{else}}bash scripts/find-free-port.sh 2{{end}}'
+        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Preferred 8080,5173{{else}}bash scripts/find-free-port.sh 8080 5173{{end}}'
       BACKEND_PORT: '{{index (splitList "\n" .PORTS) 0}}'
       FRONTEND_PORT: '{{index (splitList "\n" .PORTS) 1}}'
     deps:
@@ -55,7 +55,7 @@ tasks:
     desc: "Start backend + frontend + engine concurrently on free ports"
     vars:
       PORTS:
-        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Count 3{{else}}bash scripts/find-free-port.sh 3{{end}}'
+        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Preferred 8080,5173,5001{{else}}bash scripts/find-free-port.sh 8080 5173 5001{{end}}'
       BACKEND_PORT: '{{index (splitList "\n" .PORTS) 0}}'
       FRONTEND_PORT: '{{index (splitList "\n" .PORTS) 1}}'
       ENGINE_PORT: '{{index (splitList "\n" .PORTS) 2}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,10 @@ version: '3'
 
 output: prefixed
 
+vars:
+  FIND_FREE_PORT_PS: powershell -NoProfile -File scripts\find-free-port.ps1 -Preferred
+  FIND_FREE_PORT_SH: bash scripts/find-free-port.sh
+
 includes:
   backend:
     taskfile: .taskfiles/backend.yml
@@ -38,7 +42,7 @@ tasks:
     desc: "Start backend + frontend concurrently on free ports"
     vars:
       PORTS:
-        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Preferred 8080,5173{{else}}bash scripts/find-free-port.sh 8080 5173{{end}}'
+        sh: '{{if eq OS "windows"}}{{.FIND_FREE_PORT_PS}} 8080,5173{{else}}{{.FIND_FREE_PORT_SH}} 8080 5173{{end}}'
       BACKEND_PORT: '{{index (splitList "\n" .PORTS) 0}}'
       FRONTEND_PORT: '{{index (splitList "\n" .PORTS) 1}}'
     deps:
@@ -55,7 +59,7 @@ tasks:
     desc: "Start backend + frontend + engine concurrently on free ports"
     vars:
       PORTS:
-        sh: '{{if eq OS "windows"}}powershell -NoProfile -File scripts\find-free-port.ps1 -Preferred 8080,5173,5001{{else}}bash scripts/find-free-port.sh 8080 5173 5001{{end}}'
+        sh: '{{if eq OS "windows"}}{{.FIND_FREE_PORT_PS}} 8080,5173,5001{{else}}{{.FIND_FREE_PORT_SH}} 8080 5173 5001{{end}}'
       BACKEND_PORT: '{{index (splitList "\n" .PORTS) 0}}'
       FRONTEND_PORT: '{{index (splitList "\n" .PORTS) 1}}'
       ENGINE_PORT: '{{index (splitList "\n" .PORTS) 2}}'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,6 +39,21 @@ export default defineConfig(({ mode }) => {
 
   const tsconfigProject = TSCONFIG_MAP[effectiveMode];
 
+  // Dev server port: default 5173 (matches tauri.conf.json devUrl).
+  // Override via VITE_DEV_PORT env var; 0 lets the OS pick a free port.
+  const devPort = process.env.VITE_DEV_PORT
+    ? parseInt(process.env.VITE_DEV_PORT, 10)
+    : 5173;
+  // Backend proxy target: default localhost:8080. Override via BACKEND_URL env var
+  // so the top-level dev launcher can wire a dynamically-assigned backend port.
+  const backendUrl = process.env.BACKEND_URL || "http://localhost:8080";
+  const backendProxy = {
+    target: backendUrl,
+    changeOrigin: true,
+    secure: false,
+    xfwd: true,
+  };
+
   return {
     plugins: [
       react(),
@@ -75,10 +90,10 @@ export default defineConfig(({ mode }) => {
     ],
     server: {
       host: true,
-      // make sure this port matches the devUrl port in tauri.conf.json file
-      port: 5173,
-      // Tauri expects a fixed port, fail if that port is not available
-      strictPort: true,
+      port: devPort,
+      // Tauri expects a fixed port, and we generally want strict behaviour,
+      // except when the caller requested an OS-assigned port (0).
+      strictPort: devPort !== 0,
       watch: {
         // tell vite to ignore watching `src-tauri`
         ignored: ["**/src-tauri/**"],
@@ -88,48 +103,13 @@ export default defineConfig(({ mode }) => {
         effectiveMode === "desktop"
           ? undefined
           : {
-              "/api": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                secure: false,
-                xfwd: true,
-              },
-              "/oauth2": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                secure: false,
-                xfwd: true,
-              },
-              "/saml2": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                secure: false,
-                xfwd: true,
-              },
-              "/login/oauth2": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                secure: false,
-                xfwd: true,
-              },
-              "/login/saml2": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                secure: false,
-                xfwd: true,
-              },
-              "/swagger-ui": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                secure: false,
-                xfwd: true,
-              },
-              "/v1/api-docs": {
-                target: "http://localhost:8080",
-                changeOrigin: true,
-                secure: false,
-                xfwd: true,
-              },
+              "/api": backendProxy,
+              "/oauth2": backendProxy,
+              "/saml2": backendProxy,
+              "/login/oauth2": backendProxy,
+              "/login/saml2": backendProxy,
+              "/swagger-ui": backendProxy,
+              "/v1/api-docs": backendProxy,
             },
     },
     base: env.RUN_SUBPATH ? `/${env.RUN_SUBPATH}` : "./",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,11 +39,6 @@ export default defineConfig(({ mode }) => {
 
   const tsconfigProject = TSCONFIG_MAP[effectiveMode];
 
-  // Dev server port: default 5173 (matches tauri.conf.json devUrl).
-  // Override via VITE_DEV_PORT env var; 0 lets the OS pick a free port.
-  const devPort = process.env.VITE_DEV_PORT
-    ? parseInt(process.env.VITE_DEV_PORT, 10)
-    : 5173;
   // Backend proxy target: default localhost:8080. Override via BACKEND_URL env var
   // so the top-level dev launcher can wire a dynamically-assigned backend port.
   const backendUrl = process.env.BACKEND_URL || "http://localhost:8080";
@@ -90,10 +85,10 @@ export default defineConfig(({ mode }) => {
     ],
     server: {
       host: true,
-      port: devPort,
-      // Tauri expects a fixed port, and we generally want strict behaviour,
-      // except when the caller requested an OS-assigned port (0).
-      strictPort: devPort !== 0,
+      // make sure this port matches the devUrl port in tauri.conf.json file
+      port: 5173,
+      // Tauri expects a fixed port, fail if that port is not available
+      strictPort: true,
       watch: {
         // tell vite to ignore watching `src-tauri`
         ignored: ["**/src-tauri/**"],

--- a/scripts/find-free-port.ps1
+++ b/scripts/find-free-port.ps1
@@ -1,0 +1,18 @@
+# Prints N distinct free TCP ports on stdout, one per line.
+#
+# Binds N TcpListeners to port 0 simultaneously, so the OS assigns N distinct
+# ports. Listeners are released once we've collected their ports.
+param([int]$Count = 1)
+
+$listeners = @()
+for ($i = 0; $i -lt $Count; $i++) {
+    $l = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $l.Start()
+    $listeners += $l
+}
+foreach ($l in $listeners) {
+    Write-Output $l.LocalEndpoint.Port
+}
+foreach ($l in $listeners) {
+    $l.Stop()
+}

--- a/scripts/find-free-port.ps1
+++ b/scripts/find-free-port.ps1
@@ -1,18 +1,41 @@
-# Prints N distinct free TCP ports on stdout, one per line.
+# Prints one free TCP port per preferred port given as an argument.
 #
-# Binds N TcpListeners to port 0 simultaneously, so the OS assigns N distinct
-# ports. Listeners are released once we've collected their ports.
-param([int]$Count = 1)
+# For each element of -Preferred, emits that port if it's free; otherwise
+# emits a random free port in 20000-49999. Probes by attempting to bind a
+# TcpListener on loopback. Tracks picks within this run so outputs are
+# guaranteed distinct from each other.
+param([int[]]$Preferred)
 
-$listeners = @()
-for ($i = 0; $i -lt $Count; $i++) {
-    $l = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
-    $l.Start()
-    $listeners += $l
+$script:picked = @()
+
+function Test-PortFree {
+    param([int]$Port)
+    if ($script:picked -contains $Port) { return $false }
+    try {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
+        $listener.Start()
+        $listener.Stop()
+        return $true
+    } catch {
+        return $false
+    }
 }
-foreach ($l in $listeners) {
-    Write-Output $l.LocalEndpoint.Port
+
+function Get-RandomFreePort {
+    while ($true) {
+        $port = Get-Random -Minimum 20000 -Maximum 50000
+        if (Test-PortFree $port) { return $port }
+    }
 }
-foreach ($l in $listeners) {
-    $l.Stop()
+
+foreach ($p in $Preferred) {
+    if (Test-PortFree $p) {
+        $script:picked += $p
+    } else {
+        $script:picked += Get-RandomFreePort
+    }
+}
+
+foreach ($p in $script:picked) {
+    Write-Output $p
 }

--- a/scripts/find-free-port.ps1
+++ b/scripts/find-free-port.ps1
@@ -37,5 +37,5 @@ foreach ($p in $Preferred) {
 }
 
 foreach ($p in $script:picked) {
-    Write-Output $p
+    [Console]::Out.Write("$p`n")
 }

--- a/scripts/find-free-port.sh
+++ b/scripts/find-free-port.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Prints N distinct free TCP ports on stdout, one per line.
+#
+# Picks random ports in 20000-49999, probes via bash's /dev/tcp pseudo-device
+# (connect failure = nobody listening), and tracks picks within this run so
+# consecutive ports are guaranteed distinct from each other.
+set -euo pipefail
+
+count="${1:-1}"
+declare -a picked=()
+
+while [ "${#picked[@]}" -lt "$count" ]; do
+  port=$((RANDOM % 30000 + 20000))
+  dup=0
+  for p in ${picked[@]+"${picked[@]}"}; do
+    if [ "$p" = "$port" ]; then dup=1; break; fi
+  done
+  if [ "$dup" = 1 ]; then continue; fi
+  if ! (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1; then
+    picked+=("$port")
+  fi
+  exec 3<&- 2>/dev/null || true
+done
+
+for p in "${picked[@]}"; do
+  echo "$p"
+done

--- a/scripts/find-free-port.sh
+++ b/scripts/find-free-port.sh
@@ -1,25 +1,42 @@
 #!/usr/bin/env bash
-# Prints N distinct free TCP ports on stdout, one per line.
+# Prints one free TCP port per preferred port given as an argument.
 #
-# Picks random ports in 20000-49999, probes via bash's /dev/tcp pseudo-device
-# (connect failure = nobody listening), and tracks picks within this run so
-# consecutive ports are guaranteed distinct from each other.
+# For each argument, emits that port if it's free; otherwise emits a random
+# free port in 20000-49999. Probes via bash's /dev/tcp pseudo-device (connect
+# failure = nobody listening). Tracks picks within this run so outputs are
+# guaranteed distinct from each other.
 set -euo pipefail
 
-count="${1:-1}"
 declare -a picked=()
 
-while [ "${#picked[@]}" -lt "$count" ]; do
-  port=$((RANDOM % 30000 + 20000))
-  dup=0
+is_free() {
+  local port=$1
   for p in ${picked[@]+"${picked[@]}"}; do
-    if [ "$p" = "$port" ]; then dup=1; break; fi
+    if [ "$p" = "$port" ]; then return 1; fi
   done
-  if [ "$dup" = 1 ]; then continue; fi
-  if ! (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1; then
-    picked+=("$port")
+  if (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1; then
+    exec 3<&- 2>/dev/null || true
+    return 1
   fi
-  exec 3<&- 2>/dev/null || true
+  return 0
+}
+
+random_free_port() {
+  while true; do
+    local port=$((RANDOM % 30000 + 20000))
+    if is_free "$port"; then
+      echo "$port"
+      return
+    fi
+  done
+}
+
+for preferred in "$@"; do
+  if is_free "$preferred"; then
+    picked+=("$preferred")
+  else
+    picked+=("$(random_free_port)")
+  fi
 done
 
 for p in "${picked[@]}"; do

--- a/scripts/find-free-port.sh
+++ b/scripts/find-free-port.sh
@@ -15,7 +15,6 @@ is_free() {
     if [ "$p" = "$port" ]; then return 1; fi
   done
   if (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1; then
-    exec 3<&- 2>/dev/null || true
     return 1
   fi
   return 0


### PR DESCRIPTION
# Description of Changes
Change root `task dev` and `task dev:all` jobs so they attempt to use the default ports, but if they're in use, it automatically selects free ports and spawns the servers on those ports. This makes it much easier to work on multiple branches at once (for reviewing etc.) because it makes it trivial to run multiple separate servers at the same time.

The `frontend:dev` etc. jobs **do not** automatically choose a free port as part of this work. It's only for the top-level `dev` jobs. This was a judgement call from me that you probably don't want them running on random ports because the other servers need to know the port numbers. We could always change it in the future though if people want that functionality.