### PR TITLE
Set CI to run the same in the merge queue as it does in CI

### DIFF
--- a/.github/workflows/ai-engine.yml
+++ b/.github/workflows/ai-engine.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/build-enterprise.yml
+++ b/.github/workflows/build-enterprise.yml
@@ -19,6 +19,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    branches: ["main"]
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build and Test Workflow
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
+    branches: ["main"]
   workflow_dispatch:
 
 # cancel in-progress jobs if a new job is triggered

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,9 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: "Dependency Review"
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/frontend-backend-licenses-update.yml
+++ b/.github/workflows/frontend-backend-licenses-update.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name || github.ref }}

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description of Changes
Merge queue doesn't currently work - jobs just sit on there and don't run and then eventually the PR gets booted off the list. I think this is because the queue is a different trigger on the workflows. This PR sets all the workflows that trigger on PR CI to also run in the merge queue (except for the ones like deploy which don't make sense in the merge queue).