### PR TITLE
Fix desktop app not being able to load pdfium

### DIFF
--- a/.taskfiles/desktop.yml
+++ b/.taskfiles/desktop.yml
@@ -62,21 +62,21 @@ tasks:
     deps: [prepare]
     dir: editor
     cmds:
-      - npx tauri build --bundles app
+      - npx tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
   build:dev:windows:
     desc: "Build Tauri desktop NSIS installer (Windows)"
     deps: [prepare]
     dir: editor
     cmds:
-      - npx tauri build --bundles nsis
+      - npx tauri build --bundles nsis --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
   build:dev:linux:
     desc: "Build Tauri desktop AppImage (Linux)"
     deps: [prepare]
     dir: editor
     cmds:
-      - npx tauri build --bundles appimage
+      - npx tauri build --bundles appimage --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
   test:
     desc: "Run Tauri/Cargo tests"

--- a/frontend/editor/src/core/services/wasmPrecompiler.ts
+++ b/frontend/editor/src/core/services/wasmPrecompiler.ts
@@ -2,22 +2,19 @@ import { BASE_PATH } from "@app/constants/app";
 import pdfiumWasmAssetUrl from "@embedpdf/pdfium/pdfium.wasm?url";
 
 const getWasmUrl = (): string => {
-  if (
-    pdfiumWasmAssetUrl.startsWith("http://") ||
-    pdfiumWasmAssetUrl.startsWith("https://") ||
-    pdfiumWasmAssetUrl.startsWith("//")
-  ) {
-    return pdfiumWasmAssetUrl;
-  }
-
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  // In dev, Vite serves the statically-copied asset from the dev server root.
   if (import.meta.env.DEV) {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
     return `${origin}${BASE_PATH}/pdfium/pdfium.wasm`;
   }
-  const cleanAssetUrl = pdfiumWasmAssetUrl
-    .replace(/^\.\//, "")
-    .replace(/^\//, "");
-  return `${origin}${BASE_PATH}/${cleanAssetUrl}`;
+
+  // Vite has already produced a base-aware asset URL (absolute under a relative
+  // base, root-relative under an absolute base). Resolve it against the document
+  // to get a fetchable absolute URL that is also safe to pass to Web Workers.
+  if (typeof window !== "undefined") {
+    return new URL(pdfiumWasmAssetUrl, window.location.href).href;
+  }
+  return pdfiumWasmAssetUrl;
 };
 
 export const pdfiumWasmUrl = getWasmUrl();


### PR DESCRIPTION
# Description of Changes
The changes in [#6279](https://github.com/Stirling-Tools/Stirling-PDF/pull/6279) broke the desktop app because the wasm URL handling didn't deal with `tauri://` paths. Also I noticed that `task desktop:build:dev:mac` failed locally because it was attempting to sign the app with credentials that developers won't have (and shouldn't need), so I fixed that too. 