### PR TITLE
ci: harden workflow runners and update checkout action pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       - "/docker/frontend"
       - "/docker/base"
       - "/docker/engine"
+      - "/docker/unoserver"
+      - "/engine"
     schedule:
       interval: "weekly"
     cooldown:

--- a/.github/workflows/_runner-pick.yml
+++ b/.github/workflows/_runner-pick.yml
@@ -37,6 +37,11 @@ jobs:
     outputs:
       is_fork: ${{ steps.decide.outputs.is_fork }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Classify the trigger
         id: decide
         env:

--- a/.github/workflows/ai-engine.yml
+++ b/.github/workflows/ai-engine.yml
@@ -26,7 +26,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -75,7 +75,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository (for PKGBUILD templates)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Update stirling-pdf-desktop PKGBUILD
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,11 @@ jobs:
       - dependency-review
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Verify every required job passed (or was legitimately skipped)
         env:
           RESULTS: |

--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -2,7 +2,7 @@ name: Update Package Manager Manifests
 
 on:
   release:
-    types: [ released ]
+    types: [released]
   workflow_dispatch:
     inputs:
       version:
@@ -84,7 +84,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout homebrew-stirling-pdf tap (also hosts Scoop bucket)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Stirling-Tools/homebrew-stirling-pdf
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.14
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
# Description of Changes

Add runner hardening and housekeeping across workflows.

- .github/dependabot.yml: add /docker/unoserver and /engine to Dependabot update paths.
- .github/workflows/_runner-pick.yml and .github/workflows/build.yml: add step-security/harden-runner (egress-policy: audit) to audit outbound calls from runners.
- .github/workflows/ai-engine.yml, .github/workflows/aur-publish.yml, .github/workflows/package-managers.yml: update actions/checkout usage to the newer v6.0.2 reference.
- .github/workflows/package-managers.yml: minor YAML formatting tidy (release types array).

These changes improve CI security by auditing egress, update the checkout action to a newer release, and expand Dependabot coverage.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
