### PR TITLE
fix edge translation bug

### DIFF
--- a/frontend/src/core/utils/patchDomForTranslators.ts
+++ b/frontend/src/core/utils/patchDomForTranslators.ts
@@ -1,30 +1,12 @@
-// Browser page translators (Edge, Chrome / Google Translate, accessibility
-// overlays, extensions) rewrite text nodes by wrapping them in injected <font>
-// elements. That changes the parent of text nodes React is holding references
-// to, so when React's commit phase later tries to remove or reinsert those
-// nodes it throws:
+// Browser page translators (Edge, Chrome, extensions) wrap text nodes in
+// injected <font> elements, reparenting nodes React is holding. React's commit
+// phase then throws NotFoundError on removeChild/insertBefore and the
+// ErrorBoundary unmounts the app. https://github.com/facebook/react/issues/11538
 //
-//   NotFoundError: Failed to execute 'removeChild' on 'Node':
-//     The node to be removed is not a child of this node.
-//   NotFoundError: Failed to execute 'insertBefore' on 'Node':
-//     The node before which the new node is to be inserted is not a child of this node.
-//
-// The ErrorBoundary above the app catches the exception and unmounts the whole
-// tree, so the user sees "Something went wrong" instead of the app.
-// See: https://github.com/facebook/react/issues/11538.
-//
-// Strategy: DON'T patch Node.prototype eagerly (doing so globally changes DOM
-// semantics for every library on the page and could silently hide real bugs).
-// Instead, watch for translator fingerprints via a MutationObserver and only
-// install the prototype guards once we actually see one. For the overwhelming
-// majority of users (no translator active) this module is a no-op beyond a
-// passive observer.
-//
-// Fingerprints we watch for:
-//   - <html class="translated-ltr"> / "translated-rtl" — set by Google Translate
-//   - <font> element inserted anywhere in the document — both Edge and Chrome
-//     translators (and most accessibility overlays) use <font> wrappers; React
-//     never emits <font>, so any such node is an external mutation.
+// We watch for translator fingerprints (Google Translate's translated-* class
+// on <html>, or any injected <font>) and install guards on Node.prototype only
+// once one appears, so native DOM semantics are preserved when no translator
+// is active.
 
 declare global {
   interface Node {

--- a/frontend/src/core/utils/patchDomForTranslators.ts
+++ b/frontend/src/core/utils/patchDomForTranslators.ts
@@ -55,7 +55,8 @@ function applyDomPatch(trigger: string): void {
 }
 
 export function armTranslatorDetector(): void {
-  if (typeof window === "undefined" || typeof MutationObserver === "undefined") return;
+  if (typeof window === "undefined" || typeof MutationObserver === "undefined")
+    return;
   if (typeof document === "undefined" || !document.documentElement) return;
 
   // Edge case: class already set (e.g., bfcache restore).
@@ -66,7 +67,11 @@ export function armTranslatorDetector(): void {
 
   const observer = new MutationObserver((mutations) => {
     for (const m of mutations) {
-      if (m.type === "attributes" && m.target === document.documentElement && isGoogleTranslateActive()) {
+      if (
+        m.type === "attributes" &&
+        m.target === document.documentElement &&
+        isGoogleTranslateActive()
+      ) {
         applyDomPatch("<html> translated-* class appeared");
         observer.disconnect();
         return;

--- a/frontend/src/core/utils/patchDomForTranslators.ts
+++ b/frontend/src/core/utils/patchDomForTranslators.ts
@@ -1,0 +1,112 @@
+// Browser page translators (Edge, Chrome / Google Translate, accessibility
+// overlays, extensions) rewrite text nodes by wrapping them in injected <font>
+// elements. That changes the parent of text nodes React is holding references
+// to, so when React's commit phase later tries to remove or reinsert those
+// nodes it throws:
+//
+//   NotFoundError: Failed to execute 'removeChild' on 'Node':
+//     The node to be removed is not a child of this node.
+//   NotFoundError: Failed to execute 'insertBefore' on 'Node':
+//     The node before which the new node is to be inserted is not a child of this node.
+//
+// The ErrorBoundary above the app catches the exception and unmounts the whole
+// tree, so the user sees "Something went wrong" instead of the app.
+// See: https://github.com/facebook/react/issues/11538.
+//
+// Strategy: DON'T patch Node.prototype eagerly (doing so globally changes DOM
+// semantics for every library on the page and could silently hide real bugs).
+// Instead, watch for translator fingerprints via a MutationObserver and only
+// install the prototype guards once we actually see one. For the overwhelming
+// majority of users (no translator active) this module is a no-op beyond a
+// passive observer.
+//
+// Fingerprints we watch for:
+//   - <html class="translated-ltr"> / "translated-rtl" — set by Google Translate
+//   - <font> element inserted anywhere in the document — both Edge and Chrome
+//     translators (and most accessibility overlays) use <font> wrappers; React
+//     never emits <font>, so any such node is an external mutation.
+
+declare global {
+  interface Node {
+    __stirlingTranslatorPatched?: boolean;
+  }
+}
+
+let patchApplied = false;
+
+function isGoogleTranslateActive(): boolean {
+  const cls = document.documentElement.classList;
+  return cls.contains("translated-ltr") || cls.contains("translated-rtl");
+}
+
+function applyDomPatch(trigger: string): void {
+  if (patchApplied) return;
+  if (typeof Node === "undefined" || !Node.prototype) return;
+  if (Node.prototype.__stirlingTranslatorPatched) return;
+  patchApplied = true;
+  Node.prototype.__stirlingTranslatorPatched = true;
+
+  console.warn(
+    `[dom-patch] Browser page translator detected (${trigger}). ` +
+      "Installing removeChild/insertBefore guards to prevent React crashes. " +
+      "The UI may show minor glitches while the translator is active.",
+  );
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function patchedRemoveChild<T extends Node>(
+    this: Node,
+    child: T,
+  ): T {
+    if (child.parentNode !== this) return child;
+    return originalRemoveChild.call(this, child) as T;
+  } as typeof Node.prototype.removeChild;
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function patchedInsertBefore<T extends Node>(
+    this: Node,
+    newNode: T,
+    referenceNode: Node | null,
+  ): T {
+    if (referenceNode && referenceNode.parentNode !== this) return newNode;
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  } as typeof Node.prototype.insertBefore;
+}
+
+export function armTranslatorDetector(): void {
+  if (typeof window === "undefined" || typeof MutationObserver === "undefined") return;
+  if (typeof document === "undefined" || !document.documentElement) return;
+
+  // Edge case: class already set (e.g., bfcache restore).
+  if (isGoogleTranslateActive()) {
+    applyDomPatch("html class was already translated-* on arm");
+    return;
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      if (m.type === "attributes" && m.target === document.documentElement && isGoogleTranslateActive()) {
+        applyDomPatch("<html> translated-* class appeared");
+        observer.disconnect();
+        return;
+      }
+      if (m.type === "childList") {
+        for (const n of m.addedNodes) {
+          if (n.nodeName === "FONT") {
+            applyDomPatch("<font> element injected into DOM");
+            observer.disconnect();
+            return;
+          }
+        }
+      }
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+    childList: true,
+    subtree: true,
+  });
+}
+
+armTranslatorDetector();

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,3 +1,8 @@
+// Must be imported before React so the DOM-prototype patch is installed
+// before React's commit phase runs. Prevents browser page translators
+// (Edge / Google Translate / extensions) from crashing the app via
+// parent-mismatch DOMExceptions. See the module for details.
+import "@app/utils/patchDomForTranslators";
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
 import "../vite-env.d.ts"; // eslint-disable-line no-restricted-imports -- Outside app paths


### PR DESCRIPTION
# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
