### PR TITLE
fix(frontend): preserve pdf link targets in desktop viewer

### DIFF
--- a/frontend/src/core/components/viewer/LinkLayer.tsx
+++ b/frontend/src/core/components/viewer/LinkLayer.tsx
@@ -7,6 +7,7 @@ import {
   PdfActionType,
   type PdfLinkAnnoObject,
 } from "@embedpdf/models";
+import { getExternalHref, openExternalUrl } from "@app/utils/openExternalUrl";
 
 // ---------------------------------------------------------------------------
 // Inline SVG icons (thin-stroke, modern)
@@ -310,19 +311,11 @@ export const LinkLayer: React.FC<LinkLayerProps> = ({
           });
         } else if (action.type === PdfActionType.URI) {
           const uri = action.uri;
-          try {
-            const url = new URL(uri, window.location.href);
-            if (["http:", "https:", "mailto:"].includes(url.protocol)) {
-              window.open(uri, "_blank", "noopener,noreferrer");
-            } else {
-              console.warn(
-                "[LinkLayer] Blocked unsafe URL protocol:",
-                url.protocol,
-              );
+          void openExternalUrl(uri).then((opened) => {
+            if (!opened) {
+              console.warn("[LinkLayer] Blocked unsafe URL:", uri);
             }
-          } catch {
-            window.open(uri, "_blank", "noopener,noreferrer");
-          }
+          });
         }
       }
 
@@ -353,6 +346,11 @@ export const LinkLayer: React.FC<LinkLayerProps> = ({
         const top = annotationLink.rect.origin.y * scale;
         const width = annotationLink.rect.size.width * scale;
         const height = annotationLink.rect.size.height * scale;
+        const externalHref =
+          annotationLink.target?.type === "action" &&
+          annotationLink.target.action.type === PdfActionType.URI
+            ? getExternalHref(annotationLink.target.action.uri)
+            : null;
 
         // Flip toolbar below if link is near the top of the page
         const flipped =
@@ -363,7 +361,9 @@ export const LinkLayer: React.FC<LinkLayerProps> = ({
           <React.Fragment key={annotationLink.id}>
             {/* Hit-area overlay */}
             <a
-              href="#"
+              href={externalHref ?? "#"}
+              target={externalHref ? "_blank" : undefined}
+              rel={externalHref ? "noopener noreferrer" : undefined}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();

--- a/frontend/src/core/utils/openExternalUrl.test.ts
+++ b/frontend/src/core/utils/openExternalUrl.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  getExternalHref,
+  openExternalUrl,
+  toSafeExternalUrl,
+} from "@app/utils/openExternalUrl";
+
+describe("openExternalUrl utils", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("accepts http/https/mailto URLs", () => {
+    expect(toSafeExternalUrl("https://example.com/test")?.href).toBe(
+      "https://example.com/test",
+    );
+    expect(toSafeExternalUrl("http://example.com/test")?.href).toBe(
+      "http://example.com/test",
+    );
+    expect(toSafeExternalUrl("mailto:test@example.com")?.href).toBe(
+      "mailto:test@example.com",
+    );
+  });
+
+  test("rejects unsafe protocols", () => {
+    expect(toSafeExternalUrl("javascript:alert(1)")).toBeNull();
+    expect(toSafeExternalUrl("file:///etc/passwd")).toBeNull();
+    expect(toSafeExternalUrl("ftp://example.com")).toBeNull();
+  });
+
+  test("normalizes relative URLs against current origin", () => {
+    expect(getExternalHref("/docs/help")?.endsWith("/docs/help")).toBe(true);
+  });
+
+  test("openExternalUrl opens safe links and blocks unsafe links", async () => {
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null as Window | null);
+
+    await expect(openExternalUrl("https://example.com")).resolves.toBe(true);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://example.com/",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    openSpy.mockClear();
+
+    await expect(openExternalUrl("javascript:alert(1)")).resolves.toBe(false);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/core/utils/openExternalUrl.ts
+++ b/frontend/src/core/utils/openExternalUrl.ts
@@ -1,0 +1,34 @@
+const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+function getExternalUrlBase(): string {
+  if (typeof window !== "undefined" && window.location?.href) {
+    return window.location.href;
+  }
+  return "http://localhost/";
+}
+
+export function toSafeExternalUrl(rawUrl: string): URL | null {
+  try {
+    const parsed = new URL(rawUrl, getExternalUrlBase());
+    if (!ALLOWED_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function getExternalHref(rawUrl: string): string | null {
+  return toSafeExternalUrl(rawUrl)?.href ?? null;
+}
+
+export async function openExternalUrl(rawUrl: string): Promise<boolean> {
+  const safeUrl = toSafeExternalUrl(rawUrl);
+  if (!safeUrl) {
+    return false;
+  }
+
+  window.open(safeUrl.href, "_blank", "noopener,noreferrer");
+  return true;
+}

--- a/frontend/src/desktop/utils/openExternalUrl.ts
+++ b/frontend/src/desktop/utils/openExternalUrl.ts
@@ -1,0 +1,30 @@
+import { open as shellOpen } from "@tauri-apps/plugin-shell";
+import {
+  getExternalHref as getCoreExternalHref,
+  toSafeExternalUrl,
+} from "@core/utils/openExternalUrl";
+
+export { toSafeExternalUrl };
+
+export function getExternalHref(rawUrl: string): string | null {
+  return getCoreExternalHref(rawUrl);
+}
+
+export async function openExternalUrl(rawUrl: string): Promise<boolean> {
+  const safeUrl = toSafeExternalUrl(rawUrl);
+  if (!safeUrl) {
+    return false;
+  }
+
+  try {
+    await shellOpen(safeUrl.href);
+    return true;
+  } catch (error) {
+    console.warn(
+      "[openExternalUrl] Failed to open URL via Tauri shell, falling back to window.open",
+      error,
+    );
+    window.open(safeUrl.href, "_blank", "noopener,noreferrer");
+    return true;
+  }
+}


### PR DESCRIPTION
- give PDF URI annotations a real href so copy-link returns the source URL\n- route external URL opens through @app utils with desktop Tauri shell override\n- keep protocol allowlist (http/https/mailto) and block unsafe schemes\n- add unit tests for URL sanitization and open behavior\n\nRefs #6272

# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [x] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
