### PR TITLE
Fix main frontend validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,11 +101,14 @@ tasks.register('syncAppVersion') {
 
         def tauriConfigFile = new File(tauriConfigPath)
         if (tauriConfigFile.exists()) {
-            def parsed = new groovy.json.JsonSlurper().parse(tauriConfigFile)
-            parsed.version = appVersionStr
-            def formatted = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(parsed)) + System.lineSeparator()
-            if (tauriConfigFile.getText('UTF-8') != formatted) {
-                tauriConfigFile.write(formatted, 'UTF-8')
+            def content = tauriConfigFile.getText('UTF-8')
+            def matcher = (content =~ /(?m)^(\s*"version":\s*")([^"]*)(")/)
+            if (!matcher.find()) {
+                throw new GradleException("Could not locate version in ${tauriConfigFile} for synchronization")
+            }
+            def updatedContent = matcher.replaceFirst("${matcher.group(1)}${appVersionStr}${matcher.group(3)}")
+            if (content != updatedContent) {
+                tauriConfigFile.write(updatedContent, 'UTF-8')
             }
         }
 

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,105 +1,88 @@
 {
-    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-    "productName": "Stirling-PDF",
-    "version": "2.11.0",
-    "identifier": "stirling.pdf.dev",
-    "build": {
-        "frontendDist": "../dist",
-        "devUrl": "http://localhost:5173",
-        "beforeDevCommand": "npx vite --mode desktop",
-        "beforeBuildCommand": "npx vite build --mode desktop"
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "productName": "Stirling-PDF",
+  "version": "2.11.0",
+  "identifier": "stirling.pdf.dev",
+  "build": {
+    "frontendDist": "../dist",
+    "devUrl": "http://localhost:5173",
+    "beforeDevCommand": "npx vite --mode desktop",
+    "beforeBuildCommand": "npx vite build --mode desktop"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Stirling-PDF",
+        "width": 1280,
+        "height": 800,
+        "resizable": true,
+        "fullscreen": false,
+        "additionalBrowserArgs": "--enable-features=CertVerifierBuiltinFeature"
+      }
+    ]
+  },
+  "bundle": {
+    "active": true,
+    "publisher": "Stirling PDF Inc.",
+    "targets": ["deb", "rpm", "appimage", "dmg", "msi"],
+    "icon": [
+      "icons/icon.png",
+      "icons/icon.icns",
+      "icons/icon.ico",
+      "icons/16x16.png",
+      "icons/32x32.png",
+      "icons/64x64.png",
+      "icons/128x128.png",
+      "icons/192x192.png"
+    ],
+    "resources": ["libs/*.jar", "runtime/jre/**/*"],
+    "fileAssociations": [
+      {
+        "ext": ["pdf"],
+        "name": "PDF Document",
+        "role": "Editor",
+        "mimeType": "application/pdf"
+      }
+    ],
+    "linux": {
+      "deb": {
+        "desktopTemplate": "stirling-pdf.desktop"
+      },
+      "rpm": {
+        "desktopTemplate": "stirling-pdf.desktop"
+      },
+      "appimage": {
+        "bundleMediaFramework": false
+      }
     },
-    "app": {
-        "windows": [
-            {
-                "title": "Stirling-PDF",
-                "width": 1280,
-                "height": 800,
-                "resizable": true,
-                "fullscreen": false,
-                "additionalBrowserArgs": "--enable-features=CertVerifierBuiltinFeature"
-            }
-        ]
+    "windows": {
+      "certificateThumbprint": null,
+      "digestAlgorithm": "sha256",
+      "timestampUrl": "http://timestamp.digicert.com",
+      "wix": {
+        "fragmentPaths": ["windows/wix/provisioning.wxs"],
+        "componentGroupRefs": ["ProvisioningComponentGroup"]
+      }
     },
-    "bundle": {
-        "active": true,
-        "publisher": "Stirling PDF Inc.",
-        "targets": [
-            "deb",
-            "rpm",
-            "appimage",
-            "dmg",
-            "msi"
-        ],
-        "icon": [
-            "icons/icon.png",
-            "icons/icon.icns",
-            "icons/icon.ico",
-            "icons/16x16.png",
-            "icons/32x32.png",
-            "icons/64x64.png",
-            "icons/128x128.png",
-            "icons/192x192.png"
-        ],
-        "resources": [
-            "libs/*.jar",
-            "runtime/jre/**/*"
-        ],
-        "fileAssociations": [
-            {
-                "ext": [
-                    "pdf"
-                ],
-                "name": "PDF Document",
-                "role": "Editor",
-                "mimeType": "application/pdf"
-            }
-        ],
-        "linux": {
-            "deb": {
-                "desktopTemplate": "stirling-pdf.desktop"
-            },
-            "rpm": {
-                "desktopTemplate": "stirling-pdf.desktop"
-            },
-            "appimage": {
-                "bundleMediaFramework": false
-            }
-        },
-        "windows": {
-            "certificateThumbprint": null,
-            "digestAlgorithm": "sha256",
-            "timestampUrl": "http://timestamp.digicert.com",
-            "wix": {
-                "fragmentPaths": [
-                    "windows/wix/provisioning.wxs"
-                ],
-                "componentGroupRefs": [
-                    "ProvisioningComponentGroup"
-                ]
-            }
-        },
-        "macOS": {
-            "minimumSystemVersion": "10.15",
-            "signingIdentity": null,
-            "entitlements": null,
-            "providerShortName": null,
-            "infoPlist": "Info.plist"
-        }
-    },
-    "plugins": {
-        "shell": {
-            "open": true
-        },
-        "fs": {
-            "requireLiteralLeadingDot": false
-        },
-        "deep-link": {
-            "desktop": {
-                "schemes": [
-                    "stirlingpdf"
-                ]
-            }
-        }
+    "macOS": {
+      "minimumSystemVersion": "10.15",
+      "signingIdentity": null,
+      "entitlements": null,
+      "providerShortName": null,
+      "infoPlist": "Info.plist"
     }
+  },
+  "plugins": {
+    "shell": {
+      "open": true
+    },
+    "fs": {
+      "requireLiteralLeadingDot": false
+    },
+    "deep-link": {
+      "desktop": {
+        "schemes": ["stirlingpdf"]
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Description of Changes
#6312 reformatted `tauri.conf.json` via the Gradle script, which reformats the entire file to not match the Prettier style. This PR reformats the file back to Prettier format and changes the script to update the version number without reformatting the entire file.

To be honest I'm not a huge fan of updating the version number with regexes but it'd be a fool's errand to try and get Gradle to output JSON in Prettier format, and this seems simpler than shelling out to run Prettier over the file after the version string has been updated. Any better ideas, let me know.