### PR TITLE
FIX xhref error issue #2006

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/WebResponseUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/WebResponseUtils.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdfwriter.compress.CompressParameters;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -66,7 +67,7 @@ public class WebResponseUtils {
 
         // Open Byte Array and save document to it
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        document.save(baos);
+        document.save(baos, CompressParameters.NO_COMPRESSION);
 
         return baosToWebResponse(baos, docName);
     }
@@ -86,7 +87,7 @@ public class WebResponseUtils {
             throws IOException {
         TempFile tempFile = tempFileManager.createManagedTempFile(".pdf");
         try {
-            document.save(tempFile.getFile());
+            document.save(tempFile.getFile(), CompressParameters.NO_COMPRESSION);
         } catch (IOException e) {
             tempFile.close();
             throw e;

--- a/app/common/src/test/java/stirling/software/common/util/WebResponseUtilsTest.java
+++ b/app/common/src/test/java/stirling/software/common/util/WebResponseUtilsTest.java
@@ -11,9 +11,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -112,6 +115,37 @@ class WebResponseUtilsTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(0, response.getHeaders().getContentLength());
+    }
+
+    @Test
+    void pdfDocToWebResponse_writesClassicXrefTable() throws IOException {
+        try (PDDocument document = new PDDocument()) {
+            document.addPage(new PDPage());
+
+            ResponseEntity<byte[]> response =
+                    WebResponseUtils.pdfDocToWebResponse(document, "doc.pdf");
+
+            String body = new String(response.getBody(), StandardCharsets.ISO_8859_1);
+            assertTrue(body.matches("(?s).*\\Rxref\\R.*"));
+            assertFalse(body.contains("/Type /XRef"));
+        }
+    }
+
+    @Test
+    void pdfDocToWebResponse_withTempFileWritesClassicXrefTable() throws IOException {
+        try (PDDocument document = new PDDocument()) {
+            document.addPage(new PDPage());
+
+            ResponseEntity<Resource> response =
+                    WebResponseUtils.pdfDocToWebResponse(document, "doc.pdf", tempFileManager);
+
+            String body;
+            try (InputStream in = response.getBody().getInputStream()) {
+                body = new String(in.readAllBytes(), StandardCharsets.ISO_8859_1);
+            }
+            assertTrue(body.matches("(?s).*\\Rxref\\R.*"));
+            assertFalse(body.contains("/Type /XRef"));
+        }
     }
 
     @Test


### PR DESCRIPTION
fix XHREF errors issue #2006
https://github.com/Stirling-Tools/Stirling-PDF/issues/2006

# Description of Changes

Updated WebResponseUtils.pdfDocToWebResponse(...) to save PDDocument outputs with CompressParameters.NO_COMPRESSION.
Applied the same save mode to both response paths:
byte-array PDF responses
managed temp-file-backed PDF responses
Added regression coverage asserting generated PDF responses use a classic xref table instead of a compressed /Type /XRef stream.

Why

Issue #2006/#3920 reports PDF-XChange warnings after flattening and other PDFBox-backed operations. The provided broken sample had a compressed xref stream whose final xref object existed in the file but was not included in the stream’s /Index, causing strict editors to report xref table errors.

Saving without compression avoids PDFBox’s compressed xref-stream path and writes a classic xref table instead.


Closes #2006

---

## Checklist

### General

- [ x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x ] I have performed a self-review of my own code
- [ x] My changes generate no new warnings

### Documentation

- [ x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [x ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
