### PR TITLE
ci(github-actions): replace deprecated app-id input with client-id

### DIFF
--- a/.github/actions/setup-bot/action.yml
+++ b/.github/actions/setup-bot/action.yml
@@ -24,7 +24,7 @@ runs:
       id: generate-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
     - name: Configure Git
       run: |

--- a/scripts/translations/translation_merger.py
+++ b/scripts/translations/translation_merger.py
@@ -22,7 +22,9 @@ import tomli_w
 class TranslationMerger:
     def __init__(
         self,
-        locales_dir: str = os.path.join(os.getcwd(), "frontend", "editor", "public", "locales"),
+        locales_dir: str = os.path.join(
+            os.getcwd(), "frontend", "editor", "public", "locales"
+        ),
         ignore_file: str = os.path.join(
             os.getcwd(), "scripts", "ignore_translation.toml"
         ),


### PR DESCRIPTION
# Description of Changes

This change updates the GitHub App token generation step in the custom `setup-bot` GitHub Action to use the new `client-id` input instead of the deprecated `app-id` input when invoking `actions/create-github-app-token`.

### What was changed

- Replaced the deprecated `app-id` parameter with `client-id` in `.github/actions/setup-bot/action.yml`.
- Continued sourcing the value from the existing `inputs.app-id` action input to avoid broader interface changes.

### Why the change was made

- `actions/create-github-app-token` has deprecated the `app-id` input and now expects `client-id`.
- Updating the workflow removes the deprecation warning and ensures compatibility with current and future versions of the action.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
