### PR TITLE
fix(compare): prevent infinite re-render loop on second file upload

### DIFF
--- a/frontend/src/core/tools/Compare.tsx
+++ b/frontend/src/core/tools/Compare.tsx
@@ -157,31 +157,37 @@ const Compare = (props: BaseToolProps) => {
     }
   }, []);
 
-  // Track previous file count to detect the transition to exactly 2 files.
-  const prevAllIdsLengthRef = useRef<number | null>(null);
-
-  // Auto-fill slots when the file count first reaches 2; respect manual picker changes after that.
+  // Keep slot params in sync with the current workbench/selection state.
+  //
+  // The effect must be idempotent: it can fire repeatedly during an upload
+  // burst (ADD_FILES, SET_SELECTED_FILES, and downstream dispatches all land
+  // in quick succession), and any "did the count transition?" tracking via
+  // a ref races with React's batched re-renders under load. With workers=3
+  // in CI, that race surfaced as a "Maximum update depth exceeded" crash
+  // when the second slot was filled. So the implementation derives the
+  // target params purely from current state and bails when there's nothing
+  // to change.
   useEffect(() => {
     const selectedIds = fileState.ui.selectedFileIds as FileId[];
     const allIds = fileState.files.ids as FileId[];
-    const prevLength = prevAllIdsLengthRef.current;
-    prevAllIdsLengthRef.current = allIds.length;
-
-    if (allIds.length === 2 && prevLength !== 2) {
-      // Transitioned to exactly 2 files — auto-fill both slots.
-      const [firstId, secondId] = allIds as [FileId, FileId];
-      fileActions.setSelectedFiles([firstId, secondId]);
-      base.params.setParameters((prev) => {
-        if (prev.baseFileId === firstId && prev.comparisonFileId === secondId)
-          return prev;
-        return { ...prev, baseFileId: firstId, comparisonFileId: secondId };
-      });
-      return;
-    }
 
     if (selectedIds.length > 2) {
       fileActions.setSelectedFiles(selectedIds.slice(0, 2) as FileId[]);
       return;
+    }
+
+    // When exactly 2 files are loaded but the selection doesn't cover both,
+    // promote the selection so Compare can run. Skips when the selection is
+    // already correct so we don't dispatch a fresh array reference and
+    // retrigger this effect. Covers the upload window where ADD_FILES has
+    // landed but SET_SELECTED_FILES is still in flight.
+    if (allIds.length === 2) {
+      const selectionMatchesAllIds =
+        selectedIds.length === 2 &&
+        allIds.every((id) => selectedIds.includes(id));
+      if (!selectionMatchesAllIds) {
+        fileActions.setSelectedFiles([...allIds] as FileId[]);
+      }
     }
 
     // Sticky slot mapping: preserve the current slot if its file is still selected,


### PR DESCRIPTION
## Summary

Fixes the flaky `compare.spec.ts` test that's been failing across multiple unrelated PRs (#6291, #6195, #6191, plus the latest nightly). The failure mode was:

```
expect(locator).toHaveAttribute("data-slot-state", "filled") failed
locator resolved to <div data-slot-state="empty" data-testid="compare-slot-comparison">
```

…with the error context showing a `Something went wrong / Maximum update depth exceeded` ErrorBoundary message — i.e. a real React infinite re-render, not just a slow render.

## Root cause

The auto-fill effect in `Compare.tsx` tracked the previous `allIds.length` via a ref and only ran the "transitioned to exactly 2 files" branch when that ref disagreed with the current count. Under `--workers=3` (what CI uses), the rapid `ADD_FILES` + `SET_SELECTED_FILES` dispatch bursts during the **second** upload could interleave with React's batched re-renders in a way that kept the effect dispatching a fresh `[firstId, secondId]` array each render — triggering React's "Maximum update depth exceeded" guard, which the ErrorBoundary then caught while the comparison slot stayed visibly empty.

The first upload didn't trip this because the prior state was a clean `length=0`. Only the 1→2 transition under contention exposed the race.

## Fix

Make the effect idempotent: derive the desired slot params purely from current state, skip the `SET_SELECTED_FILES` dispatch when the selection already covers both loaded files, and drop the count-transition ref entirely. The sticky-slot logic that was already there handles the actual mapping; the only thing the dropped branch contributed was forcing the selection to cover both files when `allIds.length === 2`, and that's now done unconditionally-but-no-op-when-already-correct.

## Reproduction

Reliably reproduced locally with:
```
npx playwright test --project=stubbed --workers=3
```
Before this change: ~1 in 5 runs failed on compare.spec.ts:131. After: 5 consecutive full-suite runs (132 passing) clean.

## Other CI flakes I noticed while investigating

- The nightly run (https://github.com/Stirling-Tools/Stirling-PDF/actions/runs/25355891429) also has firefox-only flakes in `certificate-validation.spec.ts` and a batch of enterprise-license tests dying at startup. Those look infra-related (different from this React loop), so leaving them out of scope here.
- `all-tool-pages-load.spec.ts` flaked in PRs #6303 and #6248 on different tools (showJS, replaceColor, timestampPdf, bookletImposition, pdfTextEditor, formFill). That looks like a separate timing issue with the smoke-load coverage, not the same root cause.

## Test plan

- [x] `npx playwright test --project=stubbed --workers=3` — 5x clean runs (132 passing each)
- [x] `npx playwright test compare.spec.ts all-tool-pages-load.spec.ts --project=stubbed --workers=3` — 5x clean
- [ ] CI playwright-e2e-stubbed passes