### PR TITLE
fix(desktop): enable trackpad pinch-zoom in PDF viewer on Windows

### DIFF
--- a/frontend/editor/src-tauri/src/commands/window.rs
+++ b/frontend/editor/src-tauri/src/commands/window.rs
@@ -47,9 +47,14 @@ fn build_window(app: &AppHandle, label: &str, url: &str) -> Result<WebviewWindow
     // nothing more. We mirror that string byte-for-byte so windows share one data
     // dir (and thus IndexedDB / localStorage / cookies). macOS (WKWebView) and
     // Linux (WebKitGTK) don't have this constraint, so the arg is Windows-only.
+    //
+    // `--disable-pinch` turns off WebView2's built-in "Page Scale" pinch zoom,
+    // which otherwise intercepts trackpad pinches as a post-render compositor step
+    // and never dispatches the synthetic ctrl+wheel event the PDF viewer relies on
+    // for zoom. Must stay byte-for-byte in sync with tauri.conf.json.
     #[cfg(target_os = "windows")]
-    let builder =
-        builder.additional_browser_args("--enable-features=CertVerifierBuiltinFeature");
+    let builder = builder
+        .additional_browser_args("--enable-features=CertVerifierBuiltinFeature --disable-pinch");
 
     builder.build().map_err(|e| e.to_string())
 }

--- a/frontend/editor/src-tauri/tauri.conf.json
+++ b/frontend/editor/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
         "height": 800,
         "resizable": true,
         "fullscreen": false,
-        "additionalBrowserArgs": "--enable-features=CertVerifierBuiltinFeature"
+        "additionalBrowserArgs": "--enable-features=CertVerifierBuiltinFeature --disable-pinch"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Trackpad pinch-to-zoom doesn't work in the PDF viewer in the Windows desktop (Tauri/WebView2) app, though it works in Chrome and Firefox.
- **Root cause:** the viewer detects pinch via synthetic `wheel` events with `ctrlKey` set (`useWheelZoom.ts`). Chromium fires those for trackpad pinches, but WebView2 ships with `IsPinchZoomEnabled=true`, which captures the pinch as a compositor-level "Page Scale" zoom in a post-render step and never dispatches the event to JS.
- **Fix (config only):** add the `--disable-pinch` WebView2 browser arg so Chromium reverts to its standard `ctrl+wheel` dispatch, which the existing zoom handler already consumes. No UI/JS changes.

## Changes
- `frontend/editor/src-tauri/tauri.conf.json` — main window `additionalBrowserArgs`
- `frontend/editor/src-tauri/src/commands/window.rs` — spawned-window `additional_browser_args`

Both must stay byte-for-byte identical so WebView2 windows can share one user-data folder (constraint already documented in `window.rs`).

## Test plan
- [ ] Build/run the Windows desktop app
- [ ] Open a PDF in the viewer and pinch on the trackpad → document zooms in/out
- [ ] Confirm the whole-UI page-scale zoom no longer triggers on pinch
- [ ] Ctrl+scroll and Ctrl +/- zoom still work
- [ ] Multi-window: open a second window, confirm shared session/state intact (no separate user-data folder)

> Note: macOS (WKWebView) does not surface a JS event for pinch, so this fix is Windows-specific; macOS would need a separate approach.