### PR TITLE
Fix unresolved Material Symbols icon names in frontend

### DIFF
--- a/frontend/editor/src/core/components/tools/sign/SignSettings.tsx
+++ b/frontend/editor/src/core/components/tools/sign/SignSettings.tsx
@@ -1137,7 +1137,7 @@ const SignSettings = ({
               gap: "0.4rem",
             }}
           >
-            <LocalIcon icon="pause-rounded" width={20} height={20} />
+            <LocalIcon icon="pause-circle-rounded" width={20} height={20} />
             <Text component="span" size="sm" fw={500}>
               {translate("mode.pause", "Pause placement")}
             </Text>

--- a/frontend/editor/src/core/components/viewer/CommentsSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/CommentsSidebar.tsx
@@ -125,7 +125,7 @@ const TOOL_ICON_MAP: Record<string, string> = {
   squiggly: "show-chart",
   ink: "edit",
   inkHighlighter: "brush",
-  square: "crop-square",
+  square: "crop-square-outline",
   circle: "radio-button-unchecked",
   line: "show-chart",
   lineArrow: "show-chart",
@@ -144,7 +144,7 @@ function getIconByType(type: number | undefined): string {
   if (type === 1) return "comment";
   if (type === 3) return "sticky-note-2";
   if (type === 4 || type === 8) return "show-chart";
-  if (type === 5) return "crop-square";
+  if (type === 5) return "crop-square-outline";
   if (type === 6) return "radio-button-unchecked";
   if (type === 7 || type === 8) return "change-history";
   if (type === 9) return "highlight";

--- a/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
+++ b/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
@@ -259,7 +259,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
     {
       id: "square",
       label: t("annotation.square", "Square"),
-      icon: "crop-square",
+      icon: "crop-square-outline",
     },
     {
       id: "circle",

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminDatabaseSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminDatabaseSection.tsx
@@ -798,7 +798,7 @@ export default function AdminDatabaseSection() {
                     <Button
                       leftSection={
                         <LocalIcon
-                          icon="cloud-upload"
+                          icon="upload"
                           width="1rem"
                           height="1rem"
                         />

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminDatabaseSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminDatabaseSection.tsx
@@ -797,11 +797,7 @@ export default function AdminDatabaseSection() {
                     </Button>
                     <Button
                       leftSection={
-                        <LocalIcon
-                          icon="upload"
-                          width="1rem"
-                          height="1rem"
-                        />
+                        <LocalIcon icon="upload" width="1rem" height="1rem" />
                       }
                       onClick={handleCreateBackup}
                       loading={creatingBackup}

--- a/frontend/editor/src/saas/components/tools/sign/SignSettings.tsx
+++ b/frontend/editor/src/saas/components/tools/sign/SignSettings.tsx
@@ -1170,7 +1170,7 @@ const SignSettings = ({
             }}
           >
             <LocalIcon
-              icon="material-symbols:pause-rounded"
+              icon="pause-circle-rounded"
               width={20}
               height={20}
             />
@@ -1198,7 +1198,7 @@ const SignSettings = ({
             }}
           >
             <LocalIcon
-              icon="material-symbols:play-arrow-rounded"
+              icon="play-arrow-rounded"
               width={20}
               height={20}
             />

--- a/frontend/editor/src/saas/components/tools/sign/SignSettings.tsx
+++ b/frontend/editor/src/saas/components/tools/sign/SignSettings.tsx
@@ -1169,11 +1169,7 @@ const SignSettings = ({
               gap: "0.4rem",
             }}
           >
-            <LocalIcon
-              icon="pause-circle-rounded"
-              width={20}
-              height={20}
-            />
+            <LocalIcon icon="pause-circle-rounded" width={20} height={20} />
             <Text component="span" size="sm" fw={500}>
               {translate("mode.pause", "Pause placement")}
             </Text>
@@ -1197,11 +1193,7 @@ const SignSettings = ({
               gap: "0.4rem",
             }}
           >
-            <LocalIcon
-              icon="play-arrow-rounded"
-              width={20}
-              height={20}
-            />
+            <LocalIcon icon="play-arrow-rounded" width={20} height={20} />
             <Text component="span" size="sm" fw={500}>
               {translate("mode.resume", "Resume placement")}
             </Text>


### PR DESCRIPTION
### Motivation
- Remove unresolved Material Symbols icon references that caused the local icon extraction script to report missing icons and force CDN fallbacks. 
- Ensure `LocalIcon` usages and the generated `material-symbols-icons.json` bundle are consistent so icons render locally without missing-name warnings.

### Description
- Replaced `crop-square` with `crop-square-outline` in annotation and comments mappings to match available Material Symbols names. (`frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx`, `frontend/editor/src/core/components/viewer/CommentsSidebar.tsx`).
- Replaced `pause-rounded` with `pause-circle-rounded` and `play-arrow-rounded` (and removed `material-symbols:` prefixes) for signature placement controls so names match the local icon set. (`frontend/editor/src/core/components/tools/sign/SignSettings.tsx`, `frontend/editor/src/saas/components/tools/sign/SignSettings.tsx`).
- Replaced `cloud-upload` with `upload` for the admin database backup button to use an available cloud/upload icon. (`frontend/editor/src/proprietary/components/shared/config/configSections/AdminDatabaseSection.tsx`).

### Testing
- Ran the icon extraction script with `cd frontend/editor && node scripts/generate-icons.js` and it reported the icon set is up-to-date with no missing icons after the changes. (Succeeded.)
- Attempted to run the frontend quality check `task frontend:check` but the `task` CLI was not available in this environment, so it could not be executed. (Not run.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145944144c83258110b6268c093a74)