### PR TITLE
deps: align Bouncy Castle modules to shared version property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     pdfboxVersion = "3.0.7"
     imageioVersion = "3.13.1"
     lombokVersion = "1.18.46"
-    bouncycastleVersion = "1.83"
+    bouncycastleVersion = "1.84"
     springSecuritySamlVersion = "7.0.5"
     openSamlVersion = "5.2.1"
     commonmarkVersion = "0.28.0"
@@ -194,7 +194,6 @@ subprojects {
         exclude group: 'org.bouncycastle', module: 'bcutil-jdk15on'
         exclude group: 'org.bouncycastle', module: 'bcmail-jdk15on'
 
-
         // Security CVE fixes - hardcoded resolution strategy to ensure safe versions
         // Primary fixes via explicit dependencies in app/core/build.gradle:
         // - CVE-2022-25647: gson 2.8.9+ (explicit dependency overrides tabula 2.8.7)
@@ -206,9 +205,10 @@ subprojects {
         resolutionStrategy.force 'org.apache.commons:commons-lang3:3.20.0'
         // CVE-2024-47554: commons-io 2.21.0 DoS prevention
         resolutionStrategy.force 'commons-io:commons-io:2.21.0'
-        // Bouncycastle 1.83 (from bouncycastleVersion variable)
-        resolutionStrategy.force 'org.bouncycastle:bcprov-jdk18on:1.83'
-        resolutionStrategy.force 'org.bouncycastle:bcpkix-jdk18on:1.83'
+        // Keep BouncyCastle modules aligned to avoid runtime linkage errors
+        resolutionStrategy.force "org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}"
+        resolutionStrategy.force "org.bouncycastle:bcpkix-jdk18on:${bouncycastleVersion}"
+        resolutionStrategy.force "org.bouncycastle:bcutil-jdk18on:${bouncycastleVersion}"
     }
 
     dependencyManagement {


### PR DESCRIPTION
# Description of Changes

- Updated the Bouncy Castle version from `1.83` to `1.84`.
- Replaced hardcoded forced Bouncy Castle dependency versions with the shared `bouncycastleVersion` property.
- Added `bcutil-jdk18on` to the forced Bouncy Castle modules to keep related artifacts aligned.
- Removed an extra blank line in the Gradle dependency configuration.
- This change was made to prevent runtime linkage issues caused by mismatched Bouncy Castle module versions.
- No major challenges were encountered.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
