### PR TITLE
chore: fix "Endoints" typo in health route comment

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/RequestUriUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/RequestUriUtils.java
@@ -172,7 +172,7 @@ public class RequestUriUtils {
                         "/api/v1/ui-data/footer-info") // Public footer configuration
                 || trimmedUri.startsWith("/api/v1/invite/validate")
                 || trimmedUri.startsWith("/api/v1/invite/accept")
-                // Health Endoints
+                // Health Endpoints
                 || trimmedUri.startsWith("/actuator/health")
                 || trimmedUri.startsWith("/health")
                 || trimmedUri.startsWith("/healthz")


### PR DESCRIPTION
`app/common/src/main/java/stirling/software/common/util/RequestUriUtils.java:175` section comment said "Health Endoints" → "Health Endpoints". Comment-only.