### PR TITLE
Cache Rust build deps in Tauri CI to speed up desktop builds

### DIFF
--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -227,6 +227,13 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.platform == 'macos-15' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      # Cache compiled cargo deps so the cold ~40min build (webkit2gtk bindings
+      # dominate on Linux) is reused across runs; only the app crates recompile.
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: "frontend/editor/src-tauri -> target"
+
       # x86_64 JDK is set up first so the aarch64 step below can leave its
       # JAVA_HOME as the active one. The macOS universal JRE build needs
       # jmods from both arches; the x64 path is captured into the env

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -115,6 +115,13 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.platform == 'macos-15' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      # Cache compiled cargo deps so the cold ~40min build (webkit2gtk bindings
+      # dominate on Linux) is reused across runs; only the app crates recompile.
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: "frontend/editor/src-tauri -> target"
+
       - name: Set up x86_64 JDK 25 (macOS universal JRE)
         if: matrix.platform == 'macos-15'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0


### PR DESCRIPTION
## Summary
- The Tauri build matrix (`tauri-build.yml`) had **no Rust/cargo caching**, so every run recompiled all dependencies from scratch. On Linux this cold `cargo build --release` was ~40 of the job's ~44 min, dominated by the webkit2gtk/javascriptcore/soup bindings that Windows (WebView2) and macOS (WKWebView) get from the system and never compile.
- Added `Swatinem/rust-cache` scoped to the `frontend/editor/src-tauri` cargo workspace. Compiled deps are restored across runs; only the app crates recompile on a warm cache. Benefits all three platforms.

## Why this and not "skip AppImage"
The deb/rpm vs AppImage split is a red herring. Whichever Tauri build runs **first** pays the full cold compile; the second reuses the warm `target/`. Measured on run [26643477360](https://github.com/Stirling-Tools/Stirling-PDF/actions/runs/26643477360):

| Step | Builds | Duration |
|---|---|---|
| Build Tauri app | deb + rpm (cold compile) | 44m 00s |
| Build Tauri app (AppImage) | AppImage (warm) | 3m 30s |



## Test plan
- [ ] First run on this branch populates the cache (no speedup yet - expected).
- [ ] Subsequent runs: confirm a cache hit in the "Cache Rust build" step log and the Linux Tauri job drops from ~44 min toward the Windows ballpark (~19 min).
- [ ] deb, rpm, and AppImage artifacts are still produced for Linux.

## Follow-ups (not in this PR)
- The same one-line step can be added to `multiOSReleases.yml` to speed up release builds.
- Switching the matrix to Depot runners (token already present) is a larger, complementary lever.