### PR TITLE
fix: skip translation key extraction for files without i18n usage

### DIFF
--- a/frontend/src/core/tests/missingTranslations.test.ts
+++ b/frontend/src/core/tests/missingTranslations.test.ts
@@ -21,6 +21,7 @@ const IGNORED_FILE_PATTERNS = [
 const IGNORED_KEYS = new Set<string>([
   // If the script has found a false-positive that shouldn't be in the translations, include it here
 ]);
+const LIKELY_TRANSLATION_USAGE_RE = /(?:^|[^\w$])t\s*\(|\.t\s*\(|\bi18nKey\b/;
 
 type FoundKey = {
   key: string;
@@ -90,6 +91,10 @@ const getScriptKind = (file: string): ts.ScriptKind => {
  */
 const extractKeys = (file: string): FoundKey[] => {
   const code = fs.readFileSync(file, "utf8");
+  if (!LIKELY_TRANSLATION_USAGE_RE.test(code)) {
+    return [];
+  }
+
   const sourceFile = ts.createSourceFile(
     file,
     code,


### PR DESCRIPTION
# Description of Changes

Please provide a summary of the changes, including:

- Added a lightweight regular expression check to detect likely translation usage before parsing files for translation keys.
- Skipped key extraction early for files that do not contain `t(...)`, `.t(...)`, or `i18nKey` usage.
- This change was made to reduce unnecessary TypeScript parsing work and avoid scanning files that cannot contain relevant translation references.
- No major challenges were encountered.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
