### PR TITLE
fix(settings): memoize nav sections to stop background flash

### DIFF
--- a/frontend/editor/src/core/components/shared/config/configNavSections.tsx
+++ b/frontend/editor/src/core/components/shared/config/configNavSections.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { NavKey } from "@app/components/shared/config/types";
 import HotkeysSection from "@app/components/shared/config/configSections/HotkeysSection";
@@ -39,40 +39,45 @@ export const useConfigNavSections = (
 ): ConfigNavSection[] => {
   const { t } = useTranslation();
 
-  const sections: ConfigNavSection[] = [
-    {
-      title: t("settings.preferences.title", "Preferences"),
-      items: [
-        {
-          key: "general",
-          label: t("settings.general.title", "General"),
-          icon: "settings-rounded",
-          component: <GeneralSection />,
-        },
-        {
-          key: "hotkeys",
-          label: t("settings.hotkeys.title", "Keyboard Shortcuts"),
-          icon: "keyboard-rounded",
-          component: <HotkeysSection />,
-        },
-      ],
-    },
-    {
-      title: t("settings.help.title", "Help"),
-      items: [
-        {
-          key: "help",
-          label: t("settings.help.label", "Tours"),
-          icon: "help-rounded",
-          component: (
-            <HelpSection isAdmin={_isAdmin} onRequestClose={onRequestClose} />
-          ),
-        },
-      ],
-    },
-  ];
-
-  return sections;
+  // Memoize so the array identity is stable across re-renders driven by
+  // unrelated state (URL changes, etc.). Without this every settings tab click
+  // produces a fresh sections array with fresh JSX, causing every consumer to
+  // re-render the entire section tree.
+  return useMemo<ConfigNavSection[]>(
+    () => [
+      {
+        title: t("settings.preferences.title", "Preferences"),
+        items: [
+          {
+            key: "general",
+            label: t("settings.general.title", "General"),
+            icon: "settings-rounded",
+            component: <GeneralSection />,
+          },
+          {
+            key: "hotkeys",
+            label: t("settings.hotkeys.title", "Keyboard Shortcuts"),
+            icon: "keyboard-rounded",
+            component: <HotkeysSection />,
+          },
+        ],
+      },
+      {
+        title: t("settings.help.title", "Help"),
+        items: [
+          {
+            key: "help",
+            label: t("settings.help.label", "Tours"),
+            icon: "help-rounded",
+            component: (
+              <HelpSection isAdmin={_isAdmin} onRequestClose={onRequestClose} />
+            ),
+          },
+        ],
+      },
+    ],
+    [t, _isAdmin, onRequestClose],
+  );
 };
 
 // Deprecated: Use useConfigNavSections hook instead

--- a/frontend/editor/src/proprietary/components/shared/config/configNavSections.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configNavSections.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useConfigNavSections as useCoreConfigNavSections,
@@ -35,235 +35,249 @@ export const useConfigNavSections = (
 ): ConfigNavSection[] => {
   const { t } = useTranslation();
 
-  // Get the core sections (Preferences + Help)
-  const sections = useCoreConfigNavSections(
+  // Get the core sections (Preferences + Help). The core hook now returns a
+  // memoized array - we must clone it before any mutation to avoid corrupting
+  // the shared reference across renders.
+  const coreSections = useCoreConfigNavSections(
     isAdmin,
     runningEE,
     loginEnabled,
     onRequestClose,
   );
 
-  // Add account management under Preferences
-  const preferencesSection = sections.find((section) =>
-    section.items.some((item) => item.key === "general"),
-  );
-  if (preferencesSection) {
-    preferencesSection.items = preferencesSection.items.map((item) =>
-      item.key === "general"
-        ? { ...item, component: <GeneralSection /> }
-        : item,
-    );
+  return useMemo<ConfigNavSection[]>(() => {
+    // Deep-clone core sections + items so the mutations below never touch the
+    // shared memoized array.
+    const sections: ConfigNavSection[] = coreSections.map((section) => ({
+      ...section,
+      items: [...section.items],
+    }));
 
-    if (loginEnabled) {
-      preferencesSection.items.push({
-        key: "account",
-        label: t("account.accountSettings", "Account"),
-        icon: "person-rounded",
-        component: <AccountSection />,
+    // Add account management under Preferences
+    const preferencesSection = sections.find((section) =>
+      section.items.some((item) => item.key === "general"),
+    );
+    if (preferencesSection) {
+      preferencesSection.items = preferencesSection.items.map((item) =>
+        item.key === "general"
+          ? { ...item, component: <GeneralSection /> }
+          : item,
+      );
+
+      if (loginEnabled) {
+        preferencesSection.items.push({
+          key: "account",
+          label: t("account.accountSettings", "Account"),
+          icon: "person-rounded",
+          component: <AccountSection />,
+        });
+      }
+    }
+
+    // Add Admin sections if user is admin OR if login is disabled (but mark as disabled)
+    if (isAdmin || !loginEnabled) {
+      const requiresLogin = !loginEnabled;
+      const enableLoginTooltip = t(
+        "settings.tooltips.enableLoginFirst",
+        "Enable login mode first",
+      );
+      const requiresEnterpriseTooltip = t(
+        "settings.tooltips.requiresEnterprise",
+        "Requires Enterprise license",
+      );
+
+      // Workspace
+      sections.push({
+        title: t("settings.workspace.title", "Workspace"),
+        items: [
+          {
+            key: "people",
+            label: t("settings.workspace.people", "People"),
+            icon: "group-rounded",
+            component: <PeopleSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "teams",
+            label: t("settings.workspace.teams", "Teams"),
+            icon: "groups-rounded",
+            component: <TeamsSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+        ],
+      });
+
+      // Configuration
+      sections.push({
+        title: t("settings.configuration.title", "Configuration"),
+        items: [
+          {
+            key: "adminGeneral",
+            label: t(
+              "settings.configuration.systemSettings",
+              "System Settings",
+            ),
+            icon: "settings-rounded",
+            component: <AdminGeneralSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "adminFeatures",
+            label: t("settings.configuration.features", "Features"),
+            icon: "extension-rounded",
+            component: <AdminFeaturesSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "adminStorageSharing",
+            label: t(
+              "settings.configuration.storageSharing",
+              "File Storage & Sharing",
+            ),
+            icon: "storage-rounded",
+            component: <AdminStorageSharingSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+            badge: t("toolPanel.alpha", "Alpha"),
+            badgeColor: "orange",
+          },
+          {
+            key: "adminEndpoints",
+            label: t("settings.configuration.endpoints", "Endpoints"),
+            icon: "api-rounded",
+            component: <AdminEndpointsSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "adminDatabase",
+            label: t("settings.configuration.database", "Database"),
+            icon: "storage-rounded",
+            component: <AdminDatabaseSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "adminAdvanced",
+            label: t("settings.configuration.advanced", "Advanced"),
+            icon: "tune-rounded",
+            component: <AdminAdvancedSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+        ],
+      });
+
+      // Security & Authentication
+      sections.push({
+        title: t("settings.securityAuth.title", "Security & Authentication"),
+        items: [
+          {
+            key: "adminSecurity",
+            label: t("settings.securityAuth.security", "Security"),
+            icon: "shield-rounded",
+            component: <AdminSecuritySection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "adminConnections",
+            label: t("settings.securityAuth.connections", "Connections"),
+            icon: "link-rounded",
+            component: <AdminConnectionsSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+        ],
+      });
+
+      // Licensing & Analytics
+      sections.push({
+        title: t("settings.licensingAnalytics.title", "Licensing & Analytics"),
+        items: [
+          {
+            key: "adminPlan",
+            label: t("settings.licensingAnalytics.plan", "Plan"),
+            icon: "star-rounded",
+            component: <AdminPlanSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "adminAudit",
+            label: t("settings.licensingAnalytics.audit", "Audit"),
+            icon: "fact-check-rounded",
+            component: <AdminAuditSection />,
+            disabled: !runningEE || requiresLogin,
+            disabledTooltip: requiresLogin
+              ? enableLoginTooltip
+              : requiresEnterpriseTooltip,
+          },
+          {
+            key: "adminUsage",
+            label: t(
+              "settings.licensingAnalytics.usageAnalytics",
+              "Usage Analytics",
+            ),
+            icon: "analytics-rounded",
+            component: <AdminUsageSection />,
+            disabled: !runningEE || requiresLogin,
+            disabledTooltip: requiresLogin
+              ? enableLoginTooltip
+              : requiresEnterpriseTooltip,
+          },
+        ],
+      });
+
+      // Policies & Privacy
+      sections.push({
+        title: t("settings.policiesPrivacy.title", "Policies & Privacy"),
+        items: [
+          {
+            key: "adminLegal",
+            label: t("settings.policiesPrivacy.legal", "Legal"),
+            icon: "gavel-rounded",
+            component: <AdminLegalSection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+          {
+            key: "adminPrivacy",
+            label: t("settings.policiesPrivacy.privacy", "Privacy"),
+            icon: "visibility-rounded",
+            component: <AdminPrivacySection />,
+            disabled: requiresLogin,
+            disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
+          },
+        ],
       });
     }
-  }
 
-  // Add Admin sections if user is admin OR if login is disabled (but mark as disabled)
-  if (isAdmin || !loginEnabled) {
-    const requiresLogin = !loginEnabled;
-    const enableLoginTooltip = t(
-      "settings.tooltips.enableLoginFirst",
-      "Enable login mode first",
-    );
-    const requiresEnterpriseTooltip = t(
-      "settings.tooltips.requiresEnterprise",
-      "Requires Enterprise license",
-    );
+    // Add Developer section if login is enabled
+    if (loginEnabled) {
+      const developerSection: ConfigNavSection = {
+        title: t("settings.developer.title", "Developer"),
+        items: [
+          {
+            key: "api-keys",
+            label: t("settings.developer.apiKeys", "API Keys"),
+            icon: "key-rounded",
+            component: <ApiKeys />,
+          },
+        ],
+      };
 
-    // Workspace
-    sections.push({
-      title: t("settings.workspace.title", "Workspace"),
-      items: [
-        {
-          key: "people",
-          label: t("settings.workspace.people", "People"),
-          icon: "group-rounded",
-          component: <PeopleSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "teams",
-          label: t("settings.workspace.teams", "Teams"),
-          icon: "groups-rounded",
-          component: <TeamsSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-      ],
-    });
+      // Add Developer section after Preferences (or Workspace if it exists)
+      const insertIndex = isAdmin ? 2 : 1;
+      sections.splice(insertIndex, 0, developerSection);
+    }
 
-    // Configuration
-    sections.push({
-      title: t("settings.configuration.title", "Configuration"),
-      items: [
-        {
-          key: "adminGeneral",
-          label: t("settings.configuration.systemSettings", "System Settings"),
-          icon: "settings-rounded",
-          component: <AdminGeneralSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "adminFeatures",
-          label: t("settings.configuration.features", "Features"),
-          icon: "extension-rounded",
-          component: <AdminFeaturesSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "adminStorageSharing",
-          label: t(
-            "settings.configuration.storageSharing",
-            "File Storage & Sharing",
-          ),
-          icon: "storage-rounded",
-          component: <AdminStorageSharingSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-          badge: t("toolPanel.alpha", "Alpha"),
-          badgeColor: "orange",
-        },
-        {
-          key: "adminEndpoints",
-          label: t("settings.configuration.endpoints", "Endpoints"),
-          icon: "api-rounded",
-          component: <AdminEndpointsSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "adminDatabase",
-          label: t("settings.configuration.database", "Database"),
-          icon: "storage-rounded",
-          component: <AdminDatabaseSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "adminAdvanced",
-          label: t("settings.configuration.advanced", "Advanced"),
-          icon: "tune-rounded",
-          component: <AdminAdvancedSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-      ],
-    });
-
-    // Security & Authentication
-    sections.push({
-      title: t("settings.securityAuth.title", "Security & Authentication"),
-      items: [
-        {
-          key: "adminSecurity",
-          label: t("settings.securityAuth.security", "Security"),
-          icon: "shield-rounded",
-          component: <AdminSecuritySection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "adminConnections",
-          label: t("settings.securityAuth.connections", "Connections"),
-          icon: "link-rounded",
-          component: <AdminConnectionsSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-      ],
-    });
-
-    // Licensing & Analytics
-    sections.push({
-      title: t("settings.licensingAnalytics.title", "Licensing & Analytics"),
-      items: [
-        {
-          key: "adminPlan",
-          label: t("settings.licensingAnalytics.plan", "Plan"),
-          icon: "star-rounded",
-          component: <AdminPlanSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "adminAudit",
-          label: t("settings.licensingAnalytics.audit", "Audit"),
-          icon: "fact-check-rounded",
-          component: <AdminAuditSection />,
-          disabled: !runningEE || requiresLogin,
-          disabledTooltip: requiresLogin
-            ? enableLoginTooltip
-            : requiresEnterpriseTooltip,
-        },
-        {
-          key: "adminUsage",
-          label: t(
-            "settings.licensingAnalytics.usageAnalytics",
-            "Usage Analytics",
-          ),
-          icon: "analytics-rounded",
-          component: <AdminUsageSection />,
-          disabled: !runningEE || requiresLogin,
-          disabledTooltip: requiresLogin
-            ? enableLoginTooltip
-            : requiresEnterpriseTooltip,
-        },
-      ],
-    });
-
-    // Policies & Privacy
-    sections.push({
-      title: t("settings.policiesPrivacy.title", "Policies & Privacy"),
-      items: [
-        {
-          key: "adminLegal",
-          label: t("settings.policiesPrivacy.legal", "Legal"),
-          icon: "gavel-rounded",
-          component: <AdminLegalSection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-        {
-          key: "adminPrivacy",
-          label: t("settings.policiesPrivacy.privacy", "Privacy"),
-          icon: "visibility-rounded",
-          component: <AdminPrivacySection />,
-          disabled: requiresLogin,
-          disabledTooltip: requiresLogin ? enableLoginTooltip : undefined,
-        },
-      ],
-    });
-  }
-
-  // Add Developer section if login is enabled
-  if (loginEnabled) {
-    const developerSection: ConfigNavSection = {
-      title: t("settings.developer.title", "Developer"),
-      items: [
-        {
-          key: "api-keys",
-          label: t("settings.developer.apiKeys", "API Keys"),
-          icon: "key-rounded",
-          component: <ApiKeys />,
-        },
-      ],
-    };
-
-    // Add Developer section after Preferences (or Workspace if it exists)
-    const insertIndex = isAdmin ? 2 : 1;
-    sections.splice(insertIndex, 0, developerSection);
-  }
-
-  return sections;
+    return sections;
+  }, [coreSections, t, isAdmin, runningEE, loginEnabled]);
 };
 
 /**

--- a/frontend/editor/src/proprietary/routes/Landing.tsx
+++ b/frontend/editor/src/proprietary/routes/Landing.tsx
@@ -25,29 +25,6 @@ export default function Landing() {
 
   const loading = authLoading || configLoading || backendProbe.loading;
 
-  // Debug: Track Landing component lifecycle
-  useEffect(() => {
-    const mountId = Math.random().toString(36).substring(7);
-    console.log(
-      `[Landing:${mountId}] 🔵 Component mounted at ${location.pathname}`,
-    );
-    console.log(`[Landing:${mountId}] Mount state:`, {
-      authLoading,
-      configLoading,
-      backendLoading: backendProbe.loading,
-      hasSession: !!session,
-    });
-    return () => {
-      console.log(`[Landing:${mountId}] 🔴 Component unmounting`);
-    };
-  }, [
-    location.pathname,
-    authLoading,
-    configLoading,
-    backendProbe.loading,
-    session,
-  ]);
-
   // Periodically probe while backend isn't up so the screen can auto-advance when it comes online
   useEffect(() => {
     if (backendProbe.status === "up" || backendProbe.loginDisabled) {
@@ -79,21 +56,6 @@ export default function Landing() {
       void refetch();
     }
   }, [backendProbe.status, refetch]);
-
-  console.log("[Landing] ════════════════════════════════════");
-  console.log("[Landing] Render state:", {
-    pathname: location.pathname,
-    loading,
-    authLoading,
-    configLoading,
-    backendLoading: backendProbe.loading,
-    hasSession: !!session,
-    hasConfig: !!config,
-    loginEnabled: config?.enableLogin === true && !backendProbe.loginDisabled,
-    backendStatus: backendProbe.status,
-    timestamp: new Date().toISOString(),
-  });
-  console.log("[Landing] ════════════════════════════════════");
 
   // Show loading while checking auth and config
   if (loading) {


### PR DESCRIPTION
## Summary
- Wrap core and proprietary `useConfigNavSections` results in `useMemo`. Without this the array (and every `<GeneralSection />`/`<PeopleSection />`/... JSX value inside it) is recreated on every modal render, which is every URL change inside the settings modal.
- Stop the proprietary hook from mutating `preferencesSection.items` and pushing onto the array returned by `useCoreConfigNavSections`. With the core array now memoized, mutating it would corrupt the shared reference across renders.
- Drop the dev-only `[Landing] Render state` `console.log` block and the `Math.random()` mountId `useEffect` in `proprietary/routes/Landing.tsx`. They ran on every nav (300+ log lines per settings session) and the mount/unmount messages were misleading - the effect cleanup fires on every dep change, not actual component unmounts.

## Why
When clicking between settings tabs (General → People → Audit ...), `navigate('/settings/\${key}')` pushes a URL change. That re-runs every component subscribed to `useLocation()` - including `AppConfigModal`. `useConfigNavSections` returns a fresh array each call, the active section's JSX is a new element each time, `currentSection` `useMemo` invalidates, and the whole HomePage tree (FileSidebar, Workbench, RightSidebar, FileManager) reconciles behind the modal overlay. The Mantine backdrop-filter recomputed against the re-rendered DOM produced the visible "background flash."

## Test plan
- [ ] Open settings, click through several tabs - background no longer flashes
- [ ] Verify all sections still render correctly (General, People, Teams, Audit, etc.)
- [ ] Account section still appears when login is enabled
- [ ] Admin sections still hide when not admin or login disabled
- [ ] `task frontend:typecheck` passes
- [ ] `task frontend:lint` passes