### PR TITLE
bug fixes for some desktop tools

### DIFF
--- a/frontend/src/core/components/tools/certSign/modals/CertificateConfigModal.tsx
+++ b/frontend/src/core/components/tools/certSign/modals/CertificateConfigModal.tsx
@@ -112,9 +112,7 @@ export const CertificateConfigModal: React.FC<CertificateConfigModalProps> = ({
           subjectName: string | null;
           notAfter: string | null;
           error: string | null;
-        }>(endpoint, formData, {
-          headers: { "Content-Type": "multipart/form-data" },
-        });
+        }>(endpoint, formData);
 
         if (response.data.valid) {
           setCertValidation({

--- a/frontend/src/core/hooks/tools/getPdfInfo/useGetPdfInfoOperation.ts
+++ b/frontend/src/core/hooks/tools/getPdfInfo/useGetPdfInfoOperation.ts
@@ -79,9 +79,6 @@ export const useGetPdfInfoOperation = (): GetPdfInfoOperationHook => {
             const response = await apiClient.post(
               "/api/v1/security/get-info-on-pdf",
               formData,
-              {
-                headers: { "Content-Type": "multipart/form-data" },
-              },
             );
 
             const stub = selectors.getStirlingFileStub(file.fileId);

--- a/frontend/src/core/hooks/tools/showJS/useShowJSOperation.ts
+++ b/frontend/src/core/hooks/tools/showJS/useShowJSOperation.ts
@@ -72,7 +72,6 @@ export const useShowJSOperation = (): ShowJSOperationHook => {
           "/api/v1/misc/show-javascript",
           formData,
           {
-            headers: { "Content-Type": "multipart/form-data" },
             responseType: "text",
           },
         );

--- a/frontend/src/core/hooks/tools/validateSignature/useValidateSignatureOperation.ts
+++ b/frontend/src/core/hooks/tools/validateSignature/useValidateSignatureOperation.ts
@@ -102,9 +102,6 @@ export const useValidateSignatureOperation =
               const response = await apiClient.post(
                 "/api/v1/security/validate-signature",
                 formData,
-                {
-                  headers: { "Content-Type": "multipart/form-data" },
-                },
               );
 
               const data = Array.isArray(response.data)

--- a/frontend/src/core/services/apiClient.ts
+++ b/frontend/src/core/services/apiClient.ts
@@ -13,24 +13,6 @@ const apiClient = axios.create({
 // Setup interceptors (core does nothing, proprietary adds JWT auth)
 setupApiInterceptors(apiClient);
 
-// Strip a manually-set "Content-Type: multipart/form-data" (no boundary) for
-// FormData bodies so axios generates one with a boundary. Browsers' XHR/fetch
-// silently fix this up; Tauri's WebView does not, so the request reaches the
-// server boundary-less and Jetty rejects it with
-// "No multipart boundary parameter in Content-Type".
-apiClient.interceptors.request.use((config) => {
-  if (config.data instanceof FormData && config.headers) {
-    const ct =
-      (config.headers as any)["Content-Type"] ??
-      (config.headers as any)["content-type"];
-    if (typeof ct === "string" && ct.toLowerCase() === "multipart/form-data") {
-      delete (config.headers as any)["Content-Type"];
-      delete (config.headers as any)["content-type"];
-    }
-  }
-  return config;
-});
-
 // ---------- Install error interceptor ----------
 apiClient.interceptors.response.use(
   (response) => response,

--- a/frontend/src/core/services/apiClient.ts
+++ b/frontend/src/core/services/apiClient.ts
@@ -13,6 +13,24 @@ const apiClient = axios.create({
 // Setup interceptors (core does nothing, proprietary adds JWT auth)
 setupApiInterceptors(apiClient);
 
+// Strip a manually-set "Content-Type: multipart/form-data" (no boundary) for
+// FormData bodies so axios generates one with a boundary. Browsers' XHR/fetch
+// silently fix this up; Tauri's WebView does not, so the request reaches the
+// server boundary-less and Jetty rejects it with
+// "No multipart boundary parameter in Content-Type".
+apiClient.interceptors.request.use((config) => {
+  if (config.data instanceof FormData && config.headers) {
+    const ct =
+      (config.headers as any)["Content-Type"] ??
+      (config.headers as any)["content-type"];
+    if (typeof ct === "string" && ct.toLowerCase() === "multipart/form-data") {
+      delete (config.headers as any)["Content-Type"];
+      delete (config.headers as any)["content-type"];
+    }
+  }
+  return config;
+});
+
 // ---------- Install error interceptor ----------
 apiClient.interceptors.response.use(
   (response) => response,

--- a/frontend/src/core/tools/EditTableOfContents.tsx
+++ b/frontend/src/core/tools/EditTableOfContents.tsx
@@ -34,9 +34,6 @@ const extractBookmarks = async (file: File): Promise<BookmarkPayload[]> => {
   const response = await apiClient.post(
     "/api/v1/general/extract-bookmarks",
     formData,
-    {
-      headers: { "Content-Type": "multipart/form-data" },
-    },
   );
 
   return response.data as BookmarkPayload[];

--- a/frontend/src/proprietary/services/licenseService.ts
+++ b/frontend/src/proprietary/services/licenseService.ts
@@ -462,11 +462,6 @@ const licenseService = {
       const response = await apiClient.post(
         "/api/v1/admin/license-file",
         formData,
-        {
-          headers: {
-            "Content-Type": "multipart/form-data",
-          },
-        },
       );
 
       return response.data;

--- a/frontend/src/proprietary/services/workflowService.ts
+++ b/frontend/src/proprietary/services/workflowService.ts
@@ -98,11 +98,6 @@ class WorkflowService {
     const response = await api.post(
       "/api/v1/workflow/participant/submit-signature",
       formData,
-      {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      },
     );
     return response.data;
   }


### PR DESCRIPTION
# Description of Changes

Strip a manually-set "Content-Type: multipart/form-data" (no boundary) for
FormData bodies so axios generates one with a boundary. Browsers' XHR/fetch
silently fix this up; Tauri's WebView does not, so the request reaches the
server boundary-less and Jetty rejects it with
"No multipart boundary parameter in Content-Type".

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
