### PR TITLE
fix: replace deprecated payload too large status

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
+++ b/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
@@ -682,7 +682,7 @@ public class GlobalExceptionHandler {
      *
      * @param ex the MaxUploadSizeExceededException
      * @param request the HTTP servlet request
-     * @return ProblemDetail with HTTP 413 PAYLOAD_TOO_LARGE
+     * @return ProblemDetail with HTTP 413 CONTENT_TOO_LARGE
      */
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ProblemDetail> handleMaxUploadSize(
@@ -706,7 +706,7 @@ public class GlobalExceptionHandler {
                 getLocalizedMessage("error.fileTooLarge.title", ErrorTitles.FILE_TOO_LARGE_DEFAULT);
 
         ProblemDetail problemDetail =
-                createBaseProblemDetail(HttpStatus.PAYLOAD_TOO_LARGE, message, request);
+                createBaseProblemDetail(HttpStatus.CONTENT_TOO_LARGE, message, request);
         problemDetail.setType(URI.create(ErrorTypes.FILE_TOO_LARGE));
         problemDetail.setTitle(title);
         problemDetail.setProperty("title", title); // Ensure serialization
@@ -724,7 +724,7 @@ public class GlobalExceptionHandler {
         problemDetail.setProperty(
                 "actionRequired", "Reduce the file size to be within the upload limit.");
 
-        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+        return ResponseEntity.status(HttpStatus.CONTENT_TOO_LARGE)
                 .contentType(PROBLEM_JSON)
                 .body(problemDetail);
     }

--- a/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
@@ -177,14 +177,14 @@ class GlobalExceptionHandlerTest {
     void handleMaxUploadSize_returns_413() {
         MaxUploadSizeExceededException ex = new MaxUploadSizeExceededException(10485760);
         ResponseEntity<ProblemDetail> resp = handler.handleMaxUploadSize(ex, request);
-        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, resp.getStatusCode());
+        assertEquals(HttpStatus.CONTENT_TOO_LARGE, resp.getStatusCode());
     }
 
     @Test
     void handleMaxUploadSize_unknown_limit() {
         MaxUploadSizeExceededException ex = new MaxUploadSizeExceededException(-1);
         ResponseEntity<ProblemDetail> resp = handler.handleMaxUploadSize(ex, request);
-        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, resp.getStatusCode());
+        assertEquals(HttpStatus.CONTENT_TOO_LARGE, resp.getStatusCode());
         assertNull(resp.getBody().getProperties().get("maxSizeBytes"));
     }
 


### PR DESCRIPTION
# Description of Changes

- Replaced the deprecated `HttpStatus.PAYLOAD_TOO_LARGE` usage with `HttpStatus.CONTENT_TOO_LARGE` in `GlobalExceptionHandler`
- Updated the upload-size exception response creation and response status to use the newer HTTP 413 enum
- Updated related unit tests to assert `HttpStatus.CONTENT_TOO_LARGE`
- The change was made to avoid using the deprecated Spring HTTP status enum while keeping the returned status code behavior unchanged


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
