### PR TITLE
fix: Use frontend/editor for locales paths

### DIFF
--- a/.github/scripts/check_language_toml.py
+++ b/.github/scripts/check_language_toml.py
@@ -184,7 +184,7 @@ def check_for_differences(reference_file, file_list, branch, actor):
     if len(file_list) == 1:
         file_arr = file_list[0].split()
 
-    base_dir = Path.cwd() / "frontend" / "public" / "locales"
+    base_dir = Path.cwd() / "frontend" / "editor" / "public" / "locales"
 
     for file_path in file_arr:
         file_path = Path(file_path)
@@ -372,6 +372,7 @@ if __name__ == "__main__":
                 os.path.join(
                     os.getcwd(),
                     "frontend",
+                    "editor",
                     "public",
                     "locales",
                     "*",

--- a/scripts/counter_translation_v3.py
+++ b/scripts/counter_translation_v3.py
@@ -345,7 +345,7 @@ def main() -> None:
 
     # Project layout assumptions
     cwd = os.getcwd()
-    locales_dir = os.path.join(cwd, "frontend", "public", "locales")
+    locales_dir = os.path.join(cwd, "frontend", "editor", "public", "locales")
     reference_file = os.path.join(locales_dir, "en-GB", "translation.toml")
     scripts_directory = os.path.join(cwd, "scripts")
     translation_state_file = os.path.join(scripts_directory, "ignore_translation.toml")

--- a/scripts/translations/translation_merger.py
+++ b/scripts/translations/translation_merger.py
@@ -22,7 +22,7 @@ import tomli_w
 class TranslationMerger:
     def __init__(
         self,
-        locales_dir: str = os.path.join(os.getcwd(), "frontend", "public", "locales"),
+        locales_dir: str = os.path.join(os.getcwd(), "frontend", "editor", "public", "locales"),
         ignore_file: str = os.path.join(
             os.getcwd(), "scripts", "ignore_translation.toml"
         ),
@@ -371,7 +371,7 @@ def main():
     )
     parser.add_argument(
         "--locales-dir",
-        default=os.path.join(os.getcwd(), "frontend", "public", "locales"),
+        default=os.path.join(os.getcwd(), "frontend", "editor", "public", "locales"),
         help="Path to locales directory",
     )
     parser.add_argument(


### PR DESCRIPTION
# Description of Changes

Update locale directory paths to include the new 'editor' subdirectory. Modified .github/scripts/check_language_toml.py, scripts/counter_translation_v3.py, and scripts/translations/translation_merger.py to reference frontend/editor/public/locales (including the CLI default), aligning the scripts with the project's reorganized locales location.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
