### PR TITLE
build: Add Sync app version to AUR PKGBUILD files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,10 +89,12 @@ def appVersionStr = project.version.toString()
 def tauriConfigPath = layout.projectDirectory.file('frontend/src-tauri/tauri.conf.json').asFile.path
 def sim1Path = layout.projectDirectory.file('frontend/src/core/testing/serverExperienceSimulations.ts').asFile.path
 def sim2Path = layout.projectDirectory.file('frontend/src/proprietary/testing/serverExperienceSimulations.ts').asFile.path
+def aurDesktopPkgbuildPath = layout.projectDirectory.file('.github/aur/stirling-pdf-desktop/PKGBUILD').asFile.path
+def aurServerPkgbuildPath = layout.projectDirectory.file('.github/aur/stirling-pdf-server-bin/PKGBUILD').asFile.path
 
 tasks.register('syncAppVersion') {
     group = 'versioning'
-    description = 'Synchronizes app version across desktop and simulation configs.'
+    description = 'Synchronizes app version across desktop, simulation, and AUR PKGBUILD configs.'
 
     doLast {
         println "Synchronizing application version to ${appVersionStr}"
@@ -115,6 +117,20 @@ tasks.register('syncAppVersion') {
                     throw new GradleException("Could not locate appVersion in ${f} for synchronization")
                 }
                 def updatedContent = matcher.replaceFirst("${matcher.group(1)}${appVersionStr}${matcher.group(4)}")
+                if (content != updatedContent) {
+                    f.write(updatedContent, 'UTF-8')
+                }
+            }
+        }
+
+        [new File(aurDesktopPkgbuildPath), new File(aurServerPkgbuildPath)].each { f ->
+            if (f.exists()) {
+                def content = f.getText('UTF-8')
+                def matcher = (content =~ /(?m)^(pkgver=)(.*)$/)
+                if (!matcher.find()) {
+                    throw new GradleException("Could not locate pkgver in ${f} for synchronization")
+                }
+                def updatedContent = matcher.replaceFirst("\$1${appVersionStr}")
                 if (content != updatedContent) {
                     f.write(updatedContent, 'UTF-8')
                 }


### PR DESCRIPTION
# Description of Changes

This PR extends the `syncAppVersion` Gradle task to also update AUR package metadata.

- Added file paths for:
  - `.github/aur/stirling-pdf-desktop/PKGBUILD`
  - `.github/aur/stirling-pdf-server-bin/PKGBUILD`
- Updated `syncAppVersion` to synchronize the `pkgver=` line in both AUR `PKGBUILD` files.
- Added regex-based replacement for `pkgver`.
- Added a `GradleException` when a `PKGBUILD` file exists but does not contain a `pkgver=` line.
- Avoided unnecessary file rewrites by only writing when the content actually changes.
- Updated the task description to mention desktop, simulation, and AUR `PKGBUILD` synchronization.

This change ensures AUR package versions stay aligned with the application version during version synchronization.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
