### PR TITLE
fix: make PowerShell free-port task invocation compatible with go-task on Windows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@ version: '3'
 output: prefixed
 
 vars:
-  FIND_FREE_PORT_PS: powershell -NoProfile -File scripts\find-free-port.ps1 -Preferred
+  FIND_FREE_PORT_PS: powershell -NoProfile -File scripts/find-free-port.ps1 -Preferred
   FIND_FREE_PORT_SH: bash scripts/find-free-port.sh
 
 includes:

--- a/scripts/find-free-port.ps1
+++ b/scripts/find-free-port.ps1
@@ -4,7 +4,25 @@
 # emits a random free port in 20000-49999. Probes by attempting to bind a
 # TcpListener on loopback. Tracks picks within this run so outputs are
 # guaranteed distinct from each other.
-param([int[]]$Preferred)
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Preferred
+)
+
+$normalizedPreferred = @()
+foreach ($item in $Preferred) {
+    foreach ($token in ($item -split ',')) {
+        $trimmed = $token.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) { continue }
+        $parsed = 0
+        if (-not [int]::TryParse($trimmed, [ref]$parsed)) {
+            throw "Invalid port value: '$trimmed'"
+        }
+        $normalizedPreferred += $parsed
+    }
+}
+
+$Preferred = $normalizedPreferred
 
 $script:picked = @()
 


### PR DESCRIPTION
# Description of Changes

- Updated the Taskfile PowerShell script path to use forward slashes for more reliable execution on Windows.
- Adjusted `find-free-port.ps1` to accept preferred port values as string arguments.
- Added normalization for preferred port input, including comma-separated values, whitespace trimming, integer parsing, and invalid value handling.
- This change was made to prevent argument binding issues when the script is invoked through `go-task` on Windows.
- The main challenge was ensuring PowerShell argument parsing remains compatible with task runner command evaluation.


```ps
task dev:all      
```

```ps
panic: ended up with a non-nil exitStatus.err but a zero exitStatus.code

goroutine 1 [running]:
mvdan.cc/sh/v3/interp.(*Runner).Run(0x8c5959a9b88, {0x7ff68e96b160, 0x7ff68fcc07e0}, {0x7ff68e95cb78, 0x8c595c86a00})
        mvdan.cc/sh/v3@v3.13.1/interp/api.go:937 +0x40b
github.com/go-task/task/v3/internal/execext.RunCommand({0x7ff68e96b160, 0x7ff68fcc07e0}, 0x8c595e06e50)
        github.com/go-task/task/v3@v3.50.0/internal/execext/exec.go:90 +0x8e5
github.com/go-task/task/v3.(*Compiler).HandleDynamicVar(0x8c595b923c0, {{0x0, 0x0}, {0x0, 0x0}, 0x8c59605b950, {0x0, 0x0}, {0x0, 0x0}}, ...)
        github.com/go-task/task/v3@v3.50.0/compiler.go:177 +0x2c5
github.com/go-task/task/v3.(*Compiler).getVariables.(*Compiler).getVariables.func1.func3({0x8c595aca210, 0x5}, {{0x0, 0x0}, {0x0, 0x0}, 0x8c595b026e0, {0x0, 0x0}, {0x0, ...}})
        github.com/go-task/task/v3@v3.50.0/compiler.go:84 +0x28b
github.com/go-task/task/v3.(*Compiler).getVariables-range6({0x8c595aca210?, 0x8c595a034a0?}, {{0x0, 0x0}, {0x0, 0x0}, 0x8c595b026e0, {0x0, 0x0}, {0x0, ...}})
        github.com/go-task/task/v3@v3.50.0/compiler.go:140 +0xa2
github.com/go-task/task/v3.(*Compiler).getVariables.(*Vars).All.(*OrderedMap[...]).AllFromFront.func15()
        github.com/elliotchance/orderedmap/v3@v3.1.0/orderedmap.go:104 +0xdf
github.com/go-task/task/v3.(*Compiler).getVariables(0x8c595b923c0, 0x8c595c21208, 0x8c5957f7380, 0x1)
        github.com/go-task/task/v3@v3.50.0/compiler.go:139 +0xbdf
github.com/go-task/task/v3.(*Compiler).GetVariables(...)
        github.com/go-task/task/v3@v3.50.0/compiler.go:40
github.com/go-task/task/v3.(*Executor).compiledTask(0x8c5959cda40, 0x8c5957f7380, 0x1)
        github.com/go-task/task/v3@v3.50.0/variables.go:87 +0xba
github.com/go-task/task/v3.(*Executor).CompiledTask(...)
        github.com/go-task/task/v3@v3.50.0/variables.go:25
github.com/go-task/task/v3.(*Executor).RunTask(0x8c5959cda40, {0x7ff68e96b160, 0x7ff68fcc07e0}, 0x8c5957f7380)
        github.com/go-task/task/v3@v3.50.0/task.go:159 +0x256
github.com/go-task/task/v3.(*Executor).Run(0x8c5959cda40, {0x7ff68e96b160, 0x7ff68fcc07e0}, {0x8c595e92e10, 0x1, 0x1})
        github.com/go-task/task/v3@v3.50.0/task.go:95 +0x40c
main.run()
        github.com/go-task/task/v3@v3.50.0/cmd/task/task.go:202 +0x965
main.main()
        github.com/go-task/task/v3@v3.50.0/cmd/task/task.go:24 +0x1f
```


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
