### PR TITLE
Fix Merge viewer-mode auto-switch sidebar home navigation webkit

### DIFF
--- a/frontend/src/core/components/shared/quickAccessBar/ActiveToolButton.tsx
+++ b/frontend/src/core/components/shared/quickAccessBar/ActiveToolButton.tsx
@@ -169,13 +169,16 @@ const ActiveToolButton: React.FC<ActiveToolButtonProps> = ({
                   component="a"
                   href={getHomeNavigation().href}
                   onClick={(e: React.MouseEvent) => {
+                    const homeHref = getHomeNavigation().href;
                     const performNavigation = () => {
                       setActiveButton("tools");
                       handleBackToTools();
-                      // Explicit navigation: the state→URL sync in
-                      // useNavigationUrlSync does not reliably fire on webkit
-                      // when triggered only by selectedTool → null.
-                      navigate("/");
+                      // Mirror the anchor's href via the router. The state→URL
+                      // sync in useNavigationUrlSync (selectedTool → null →
+                      // clearToolRoute) does not fire reliably on webkit; this
+                      // keeps the URL in lockstep with the declared destination
+                      // on every browser.
+                      navigate(homeHref);
                     };
                     if (hasUnsavedChanges) {
                       e.preventDefault();

--- a/frontend/src/core/components/shared/quickAccessBar/ActiveToolButton.tsx
+++ b/frontend/src/core/components/shared/quickAccessBar/ActiveToolButton.tsx
@@ -13,6 +13,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ActionIcon, Divider } from "@mantine/core";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
@@ -42,6 +43,7 @@ const ActiveToolButton: React.FC<ActiveToolButtonProps> = ({
   const { hasUnsavedChanges } = useNavigationState();
   const { actions: navigationActions } = useNavigationActions();
   const { getHomeNavigation } = useSidebarNavigation();
+  const navigate = useNavigate();
 
   // Determine if the indicator should be visible (do not require selectedTool to be resolved yet)
   // Special case: multiTool should always show even when sidebars are hidden
@@ -170,6 +172,10 @@ const ActiveToolButton: React.FC<ActiveToolButtonProps> = ({
                     const performNavigation = () => {
                       setActiveButton("tools");
                       handleBackToTools();
+                      // Explicit navigation: the state→URL sync in
+                      // useNavigationUrlSync does not reliably fire on webkit
+                      // when triggered only by selectedTool → null.
+                      navigate("/");
                     };
                     if (hasUnsavedChanges) {
                       e.preventDefault();

--- a/frontend/src/core/tools/Merge.tsx
+++ b/frontend/src/core/tools/Merge.tsx
@@ -46,7 +46,7 @@ const Merge = (props: BaseToolProps) => {
       hasAutoSwitchedRef.current = true;
       navActions.setWorkbench("fileEditor");
     }
-  }, []);
+  }, [isViewerMode, navActions]);
   const naturalCompare = useCallback((a: string, b: string): number => {
     const isDigit = (char: string) => char >= "0" && char <= "9";
 


### PR DESCRIPTION
Merge.tsx:
  The auto-switch effect that moves the workbench out of "viewer" mode
  had [] dependencies, so it only evaluated on mount. Files uploaded
  after navigating to /merge flip the workbench to "viewer" after mount,
  leaving the effect's isViewerMode check stale — the run button stays
  disabled with the "Merge needs 2 or more files" hint even though two
  files are selected. Add isViewerMode and navActions to the deps so the
  effect reacts to the state change (the ref still prevents repeat
  switches per mount).

ActiveToolButton.tsx:
  The sidebar "active tool" button renders as <a href="/"> and relies on
  a chain: onClick → handleBackToTools → setSelectedTool(null) →
  useNavigationUrlSync effect → pushState("/"). On webkit this chain
  does not reliably update the URL, so the user stays on the tool page
  even after clicking the breadcrumb. Make navigation explicit by
  calling navigate("/") alongside the state updates.

# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
