### PR TITLE
Auto-delete CI linting comments on success

### DIFF
--- a/.github/workflows/ai-engine.yml
+++ b/.github/workflows/ai-engine.yml
@@ -1,8 +1,9 @@
 name: AI Engine CI
 
-# Validates the Python AI engine: regenerates tool models, runs fixers,
-# lint, type-check, and tests. Called from build.yml on PRs and merge_group;
-# also runs directly on push to main as a post-merge safety net.
+# Validates the Python AI engine: regenerates tool models and runs the
+# engine quality gate (lint, type-check, format-check, tests). Called from
+# build.yml on PRs and merge_group; also runs directly on push to main as
+# a post-merge safety net.
 on:
   workflow_call:
   push:
@@ -51,27 +52,94 @@ jobs:
         run: task engine:tool-models
 
       - name: Verify tool models are up to date
+        id: tool-models-check
+        continue-on-error: true
+        run: git diff --exit-code engine/src/stirling/models/tool_models.py
+
+      - name: Comment on tool models out of date
+        # Only post a comment on PRs. github-script's PR helpers need an
+        # issue/PR number, which doesn't exist on merge_group runs.
+        if: steps.tool-models-check.outcome == 'failure' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- tool-models-check -->';
+            const body = [
+              marker,
+              '### Tool Models Out Of Date',
+              '',
+              '`engine/src/stirling/models/tool_models.py` is out of date with the Java OpenAPI spec.',
+              '',
+              'Run `task engine:tool-models` locally and commit the updated file.',
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if tool models are out of date
+        if: steps.tool-models-check.outcome == 'failure'
         run: |
-          if ! git diff --exit-code engine/src/stirling/models/tool_models.py; then
-            echo "tool_models.py is out of date."
-            echo "Run 'task engine:tool-models' locally and commit the updated file."
-            exit 1
-          fi
+          echo "============================================"
+          echo "  Tool Models Out Of Date"
+          echo "============================================"
+          echo ""
+          echo "engine/src/stirling/models/tool_models.py is"
+          echo "out of date with the Java OpenAPI spec."
+          echo ""
+          echo "Run 'task engine:tool-models' locally and"
+          echo "commit the updated file."
+          echo "============================================"
+          exit 1
 
-      - name: Run fixers
-        run: task engine:fix
+      - name: Remove tool models comment on success
+        if: steps.tool-models-check.outcome == 'success' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- tool-models-check -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }
 
-      - name: Verify fixes are committed
-        id: fixer_changes
-        run: |
-          if ! git diff --quiet; then
-            git --no-pager diff --stat
-            echo "::error::There are issues with your Python code that will need to be fixed before they can be merged in. Run 'task engine:fix' to auto-fix what can be fixed automatically, then run 'task engine:check' to see what still needs fixing manually."
-            exit 1
-          fi
+      - name: Quality-check engine
+        id: engine-check
+        run: task engine:check
+        continue-on-error: true
 
-      - name: Comment on fixer failures
-        if: steps.fixer_changes.outcome == 'failure' && github.event_name == 'pull_request'
+      - name: Comment on engine check failure
+        # Only post a comment on PRs. github-script's PR helpers need an
+        # issue/PR number, which doesn't exist on merge_group runs.
+        if: steps.engine-check.outcome == 'failure' && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -107,11 +175,39 @@ jobs:
               });
             }
 
-      - name: Run linting
-        run: task engine:lint
+      - name: Fail if engine check failed
+        if: steps.engine-check.outcome == 'failure'
+        run: |
+          echo "============================================"
+          echo "  Engine Check Failed"
+          echo "============================================"
+          echo ""
+          echo "There are issues with your Python code that"
+          echo "will need to be fixed before they can be merged in."
+          echo ""
+          echo "Run 'task engine:fix' to auto-fix what can be"
+          echo "fixed automatically, then run 'task engine:check'"
+          echo "to see what still needs fixing manually."
+          echo "============================================"
+          exit 1
 
-      - name: Run type checking
-        run: task engine:typecheck
-
-      - name: Run tests
-        run: task engine:test
+      - name: Remove engine check comment on success
+        if: steps.engine-check.outcome == 'success' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- engine-check -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }

--- a/.github/workflows/ai-engine.yml
+++ b/.github/workflows/ai-engine.yml
@@ -56,7 +56,7 @@ jobs:
         continue-on-error: true
         run: git diff --exit-code engine/src/stirling/models/tool_models.py
 
-      - name: Comment on tool models out of date
+      - name: Comment on tool models check failure
         # Only post a comment on PRs. github-script's PR helpers need an
         # issue/PR number, which doesn't exist on merge_group runs.
         if: steps.tool-models-check.outcome == 'failure' && github.event_name == 'pull_request'
@@ -67,11 +67,11 @@ jobs:
             const marker = '<!-- tool-models-check -->';
             const body = [
               marker,
-              '### Tool Models Out Of Date',
+              '### Tool Models Check Failed',
               '',
-              '`engine/src/stirling/models/tool_models.py` is out of date with the Java OpenAPI spec.',
+              'The generated `engine/src/stirling/models/tool_models.py` is out of date with the Java OpenAPI spec and will need to be regenerated before it can be merged in.',
               '',
-              'Run `task engine:tool-models` locally and commit the updated file.',
+              'Run `task engine:tool-models` to regenerate, then commit the updated file.',
             ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -95,22 +95,23 @@ jobs:
               });
             }
 
-      - name: Fail if tool models are out of date
+      - name: Fail if tool models check failed
         if: steps.tool-models-check.outcome == 'failure'
         run: |
           echo "============================================"
-          echo "  Tool Models Out Of Date"
+          echo "  Tool Models Check Failed"
           echo "============================================"
           echo ""
-          echo "engine/src/stirling/models/tool_models.py is"
-          echo "out of date with the Java OpenAPI spec."
+          echo "The generated engine/src/stirling/models/tool_models.py"
+          echo "is out of date with the Java OpenAPI spec and will"
+          echo "need to be regenerated before it can be merged in."
           echo ""
-          echo "Run 'task engine:tool-models' locally and"
+          echo "Run 'task engine:tool-models' to regenerate, then"
           echo "commit the updated file."
           echo "============================================"
           exit 1
 
-      - name: Remove tool models comment on success
+      - name: Remove tool models check comment on success
         if: steps.tool-models-check.outcome == 'success' && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -126,6 +126,27 @@ jobs:
           echo "============================================"
           exit 1
 
+      - name: Remove Java formatting check comment on success
+        if: steps.spotless-check.outcome == 'success' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- java-formatting-check -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }
+
       - name: Build with Gradle and spring security ${{ matrix.spring-security }}
         run: task backend:build:ci
         env:

--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -67,7 +67,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_PUBLIC_URL: ${{ secrets.MAVEN_PUBLIC_URL }}
 
-      - name: Comment on Java formatting failure
+      - name: Comment on backend format check failure
         # Only post a comment on PRs. github-script's PR helpers need an
         # issue/PR number, which doesn't exist on merge_group runs.
         if: steps.spotless-check.outcome == 'failure' && github.event_name == 'pull_request'
@@ -78,15 +78,11 @@ jobs:
             const marker = '<!-- java-formatting-check -->';
             const body = [
               marker,
-              '### Java Formatting Check Failed',
+              '### Backend Format Check Failed',
               '',
-              'Your code has formatting issues. Run the following command to fix them:',
+              'There are formatting issues in your Java code that will need to be fixed before they can be merged in.',
               '',
-              '```bash',
-              'task backend:format',
-              '```',
-              '',
-              'Then commit and push the changes.',
+              'Run `task backend:format` to auto-fix, then commit and push the changes.',
             ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -110,23 +106,23 @@ jobs:
               });
             }
 
-      - name: Fail if Java formatting issues found
+      - name: Fail if backend format check failed
         if: steps.spotless-check.outcome == 'failure'
         run: |
           echo "============================================"
-          echo "  Java Formatting Check Failed"
+          echo "  Backend Format Check Failed"
           echo "============================================"
           echo ""
-          echo "Your code has formatting issues."
-          echo "Run the following command to fix them:"
+          echo "There are formatting issues in your Java code"
+          echo "that will need to be fixed before they can be"
+          echo "merged in."
           echo ""
-          echo "  task backend:format"
-          echo ""
-          echo "Then commit and push the changes."
+          echo "Run 'task backend:format' to auto-fix, then"
+          echo "commit and push the changes."
           echo "============================================"
           exit 1
 
-      - name: Remove Java formatting check comment on success
+      - name: Remove backend format check comment on success
         if: steps.spotless-check.outcome == 'success' && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
# Description of Changes
Set CI backend & engine comments to auto-delete once the CI has passed. 

Also redesign the engine CI to call `task engine:check` like it should have been, and make it post a comment when the tool models need to be updated.

Also makes the comment wording more consistent between the three languages.