### PR TITLE
Fix Task commands in Powershell

### DIFF
--- a/.taskfiles/desktop.yml
+++ b/.taskfiles/desktop.yml
@@ -1,12 +1,7 @@
 version: '3'
 
 vars:
-  # Single source of truth for the jlink module list (also read by
-  # frontend/scripts/build-universal-mac-jre.sh during CI). The desktop
-  # taskfile runs with dir: frontend (see Taskfile.yml), so this path
-  # is relative to that directory.
-  JLINK_MODULES:
-    sh: tr -d '\n' < src-tauri/jlink-modules.txt
+  JLINK_MODULES: "java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.unsupported"
 
 tasks:
   prepare:

--- a/frontend/src-tauri/jlink-modules.txt
+++ b/frontend/src-tauri/jlink-modules.txt
@@ -1,1 +1,0 @@
-java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.unsupported


### PR DESCRIPTION
# Description of Changes
#6302 introduced a minor change to the Task commands that used a Bash-specific command that Task will eagerly evaluate, which means that running Task commands from Powershell will fail with an error currently. This reverts that change to just use an inline string again, since the change was unnecessary by the time the PR was finished.