### PR TITLE
Add Dependabot groups for frontend npm + cargo deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,81 @@ updates:
     cooldown:
       default-days: 7
     rebase-strategy: "auto"
+    groups:
+      embedpdf:
+        patterns:
+          - "@embedpdf/*"
+      mantine:
+        patterns:
+          - "@mantine/*"
+          - "postcss-preset-mantine"
+      mui:
+        patterns:
+          - "@mui/*"
+      tauri-js:
+        patterns:
+          - "@tauri-apps/*"
+      emotion:
+        patterns:
+          - "@emotion/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      testing-library:
+        patterns:
+          - "@testing-library/*"
+      i18next:
+        patterns:
+          - "i18next"
+          - "i18next-*"
+          - "react-i18next"
+      iconify:
+        patterns:
+          - "@iconify/*"
+          - "@iconify-json/*"
+      stripe:
+        patterns:
+          - "@stripe/*"
+      posthog:
+        patterns:
+          - "@posthog/*"
+          - "posthog-js"
+      supabase:
+        patterns:
+          - "@supabase/*"
+      dnd-kit:
+        patterns:
+          - "@dnd-kit/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      postcss:
+        patterns:
+          - "postcss"
+          - "postcss-*"
+        exclude-patterns:
+          - "postcss-preset-mantine"
 
   - package-ecosystem: cargo
     directories:
@@ -59,6 +134,24 @@ updates:
     cooldown:
       default-days: 7
     rebase-strategy: "auto"
+    groups:
+      tauri:
+        patterns:
+          - "tauri"
+          - "tauri-build"
+          - "tauri-plugin-*"
+      serde:
+        patterns:
+          - "serde"
+          - "serde_*"
+      tracing:
+        patterns:
+          - "tracing"
+          - "tracing-*"
+      tokio:
+        patterns:
+          - "tokio"
+          - "tokio-*"
 
   - package-ecosystem: pip
     directory: /testing/cucumber


### PR DESCRIPTION
## Summary
- Adds `groups:` to npm and cargo entries in `.github/dependabot.yml` so version-locked package families are bumped together in a single PR.
- Fixes the failure mode seen in [#6284](https://github.com/Stirling-Tools/Stirling-PDF/pull/6284), where bumping only `@embedpdf/plugin-viewport` triggered an `ERESOLVE` because the rest of `@embedpdf/*` stayed at the old version (those packages have exact-match peer deps on each other).

## Frontend npm groups
embedpdf, mantine, mui, tauri-js (`@tauri-apps/*`), emotion, react (`react`/`react-dom` + types), typescript-eslint, eslint, vite, vitest, testing-library, i18next, iconify, stripe, posthog, supabase, dnd-kit, tailwind, postcss

## Cargo groups (Tauri side)
tauri (`tauri`, `tauri-build`, `tauri-plugin-*`), serde, tracing, tokio

## Test plan
- [ ] Merge and wait for next Dependabot run; confirm a single grouped PR is opened for `@embedpdf/*` instead of one per package.
- [ ] Confirm grouped PR resolves cleanly with `npm ci` (no `ERESOLVE`).