### PR TITLE
fix folder causing 500 toast when deleted on another machine

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
+++ b/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
@@ -1016,7 +1016,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ProblemDetail> handleNoResourceFound(
             NoResourceFoundException ex, HttpServletRequest request) {
-        log.warn("No resource at {}: {}", request.getRequestURI(), ex.getMessage());
+        // Log level depends on the path. This handler catches every fall-through to the static
+        // resource layer - including favicon.ico, /robots.txt, /.well-known/*, and every URL a
+        // scanner probes (/wp-login.php, /.env, etc). Logging all of those at WARN floods prod
+        // logs with non-actionable noise. A miss under /api/* is different: it almost always
+        // means a controller is missing from this build (the case that prompted this handler),
+        // which IS operator-relevant, so /api paths stay at WARN.
+        String uri = request.getRequestURI();
+        if (uri != null && uri.startsWith("/api/")) {
+            log.warn("No resource at {}: {}", uri, ex.getMessage());
+        } else {
+            log.debug("No resource at {}: {}", uri, ex.getMessage());
+        }
 
         String title = getLocalizedMessage("error.notFound.title", ErrorTitles.NOT_FOUND_DEFAULT);
         String detail =

--- a/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
+++ b/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -979,6 +980,60 @@ public class GlobalExceptionHandler {
         problemDetail.setTitle(title);
         problemDetail.setProperty("title", title); // Ensure serialization
         problemDetail.setProperty("method", ex.getHttpMethod());
+        addStandardHints(
+                problemDetail,
+                "error.notFound.hints",
+                List.of(
+                        "Verify the URL path and HTTP method are correct.",
+                        "Check the API base path and version if applicable.",
+                        "Ensure there are no typos in the endpoint path."));
+        problemDetail.setProperty("actionRequired", "Use a valid endpoint URL and method.");
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .contentType(PROBLEM_JSON)
+                .body(problemDetail);
+    }
+
+    /**
+     * Handle {@link NoResourceFoundException} - Spring 6.1+ throws this when the {@link
+     * org.springframework.web.servlet.DispatcherServlet} routes a request to its static-resource
+     * handler and no matching resource exists. The classic catch-all in this advice would otherwise
+     * downgrade it to a generic 500, which fires noisy "An unexpected error occurred" banners on
+     * the frontend whenever a UI build is paired with a backend that doesn't map a route (e.g. an
+     * older backend missing a controller the new editor calls). A clean 404 lets the client treat
+     * the route as "endpoint not deployed" and degrade gracefully.
+     *
+     * <p>Note: this is distinct from {@link NoHandlerFoundException}, which only fires when {@code
+     * spring.mvc.throw-exception-if-no-handler-found=true} and the default servlet handling is off.
+     * In a typical Spring Boot config the static-resource fallthrough triggers {@link
+     * NoResourceFoundException} instead, so without this handler an unmapped REST URL becomes a
+     * 500.
+     *
+     * @param ex the NoResourceFoundException
+     * @param request the HTTP servlet request
+     * @return ProblemDetail with HTTP 404 NOT_FOUND
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ProblemDetail> handleNoResourceFound(
+            NoResourceFoundException ex, HttpServletRequest request) {
+        log.warn("No resource at {}: {}", request.getRequestURI(), ex.getMessage());
+
+        String title = getLocalizedMessage("error.notFound.title", ErrorTitles.NOT_FOUND_DEFAULT);
+        String detail =
+                getLocalizedMessage(
+                        "error.notFound.detail",
+                        String.format(
+                                "No endpoint found for %s %s",
+                                request.getMethod(), request.getRequestURI()),
+                        request.getMethod(),
+                        request.getRequestURI());
+
+        ProblemDetail problemDetail =
+                createBaseProblemDetail(HttpStatus.NOT_FOUND, detail, request);
+        problemDetail.setType(URI.create(ErrorTypes.NOT_FOUND));
+        problemDetail.setTitle(title);
+        problemDetail.setProperty("title", title);
+        problemDetail.setProperty("method", request.getMethod());
         addStandardHints(
                 problemDetail,
                 "error.notFound.hints",

--- a/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
+++ b/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
@@ -994,34 +994,12 @@ public class GlobalExceptionHandler {
                 .body(problemDetail);
     }
 
-    /**
-     * Handle {@link NoResourceFoundException} - Spring 6.1+ throws this when the {@link
-     * org.springframework.web.servlet.DispatcherServlet} routes a request to its static-resource
-     * handler and no matching resource exists. The classic catch-all in this advice would otherwise
-     * downgrade it to a generic 500, which fires noisy "An unexpected error occurred" banners on
-     * the frontend whenever a UI build is paired with a backend that doesn't map a route (e.g. an
-     * older backend missing a controller the new editor calls). A clean 404 lets the client treat
-     * the route as "endpoint not deployed" and degrade gracefully.
-     *
-     * <p>Note: this is distinct from {@link NoHandlerFoundException}, which only fires when {@code
-     * spring.mvc.throw-exception-if-no-handler-found=true} and the default servlet handling is off.
-     * In a typical Spring Boot config the static-resource fallthrough triggers {@link
-     * NoResourceFoundException} instead, so without this handler an unmapped REST URL becomes a
-     * 500.
-     *
-     * @param ex the NoResourceFoundException
-     * @param request the HTTP servlet request
-     * @return ProblemDetail with HTTP 404 NOT_FOUND
-     */
+    /** Unmapped path → clean 404 instead of falling through to the generic 500 catch-all. */
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ProblemDetail> handleNoResourceFound(
             NoResourceFoundException ex, HttpServletRequest request) {
-        // Log level depends on the path. This handler catches every fall-through to the static
-        // resource layer - including favicon.ico, /robots.txt, /.well-known/*, and every URL a
-        // scanner probes (/wp-login.php, /.env, etc). Logging all of those at WARN floods prod
-        // logs with non-actionable noise. A miss under /api/* is different: it almost always
-        // means a controller is missing from this build (the case that prompted this handler),
-        // which IS operator-relevant, so /api paths stay at WARN.
+        // /api/* miss = likely missing controller (operator-relevant); other paths = favicons,
+        // robots.txt, scanner noise. Demote the latter so prod logs aren't flooded.
         String uri = request.getRequestURI();
         if (uri != null && uri.startsWith("/api/")) {
             log.warn("No resource at {}: {}", uri, ex.getMessage());

--- a/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
@@ -211,11 +211,7 @@ class GlobalExceptionHandlerTest {
     }
 
     // ---- NoResourceFoundException ----
-    // Regression guard: pre-fix this fell through to the generic Exception catch-all and became a
-    // 500, which fired noisy "Folder sync failed" banners on the frontend whenever a controller
-    // was missing from the backend build (e.g. running the editor against an older app jar). The
-    // handler must keep returning 404 so the frontend's existing endpoint-missing path can
-    // gracefully degrade.
+    // Regression guard: was falling through to the 500 catch-all.
 
     @Test
     void handleNoResourceFound_returns_404_not_500() {

--- a/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.MessageSource;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -206,6 +208,23 @@ class GlobalExceptionHandlerTest {
         NoHandlerFoundException ex = new NoHandlerFoundException("GET", "/api/missing", null);
         ResponseEntity<ProblemDetail> resp = handler.handleNotFound(ex, request);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    // ---- NoResourceFoundException ----
+    // Regression guard: pre-fix this fell through to the generic Exception catch-all and became a
+    // 500, which fired noisy "Folder sync failed" banners on the frontend whenever a controller
+    // was missing from the backend build (e.g. running the editor against an older app jar). The
+    // handler must keep returning 404 so the frontend's existing endpoint-missing path can
+    // gracefully degrade.
+
+    @Test
+    void handleNoResourceFound_returns_404_not_500() {
+        when(request.getMethod()).thenReturn("GET");
+        NoResourceFoundException ex =
+                new NoResourceFoundException(HttpMethod.GET, "/api/v1/storage/folders", "");
+        ResponseEntity<ProblemDetail> resp = handler.handleNoResourceFound(ex, request);
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+        assertEquals("GET", resp.getBody().getProperties().get("method"));
     }
 
     // ---- IllegalArgumentException ----

--- a/frontend/editor/src/core/contexts/FolderContext.test.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 
 import { FolderProvider, useFolders } from "@app/contexts/FolderContext";
+import { createFolderId, FolderRecord } from "@app/types/folder";
 
 /**
  * Regression test for the sync-banner 4xx gating fix in commit c38b646c5.
@@ -25,21 +26,46 @@ import { FolderProvider, useFolders } from "@app/contexts/FolderContext";
 // require a running backend (folderSyncService) and a populated IDB
 // (folderStorage). Both are out of scope for testing the error gate.
 const mockList = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
 vi.mock("@app/services/folderSyncService", () => ({
   folderSyncService: {
     list: () => mockList(),
     create: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
+    update: (...args: unknown[]) => mockUpdate(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
   },
 }));
 
+// Stateful IDB mock - the FolderContext's revision-driven refresh effect
+// re-reads `getAllFolders()` after every state change, so a stateless mock
+// returning `[]` would clobber the in-memory folders set by pullFromServer.
+// Hoisted so the vi.mock factory below can see it; mutated via the standard
+// `replaceAll`/`upsertFolder`/`removeFolders` API.
+const { mockIdb } = vi.hoisted(() => ({
+  mockIdb: { folders: [] as { id: string }[] },
+}));
 vi.mock("@app/services/folderStorage", () => ({
   folderStorage: {
-    getAllFolders: vi.fn().mockResolvedValue([]),
-    replaceAll: vi.fn().mockResolvedValue(undefined),
-    upsert: vi.fn().mockResolvedValue(undefined),
+    getAllFolders: vi.fn(() => Promise.resolve([...mockIdb.folders])),
+    replaceAll: vi.fn((next: { id: string }[]) => {
+      mockIdb.folders = [...next];
+      return Promise.resolve();
+    }),
+    upsert: vi.fn(),
+    upsertFolder: vi.fn((next: { id: string }) => {
+      mockIdb.folders = [
+        ...mockIdb.folders.filter((f) => f.id !== next.id),
+        next,
+      ];
+      return Promise.resolve();
+    }),
     delete: vi.fn().mockResolvedValue(undefined),
+    removeFolders: vi.fn((ids: string[]) => {
+      const drop = new Set(ids);
+      mockIdb.folders = mockIdb.folders.filter((f) => !drop.has(f.id));
+      return Promise.resolve();
+    }),
   },
 }));
 
@@ -104,6 +130,8 @@ async function renderAndWaitForPull(): Promise<void> {
 describe("FolderContext sync-banner gating", () => {
   beforeEach(() => {
     mockList.mockReset();
+    mockUpdate.mockReset();
+    mockDelete.mockReset();
   });
 
   test("401 (unauthorized) does NOT surface a banner", async () => {
@@ -150,5 +178,153 @@ describe("FolderContext sync-banner gating", () => {
     await renderAndWaitForPull();
     expect(screen.getByTestId("error").textContent).toBe("<null>");
     expect(screen.getByTestId("reachable").textContent).toBe("false");
+  });
+});
+
+/**
+ * Regression coverage for the stale-folder 404 cleanup.
+ *
+ * When a per-folder mutation (rename/move/appearance/delete) returns 404, the
+ * server is telling us the folder no longer exists - almost always because
+ * another client session deleted it. The context should drop the folder + its
+ * local descendants from in-memory state, suppress the error banner, and
+ * fire a fresh pullFromServer to converge. The user perceives the folder
+ * silently disappearing rather than a confusing "Folder operation failed"
+ * alert for a folder they can't even see anymore.
+ */
+describe("FolderContext stale-folder 404 cleanup", () => {
+  beforeEach(() => {
+    mockList.mockReset();
+    mockUpdate.mockReset();
+    mockDelete.mockReset();
+    // Reset the stateful IDB mock so each test starts with an empty cache.
+    mockIdb.folders = [];
+  });
+
+  function makeFolder(name: string, parentFolderId: string | null = null) {
+    return {
+      id: createFolderId(),
+      name,
+      parentFolderId,
+      createdAt: 0,
+      updatedAt: 0,
+    } as FolderRecord;
+  }
+
+  type ProbeApi = {
+    error: string | null;
+    folderCount: number;
+    rename: (id: string, name: string) => Promise<unknown>;
+    delete: (id: string) => Promise<unknown>;
+  };
+
+  function ApiProbe(props: { onReady: (api: ProbeApi) => void }) {
+    const f = useFolders();
+    React.useEffect(() => {
+      props.onReady({
+        error: f.error,
+        folderCount: f.folders.length,
+        rename: (id, name) => f.renameFolder(id as never, name),
+        delete: (id) => f.deleteFolder(id as never),
+      });
+    }, [f, props]);
+    return (
+      <>
+        <div data-testid="error">{f.error ?? "<null>"}</div>
+        <div data-testid="reachable">{String(f.serverReachable)}</div>
+        <div data-testid="count">{f.folders.length}</div>
+      </>
+    );
+  }
+
+  async function setupWithFolders(initial: FolderRecord[]): Promise<ProbeApi> {
+    // First pull returns the seeded folders; second pull (triggered by the
+    // stale-folder handler) returns the same minus the stale id so the test
+    // can observe convergence.
+    mockList.mockResolvedValueOnce(initial);
+    let captured: ProbeApi | null = null;
+    render(
+      <FolderProvider>
+        <ApiProbe onReady={(api) => (captured = api)} />
+      </FolderProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("count").textContent).toBe(
+        String(initial.length),
+      ),
+    );
+    if (!captured) throw new Error("ApiProbe never reported ready");
+    return captured;
+  }
+
+  test("renameFolder 404 silently drops folder + descendants, no banner", async () => {
+    const parent = makeFolder("parent");
+    const child = makeFolder("child", parent.id);
+    const sibling = makeFolder("sibling");
+    const api = await setupWithFolders([parent, child, sibling]);
+
+    // Second list (the convergence pull) - confirm parent + child are gone
+    // server-side; sibling remains.
+    mockList.mockResolvedValueOnce([sibling]);
+    mockUpdate.mockRejectedValueOnce(axiosError(404, "Folder not found"));
+
+    await act(async () => {
+      const result = await api.rename(parent.id, "newname");
+      // 404 resolves with null (silent cleanup) rather than throwing.
+      expect(result).toBeNull();
+    });
+
+    // Banner stays clean.
+    expect(screen.getByTestId("error").textContent).toBe("<null>");
+    // Local state dropped parent + child immediately (before the pull lands).
+    // After the pull, only `sibling` should be visible.
+    await waitFor(() =>
+      expect(screen.getByTestId("count").textContent).toBe("1"),
+    );
+    expect(screen.getByTestId("reachable").textContent).toBe("true");
+  });
+
+  test("deleteFolder 404 is treated as already-deleted, returns [id], no banner", async () => {
+    const target = makeFolder("target");
+    const other = makeFolder("other");
+    const api = await setupWithFolders([target, other]);
+
+    mockList.mockResolvedValueOnce([other]);
+    mockDelete.mockRejectedValueOnce(axiosError(404, "Folder not found"));
+
+    let result: unknown;
+    await act(async () => {
+      result = await api.delete(target.id);
+    });
+    expect(result).toEqual([target.id]);
+
+    expect(screen.getByTestId("error").textContent).toBe("<null>");
+    await waitFor(() =>
+      expect(screen.getByTestId("count").textContent).toBe("1"),
+    );
+    expect(screen.getByTestId("reachable").textContent).toBe("true");
+  });
+
+  test("non-404 mutation errors still surface (regression guard)", async () => {
+    // Make sure the silent-cleanup branch only triggers on 404 - a 500 must
+    // still throw and surface the banner so the user knows the op failed.
+    const target = makeFolder("target");
+    const api = await setupWithFolders([target]);
+
+    mockUpdate.mockRejectedValueOnce(axiosError(500, "boom"));
+
+    let threw = false;
+    await act(async () => {
+      try {
+        await api.rename(target.id, "newname");
+      } catch {
+        threw = true;
+      }
+    });
+    expect(threw).toBe(true);
+    // Folder still present (we didn't drop it - this wasn't a stale signal).
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    // Error banner DID surface (formatServerError result).
+    expect(screen.getByTestId("error").textContent).not.toBe("<null>");
   });
 });

--- a/frontend/editor/src/core/contexts/FolderContext.test.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 
 import { FolderProvider, useFolders } from "@app/contexts/FolderContext";
-import { createFolderId, FolderRecord } from "@app/types/folder";
+import { createFolderId, FolderId, FolderRecord } from "@app/types/folder";
 
 /**
  * Regression test for the sync-banner 4xx gating fix in commit c38b646c5.
@@ -201,7 +201,7 @@ describe("FolderContext stale-folder 404 cleanup", () => {
     mockIdb.folders = [];
   });
 
-  function makeFolder(name: string, parentFolderId: string | null = null) {
+  function makeFolder(name: string, parentFolderId: FolderId | null = null) {
     return {
       id: createFolderId(),
       name,
@@ -214,8 +214,10 @@ describe("FolderContext stale-folder 404 cleanup", () => {
   type ProbeApi = {
     error: string | null;
     folderCount: number;
-    rename: (id: string, name: string) => Promise<unknown>;
-    delete: (id: string) => Promise<unknown>;
+    currentFolderId: FolderId | null;
+    setCurrentFolderId: (id: FolderId | null) => void;
+    rename: (id: FolderId, name: string) => Promise<unknown>;
+    delete: (id: FolderId) => Promise<unknown>;
   };
 
   function ApiProbe(props: { onReady: (api: ProbeApi) => void }) {
@@ -224,8 +226,10 @@ describe("FolderContext stale-folder 404 cleanup", () => {
       props.onReady({
         error: f.error,
         folderCount: f.folders.length,
-        rename: (id, name) => f.renameFolder(id as never, name),
-        delete: (id) => f.deleteFolder(id as never),
+        currentFolderId: f.currentFolderId,
+        setCurrentFolderId: f.setCurrentFolderId,
+        rename: (id, name) => f.renameFolder(id, name),
+        delete: (id) => f.deleteFolder(id),
       });
     }, [f, props]);
     return (
@@ -233,19 +237,28 @@ describe("FolderContext stale-folder 404 cleanup", () => {
         <div data-testid="error">{f.error ?? "<null>"}</div>
         <div data-testid="reachable">{String(f.serverReachable)}</div>
         <div data-testid="count">{f.folders.length}</div>
+        <div data-testid="current">{f.currentFolderId ?? "<null>"}</div>
       </>
     );
   }
 
-  async function setupWithFolders(initial: FolderRecord[]): Promise<ProbeApi> {
+  async function setupWithFolders(
+    initial: FolderRecord[],
+  ): Promise<{ current: ProbeApi }> {
     // First pull returns the seeded folders; second pull (triggered by the
     // stale-folder handler) returns the same minus the stale id so the test
     // can observe convergence.
+    //
+    // We hand back a `{ current }` ref rather than a plain ProbeApi so the
+    // test always sees the LATEST f-bound api. The probe re-issues onReady
+    // on every render of FolderContext state changes (setCurrentFolderId,
+    // mutation returns, etc.), and tests that interact with the api after
+    // navigation need the post-navigation closures.
     mockList.mockResolvedValueOnce(initial);
-    let captured: ProbeApi | null = null;
+    const apiRef: { current: ProbeApi | null } = { current: null };
     render(
       <FolderProvider>
-        <ApiProbe onReady={(api) => (captured = api)} />
+        <ApiProbe onReady={(api) => (apiRef.current = api)} />
       </FolderProvider>,
     );
     await waitFor(() =>
@@ -253,8 +266,8 @@ describe("FolderContext stale-folder 404 cleanup", () => {
         String(initial.length),
       ),
     );
-    if (!captured) throw new Error("ApiProbe never reported ready");
-    return captured;
+    if (!apiRef.current) throw new Error("ApiProbe never reported ready");
+    return apiRef as { current: ProbeApi };
   }
 
   test("renameFolder 404 silently drops folder + descendants, no banner", async () => {
@@ -269,7 +282,7 @@ describe("FolderContext stale-folder 404 cleanup", () => {
     mockUpdate.mockRejectedValueOnce(axiosError(404, "Folder not found"));
 
     await act(async () => {
-      const result = await api.rename(parent.id, "newname");
+      const result = await api.current.rename(parent.id, "newname");
       // 404 resolves with null (silent cleanup) rather than throwing.
       expect(result).toBeNull();
     });
@@ -294,7 +307,7 @@ describe("FolderContext stale-folder 404 cleanup", () => {
 
     let result: unknown;
     await act(async () => {
-      result = await api.delete(target.id);
+      result = await api.current.delete(target.id);
     });
     expect(result).toEqual([target.id]);
 
@@ -303,6 +316,38 @@ describe("FolderContext stale-folder 404 cleanup", () => {
       expect(screen.getByTestId("count").textContent).toBe("1"),
     );
     expect(screen.getByTestId("reachable").textContent).toBe("true");
+  });
+
+  test("stale 404 strand-resets currentFolderId when user is inside the dropped subtree", async () => {
+    // The user is browsing /parent/child when another session deletes
+    // /parent. The 404 on a mutation against /parent (or anywhere in the
+    // subtree) must navigate the user out, otherwise the breadcrumb points
+    // at a folder id no longer in the local map.
+    const parent = makeFolder("parent");
+    const child = makeFolder("child", parent.id);
+    const sibling = makeFolder("sibling");
+    const api = await setupWithFolders([parent, child, sibling]);
+
+    // Navigate the user into the child folder before the mutation fires.
+    act(() => {
+      api.current.setCurrentFolderId(child.id);
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("current").textContent).toBe(child.id),
+    );
+
+    // Convergence pull will return just the sibling (parent + child gone).
+    mockList.mockResolvedValueOnce([sibling]);
+    mockUpdate.mockRejectedValueOnce(axiosError(404, "Folder not found"));
+
+    await act(async () => {
+      await api.current.rename(parent.id, "doomed-rename");
+    });
+
+    // currentFolderId must reset to root - ROOT_FOLDER_ID is null so the
+    // probe renders the sentinel "<null>" rather than the child uuid.
+    expect(screen.getByTestId("current").textContent).toBe("<null>");
+    expect(screen.getByTestId("error").textContent).toBe("<null>");
   });
 
   test("non-404 mutation errors still surface (regression guard)", async () => {
@@ -316,7 +361,7 @@ describe("FolderContext stale-folder 404 cleanup", () => {
     let threw = false;
     await act(async () => {
       try {
-        await api.rename(target.id, "newname");
+        await api.current.rename(target.id, "newname");
       } catch {
         threw = true;
       }

--- a/frontend/editor/src/core/contexts/FolderContext.test.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.test.tsx
@@ -37,11 +37,8 @@ vi.mock("@app/services/folderSyncService", () => ({
   },
 }));
 
-// Stateful IDB mock - the FolderContext's revision-driven refresh effect
-// re-reads `getAllFolders()` after every state change, so a stateless mock
-// returning `[]` would clobber the in-memory folders set by pullFromServer.
-// Hoisted so the vi.mock factory below can see it; mutated via the standard
-// `replaceAll`/`upsertFolder`/`removeFolders` API.
+// Stateful IDB mock - the revision-driven refresh re-reads getAllFolders
+// after every state change, so a stateless [] mock would clobber pull results.
 const { mockIdb } = vi.hoisted(() => ({
   mockIdb: { folders: [] as { id: string }[] },
 }));
@@ -181,17 +178,7 @@ describe("FolderContext sync-banner gating", () => {
   });
 });
 
-/**
- * Regression coverage for the stale-folder 404 cleanup.
- *
- * When a per-folder mutation (rename/move/appearance/delete) returns 404, the
- * server is telling us the folder no longer exists - almost always because
- * another client session deleted it. The context should drop the folder + its
- * local descendants from in-memory state, suppress the error banner, and
- * fire a fresh pullFromServer to converge. The user perceives the folder
- * silently disappearing rather than a confusing "Folder operation failed"
- * alert for a folder they can't even see anymore.
- */
+/** Per-folder mutation 404 = silent cleanup (drop subtree, no banner, pull). */
 describe("FolderContext stale-folder 404 cleanup", () => {
   beforeEach(() => {
     mockList.mockReset();
@@ -245,15 +232,7 @@ describe("FolderContext stale-folder 404 cleanup", () => {
   async function setupWithFolders(
     initial: FolderRecord[],
   ): Promise<{ current: ProbeApi }> {
-    // First pull returns the seeded folders; second pull (triggered by the
-    // stale-folder handler) returns the same minus the stale id so the test
-    // can observe convergence.
-    //
-    // We hand back a `{ current }` ref rather than a plain ProbeApi so the
-    // test always sees the LATEST f-bound api. The probe re-issues onReady
-    // on every render of FolderContext state changes (setCurrentFolderId,
-    // mutation returns, etc.), and tests that interact with the api after
-    // navigation need the post-navigation closures.
+    // Ref (not plain object) so tests see the latest f-bound api after re-renders.
     mockList.mockResolvedValueOnce(initial);
     const apiRef: { current: ProbeApi | null } = { current: null };
     render(
@@ -276,21 +255,16 @@ describe("FolderContext stale-folder 404 cleanup", () => {
     const sibling = makeFolder("sibling");
     const api = await setupWithFolders([parent, child, sibling]);
 
-    // Second list (the convergence pull) - confirm parent + child are gone
-    // server-side; sibling remains.
+    // Convergence pull returns just sibling after the local drop.
     mockList.mockResolvedValueOnce([sibling]);
     mockUpdate.mockRejectedValueOnce(axiosError(404, "Folder not found"));
 
     await act(async () => {
       const result = await api.current.rename(parent.id, "newname");
-      // 404 resolves with null (silent cleanup) rather than throwing.
       expect(result).toBeNull();
     });
 
-    // Banner stays clean.
     expect(screen.getByTestId("error").textContent).toBe("<null>");
-    // Local state dropped parent + child immediately (before the pull lands).
-    // After the pull, only `sibling` should be visible.
     await waitFor(() =>
       expect(screen.getByTestId("count").textContent).toBe("1"),
     );
@@ -319,16 +293,12 @@ describe("FolderContext stale-folder 404 cleanup", () => {
   });
 
   test("stale 404 strand-resets currentFolderId when user is inside the dropped subtree", async () => {
-    // The user is browsing /parent/child when another session deletes
-    // /parent. The 404 on a mutation against /parent (or anywhere in the
-    // subtree) must navigate the user out, otherwise the breadcrumb points
-    // at a folder id no longer in the local map.
+    // User is parked inside the about-to-be-deleted subtree → must navigate out.
     const parent = makeFolder("parent");
     const child = makeFolder("child", parent.id);
     const sibling = makeFolder("sibling");
     const api = await setupWithFolders([parent, child, sibling]);
 
-    // Navigate the user into the child folder before the mutation fires.
     act(() => {
       api.current.setCurrentFolderId(child.id);
     });
@@ -336,7 +306,6 @@ describe("FolderContext stale-folder 404 cleanup", () => {
       expect(screen.getByTestId("current").textContent).toBe(child.id),
     );
 
-    // Convergence pull will return just the sibling (parent + child gone).
     mockList.mockResolvedValueOnce([sibling]);
     mockUpdate.mockRejectedValueOnce(axiosError(404, "Folder not found"));
 
@@ -344,15 +313,12 @@ describe("FolderContext stale-folder 404 cleanup", () => {
       await api.current.rename(parent.id, "doomed-rename");
     });
 
-    // currentFolderId must reset to root - ROOT_FOLDER_ID is null so the
-    // probe renders the sentinel "<null>" rather than the child uuid.
+    // ROOT_FOLDER_ID is null → probe renders "<null>".
     expect(screen.getByTestId("current").textContent).toBe("<null>");
     expect(screen.getByTestId("error").textContent).toBe("<null>");
   });
 
   test("non-404 mutation errors still surface (regression guard)", async () => {
-    // Make sure the silent-cleanup branch only triggers on 404 - a 500 must
-    // still throw and surface the banner so the user knows the op failed.
     const target = makeFolder("target");
     const api = await setupWithFolders([target]);
 
@@ -367,9 +333,7 @@ describe("FolderContext stale-folder 404 cleanup", () => {
       }
     });
     expect(threw).toBe(true);
-    // Folder still present (we didn't drop it - this wasn't a stale signal).
     expect(screen.getByTestId("count").textContent).toBe("1");
-    // Error banner DID surface (formatServerError result).
     expect(screen.getByTestId("error").textContent).not.toBe("<null>");
   });
 });

--- a/frontend/editor/src/core/contexts/FolderContext.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.tsx
@@ -178,17 +178,7 @@ function reachabilityFromError(err: unknown): boolean {
   return status !== undefined && status >= 400 && status < 500;
 }
 
-/**
- * Collect `rootId` plus every local descendant reachable via `parentFolderId`.
- *
- * Used when the server reports a folder no longer exists (404 on a mutation):
- * we assume the cascade also took its children locally, so we can drop the
- * whole subtree immediately for snappy UX. The follow-up pullFromServer
- * re-adds anything we dropped in error (e.g. a child that was reparented
- * out of this subtree before the deletion).
- *
- * Bounded so a corrupted parent chain can't run away here.
- */
+/** Root + every local descendant via parentFolderId. Bounded for corrupted chains. */
 function collectLocalSubtreeIds(
   rootId: FolderId,
   folders: FolderRecord[],
@@ -434,31 +424,10 @@ export function FolderProvider({ children }: FolderProviderProps) {
 
   // ─── mutations: server-first, cache update on success ──────────────
 
-  // Lifted above `runFolderMutation` so the stale-folder handler below can
-  // use it (file/folder cleanup on 404 reuses the same primitive as delete).
+  // Lifted up so handleStaleFolder below can reuse the file-detach primitive.
   const { clearFolderForFiles } = useIndexedDB();
 
-  /**
-   * Silently reconcile a per-folder 404 from the server.
-   *
-   * A 404 on a mutation targeting an existing-looking folder id means the
-   * server no longer knows about it - almost always because another client
-   * session (or the same user in another tab) deleted it. Rather than
-   * surfacing a "Folder operation failed" banner for a folder the user can't
-   * see anyway, we treat the 404 as a delete signal:
-   *
-   *   1. Drop the folder + every local descendant from in-memory state.
-   *   2. Strand-reset `currentFolderId` if the user was browsing inside.
-   *   3. Best-effort cleanup of the IDB cache and any local files'
-   *      folder-id pointers (file rows stay; their folder pointer clears).
-   *   4. Fire {@link pullFromServer} to reconverge - if we dropped too much
-   *      (e.g. a child reparented out of this subtree before the delete),
-   *      the pull re-adds it; if we missed something (deeper cascade), the
-   *      pull's `replaceAll` drops it too.
-   *
-   * Server-reachable flips true because the server DID answer - it just
-   * doesn't have this folder.
-   */
+  /** Treat a per-folder 404 as "deleted elsewhere": drop subtree, strand-reset, pull. */
   const handleStaleFolder = useCallback(
     (staleId: FolderId, foldersSnapshot: FolderRecord[]) => {
       const subtree = collectLocalSubtreeIds(staleId, foldersSnapshot);
@@ -474,20 +443,12 @@ export function FolderProvider({ children }: FolderProviderProps) {
         }
       }
       const subtreeIds = [...subtree];
-      // Best-effort - pullFromServer will fix anything these miss.
+      // Best-effort - pullFromServer is authoritative if these miss.
       void folderStorage
         .removeFolders(subtreeIds)
-        .catch((e) =>
-          console.warn(
-            "[FolderContext] cache cleanup after stale 404 failed",
-            e,
-          ),
-        );
+        .catch((e) => console.warn("[FolderContext] stale cache cleanup", e));
       void clearFolderForFiles(subtreeIds).catch((e) =>
-        console.warn(
-          "[FolderContext] file folder cleanup after stale 404 failed",
-          e,
-        ),
+        console.warn("[FolderContext] stale file-folder cleanup", e),
       );
       bumpFolderRevision();
       void pullFromServer();
@@ -496,20 +457,8 @@ export function FolderProvider({ children }: FolderProviderProps) {
   );
 
   /**
-   * Centralised mutation wrapper:
-   *   1. Calls the server op.
-   *   2. On success: flips `serverReachable=true`, updates in-memory state
-   *      from the server response, then best-effort writes the cache (cache
-   *      failure does NOT roll back; the in-memory truth came from the server).
-   *   3. On 404 against a known folder: hands off to {@link handleStaleFolder}
-   *      and resolves with `null` (caller treats the op as a no-op; the
-   *      folder is now gone from local state too). The `staleFolderId` arg
-   *      tells the wrapper which id to clean up on 404; pass null for ops
-   *      that create new ids (where 404 wouldn't reference an existing local
-   *      folder).
-   *   4. On other failures: updates `serverReachable` per the error class,
-   *      surfaces via {@link setError}, re-throws so the caller's dialog can
-   *      stay open.
+   * Server-first mutation wrapper. On 404 with `staleFolderId`, hands off to
+   * handleStaleFolder and resolves `null`; other errors surface + re-throw.
    */
   const runFolderMutation = useCallback(
     async <T,>(
@@ -522,13 +471,8 @@ export function FolderProvider({ children }: FolderProviderProps) {
         result = await serverOp();
       } catch (err) {
         if (errorStatus(err) === 404 && staleFolderId !== null) {
-          // `folders` here is the snapshot captured when the mutation was
-          // kicked off. If a concurrent mutation has shifted state between
-          // start and rejection the subtree we compute may be slightly stale,
-          // but the actual in-memory drop runs via `setFolders((prev) =>
-          // prev.filter(...))` (functional update) and the follow-up
-          // pullFromServer is authoritative either way - so the worst case
-          // is one extra round-trip, not corrupt state.
+          // `folders` is a closure snapshot; functional setFolders + the pull
+          // keep this race-safe even if a concurrent mutation shifted state.
           handleStaleFolder(staleFolderId, folders);
           return null;
         }
@@ -545,13 +489,8 @@ export function FolderProvider({ children }: FolderProviderProps) {
       try {
         await onSuccess(result);
       } catch (cacheErr) {
-        // The server is authoritative - a cache write failure must not be
-        // surfaced as if the operation failed. Log + leave the in-memory
-        // state authoritative; next pullFromServer will re-seed the cache.
-        console.warn(
-          "[FolderContext] cache update failed after successful mutation",
-          cacheErr,
-        );
+        // Cache write failure is non-fatal; next pull re-seeds.
+        console.warn("[FolderContext] cache update after mutation", cacheErr);
       }
       bumpFolderRevision();
       return result;
@@ -565,13 +504,8 @@ export function FolderProvider({ children }: FolderProviderProps) {
       parentFolderId: FolderId | null = currentFolderId,
     ): Promise<FolderRecord> => {
       const color = pickFolderColor(name);
-      // Generate id client-side so the server's idempotency check makes
-      // retries safe (network blip → second POST returns the same row).
+      // Client-side id makes server idempotency check safe on retry.
       const id = createFolderId();
-      // runFolderMutation returns `T | null` to cover the stale-folder 404
-      // branch, but create never passes a staleFolderId so the branch can't
-      // fire here - the result is always a folder. Throws still propagate
-      // for genuine create failures (400 parent missing, 409 conflict).
       const result = await runFolderMutation(
         () =>
           folderSyncService.create({
@@ -588,9 +522,8 @@ export function FolderProvider({ children }: FolderProviderProps) {
           await folderStorage.upsertFolder(record);
         },
       );
+      // No staleFolderId passed → null branch can't fire; defensive throw.
       if (result === null) {
-        // Defensive - matches the type-level claim that create can't go
-        // stale. If this ever fires the contract has drifted.
         throw new Error("createFolder unexpectedly returned null");
       }
       return result;
@@ -668,13 +601,7 @@ export function FolderProvider({ children }: FolderProviderProps) {
         removed = await folderSyncService.delete(id);
       } catch (err) {
         if (errorStatus(err) === 404) {
-          // Already gone (deleted by another session). Treat the same as a
-          // successful delete - silently drop the local subtree and reconverge
-          // via pullFromServer. We can't know the server's exact cascade so
-          // we return just `id`; the pull updates state authoritatively.
-          // Same closure-snapshot caveat as runFolderMutation's 404 branch:
-          // `folders` is captured at callback creation; concurrent mutations
-          // could leave it slightly stale, but the pull reconverges.
+          // Already gone; treat as success. Return [id]; pull is authoritative.
           handleStaleFolder(id, folders);
           return [id];
         }

--- a/frontend/editor/src/core/contexts/FolderContext.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.tsx
@@ -522,6 +522,13 @@ export function FolderProvider({ children }: FolderProviderProps) {
         result = await serverOp();
       } catch (err) {
         if (errorStatus(err) === 404 && staleFolderId !== null) {
+          // `folders` here is the snapshot captured when the mutation was
+          // kicked off. If a concurrent mutation has shifted state between
+          // start and rejection the subtree we compute may be slightly stale,
+          // but the actual in-memory drop runs via `setFolders((prev) =>
+          // prev.filter(...))` (functional update) and the follow-up
+          // pullFromServer is authoritative either way - so the worst case
+          // is one extra round-trip, not corrupt state.
           handleStaleFolder(staleFolderId, folders);
           return null;
         }
@@ -665,6 +672,9 @@ export function FolderProvider({ children }: FolderProviderProps) {
           // successful delete - silently drop the local subtree and reconverge
           // via pullFromServer. We can't know the server's exact cascade so
           // we return just `id`; the pull updates state authoritatively.
+          // Same closure-snapshot caveat as runFolderMutation's 404 branch:
+          // `folders` is captured at callback creation; concurrent mutations
+          // could leave it slightly stale, but the pull reconverges.
           handleStaleFolder(id, folders);
           return [id];
         }

--- a/frontend/editor/src/core/contexts/FolderContext.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.tsx
@@ -179,6 +179,50 @@ function reachabilityFromError(err: unknown): boolean {
 }
 
 /**
+ * Collect `rootId` plus every local descendant reachable via `parentFolderId`.
+ *
+ * Used when the server reports a folder no longer exists (404 on a mutation):
+ * we assume the cascade also took its children locally, so we can drop the
+ * whole subtree immediately for snappy UX. The follow-up pullFromServer
+ * re-adds anything we dropped in error (e.g. a child that was reparented
+ * out of this subtree before the deletion).
+ *
+ * Bounded so a corrupted parent chain can't run away here.
+ */
+function collectLocalSubtreeIds(
+  rootId: FolderId,
+  folders: FolderRecord[],
+): Set<FolderId> {
+  const childrenByParent = new Map<FolderId, FolderId[]>();
+  for (const f of folders) {
+    if (f.parentFolderId === null) continue;
+    const list = childrenByParent.get(f.parentFolderId) ?? [];
+    list.push(f.id);
+    childrenByParent.set(f.parentFolderId, list);
+  }
+  const result = new Set<FolderId>([rootId]);
+  const stack: FolderId[] = [rootId];
+  const MAX_LOCAL_SUBTREE_NODES = 10_000;
+  while (stack.length > 0 && result.size < MAX_LOCAL_SUBTREE_NODES) {
+    const cur = stack.pop()!;
+    const children = childrenByParent.get(cur);
+    if (!children) continue;
+    for (const childId of children) {
+      if (!result.has(childId)) {
+        result.add(childId);
+        stack.push(childId);
+      }
+    }
+  }
+  return result;
+}
+
+/** Extract HTTP status off an axios-style error, or undefined on network failure. */
+function errorStatus(err: unknown): number | undefined {
+  return (err as { response?: { status?: number } })?.response?.status;
+}
+
+/**
  * True if `currentId` or any of its ancestors is in `removedSet`. Walks up via
  * `parentFolderId` using the pre-removal `folders` snapshot so the chain is
  * still discoverable while the cascade is in flight. Used to force-reset
@@ -390,24 +434,97 @@ export function FolderProvider({ children }: FolderProviderProps) {
 
   // ─── mutations: server-first, cache update on success ──────────────
 
+  // Lifted above `runFolderMutation` so the stale-folder handler below can
+  // use it (file/folder cleanup on 404 reuses the same primitive as delete).
+  const { clearFolderForFiles } = useIndexedDB();
+
+  /**
+   * Silently reconcile a per-folder 404 from the server.
+   *
+   * A 404 on a mutation targeting an existing-looking folder id means the
+   * server no longer knows about it - almost always because another client
+   * session (or the same user in another tab) deleted it. Rather than
+   * surfacing a "Folder operation failed" banner for a folder the user can't
+   * see anyway, we treat the 404 as a delete signal:
+   *
+   *   1. Drop the folder + every local descendant from in-memory state.
+   *   2. Strand-reset `currentFolderId` if the user was browsing inside.
+   *   3. Best-effort cleanup of the IDB cache and any local files'
+   *      folder-id pointers (file rows stay; their folder pointer clears).
+   *   4. Fire {@link pullFromServer} to reconverge - if we dropped too much
+   *      (e.g. a child reparented out of this subtree before the delete),
+   *      the pull re-adds it; if we missed something (deeper cascade), the
+   *      pull's `replaceAll` drops it too.
+   *
+   * Server-reachable flips true because the server DID answer - it just
+   * doesn't have this folder.
+   */
+  const handleStaleFolder = useCallback(
+    (staleId: FolderId, foldersSnapshot: FolderRecord[]) => {
+      const subtree = collectLocalSubtreeIds(staleId, foldersSnapshot);
+      if (mountedRef.current) {
+        setServerReachable(true);
+        setError(null);
+        setFolders((prev) => prev.filter((f) => !subtree.has(f.id)));
+        if (
+          currentFolderId !== null &&
+          shouldStrandedReset(currentFolderId, subtree, foldersSnapshot)
+        ) {
+          setCurrentFolderId(ROOT_FOLDER_ID);
+        }
+      }
+      const subtreeIds = [...subtree];
+      // Best-effort - pullFromServer will fix anything these miss.
+      void folderStorage
+        .removeFolders(subtreeIds)
+        .catch((e) =>
+          console.warn(
+            "[FolderContext] cache cleanup after stale 404 failed",
+            e,
+          ),
+        );
+      void clearFolderForFiles(subtreeIds).catch((e) =>
+        console.warn(
+          "[FolderContext] file folder cleanup after stale 404 failed",
+          e,
+        ),
+      );
+      bumpFolderRevision();
+      void pullFromServer();
+    },
+    [bumpFolderRevision, clearFolderForFiles, currentFolderId, pullFromServer],
+  );
+
   /**
    * Centralised mutation wrapper:
    *   1. Calls the server op.
    *   2. On success: flips `serverReachable=true`, updates in-memory state
    *      from the server response, then best-effort writes the cache (cache
    *      failure does NOT roll back; the in-memory truth came from the server).
-   *   3. On failure: updates `serverReachable` per the error class, surfaces
-   *      via {@link setError}, re-throws so the caller's dialog can stay open.
+   *   3. On 404 against a known folder: hands off to {@link handleStaleFolder}
+   *      and resolves with `null` (caller treats the op as a no-op; the
+   *      folder is now gone from local state too). The `staleFolderId` arg
+   *      tells the wrapper which id to clean up on 404; pass null for ops
+   *      that create new ids (where 404 wouldn't reference an existing local
+   *      folder).
+   *   4. On other failures: updates `serverReachable` per the error class,
+   *      surfaces via {@link setError}, re-throws so the caller's dialog can
+   *      stay open.
    */
   const runFolderMutation = useCallback(
     async <T,>(
       serverOp: () => Promise<T>,
       onSuccess: (result: T) => void | Promise<void>,
-    ): Promise<T> => {
+      staleFolderId: FolderId | null = null,
+    ): Promise<T | null> => {
       let result: T;
       try {
         result = await serverOp();
       } catch (err) {
+        if (errorStatus(err) === 404 && staleFolderId !== null) {
+          handleStaleFolder(staleFolderId, folders);
+          return null;
+        }
         if (mountedRef.current) {
           setServerReachable(reachabilityFromError(err));
           setError(formatServerError(err));
@@ -432,7 +549,7 @@ export function FolderProvider({ children }: FolderProviderProps) {
       bumpFolderRevision();
       return result;
     },
-    [bumpFolderRevision],
+    [bumpFolderRevision, folders, handleStaleFolder],
   );
 
   const createFolder = useCallback(
@@ -444,7 +561,11 @@ export function FolderProvider({ children }: FolderProviderProps) {
       // Generate id client-side so the server's idempotency check makes
       // retries safe (network blip → second POST returns the same row).
       const id = createFolderId();
-      return runFolderMutation(
+      // runFolderMutation returns `T | null` to cover the stale-folder 404
+      // branch, but create never passes a staleFolderId so the branch can't
+      // fire here - the result is always a folder. Throws still propagate
+      // for genuine create failures (400 parent missing, 409 conflict).
+      const result = await runFolderMutation(
         () =>
           folderSyncService.create({
             id,
@@ -460,6 +581,12 @@ export function FolderProvider({ children }: FolderProviderProps) {
           await folderStorage.upsertFolder(record);
         },
       );
+      if (result === null) {
+        // Defensive - matches the type-level claim that create can't go
+        // stale. If this ever fires the contract has drifted.
+        throw new Error("createFolder unexpectedly returned null");
+      }
+      return result;
     },
     [currentFolderId, runFolderMutation],
   );
@@ -474,6 +601,7 @@ export function FolderProvider({ children }: FolderProviderProps) {
           );
           await folderStorage.upsertFolder(record);
         },
+        id,
       );
     },
     [runFolderMutation],
@@ -493,6 +621,7 @@ export function FolderProvider({ children }: FolderProviderProps) {
           );
           await folderStorage.upsertFolder(record);
         },
+        id,
       );
     },
     [runFolderMutation],
@@ -515,12 +644,11 @@ export function FolderProvider({ children }: FolderProviderProps) {
           );
           await folderStorage.upsertFolder(record);
         },
+        id,
       );
     },
     [runFolderMutation],
   );
-
-  const { clearFolderForFiles } = useIndexedDB();
 
   const deleteFolder = useCallback(
     async (id: FolderId): Promise<FolderId[]> => {
@@ -532,6 +660,14 @@ export function FolderProvider({ children }: FolderProviderProps) {
       try {
         removed = await folderSyncService.delete(id);
       } catch (err) {
+        if (errorStatus(err) === 404) {
+          // Already gone (deleted by another session). Treat the same as a
+          // successful delete - silently drop the local subtree and reconverge
+          // via pullFromServer. We can't know the server's exact cascade so
+          // we return just `id`; the pull updates state authoritatively.
+          handleStaleFolder(id, folders);
+          return [id];
+        }
         if (mountedRef.current) {
           setServerReachable(reachabilityFromError(err));
           setError(formatServerError(err));
@@ -580,7 +716,13 @@ export function FolderProvider({ children }: FolderProviderProps) {
       }
       return removed;
     },
-    [bumpFolderRevision, clearFolderForFiles, currentFolderId, folders],
+    [
+      bumpFolderRevision,
+      clearFolderForFiles,
+      currentFolderId,
+      folders,
+      handleStaleFolder,
+    ],
   );
 
   const value = useMemo<FolderContextValue>(


### PR DESCRIPTION
# Description of Changes

fix folder causing 500 toast when deleted on another machine
---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
