### PR TITLE
Delete dead translations

### DIFF
--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -327,19 +327,19 @@ tasks:
 
   test:
     desc: "Run tests"
-    deps: [install]
+    deps: [prepare]
     cmds:
       - npx vitest run --root editor
 
   test:watch:
     desc: "Run tests in watch mode"
-    deps: [install]
+    deps: [prepare]
     cmds:
       - npx vitest --watch --root editor
 
   test:coverage:
     desc: "Run tests with coverage (one-shot; CI-friendly)."
-    deps: [install]
+    deps: [prepare]
     cmds:
       # `vitest run` makes this CI-safe (the bare `vitest` form enters watch
       # mode). Explicit reporter list because v8 + json-summary is what the

--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -205,6 +205,9 @@ signedInAs = "Signed in as: {{email}}"
 [add-page-numbers]
 tags = "paginate,label,organize,index"
 
+[addAttachments]
+tags = "embed,attach,include,attachments,attach files,embed files,include files,add files,file attachment,associated files,supplementary files"
+
 [addAttachments.error]
 failed = "An error occurred while adding attachments to the PDF."
 
@@ -238,6 +241,9 @@ header = "Add images to PDFs"
 tags = "img,jpg,picture,photo"
 title = "Add Image"
 
+[addImage.canvas]
+colorPickerTitle = "Choose stroke colour"
+
 [addImage.error]
 failed = "An error occurred while adding image to the PDF."
 
@@ -264,8 +270,26 @@ resume = "Resume placement"
 title = "Add Image Results"
 
 [addImage.saved]
+defaultCanvasLabel = "Drawing signature"
 defaultImageLabel = "Uploaded image"
 defaultLabel = "Image"
+defaultTextLabel = "Typed signature"
+delete = "Remove"
+emptyTitle = "No saved signatures yet"
+heading = "Saved signatures"
+label = "Label"
+limitTitle = "Limit reached"
+next = "Next"
+personalHeading = "Personal Signatures"
+prev = "Previous"
+savePersonal = "Save Personal"
+saveShared = "Save Shared"
+sharedHeading = "Shared Signatures"
+
+[addImage.saved.type]
+canvas = "Drawing"
+image = "Upload"
+text = "Text"
 
 [addImage.step]
 createDesc = "Upload the image you want to add"
@@ -275,7 +299,21 @@ placeDesc = "Click on the PDF to add your image"
 [addImage.steps]
 configure = "Configure Image"
 
+[addImage.text]
+colorLabel = "Text colour"
+fontLabel = "Font"
+fontSizeLabel = "Font size"
+name = "Text"
+placeholder = "Enter text"
+
+[addImage.type]
+canvas = "Canvas"
+image = "Image"
+saved = "Saved"
+text = "Text"
+
 [addPageNumbers]
+tags = "number,pagination,count,add page numbers,page numbering,page numbers,footer,header,number pages,sequential,pagination tool"
 configuration = "Configuration"
 customize = "Customize Appearance"
 customNumberDesc = "e.g., \"Page {n}\" or leave blank for just numbers"
@@ -308,6 +346,7 @@ title = "Page Number Results"
 6 = "Custom Text Format"
 
 [addPassword]
+tags = "encrypt,password,lock,secure,protect,security,encryption,safeguard,confidential,private,restrict access"
 completed = "Password protection applied"
 desc = "Encrypt your PDF document with a password."
 filenamePrefix = "encrypted"
@@ -468,10 +507,42 @@ fontSizePlaceholder = "Type or select font size (8-200)"
 name = "Text content"
 placeholder = "Enter the text you want to add"
 
+[addText.canvas]
+colorPickerTitle = "Choose stroke colour"
+
+[addText.saved]
+defaultCanvasLabel = "Drawing signature"
+defaultImageLabel = "Uploaded signature"
+defaultLabel = "Signature"
+defaultTextLabel = "Typed signature"
+delete = "Remove"
+emptyTitle = "No saved signatures yet"
+heading = "Saved signatures"
+label = "Label"
+limitTitle = "Limit reached"
+next = "Next"
+personalHeading = "Personal Signatures"
+prev = "Previous"
+savePersonal = "Save Personal"
+saveShared = "Save Shared"
+sharedHeading = "Shared Signatures"
+
+[addText.saved.type]
+canvas = "Drawing"
+image = "Upload"
+text = "Text"
+
+[addText.type]
+canvas = "Canvas"
+image = "Image"
+saved = "Saved"
+text = "Text"
+
 [adjust-contrast]
 tags = "color-correction,tune,modify,enhance,colour-correction"
 
 [adjustContrast]
+tags = "contrast,brightness,saturation,adjust colors,color correction,enhance,lighten,darken,improve quality,color balance,hue,vibrance"
 adjustColors = "Adjust Colors"
 basic = "Basic Adjustments"
 blue = "Blue"
@@ -1849,6 +1920,7 @@ text = "Automatically finds the title from your PDF content and uses it as the f
 title = "Smart Renaming"
 
 [automate]
+tags = "workflow,sequence,automation,automate,batch,batch processing,pipeline,chain,multi-step,recurring,scheduled,automatic,process multiple,bulk operations"
 copyToSaved = "Copy to Saved"
 desc = "Build multi-step workflows by chaining together PDF actions. Ideal for recurring tasks."
 export = "Export"
@@ -1966,6 +2038,7 @@ secureWorkflow = "Security Workflow"
 secureWorkflowDesc = "Secures PDF documents by removing potentially malicious content like JavaScript and embedded files, then adds password protection to prevent unauthorised access. Password is set to 'password' by default."
 
 [autoRename]
+tags = "auto-detect,header-based,organize,relabel,auto rename,automatic rename,smart rename,rename by content,filename,file naming,detect title"
 description = "This tool will automatically rename PDF files based on their content. It analyzes the document to find the most suitable title from the text."
 
 [autoSizeSplitPDF]
@@ -2591,6 +2664,7 @@ submit = "Submit Changes"
 title = "Change Credentials"
 
 [changeMetadata]
+tags = "edit,modify,update,metadata,properties,document properties,author,title,subject,keywords,creator,producer,info,document info,file properties"
 filenamePrefix = "metadata"
 header = "Change Metadata"
 submit = "Change"
@@ -2712,6 +2786,7 @@ true = "True"
 unknown = "Unknown"
 
 [changePermissions]
+tags = "permissions,restrictions,rights,access control,allow,deny,printing,copying,editing,modify permissions,security settings,user rights"
 completed = "Permissions changed"
 desc = "Change document restrictions and permissions."
 submit = "Change Permissions"
@@ -2934,6 +3009,7 @@ message = "One or both of the selected PDFs have no text content. Please choose 
 
 [compare.original]
 label = "Original PDF"
+placeholder = "Select the original PDF"
 
 [compare.pixel]
 base = "Original"
@@ -3005,6 +3081,7 @@ unlinkedTitle = "Independent scroll & pan enabled"
 message = "These documents appear highly dissimilar. Comparison was stopped to save time."
 
 [compress]
+tags = "shrink,reduce,optimize,compress,smaller,downsize,file size,reduce size,minimize,make smaller,decrease size,optimize size"
 credit = "This service uses qpdf for PDF Compress/Optimisation."
 desc = "Compress PDFs to reduce their file size."
 header = "Compress PDF"
@@ -3195,6 +3272,7 @@ selfhostedOffline = "Self-hosted server unreachable"
 selfhostedOnline = "Connected to self-hosted server"
 
 [convert]
+tags = "transform,change,convert,PDF to Word,PDF to Excel,PDF to image,Word to PDF,Excel to PDF,PowerPoint to PDF,HTML to PDF,export,import,file conversion,format change,save as"
 autoRotate = "Auto Rotate"
 autoRotateDescription = "Automatically rotate images to better fit the PDF page"
 blackwhite = "Black & White"
@@ -3551,6 +3629,7 @@ edit = "Edit"
 editSecretValue = "Edit secret value"
 
 [editTableOfContents]
+tags = "bookmarks,contents,edit,table of contents,TOC,outline,navigation,chapters,sections,add bookmarks,edit bookmarks,PDF outline"
 submit = "Apply table of contents"
 
 [editTableOfContents.actions]
@@ -3735,6 +3814,7 @@ title = "Settings"
 tags = "extract"
 
 [extractPages]
+tags = "pull,select,copy,extract,extract pages,get pages,pull out,save pages,export pages,copy pages,select pages,specific pages"
 submit = "Extract Pages"
 title = "Extract Pages"
 
@@ -4191,6 +4271,7 @@ welcomeMessage = "For security reasons, you must change your password on your fi
 welcomeTitle = "Welcome!"
 
 [flatten]
+tags = "simplify,remove,interactive,flatten,flatten form,remove form fields,make static,finalize form,lock form,disable editing,convert to image,non-editable"
 filenamePrefix = "flattened"
 flattenOnlyForms = "Flatten only forms"
 header = "Flatten PDF"
@@ -5822,6 +5903,7 @@ REVERSE_ORDER = "Flip the document so the last page becomes first and so on."
 SIDE_STITCH_BOOKLET_SORT = "Arrange pages for side‑stitch booklet printing (optimized for binding on the side)."
 
 [pdfTextEditor]
+tags = "edit text,modify text,change text,edit content,update text,rewrite,correct,amend,redline,revise,text editor,content editor"
 conversionFailed = "Failed to convert PDF. Please try again."
 converting = "Converting PDF to editable format..."
 currentFile = "Current file: {{name}}"
@@ -5922,6 +6004,10 @@ descriptionInline = "Tip: Hold Ctrl (Cmd) or Shift to multi-select text boxes. A
 [pdfTextEditor.pageType]
 paragraph = "Paragraph page"
 sparse = "Sparse text"
+
+[pdfTextEditor.stages]
+processing = "Processing"
+uploading = "Uploading"
 
 [pdfTextEditor.tooltip.alpha]
 text = "This alpha viewer is still evolving-certain fonts, colours, transparency effects, and layout details may shift slightly. Please double-check the generated PDF before sharing."
@@ -6033,6 +6119,7 @@ title = "PDF to Presentation"
 tags = "single page"
 
 [pdfToSinglePage]
+tags = "combine,merge,single,single page,one page,merge to single,combine all,stitch pages,concatenate vertical,long page,poster"
 description = "This tool will merge all pages of your PDF into one large single page. The width will remain the same as the original pages, but the height will be the sum of all page heights."
 filenamePrefix = "single_page"
 header = "PDF To Single Page"
@@ -6763,6 +6850,7 @@ title = "What it does"
 title = "About Remove Annotations"
 
 [removeBlanks]
+tags = "delete,clean,empty,remove blank,delete blank pages,empty pages,white pages,remove empty,clean up,cleanup blank"
 header = "Remove Blank Pages"
 submit = "Remove blank pages"
 title = "Remove Blanks"
@@ -6829,6 +6917,7 @@ placeholder = "Select a PDF file in the main view to get started"
 title = "Certificate Removal Results"
 
 [removeImage]
+tags = "remove,delete,clean,remove image,delete image,strip images,remove pictures,delete photos,clean images,reduce size,remove graphics"
 header = "Remove image"
 removeImage = "Remove image"
 submit = "Remove image"
@@ -6919,6 +7008,7 @@ title = "Decrypted PDFs"
 description = "Removing password protection requires the password that was used to encrypt the PDF. This will decrypt the document, making it accessible without a password."
 
 [reorganizePages]
+tags = "rearrange,reorder,organize,reorganize,move pages,page order,sort pages,arrange pages,shuffle,resequence"
 submit = "Reorganize Pages"
 
 [reorganizePages.error]
@@ -7019,6 +7109,7 @@ text = "Completely invert all colours in the PDF, creating a negative-like effec
 title = "Invert All Colours"
 
 [rotate]
+tags = "turn,flip,orient,rotate,orientation,landscape,portrait,90 degrees,180 degrees,clockwise,anticlockwise,counter-clockwise,fix orientation"
 rotateLeft = "Rotate Anticlockwise"
 rotateRight = "Rotate Clockwise"
 selectRotation = "Select Rotation Angle (Clockwise)"
@@ -7042,6 +7133,7 @@ text = "Rotate your PDF pages clockwise or anticlockwise in 90-degree increments
 title = "Rotate Settings Overview"
 
 [sanitize]
+tags = "clean,purge,remove,sanitize,sanitise,remove scripts,remove javascript,remove metadata,strip metadata,security,clean document,remove hidden data,privacy"
 completed = "Sanitisation completed successfully"
 desc = "Remove potentially harmful elements from PDF files."
 filenamePrefix = "sanitised"
@@ -7106,6 +7198,7 @@ title = "Sanitise PDF"
 6 = "Remove Document Info Metadata"
 
 [scalePages]
+tags = "resize,adjust,scale,page size,resize page,scale page,change size,adjust size,enlarge,shrink page,fit to page,A4,letter size"
 header = "Adjust page-scale"
 keepPageSize = "Original Size"
 pageSize = "Size of a page of the document."
@@ -7115,7 +7208,6 @@ title = "Adjust page-scale"
 
 [ScannerImageSplit]
 info = "Python is not installed. It is required to run."
-tags = "separate,auto-detect,scans,multi-photo,organize"
 
 [ScannerImageSplit.selectText]
 1 = "Angle Threshold:"
@@ -7131,6 +7223,7 @@ tags = "separate,auto-detect,scans,multi-photo,organize"
 
 [scannerImageSplit]
 submit = "Extract Image Scans"
+tags = "separate,auto-detect,scans,multi-photo,organize"
 title = "Extracted Images"
 
 [scannerImageSplit.error]
@@ -7600,6 +7693,7 @@ title = "Extracted JavaScript"
 toggle = "Toggle Sidebar"
 
 [sign]
+tags = "signature,autograph,e-sign,electronic signature,digital signature,sign document,approval,signoff,authorize,endorse,ink signature,handwriting"
 activate = "Activate Signature Placement"
 add = "Add"
 addToAll = "Add to all pages"
@@ -7805,6 +7899,7 @@ small = "Small"
 x-large = "X-Large"
 
 [split]
+tags = "divide,separate,break,split,extract pages,separate pages,divide document,break apart,separate files,unbind,split by page,divide by chapter"
 header = "Split PDF"
 resultsTitle = "Split Results"
 selectMethod = "Select a split method"
@@ -8290,6 +8385,7 @@ justNow = "just now"
 minutesAgo = "{{count}}m ago"
 
 [timestampPdf]
+tags = "timestamp,RFC 3161,TSA,time stamp authority,document timestamp,proof of existence,timestamp token,trusted timestamp,sign timestamp,notarise"
 completed = "PDF timestamped successfully"
 desc = "Add an RFC 3161 document timestamp to your PDF using a trusted Time Stamp Authority (TSA) server."
 filenamePrefix = "timestamped"
@@ -8738,6 +8834,7 @@ title = "View/Edit PDF"
 tooltipTitle = "Warning"
 
 [watermark]
+tags = "stamp,mark,overlay,watermark,branding,logo,confidential,draft,copyright,trademark,text overlay,image overlay,background text"
 completed = "Watermark added"
 desc = "Add text or image watermarks to PDF files"
 filenamePrefix = "watermarked"
@@ -9274,3 +9371,28 @@ cancel = "Cancel"
 confirm = "Extract"
 message = "This ZIP contains {{count}} files. Extract anyway?"
 title = "Large ZIP File"
+
+[addStamp]
+tags = "stamp,mark,seal,approved,rejected,confidential,stamp tool,rubber stamp,date stamp,approval stamp,received,void,copy,original"
+
+[annotate]
+tags = "annotate,highlight,draw,markup,comment,notes,review,redline,feedback,markup tools,sticky notes,shapes,arrows,text box,freehand"
+
+[devAirgapped]
+tags = "air-gapped,offline,isolated,no internet,disconnected,secure,network isolation,standalone"
+
+[devApi]
+tags = "API,development,documentation,developer,REST,integration,endpoints,programmatic,automation,scripting"
+
+[devFolderScanning]
+tags = "automation,folder,scanning,watch folder,hot folder,automatic processing,batch,monitor folder,auto process,folder monitoring"
+
+[devSsoGuide]
+tags = "SSO,single sign-on,authentication,SAML,OAuth,OIDC,login,enterprise,identity provider,IdP"
+
+[read]
+tags = "view,open,display,read,viewer,PDF viewer,PDF reader,open PDF,view PDF,display PDF,preview,browse"
+
+[scannerEffect]
+tags = "scan,simulate,create,fake scan,look scanned,scanner effect,make look scanned,photocopy effect,simulate scanner,realistic scan"
+

--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -1,5 +1,4 @@
 accessInvite = "Invite"
-addToDoc = "Add to Document"
 alphabet = "Alphabet"
 apply = "Apply"
 applyAndContinue = "Save & Leave"
@@ -7,9 +6,7 @@ areYouSure = "Are you sure you want to leave?"
 back = "Back"
 black = "Black"
 blue = "Blue"
-bored = "Bored Waiting?"
 cancel = "Cancel"
-changedCredsMessage = "Credentials changed!"
 chooseFile = "Choose File"
 close = "Close"
 comingSoon = "Coming soon"
@@ -24,22 +21,13 @@ confirmCloseSaveFailed = "Saved with errors. {{count}} file{{plural}} could not 
 confirmCloseSaveFailedTitle = "Save Failed"
 confirmCloseUnsaved = "This file has unsaved changes."
 confirmCloseUnsavedList = "You have {{count}} file{{plural}} with unsaved changes.\n\n{{fileList}}"
-confirmPasswordErrorMessage = "New Password and Confirm New Password must match."
 custom = "Custom..."
 customPosition = "Custom Position"
 customTextTooltip = "Optional custom format for page numbers. Use {n} as placeholder for the number. Example: \"Page {n}\" will show \"Page 1\", \"Page 2\", etc."
 delete = "Delete"
-deleteCurrentUserMessage = "Cannot delete currently logged in user."
-deleteUsernameExistsMessage = "The username does not exist and cannot be deleted."
 details = "Details"
-disabledCurrentUserMessage = "The current user cannot be disabled"
 discardChanges = "Discard & Leave"
-discardRedactions = "Discard & Leave"
-donate = "Donate"
-downgradeCurrentUserLongMessage = "Cannot downgrade current user's role. Hence, current user will not be shown."
-downgradeCurrentUserMessage = "Cannot downgrade current user's role"
 download = "Download"
-downloadComplete = "Download Complete"
 downloadPdf = "Download PDF"
 downloadUnavailable = "Download unavailable for this item"
 edit = "Edit"
@@ -57,18 +45,13 @@ font = "Font"
 fontSizeTooltip = "Size of the page number text in points. Larger numbers create bigger text."
 fontTypeTooltip = "Font family for the page numbers. Choose based on your document style."
 genericSubmit = "Submit"
-goHomepage = "Go to Homepage"
-goToPage = "Go"
 green = "Green"
 help = "Help"
 imgPrompt = "Select Image(s)"
 incorrectPasswordMessage = "Current password is incorrect."
 info = "Info"
 insufficientCredits = "Insufficient credits. Required: {{requiredCredits}}, Available: {{currentBalance}}, Shortfall: {{shortfall}}"
-invalidPasswordMessage = "The password must not be empty and must not have spaces at the beginning or end."
 invalidUndoData = "Cannot undo: invalid operation data"
-invalidUsernameMessage = "Invalid username, username can only contain letters, numbers and the following special characters @._+- or must be a valid email address."
-joinDiscord = "Join our Discord server"
 keepWorking = "Keep Working"
 loading = "Loading..."
 loadingCredits = "Checking credits..."
@@ -76,15 +59,12 @@ loadingProStatus = "Checking subscription status..."
 logOut = "Log out"
 marginTooltip = "Distance between the page number and the edge of the page."
 moreOptions = "More Options"
-multiPdfDropPrompt = "Select (or drag & drop) all PDFs you require"
 multiPdfPrompt = "Select PDFs (2+)"
 never = "Never"
 no = "No"
-noFavourites = "No favourites added"
 noFileSelected = "No file loaded. Please upload one."
 noFilesToUndo = "Cannot undo: no files were processed in the last operation"
 noOperationToUndo = "No operation to undo"
-notAuthenticatedMessage = "User not authenticated."
 nothingToUndo = "Nothing to undo"
 noticeTopUpOrPlan = "Not enough credits, please top up or upgrade to a plan"
 noValidFiles = "No valid files to process"
@@ -99,26 +79,18 @@ pages = "Pages"
 pageSelectionPrompt = "Custom Page Selection (Enter a comma-separated list of page numbers 1,5,6 or Functions like 2n+1)"
 password = "Password"
 pdfPrompt = "Select PDF(s)"
-pendingRedactions = "You have unapplied redactions that will be lost."
-pendingRedactionsTitle = "Unapplied Redactions"
 pin = "Pin File (keep active after tool run)"
-poweredBy = "Powered by"
 pro = "Pro"
 processingComplete = "Your file is ready."
 processingCompleteMultiple = "{{count}} files are ready."
-processTimeWarning = "Warning: This process can take up to a minute depending on file-size"
 property = "Property"
 quickPosition = "Quick Position"
 red = "Red"
 reset = "Reset"
 review = "Review"
 save = "Save"
-saveToBrowser = "Save to Browser"
 saveUnavailable = "Save unavailable for this item"
-seeDockerHub = "See Docker Hub"
-selectFillter = "-- Select --"
 size = "Size"
-sponsor = "Sponsor"
 startingNumberTooltip = "The first number to display. Subsequent pages will increment from this number."
 submit = "Submit"
 success = "Success"
@@ -137,18 +109,9 @@ unpin = "Unpin File (replace after tool run)"
 unsavedChanges = "You have unsaved changes to your PDF."
 unsavedChangesTitle = "Unsaved Changes"
 unsupported = "Unsupported"
-uploadLimit = "Maximum file size:"
-uploadLimitExceededPlural = "are too large. Maximum allowed size is"
-uploadLimitExceededSingular = "is too large. Maximum allowed size is"
-userAlreadyExistsOAuthMessage = "The user already exists as an OAuth2 user."
-userAlreadyExistsWebMessage = "The user already exists as an web user."
 username = "Username"
-usernameExistsMessage = "New Username already exists."
-userNotFoundMessage = "User not found."
-visitGithub = "Visit Github Repository"
 welcome = "Welcome"
 white = "White"
-WorkInProgess = "Work in progress, May not work or be buggy, Please report any problems!"
 yes = "Yes"
 
 [account]
@@ -217,7 +180,6 @@ attachments = "Select Attachments"
 info = "Select files to attach to your PDF. These files will be embedded and accessible through the PDF's attachment panel."
 placeholder = "Choose files..."
 selectedFiles = "Selected Files"
-selectFiles = "Select Files to Attach"
 submit = "Add Attachments"
 
 [AddAttachmentsRequest.error]
@@ -314,13 +276,10 @@ text = "Text"
 
 [addPageNumbers]
 tags = "number,pagination,count,add page numbers,page numbering,page numbers,footer,header,number pages,sequential,pagination tool"
-configuration = "Configuration"
 customize = "Customize Appearance"
 customNumberDesc = "e.g., \"Page {n}\" or leave blank for just numbers"
-customTextDesc = "Custom Text"
 fontName = "Font Name"
 fontSize = "Font Size"
-header = "Add Page Numbers"
 numberPagesDesc = "e.g., 1,3,5-8 or leave blank for all pages"
 pagesAndStarting = "Pages & Starting Number"
 positionAndPages = "Position & Pages"
@@ -338,18 +297,14 @@ failed = "Add page numbers operation failed"
 title = "Page Number Results"
 
 [addPageNumbers.selectText]
-1 = "Select PDF file:"
 2 = "Margin Size"
-3 = "Position Selection"
 4 = "Starting Number"
 5 = "Pages to Number"
 6 = "Custom Text Format"
 
 [addPassword]
 tags = "encrypt,password,lock,secure,protect,security,encryption,safeguard,confidential,private,restrict access"
-completed = "Password protection applied"
 desc = "Encrypt your PDF document with a password."
-filenamePrefix = "encrypted"
 submit = "Encrypt"
 title = "Add Password"
 
@@ -363,7 +318,6 @@ label = "Encryption Key Length"
 failed = "An error occurred while encrypting the PDF."
 
 [addPassword.passwords]
-completed = "Passwords configured"
 stepTitle = "Passwords & Encryption"
 
 [addPassword.passwords.owner]
@@ -402,7 +356,6 @@ alphabet = "Alphabet"
 clickToExpand = "Click to expand"
 customColor = "Custom Text Colour"
 customDateDesc = "Custom format"
-customMargin = "Custom Margin"
 customPosition = "Drag the stamp to the desired location in the preview window."
 dateDesc = "Current date"
 datetimeDesc = "Date and time combined"
@@ -413,7 +366,6 @@ filenameDesc = "Filename without extension"
 filenameFullDesc = "Filename with extension"
 fileVars = "File Information"
 fontSize = "Font/Image Size"
-header = "Stamp PDF"
 imageSize = "Image Size"
 margin = "Margin"
 metadataDesc = "From PDF document properties"
@@ -422,8 +374,6 @@ multiLine = "multi-line"
 noStampSelected = "No stamp selected. Return to Step 1."
 opacity = "Opacity"
 otherVars = "Other"
-overrideX = "Override X Coordinate"
-overrideY = "Override Y Coordinate"
 pageNumberDesc = "Current page number"
 pageVars = "Page Information"
 position = "Position"
@@ -432,7 +382,6 @@ preview = "Preview:"
 quickPosition = "Select a position on the page to place the stamp."
 rotation = "Rotation"
 selectTemplate = "Select a template..."
-stampImage = "Stamp Image"
 stampSetup = "Stamp Setup"
 stampText = "Stamp Text"
 stampTextDescription = "Use dynamic variables below. Use @@ for literal @. Use \\n for new lines."
@@ -549,9 +498,7 @@ blue = "Blue"
 brightness = "Brightness:"
 confirm = "Confirm"
 contrast = "Contrast:"
-download = "Download"
 green = "Green"
-header = "Adjust Colors/Contrast"
 noPreview = "Select a PDF to preview"
 red = "Red"
 saturation = "Saturation:"
@@ -564,7 +511,6 @@ failed = "Failed to adjust colors/contrast"
 title = "Adjusted PDF"
 
 [adjustPageScale]
-header = "Adjust Page Scale"
 submit = "Adjust Page Scale"
 tags = "resize,modify,dimension,adapt"
 title = "Adjust Page Scale"
@@ -608,7 +554,6 @@ title = "Scale Factor"
 close = "Close"
 error = "Error"
 expand = "Expand"
-success = "Success"
 
 [admin.settings]
 discard = "Discard"
@@ -1551,10 +1496,6 @@ hint = "You have unsaved changes"
 message = "You have unsaved changes. Do you want to discard them?"
 title = "Unsaved Changes"
 
-[admin.status]
-active = "Active"
-inactive = "Inactive"
-
 [adminOnboarding]
 adminTools = "Finally, we have advanced administration tools like <strong>Auditing</strong> to track system activity and <strong>Usage Analytics</strong> to monitor how your users interact with the platform."
 configButton = "Open <strong>Settings</strong> to access all system configuration and administrative controls."
@@ -1567,35 +1508,8 @@ welcome = "Welcome to the <strong>Admin Tour</strong>! Let's explore the powerfu
 wrapUp = "That's the admin tour! You've seen the enterprise features that make Stirling PDF a powerful, customisable solution for organisations. You can replay it anytime - just open <strong>Settings</strong> and find it here in the <strong>Tours</strong> section under Help."
 
 [adminUserSettings]
-actions = "Actions"
-activeUsers = "Active Users:"
-addUser = "Add New User"
 admin = "Admin"
-apiUser = "Limited API User"
-authenticated = "Authenticated"
-changeUserRole = "Change User's Role"
-confirmChangeUserStatus = "Should the user be disabled/enabled?"
-confirmDeleteUser = "Should the user be deleted?"
-deleteUser = "Delete User"
-demoUser = "Demo User (No custom settings)"
-disabledUser = "disabled user"
-disabledUsers = "Disabled Users:"
-editOwnProfil = "Edit own profile"
-enabledUser = "enabled user"
-extraApiUser = "Additional Limited API User"
-forceChange = "Force user to change password on login"
-header = "Admin User Control Settings"
-internalApiUser = "Internal API User"
-lastRequest = "Last Request"
-role = "Role"
-roles = "Roles"
-submit = "Save User"
 title = "User Control Settings"
-totalUsers = "Total Users:"
-usage = "View Usage"
-user = "User"
-usernameInfo = "Username can only contain letters, numbers and the following special characters @._+- or must be a valid email address."
-webOnlyUser = "Web Only User"
 
 [agents]
 auto_redaction_description = "Redact PII automatically"
@@ -1610,7 +1524,6 @@ doc_summary_description = "Summarise long documents"
 doc_summary_name = "Summariser"
 form_filler_description = "Fill PDF forms intelligently"
 form_filler_name = "Form Filler"
-fullscreen_title = "Stirling Agents"
 pdf_to_markdown_description = "Convert PDFs to clean Markdown"
 pdf_to_markdown_name = "PDF to Markdown"
 section_title = "Agents"
@@ -1625,18 +1538,13 @@ stirling_tooltip = "Stirling agent"
 view_all = "View all agents"
 
 [analytics]
-disable = "Disable analytics"
-enable = "Enable analytics"
 learnMore = "Learn more about our analytics"
 paragraph1 = "Stirling PDF has opt-in analytics to help us improve the product. We do not track any personal information or file contents."
 paragraph2 = "Please consider enabling analytics to help Stirling-PDF grow and to allow us to understand our users better."
-privacyAssurance = "We do not track any personal information or the contents of your files."
-settings = "You can change the settings for analytics in the config/settings.yml file"
 title = "Do you want to help make Stirling PDF better?"
 
 [annotation]
 annotationStyle = "Annotation style"
-applyChanges = "Apply Changes"
 backgroundColor = "Background colour"
 borderOff = "Border: Off"
 borderOn = "Border: On"
@@ -1649,36 +1557,20 @@ comment = "Comment"
 comments = "Comments"
 contents = "Text"
 delete = "Delete"
-desc = "Use highlight, pen, text, and notes. Changes stay live-no flattening required."
 drawing = "Drawing"
-duplicate = "Duplicate"
-editCircle = "Edit Circle"
-editInk = "Edit Pen"
-editLine = "Edit Line"
-editNote = "Edit Note"
-editPolygon = "Edit Polygon"
 editSelectDescription = "Click an existing annotation to edit its colour, opacity, text, or size."
-editSelected = "Edit Annotation"
-editSquare = "Edit Square"
-editStampHint = "To change the image, delete this stamp and add a new one."
-editSwitchToSelect = "Switch to Select & Edit to edit this annotation."
 editText = "Edit"
-editTextMarkup = "Edit Text Markup"
-ellipse = "Ellipse"
-exit = "Exit annotation mode"
 fillColor = "Fill Colour"
 fillOpacity = "Fill Opacity"
 fontSize = "Font size"
 freehandHighlighter = "Freehand Highlighter"
 highlight = "Highlight"
 imagePreview = "Preview"
-inkHighlighter = "Freehand Highlighter"
 insertText = "Insert Text"
 line = "Line"
 lineArrow = "Arrow"
 noBackground = "No background"
 note = "Note"
-noteIcon = "Note Icon"
 notesStamps = "Notes & Stamps"
 opacity = "Opacity"
 pen = "Pen"
@@ -1686,12 +1578,8 @@ polygon = "Polygon"
 polyline = "Polyline"
 properties = "Properties"
 rectangle = "Rectangle"
-redo = "Redo"
 replaceText = "Replace Text"
 saveChanges = "Save Changes"
-saveFailed = "Unable to save copy"
-saveReady = "Download ready"
-savingCopy = "Preparing download..."
 select = "Select"
 selectAndMove = "Select and Edit"
 settings = "Settings"
@@ -1709,24 +1597,17 @@ textAlignment = "Text Alignment"
 textMarkup = "Text Markup"
 title = "Annotate"
 underline = "Underline"
-undo = "Undo"
-unsupportedType = "This annotation type is not fully supported for editing."
 width = "Width"
 
 [app]
 description = "The Free Adobe Acrobat alternative (10M+ Downloads)"
 
 [attachments]
-add = "Add Attachment"
 convertToPdfA3b = "Convert to PDF/A-3b"
 convertToPdfA3bDescription = "Creates an archival PDF with embedded attachments"
 convertToPdfA3bTooltip = "PDF/A-3b is an archival format ensuring long-term preservation. It allows embedding arbitrary file formats as attachments. Conversion requires Ghostscript and may take longer for large files."
 convertToPdfA3bTooltipHeader = "About PDF/A-3b Conversion"
 convertToPdfA3bTooltipTitle = "What it does"
-embed = "Embed Attachment"
-header = "Add Attachments"
-remove = "Remove Attachment"
-submit = "Add Attachments"
 tags = "attachments,add,remove,embed,file"
 title = "Add Attachments"
 
@@ -1742,12 +1623,10 @@ notAvailable = "Audit system not available"
 notAvailableMessage = "The audit system is not configured or not available."
 
 [audit.charts]
-byTool = "Top Tools Used"
 byType = "Events by Type"
 byUser = "Top Users"
 day = "Day"
 error = "Error loading charts"
-hourlyActivity = "Hourly Activity"
 month = "Month"
 noData = "No data for this period"
 overTime = "Events Over Time"
@@ -1784,17 +1663,12 @@ documentName = "Document"
 endDate = "End date"
 error = "Error loading events"
 eventDetails = "Event Details"
-failure = "Failure"
 fileHash = "File Hash"
 filterByType = "Filter by type"
 filterByUser = "Filter by user"
 ipAddress = "IP Address"
 noEvents = "No events found"
-outcome = "Status"
-sortAsc = "Sort ascending"
-sortDesc = "Sort descending"
 startDate = "Start date"
-success = "Success"
 timestamp = "Timestamp"
 title = "Audit Events"
 type = "Type"
@@ -1802,9 +1676,7 @@ user = "User"
 viewDetails = "View Details"
 
 [audit.export]
-clearFilters = "Clear"
 description = "Export audit events to CSV or JSON format. Use filters to limit the exported data."
-endDate = "End date"
 error = "Failed to export data"
 exportButton = "Export Data"
 fieldAuthor = "Author (from PDF)"
@@ -1816,23 +1688,15 @@ fieldOperationResults = "Operation Results"
 fieldOutcome = "Outcome (Success/Failure)"
 fieldTool = "Tool"
 fieldUsername = "Username"
-filterByType = "Filter by type"
-filterByUser = "Filter by user"
 filters = "Filters (Optional)"
 format = "Export Format"
 selectFields = "Select Fields to Include"
-startDate = "Start date"
 title = "Export Audit Data"
-verboseRequired = "Requires VERBOSE audit level"
 
 [audit.filters]
-allOutcomes = "All"
-failureOnly = "Failures only"
 last30Days = "Last 30 days"
 last7Days = "Last 7 days"
-outcomeFilter = "Outcome"
 quickPresets = "Quick filters"
-successOnly = "Success only"
 thisMonth = "This month"
 today = "Today"
 
@@ -1841,18 +1705,14 @@ activeUsers = "Active Users"
 attention = "Attention needed"
 avgLatency = "Avg Latency"
 error = "Error loading statistics"
-errorLoadingStats = "Failed to load statistics"
 excellent = "Excellent"
 good = "Good"
 noData = "N/A"
 successRate = "Success Rate"
-title = "Summary"
 totalEvents = "Total Events"
 vsLastPeriod = "vs last period"
 
 [audit.systemStatus]
-autoRefresh = "Auto-refresh"
-autoRefreshLabel = "Auto-refresh every 30s"
 captureBySettings = "Enable in settings"
 capturedFields = "Captured Fields"
 date = "Date"
@@ -1869,7 +1729,6 @@ title = "System Status"
 tool = "Tool"
 totalEvents = "Total Events"
 username = "Username"
-verboseOnly = "VERBOSE only"
 
 [audit.tabs]
 clearData = "Clear Data"
@@ -1880,8 +1739,6 @@ export = "Export"
 [auth]
 accessDenied = "Access Denied"
 insufficientPermissions = "You do not have permission to perform this action."
-pleaseLoginAgain = "Please login again."
-sessionExpired = "Session Expired"
 
 [auth.displayName]
 guest = "Guest"
@@ -1889,16 +1746,12 @@ user = "User"
 
 [auto-rename]
 description = "Automatically finds the title from your PDF content and uses it as the filename."
-header = "Auto Rename PDF"
 submit = "Auto Rename"
 tags = "auto-detect,header-based,organize,relabel"
 title = "Auto Rename"
 
 [auto-rename.error]
 failed = "An error occurred whilst auto-renaming the PDF."
-
-[auto-rename.files]
-placeholder = "Select a PDF file in the main view to get started"
 
 [auto-rename.results]
 title = "Auto-Rename Results"
@@ -1916,7 +1769,6 @@ title = "How Auto-Rename Works"
 bullet1 = "Looks for text that appears to be a title or heading"
 bullet2 = "Creates a clean, valid filename from the detected title"
 bullet3 = "Keeps the original name if no suitable title is found"
-text = "Automatically finds the title from your PDF content and uses it as the filename."
 title = "Smart Renaming"
 
 [automate]
@@ -1935,7 +1787,6 @@ title = "Automate"
 [automate.config]
 cancel = "Cancel"
 description = "Configure the settings for this tool. These settings will be applied when the automation runs."
-loading = "Loading tool configuration..."
 noSettings = "This tool does not have configurable settings."
 save = "Save Configuration"
 title = "Configure {{toolName}}"
@@ -1976,16 +1827,6 @@ title = "Unsaved Changes"
 
 [automate.entryMenu]
 label = "Open menu for {{title}}"
-
-[automate.files]
-placeholder = "Select files to process with this automation"
-
-[automate.folderScanWarning]
-advice = "You can still download the file (e.g. to inspect or hand-edit it), but the unsupported steps will need to be removed before the backend can run it."
-cancel = "Cancel"
-confirm = "Export anyway"
-intro = "Folder scanning runs on the backend, so it can only execute tools that have a backend endpoint. The following step(s) in this automation do not, and will fail when the pipeline runs:"
-title = "Some steps cannot run in folder scanning"
 
 [automate.importModal]
 cancel = "Cancel"
@@ -2045,20 +1886,10 @@ description = "This tool will automatically rename PDF files based on their cont
 tags = "pdf,split,document,organization"
 
 [autoSplitPDF]
-description = "Print, Insert, Scan, upload, and let us auto-separate your documents. No manual work sorting needed."
 dividerDownload2 = "Download 'Auto Splitter Divider (with instructions).pdf'"
 duplexMode = "Duplex Mode (Front and back scanning)"
-formPrompt = "Submit PDF containing Stirling-PDF Page dividers:"
-header = "Auto Split PDF"
-submit = "Submit"
 tags = "QR-based,separate,scan-segment,organize"
 title = "Auto Split PDF"
-
-[autoSplitPDF.selectText]
-1 = "Print out some divider sheets from below (Black and white is fine)."
-2 = "Scan all your documents at once by inserting the divider sheet between them."
-3 = "Upload the single large scanned PDF file and let Stirling PDF handle the rest."
-4 = "Divider pages are automatically detected and removed, guaranteeing a neat final document."
 
 [backendHealth]
 checking = "Checking backend status..."
@@ -2096,7 +1927,6 @@ whatHappensNext = "What happens next?"
 error = "Failed to open billing portal"
 
 [bookletImposition]
-header = "Booklet Imposition"
 paperSizeNote = "Paper size is automatically derived from your first page."
 submit = "Create Booklet"
 tags = "booklet,imposition,printing,binding,folding,signature"
@@ -2142,11 +1972,6 @@ title = "Manual Duplex Mode"
 [bookletImposition.rtlBinding]
 label = "Right-to-left binding"
 tooltip = "For Arabic, Hebrew, or other right-to-left languages"
-
-[bookletImposition.spineLocation]
-label = "Spine Location"
-left = "Left (Standard)"
-right = "Right (RTL)"
 
 [bookletImposition.tooltip.advanced]
 bullet1 = "Right-to-Left Binding: For Arabic, Hebrew, or RTL languages"
@@ -2287,7 +2112,6 @@ description = "Use your own PKCS#12 certificate file. Provides full control over
 title = "Upload Custom P12"
 
 [certSign]
-allSigned = "All participants have signed. Ready to finalize."
 awaitingSignatures = "Awaiting signatures"
 chooseCertificate = "Choose Certificate File"
 chooseJksFile = "Choose JKS File"
@@ -2296,7 +2120,6 @@ choosePfxFile = "Choose PFX File"
 choosePrivateKey = "Choose Private Key File"
 declined = "Declined"
 fetchFailed = "Failed to load signing data"
-filenamePrefix = "signed"
 finalized = "Finalized"
 location = "Location"
 logoTitle = "Logo"
@@ -2304,7 +2127,6 @@ name = "Name"
 noLogo = "No Logo"
 notified = "Pending"
 pageNumber = "Page Number"
-partialNote = "You can finalize early with current signatures. Unsigned participants will be excluded."
 password = "Certificate Password"
 passwordOptional = "Leave empty if no password"
 pending = "Pending"
@@ -2372,12 +2194,8 @@ stepTitle = "Certificate Format"
 
 [certSign.collab.addParticipants]
 add = "Add {{count}} Participant(s)"
-back = "Back"
-configureSignatures = "Configure Signature Settings"
-continue = "Continue to Signature Settings"
 reasonHelp = "Pre-set a signing reason for these participants (optional, they can override when signing)"
 reasonPlaceholder = "e.g. Approval, Review..."
-selectUsers = "Select Users"
 
 [certSign.collab.finalize]
 button = "Finalize and Load Signed PDF"
@@ -2396,7 +2214,6 @@ includeSummaryPage = "Include Signature Summary Page"
 includeSummaryPageHelp = "A summary page will be added at the end with all signature metadata. The digital certificate signature boxes on individual pages will be suppressed (wet signatures are unaffected)."
 
 [certSign.collab.sessionDetail]
-addButton = "Add Participants"
 addParticipants = "Add Participants"
 addParticipantsError = "Failed to add participants"
 backToList = "Back to Sessions"
@@ -2409,7 +2226,6 @@ finalizeError = "Failed to finalize session"
 loadPdfError = "Failed to load signed PDF"
 loadSignedPdf = "Load Signed PDF into Active Files"
 messageLabel = "Message"
-noAdditionalInfo = "No additional information"
 owner = "Owner"
 participantRemoved = "Participant removed"
 participants = "Participants"
@@ -2430,7 +2246,6 @@ title = "Signature Appearance"
 
 [certSign.collab.signRequest]
 addedToFiles = "Document added to active files"
-addSignature = "Add Your Signature"
 addToFiles = "Add to Active Files"
 advancedSettings = "Advanced Settings"
 backToList = "Back to Sign Requests"
@@ -2443,35 +2258,27 @@ decline = "Decline Request"
 declineButton = "Decline"
 deleteSelected = "Delete selected signature"
 drawSignature = "Draw your signature below"
-dueDate = "Due Date"
 fileTooLarge = "File size must be less than 5MB"
 fontFamily = "Font Family"
 fontSize = "Font Size: {{size}}px"
 fontSizePlaceholder = "Size"
 from = "From"
-invalidCertFile = "Please select a P12 or PFX certificate file"
 invalidFileType = "Please select an image file"
 location = "Location (Optional)"
 locationPlaceholder = "Where are you signing from?"
-message = "Message"
 noCertificate = "Please select a certificate file"
 noSignatures = "Please place at least one signature on the PDF"
 p12File = "P12/PFX Certificate File"
 password = "Certificate Password"
-passwordPlaceholder = "Enter password..."
 penColor = "Pen Color"
 penSize = "Pen Size: {{size}}px"
-placementActive = "Click PDF to place"
-placeSignatureButton = "Place Signature on PDF"
 reason = "Reason (Optional)"
 reasonPlaceholder = "Why are you signing?"
-removeCertFile = "Remove File"
 removeImage = "Remove Image"
 savedSignatures = "Saved Signatures"
 selectFile = "Select Image File"
 selectSignatureTitle = "Select or Create Signature"
 signatureInfo = "These settings are configured by the document owner"
-signaturePlaced = "Signature placed on page"
 signatureSettings = "Signature Settings"
 signatureText = "Signature Text"
 signatureTextPlaceholder = "Enter your name..."
@@ -2503,9 +2310,6 @@ description = "You have placed {{count}} signature(s). Choose your certificate t
 sign = "Sign Document"
 title = "Configure Certificate"
 
-[certSign.collab.signRequest.image]
-hint = "Upload a PNG or JPG image of your signature"
-
 [certSign.collab.signRequest.mode]
 move = "Move Signature"
 place = "Place Signature"
@@ -2515,10 +2319,6 @@ title = "Sign or move mode"
 draw = "Draw"
 image = "Upload"
 text = "Type"
-
-[certSign.collab.signRequest.placeSignature]
-message = "Click on the PDF to place your signature"
-title = "Place Signature"
 
 [certSign.collab.signRequest.preview]
 imageAlt = "Selected signature"
@@ -2649,24 +2449,19 @@ text = "When you check signatures, the tool tells you if they're valid, who sign
 title = "Checking Signatures"
 
 [changeCreds]
-changePassword = "You are using default login credentials. Please enter a new password"
 changeUsername = "Update your username. You will be logged out after updating."
-confirmNewPassword = "Confirm New Password"
 credsUpdated = "Account updated"
 description = "Changes saved. Please log in again."
 error = "Unable to update username. Please verify your password and try again."
 header = "Update Your Account Details"
-newPassword = "New Password"
 newUsername = "New Username"
 oldPassword = "Current Password"
 ssoManaged = "Your account is managed by your identity provider."
-submit = "Submit Changes"
 title = "Change Credentials"
 
 [changeMetadata]
 tags = "edit,modify,update,metadata,properties,document properties,author,title,subject,keywords,creator,producer,info,document info,file properties"
 filenamePrefix = "metadata"
-header = "Change Metadata"
 submit = "Change"
 
 [changeMetadata.advanced]
@@ -2719,9 +2514,6 @@ placeholder = "Document producer"
 [changeMetadata.results]
 title = "Updated PDFs"
 
-[changeMetadata.settings]
-title = "Metadata Settings"
-
 [changeMetadata.standardFields]
 title = "Standard Fields"
 
@@ -2760,16 +2552,6 @@ title = "Date Fields"
 text = "Complete metadata deletion to ensure privacy."
 title = "Remove Existing Metadata"
 
-[changeMetadata.tooltip.header]
-title = "PDF Metadata Overview"
-
-[changeMetadata.tooltip.options]
-bullet1 = "Custom Metadata: Add your own key-value pairs"
-bullet2 = "Trapped Status: High-quality printing setting"
-bullet3 = "Delete All: Remove all metadata for privacy"
-text = "Custom fields and privacy controls."
-title = "Additional Options"
-
 [changeMetadata.tooltip.standardFields]
 bullet1 = "Title: Document name or heading"
 bullet2 = "Author: Person who created the document"
@@ -2787,7 +2569,6 @@ unknown = "Unknown"
 
 [changePermissions]
 tags = "permissions,restrictions,rights,access control,allow,deny,printing,copying,editing,modify permissions,security settings,user rights"
-completed = "Permissions changed"
 desc = "Change document restrictions and permissions."
 submit = "Change Permissions"
 title = "Change Permissions"
@@ -2840,10 +2621,8 @@ copy = "Copy message"
 [chat.header]
 agentMenu = "Stirling agent options"
 clearChat = "Clear chat"
-settings = "Agent settings"
 
 [chat.input]
-attach = "Attach files"
 placeholder = "What do you want to do?"
 send = "Send message"
 
@@ -2868,8 +2647,6 @@ compressMany = "Compress these documents"
 compressOne = "Compress this document"
 convertMany = "Convert these documents to PDF"
 convertOne = "Convert this document to PDF"
-fileSummary_one = "1 file in workbench ({{types}})"
-fileSummary_other = "{{count}} files in workbench ({{types}})"
 heading = "Get started"
 mergeMany = "Merge these {{count}} documents into 1"
 moreFiles = "+{{count}} more"
@@ -2890,8 +2667,6 @@ unsupported_capability = "Unsupported capability: {{capability}}"
 
 [chat.toolsUsed]
 summary = "Ran {{count}} tools"
-summary_one = "Ran 1 tool"
-summary_other = "Ran {{count}} tools"
 unknownTool = "Unknown tool"
 
 [cloudBadge]
@@ -2909,7 +2684,6 @@ back = "Back"
 cancel = "Cancel"
 close = "Close"
 collapse = "Collapse"
-collapsed = "collapsed"
 continue = "Continue"
 copied = "Copied!"
 copy = "Copy"
@@ -2917,57 +2691,39 @@ done = "Done"
 error = "Error"
 expand = "Expand"
 learnMore = "Learn more"
-lines = "lines"
 loading = "Loading..."
 next = "Next"
 operation = "this operation"
 preview = "Preview"
 previous = "Previous"
 refresh = "Refresh"
-remaining = "remaining"
 retry = "Retry"
 save = "Save"
 used = "used"
 
 [compare]
-addFilesHint = "Add PDFs in the Files step to enable selection."
 clearSelected = "Clear selected"
 clearSlot = "Remove file"
 cta = "Compare"
-header = "Compare PDFs"
 loading = "Comparing..."
 newLine = "new-line"
-noFiles = "No PDFs available yet"
 pages = "Pages"
 tags = "differentiate,contrast,changes,analysis"
 title = "Compare"
 
 [compare.actions]
 linkScroll = "Link scroll"
-linkScrollPan = "Link scroll and pan"
 placeSideBySide = "Place side by side"
 resetView = "Reset view"
 stackVertically = "Stack vertically"
 unlinkScroll = "Unlink scroll"
-unlinkScrollPan = "Unlink scroll and pan"
 zoomIn = "Zoom in"
 zoomOut = "Zoom out"
-
-[compare.base]
-label = "Original document"
-placeholder = "Select the original PDF"
 
 [compare.clear]
 confirm = "Clear Selected"
 confirmBody = "This will close the current comparison and take you back to Active Files."
 confirmTitle = "Clear selected PDFs?"
-
-[compare.comparison]
-label = "Edited document"
-placeholder = "Select the edited PDF"
-
-[compare.complex]
-message = "One or both of the provided documents are large files, accuracy of comparison may be reduced"
 
 [compare.dropdown]
 additions = "Additions ({{count}})"
@@ -2999,10 +2755,6 @@ message = "One or Both of the provided documents are too large to process"
 [compare.longJob]
 body = "These PDFs together exceed 2,000 pages. Processing can take several minutes."
 title = "Large comparison in progress"
-
-[compare.mode]
-pixel = "Pixel Comparison"
-text = "Text Comparison"
 
 [compare.no.text]
 message = "One or both of the selected PDFs have no text content. Please choose PDFs with text for comparison."
@@ -3043,18 +2795,10 @@ pagesRendered = "pages rendered"
 rendering = "rendering"
 
 [compare.review]
-actionsHint = "Review the comparison, switch document roles, or export the summary."
-exportSummary = "Export summary"
-switchOrder = "Switch order"
 title = "Comparison Result"
 
 [compare.selection]
 originalEditedTitle = "Select Original and Edited PDFs"
-
-[compare.slowOperation]
-body = "This comparison is taking longer than usual. You can let it continue or cancel it."
-cancel = "Cancel comparison"
-title = "Still working…"
 
 [compare.status]
 complete = "Comparison ready"
@@ -3082,9 +2826,7 @@ message = "These documents appear highly dissimilar. Comparison was stopped to s
 
 [compress]
 tags = "shrink,reduce,optimize,compress,smaller,downsize,file size,reduce size,minimize,make smaller,decrease size,optimize size"
-credit = "This service uses qpdf for PDF Compress/Optimisation."
 desc = "Compress PDFs to reduce their file size."
-header = "Compress PDF"
 submit = "Compress"
 title = "Compress"
 
@@ -3116,15 +2858,6 @@ unavailable = "ImageMagick is not installed or enabled on this server"
 filesize = "File Size"
 quality = "Quality"
 title = "Compression Method"
-
-[compress.selectText]
-2 = "Optimisation level:"
-4 = "Auto mode - Auto adjusts quality to get PDF to exact size"
-5 = "Expected PDF Size (e.g. 25MB, 10.8MB, 25KB)"
-
-[compress.selectText.1]
-1 = "1-3 PDF compression,</br> 4-6 lite image compression,</br> 7-9 intense image compression Will dramatically reduce image quality"
-_value = "Compression Settings"
 
 [compress.settings]
 desiredSize = "Desired File Size"
@@ -3231,7 +2964,6 @@ publicKeyAriaLabel = "Public API key"
 purchasedCredits = "Purchased credits"
 refreshAriaLabel = "Refresh API key"
 schemaLink = "API Schema Reference"
-totalCredits = "Total Credits"
 usage = "Include this key in the X-API-KEY header with all API requests."
 
 [config.apiKeys.alert]
@@ -3263,14 +2995,6 @@ integration = "Integration Configuration"
 security = "Security Configuration"
 system = "System Configuration"
 
-[connectionMode.status]
-localOffline = "Offline mode running"
-localOnline = "Offline mode running"
-saas = "Connected to Stirling Cloud"
-selfhostedChecking = "Connected to self-hosted server (checking...)"
-selfhostedOffline = "Self-hosted server unreachable"
-selfhostedOnline = "Connected to self-hosted server"
-
 [convert]
 tags = "transform,change,convert,PDF to Word,PDF to Excel,PDF to image,Word to PDF,Excel to PDF,PowerPoint to PDF,HTML to PDF,export,import,file conversion,format change,save as"
 autoRotate = "Auto Rotate"
@@ -3290,64 +3014,39 @@ combineImages = "Combine Images"
 combineImagesDescription = "Combine all images into one PDF, or create separate PDFs for each image"
 combineSvgs = "Combine SVGs into single PDF"
 combineSvgsDescription = "Combine all SVG files into one PDF with multiple pages, or create separate PDFs for each SVG"
-conversionCompleted = "Conversion completed"
 conversionResults = "Conversion Results"
 convertFiles = "Convert Files"
 convertFrom = "Convert from"
 converting = "Converting..."
 convertTo = "Convert to"
-defaultFilename = "converted_file"
 desc = "Convert files between different formats"
-downloadConverted = "Download Converted File"
 downloadHtml = "Download HTML intermediate file instead of PDF"
 dpi = "DPI"
 ebookToPdf = "eBook → PDF"
 emailOptions = "Email to PDF Options"
 emlToPdf = "Email → PDF"
 errorConversion = "An error occurred while converting the file."
-errorNoFiles = "Please select at least one file to convert."
-errorNoFormat = "Please select both source and target formats."
-errorNotSupported = "Conversion from {{from}} to {{to}} is not supported."
-fileFormat = "File Format"
-files = "Files"
 fileToPdf = "Office/Document → PDF"
 fillPage = "Fill Page"
 fitDocumentToPage = "Fit Document to Page"
 fitOption = "Fit Option"
 grayscale = "Greyscale"
-greyscale = "Greyscale"
 imageOptions = "Image Options"
-images = "Images"
-imagesExt = "Images (JPG, PNG, etc.)"
 includeAllRecipients = "Include CC and BCC recipients in header"
 includeAttachments = "Include email attachments"
 maintainAspectRatio = "Maintain Aspect Ratio"
-markdown = "Markdown"
 maxAttachmentSize = "Maximum attachment size (MB)"
 multiple = "Multiple"
-noFileSelected = "No file loaded. Use the file panel to add files."
-odpExt = "OpenDocument Presentation (.odp)"
-odtExt = "OpenDocument Text (.odt)"
-officeDocs = "Office Documents (Word, Excel, PowerPoint)"
 optimizeForEbook = "Optimize PDF for ebook readers (uses Ghostscript)"
 output = "Output"
 outputFormat = "Output Format"
-outputOptions = "Output Options"
 pdfaDigitalSignatureWarning = "The PDF contains a digital signature. This will be removed in the next step."
-pdfaFormat = "PDF/A Format"
 pdfaNote = "PDF/A-1b is more compatible, PDF/A-2b supports more features, PDF/A-3b supports embedded files."
 pdfaOptions = "PDF/A Options"
 pdfOptions = "PDF Options"
 pdfToCbr = "PDF → CBR"
 pdfToCbz = "PDF → CBZ"
 pdfToEpub = "PDF → EPUB"
-pdfxDescription = "PDF/X is an ISO standard PDF subset for reliable printing and graphics exchange."
-pdfxDigitalSignatureWarning = "The PDF contains a digital signature. This will be removed in the next step."
-pptExt = "PowerPoint (.pptx)"
-results = "Results"
-rtfExt = "Rich Text Format (.rtf)"
-selectedFiles = "Active files"
-selectFilesPlaceholder = "Add files to the workbench to get started"
 selectSourceFormatFirst = "Choose a source format first"
 settings = "Settings"
 single = "Single"
@@ -3358,17 +3057,11 @@ svgPdfOptions = "SVG to PDF Options"
 svgToPdf = "SVG → PDF"
 svgVectorNote = "SVG files are rendered as vector graphics for crisp output at any resolution. Dimensions from the SVG determine the PDF page size."
 targetFormatPlaceholder = "Target format"
-textRtf = "Text/RTF"
 title = "Convert"
-txtExt = "Plain Text (.txt)"
 webOptions = "Web to PDF Options"
-wordDoc = "Word Document"
-wordDocExt = "Word Document (.docx)"
 zoomLevel = "Zoom Level"
 
 [convert.ebookOptions]
-ebookOptions = "eBook to PDF Options"
-ebookOptionsDesc = "Options for converting eBooks to PDF"
 embedAllFonts = "Embed all fonts"
 embedAllFontsDesc = "Embed all fonts from the eBook into the generated PDF"
 includePageNumbers = "Include page numbers"
@@ -3381,8 +3074,6 @@ optimizeForEbookPdfDesc = "Optimize the PDF for eBook reading (smaller file size
 [convert.epubOptions]
 detectChapters = "Detect chapters"
 detectChaptersDesc = "Detect headings that look like chapters and insert EPUB page breaks"
-epubOptions = "PDF to eBook Options"
-epubOptionsDesc = "Options for converting PDF to EPUB/AZW3"
 kindleEink = "Kindle e-Ink (text optimized)"
 outputFormat = "Output format"
 outputFormatDesc = "Choose the output format for the ebook"
@@ -3495,14 +3186,8 @@ unlimitedApiAccess = "Unlimited API access"
 unlimitedMonthlyCredits = "Site License"
 unlimitedSeats = "Unlimited seats"
 
-[credits.modal.features]
-everythingInCredits = "Everything in Credits, plus:"
-everythingInFree = "Everything in Free, plus:"
-forRegularWork = "For regular PDF work:"
-
 [crop]
 autoCrop = "Auto-crop whitespace"
-header = "Crop PDF"
 noFileSelected = "Add a PDF file to begin cropping"
 reset = "Reset to full PDF"
 submit = "Apply Crop"
@@ -3553,39 +3238,10 @@ title = "How to Crop PDFs"
 
 [database]
 backupCreated = "Database backup successful"
-createBackupFile = "Create Backup File"
-creationDate = "Creation Date"
-deleteBackupFile = "Delete Backup File"
-downloadBackupFile = "Download Backup File"
-failedImportFile = "Failed to import file"
 fileName = "File Name"
-fileNotFound = "File not found"
-fileNullOrEmpty = "File must not be null or empty"
-fileSize = "File Size"
-header = "Database Import/Export"
-importBackupFile = "Import Backup File"
-importIntoDatabaseSuccessed = "Import into database successed"
-info_1 = "When importing data, it is crucial to ensure the correct structure. If you are unsure of what you are doing, seek advice and support from a professional. An error in the structure can cause application malfunctions, up to and including the complete inability to run the application."
-info_2 = "The file name does not matter when uploading. It will be renamed afterward to follow the format backup_user_yyyyMMddHHmm.sql, ensuring a consistent naming convention."
-notSupported = "This function is not available for your database connection."
-submit = "Import Backup"
 title = "Database Import/Export"
 
-[decrypt]
-cancelled = "Operation cancelled for PDF: {0}"
-invalidPassword = "Please try again with the correct password."
-invalidPasswordHeader = "Incorrect password or unsupported encryption for PDF: {0}"
-noPassword = "No password provided for encrypted PDF: {0}"
-passwordPrompt = "This file is password-protected. Please enter the password:"
-serverError = "Server error while decrypting: {0}"
-success = "File decrypted successfully."
-unexpectedError = "There was an error processing the file. Please try again."
-
 [defaultApp]
-description = "You can change this later in your system settings."
-dismiss = "Dismiss"
-message = "Would you like to set Stirling PDF as your default PDF editor?"
-notNow = "Not Now"
 setDefault = "Set Default"
 title = "Set as Default PDF App"
 
@@ -3595,7 +3251,6 @@ title = "Error"
 
 [defaultApp.prompt]
 message = "Make Stirling PDF your default application for opening PDF files."
-title = "Set as Default PDF Editor"
 
 [defaultApp.settingsOpened]
 message = "In Windows Settings, search for 'PDF' and select Stirling PDF as your default app"
@@ -3705,12 +3360,9 @@ title = "Bookmarks & outline"
 
 [editTableOfContents.workbench]
 changeFile = "Change PDF"
-fileLabel = "Changes will be applied to the currently selected PDF."
 filePrompt = "Select a PDF from your library or upload a new one to begin."
-noFile = "No PDF selected"
 selectFile = "Select PDF"
 subtitle = "Import bookmarks, build hierarchies, and apply the outline without cramped side panels."
-tabTitle = "Outline workspace"
 
 [editTableOfContents.workbench.empty]
 description = "Select the Edit Table of Contents tool to load its workspace."
@@ -3743,62 +3395,15 @@ label = "PDF password"
 placeholder = "Enter the PDF password"
 
 [endpointStatistics]
-all = "All"
-dataTypeAll = "All"
-dataTypeApi = "API"
-dataTypeLabel = "Data Type:"
-dataTypeUi = "UI"
-endpoint = "Endpoint"
-failedToLoad = "Failed to load endpoint data. Please try refreshing."
-header = "Endpoint Statistics"
-home = "Home"
-loading = "Loading..."
-login = "Login"
-numberOfVisits = "Number of Visits"
-percentage = "Percentage"
-refresh = "Refresh"
-retry = "Retry"
-selectedVisits = "Selected Visits"
-showing = "Showing"
 title = "Endpoint Statistics"
-top = "Top"
-top10 = "Top 10"
-top20 = "Top 20"
-totalEndpoints = "Total Endpoints"
-totalVisits = "Total Visits"
-visits = "Visits"
-visitsTooltip = "Visits: {0} ({1}% of total)"
-
-[enterpriseEdition]
-button = "Upgrade to Pro"
-ssoAdvert = "Looking for more user management features? Check out Stirling PDF Pro"
-warning = "This feature is only available to Pro users."
-yamlAdvert = "Stirling PDF Pro supports YAML configuration files and other SSO features."
 
 [error]
 _value = "Error"
-contactTip = "If you're still having trouble, don't hesitate to reach out to us for help. You can submit a ticket on our GitHub page or contact us through Discord:"
-copyStack = "Copy Stack Trace"
-discordSubmit = "Discord - Submit Support post"
 dismissAllErrors = "Dismiss All Errors"
-encryptedPdfMustRemovePassword = "This PDF is encrypted or password-protected. Please unlock it before converting to PDF/A."
 generic = "An error occurred"
-github = "Submit a ticket on GitHub"
-githubSubmit = "GitHub - Submit a ticket"
-incorrectPasswordProvided = "The PDF password is incorrect or not provided."
-needHelp = "Need help / Found an issue?"
-pdfPassword = "The PDF Document is passworded and either the password was not provided or was incorrect"
-showStack = "Show Stack Trace"
-sorry = "Sorry for the issue!"
-
-[error.404]
-1 = "We can't seem to find the page you're looking for."
-2 = "Something went wrong"
-head = "404 - Page Not Found | Oops, we tripped in the code!"
 
 [extractImages]
 allowDuplicates = "Save duplicate images"
-header = "Extract Images"
 selectText = "Select image format to convert extracted images to"
 submit = "Extract"
 tags = "picture,photo,save,archive,zip,capture,grab"
@@ -3838,23 +3443,11 @@ description = "Extracts the selected pages into a new PDF, preserving order."
 openInFileEditor = "Open in File Editor"
 viewInViewer = "View in Viewer"
 
-[fileChooser]
-click = "Click"
-dragAndDrop = "Drag & Drop"
-dragAndDropImage = "Drag & Drop Image file"
-dragAndDropPDF = "Drag & Drop PDF file"
-extractPDF = "Extracting..."
-hoveredDragAndDrop = "Drag & Drop file(s) here"
-or = "or"
-
 [fileDropdownMenu]
 closeFile = "Close file"
 
 [fileEditor]
 addFiles = "Add Files"
-pageCount = "{{count}} pages"
-pageCount_one = "{{count}} page"
-pageCount_other = "{{count}} pages"
 
 [fileManager]
 active = "Active"
@@ -3862,7 +3455,6 @@ addToUpload = "Add to Upload"
 changesNotUploaded = "Changes not uploaded"
 clearAll = "Clear All"
 clearSelection = "Clear"
-clickToUpload = "Click to upload files"
 closeAllFiles = "Close all files"
 closeFile = "Close File"
 cloudFile = "Cloud file"
@@ -3875,10 +3467,7 @@ deselectAll = "Uncheck All"
 details = "File Details"
 download = "Download"
 downloadSelected = "Download Files"
-dragDrop = "Drag & Drop files here"
 dropFilesHere = "Drop files here"
-failedToLoad = "Failed to load file to active set."
-failedToOpen = "Failed to open file. It may have been removed from storage."
 fileFormat = "Format"
 fileHistory = "File History"
 fileName = "Name"
@@ -3900,8 +3489,6 @@ leaveShare = "Remove from my list"
 leaveShareFailed = "Could not remove the shared file."
 leaveShareSuccess = "Removed from your shared list."
 loadingFiles = "Loading files..."
-loadingHistory = "Loading History..."
-localFiles = "Local Files"
 localOnly = "Local only"
 makeCopy = "Make a copy"
 mobileShort = "Mobile"
@@ -3909,7 +3496,6 @@ mobileUpload = "Mobile Upload"
 mobileUploadNotAvailable = "Mobile upload not enabled"
 myFiles = "My Files"
 noFiles = "No files available"
-noFileSelected = "No files chosen"
 noFilesFound = "No files found matching your search"
 noRecentFiles = "No recent files found"
 openFile = "Open File"
@@ -3919,7 +3505,6 @@ openInPageEditor = "Open in Page Editor"
 owner = "Owner"
 ownerUnknown = "Unknown"
 recent = "Recent"
-reloadFiles = "Reload Files"
 removeBoth = "Remove from both"
 removeFilePrompt = "This file is saved on this device and on your server. Where would you like to remove it from?"
 removeFileTitle = "Remove file"
@@ -3936,7 +3521,6 @@ saveSelected = "Save Files"
 searchFiles = "Search files..."
 selectAll = "Check All"
 selectedCount = "{{count}} checked"
-selectedFiles = "Files Added"
 share = "Share"
 shared = "Shared"
 sharedByYou = "Shared by you"
@@ -3952,20 +3536,13 @@ sortByDate = "Sort by Date"
 sortByName = "Sort by Name"
 sortBySize = "Sort by Size"
 storage = "Storage"
-storageCleared = "Browser cleared storage. Files have been removed. Please re-upload."
-storageError = "Storage error occurred"
-storageLow = "Storage is running low. Consider removing old files."
 storageState = "Storage"
-subtitle = "Add files to your storage for easy access across tools"
-supportMessage = "Powered by browser database storage for unlimited capacity"
 synced = "Synced"
 title = "Upload PDF Files"
 toolChain = "Tools Applied"
-totalSelected = "Total Files"
 unsupported = "Unsupported"
 unzip = "Unzip"
 updateOnServer = "Update on Server"
-uploadError = "Failed to upload some files."
 uploadSelected = "Upload Files"
 uploadToServer = "Upload to Server"
 
@@ -4037,7 +3614,6 @@ cycleBlocked = "Can't move a folder into one of its own subfolders."
 delete = "Delete"
 deleteFolder = "Delete folder"
 deleteFolderBody = "Delete folder \"{{name}}\"?"
-deleteFolderConfirm = "Delete folder \"{{name}}\"? Files inside will be moved to All files. {{count}} file(s) affected."
 deleteFolderContents = "Also delete {{count}} file(s) inside the folder"
 deleteFolderContentsWarning = "Files will be permanently removed and cannot be recovered."
 deleteFolderError = "Could not delete the folder. Try again."
@@ -4062,18 +3638,14 @@ inWorkspace = "Open"
 inWorkspaceAria = "Already in workspace"
 loading = "Loading…"
 localFoldersUnavailable = "Folders are cloud-only - save a file to the cloud to organise it."
-moreActions = "More folder actions"
-moveLocalToCloudBlocked = "Local-only files can't be moved into cloud folders. Save them to the cloud first."
 moveSkippedRemote = "{{count}} file(s) couldn't be moved on the server (no permission or already deleted)."
 moveTo = "Move to…"
 myFiles = "My Files"
 newFolder = "New folder"
 newFolderStorageDisabled = "Server folder storage isn't enabled. Ask your admin to turn it on."
 newFolderTabUnavailable = "Switch to All or Cloud to create folders."
-newRootFolder = "New folder at root"
 offlineNoFolderEdits = "Server folder sync unavailable - folder changes are disabled. Check sign-in and storage configuration."
 open = "Open"
-openInWorkbench = "Open in workbench"
 openVersionInWorkspace = "Open in workspace"
 originFilter = "Filter by source"
 quickView = "Quick view"
@@ -4097,8 +3669,6 @@ shareDisabledHint = "File sharing isn't enabled on this server. Ask your admin t
 shareManage = "Manage sharing"
 showDetails = "Show details"
 summary = "{{count}} items"
-syncFailed = "Folder sync failed: {{message}}"
-syncPartial = "Folder sync partial: {{failed}} of {{total}} folders could not be merged."
 tree = "Folders"
 upload = "Upload"
 uploadedToLocal = "Uploaded files start in Local. Use 'Save to cloud' to put them in a folder."
@@ -4195,15 +3765,11 @@ tabName.shared = "Shared with me"
 tabName.sharedByMe = "Shared by me"
 tabs.all = "All"
 tabs.ariaLabel = "File views"
-tabs.cloud = "Cloud"
-tabs.local = "Local"
 tabs.recent = "Recent"
 tabs.shared = "Shared with me"
 tabs.sharedByMe = "Shared by me"
 treeMenu.actions = "Folder actions for {{name}}"
-treeMenu.collapse = "Collapse folder"
 treeMenu.delete = "Delete folder"
-treeMenu.expand = "Expand folder"
 treeMenu.newSubfolder = "New subfolder"
 treeMenu.rename = "Rename"
 typeFilter.allTypes = "All types"
@@ -4213,39 +3779,20 @@ viewMode.label = "View mode"
 viewMode.list = "List view"
 
 [fileToPDF]
-credit = "This service uses LibreOffice and Unoconv for file conversion."
-header = "Convert any file to PDF"
-submit = "Convert to PDF"
-supportedFileTypes = "Supported file types should include the below however for a full updated list of supported formats, please refer to the LibreOffice documentation"
-supportedFileTypesInfo = "Supported File types"
 tags = "transformation,format,document,picture,slide,text,conversion,office,docs,word,excel,powerpoint"
 title = "File to PDF"
 
 [fileUpload]
-addFiles = "Add Files"
-backToTools = "Back to Tools"
-chooseFromStorage = "Choose a file from storage or upload a new PDF"
-chooseFromStorageMultiple = "Choose files from storage or upload new PDFs"
-dragFilesInOrClick = "Drag files in or click \"Add Files\" to browse"
-dropFileHere = "Drop file here or click to upload"
 dropFilesHere = "Drop files here or click the upload button"
 dropFilesHereOpen = "Drop files here or click the open button"
 filesAvailable = "files available"
 loadFromStorage = "Load from Storage"
-loading = "Loading..."
 noFilesInStorage = "No files available in storage. Upload some files first."
 noFilesInStorageOpen = "No files available in storage. Open some files first."
 open = "Open"
 openFile = "Open File"
 openFiles = "Open Files"
-or = "or"
-pdfFilesOnly = "PDF files only"
-selectFile = "Select a file"
-selectFiles = "Select files"
 selectFromStorage = "Select from Storage"
-selectPdfToEdit = "Select a PDF to edit"
-selectPdfToView = "Select a PDF to view"
-supportedFileTypes = "Supported file types"
 upload = "Upload"
 uploadFile = "Upload File"
 uploadFiles = "Upload Files"
@@ -4272,22 +3819,14 @@ welcomeTitle = "Welcome!"
 
 [flatten]
 tags = "simplify,remove,interactive,flatten,flatten form,remove form fields,make static,finalize form,lock form,disable editing,convert to image,non-editable"
-filenamePrefix = "flattened"
-flattenOnlyForms = "Flatten only forms"
-header = "Flatten PDF"
 submit = "Flatten"
 title = "Flatten"
 
 [flatten.error]
 failed = "An error occurred while flattening the PDF."
 
-[flatten.files]
-placeholder = "Select a PDF file in the main view to get started"
-
 [flatten.options]
-note = "Flattening removes interactive elements from the PDF, making them non-editable."
 stepTitle = "Flatten Options"
-title = "Flatten Options"
 
 [flatten.options.flattenOnlyForms]
 desc = "Only flatten form fields, leaving other interactive elements intact"
@@ -4300,9 +3839,6 @@ placeholder = "e.g. 150"
 
 [flatten.results]
 title = "Flatten Results"
-
-[flatten.steps]
-settings = "Settings"
 
 [flatten.tooltip.description]
 bullet1 = "Text boxes become regular text (can't be edited)"
@@ -4339,7 +3875,6 @@ close = "Close sidebar"
 [getPdfInfo]
 downloadJson = "Download JSON"
 downloads = "Downloads"
-header = "Get Info on PDF"
 indexTitle = "Index"
 noneDetected = "None detected"
 noResults = "Run the tool to generate a report."
@@ -4350,12 +3885,8 @@ tags = "infomation,data,stats,statistics"
 title = "Get Info on PDF"
 
 [getPdfInfo.compliance]
-compliant = "Compliant"
 failed = "Failed"
 failedCount = "failed"
-nonCompliant = "Non-Compliant"
-none = "No standards detected"
-notDetected = "Not Detected"
 noVerification = "No Verification Performed"
 noVerificationDesc = "PDF standards compliance was not verified for this document."
 passed = "Passed"
@@ -4383,7 +3914,6 @@ size = "Size"
 xobjects = "XObject Counts"
 
 [getPdfInfo.report]
-entryLabel = "Full information summary"
 shortTitle = "PDF Information"
 
 [getPdfInfo.sections]
@@ -4409,7 +3939,6 @@ compliancePassed = "{{standards}} compliant"
 created = "Created"
 documentInfo = "Document Information"
 fileSize = "File Size"
-hasCompliance = "Has compliance standards"
 language = "Language"
 modified = "Modified"
 noCompliance = "No Compliance Standards"
@@ -4519,18 +4048,6 @@ message = "Create a free account to save your work, access more features, and su
 signUp = "Sign Up Free"
 title = "You're using Stirling PDF as a guest!"
 
-[home]
-alphabetical = "Alphabetical"
-desc = "Your locally hosted one-stop-shop for all your PDF needs."
-globalPopularity = "Global Popularity"
-hideFavorites = "Hide Favourites"
-legacyHomepage = "Old homepage"
-newHomePage = "Try our new homepage!"
-searchBar = "Search for features..."
-setFavorites = "Set Favourites"
-showFavorites = "Show Favourites"
-sortBy = "Sort by:"
-
 [home.addAttachments]
 desc = "Add or remove embedded files (attachments) to/from a PDF"
 tags = "embed,attach,include,attachments,attach files,embed files,include files,add files,file attachment,associated files,supplementary files"
@@ -4582,12 +4099,10 @@ tags = "auto-detect,header-based,organize,relabel,auto rename,automatic rename,s
 title = "Auto Rename PDF File"
 
 [home.autoSizeSplitPDF]
-desc = "Automatically split PDFs by file size or page count"
 tags = "auto,split,size"
 title = "Auto Split by Size/Count"
 
 [home.autoSplitPDF]
-desc = "Auto Split Scanned PDF with physical scanned page splitter QR Code"
 tags = "auto,split,QR,auto split,QR code,QR split,barcode,automatic split,divider page,separator page,scan divider,batch scanning"
 title = "Auto Split Pages"
 
@@ -4681,7 +4196,6 @@ tags = "info,metadata,details,PDF info,document info,properties,file info,get in
 title = "Get ALL Info on PDF"
 
 [home.manageCertificates]
-desc = "Import, export, or delete digital certificate files used for signing PDFs."
 tags = "certificates,import,export,manage certificates,digital certificates,certificate management,PFX,P12,keystore,import certificate,export certificate,certificate store,PKI"
 title = "Manage Certificates"
 
@@ -4726,7 +4240,6 @@ tags = "AI,agent,comment,annotate,sticky note,review,feedback,notes"
 title = "Add AI comments"
 
 [home.pdfOrganiser]
-desc = "Remove/Rearrange pages in any order"
 tags = "organize,rearrange,reorder,organise,arrange pages,sort,move pages,delete pages,remove pages,page management,page organizer,page organiser,resequence"
 title = "Organise"
 
@@ -4836,17 +4349,14 @@ tags = "divide,separate,break,split,extract pages,separate pages,divide document
 title = "Split"
 
 [home.splitByChapters]
-desc = "Split a PDF into multiple files based on its chapter structure."
 tags = "split,chapters,structure,split by chapters,split by bookmarks,bookmarks,outline,table of contents,TOC split,chapter split,divide by sections"
 title = "Split PDF by Chapters"
 
 [home.splitBySections]
-desc = "Divide each page of a PDF into smaller horizontal and vertical sections"
 tags = "split,sections,divide,split by sections,grid split,divide pages,split into sections,cut pages,divide grid,section split,horizontal split,vertical split"
 title = "Split PDF by Sections"
 
 [home.swagger]
-desc = "View API documentation and test endpoints"
 tags = "API,documentation,test,swagger,API docs,REST API,endpoints,developer,API reference,API testing,OpenAPI,integration,developer docs"
 title = "API Documentation"
 
@@ -4866,7 +4376,6 @@ tags = "validate,verify,certificate,validate signature,verify signature,check si
 title = "Validate PDF Signature"
 
 [home.viewPdf]
-desc = "View, annotate, draw, add text or images"
 title = "View/Edit PDF"
 
 [home.watermark]
@@ -4875,25 +4384,9 @@ tags = "stamp,mark,overlay,watermark,branding,logo,confidential,draft,copyright,
 title = "Add Watermark"
 
 [HTMLToPDF]
-credit = "Uses WeasyPrint"
-cssMediaType = "Change the CSS media type of the page."
-defaultHeader = "Enable Default Header (Name and page number)"
 header = "HTML To PDF"
-help = "Accepts HTML files and ZIPs containing html/css/images etc required"
-marginBottom = "Bottom margin of the page in millimeters. (Blank to default)"
-marginLeft = "Left margin of the page in millimeters. (Blank to default)"
-marginRight = "Right margin of the page in millimeters. (Blank to default)"
-marginTop = "Top margin of the page in millimeters. (Blank to default)"
-none = "None"
-pageHeight = "Height of the page in centimeters. (Blank to default)"
-pageWidth = "Width of the page in centimeters. (Blank to default)"
-print = "Print"
-printBackground = "Render the background of websites."
-screen = "Screen"
-submit = "Convert"
 tags = "markup,web-content,transformation,convert"
 title = "HTML To PDF"
-zoom = "Zoom level for displaying the website."
 
 [image.upload]
 hint = "Upload a PNG, JPG, SVG, or other image file to place on the PDF. SVG files will be converted to PNG for compatibility."
@@ -4904,19 +4397,8 @@ placeholder = "Select image file"
 tags = "conversion,img,jpg,picture,photo"
 
 [imageToPDF]
-fillPage = "Fill Page"
-fitDocumentToImage = "Fit Page to Image"
 header = "Image to PDF"
-maintainAspectRatio = "Maintain Aspect Ratios"
-selectLabel = "Image Fit Options"
-submit = "Convert"
 title = "Image to PDF"
-
-[imageToPDF.selectText]
-2 = "Auto rotate PDF"
-3 = "Multi file logic (Only enabled if working with multiple images)"
-4 = "Merge into single PDF"
-5 = "Convert to separate PDFs"
 
 [infoBanner]
 dismiss = "Dismiss"
@@ -4941,7 +4423,6 @@ linkExpires = "Link expires"
 passwordMismatch = "Passwords do not match"
 passwordPlaceholder = "Enter your password"
 passwordRequired = "Password is required"
-passwordTooShort = "Password must be at least 6 characters"
 signIn = "Sign in"
 validating = "Validating invitation..."
 validationError = "Failed to validate invitation link"
@@ -4970,20 +4451,10 @@ showCookieBanner = "Cookie Preferences"
 terms = "Terms and Conditions"
 
 [licenses]
-header = "3rd Party Licences"
-license = "Licence"
-module = "Module"
-nav = "Licences"
 title = "3rd Party Licences"
-version = "Version"
 
 [localMode]
 toolUnavailable = "This tool requires an account. Sign in to Stirling Cloud or connect to a self-hosted server to use it."
-
-[localMode.banner]
-message = "Sign in to unlock all tools."
-signIn = "Sign In"
-title = "Running locally"
 
 [localMode.toolPicker]
 message = "Sign in to unlock all tools."
@@ -4991,15 +4462,10 @@ signIn = "Sign In"
 
 [login]
 accountCreatedSuccess = "Account created successfully! You can now sign in."
-alreadyLoggedIn = "You are already logged in to"
-alreadyLoggedIn2 = "devices. Please log out of the devices and try again."
 backToSignIn = "Back to sign in"
-cancel = "Cancel"
 changePasswordWarning = "Please change your password after logging in for the first time"
 credentialsUpdated = "Your credentials have been updated. Please sign in again."
-debug = "Debug"
 defaultCredentials = "Default Login Credentials"
-dontHaveAccount = "Don't have an account? Sign up"
 email = "Email"
 enterEmail = "Enter your email"
 enterEmailForMagicLink = "Enter your email for magic link"
@@ -5008,29 +4474,12 @@ enterPassword = "Enter your password"
 enterUsername = "Enter username"
 failedToSignIn = "Failed to sign in with {{provider}}: {{message}}"
 forgotPassword = "Forgot your password?"
-header = "Sign in"
-home = "Home"
-invalid = "Invalid username or password."
-locked = "Your account has been locked."
 loggingIn = "Logging In..."
 logIn = "Log In"
 login = "Login"
-logoutMessage = "You have been logged out."
 magicLinkSent = "Magic link sent to {{email}}! Check your email and click the link to sign in."
-maxUsersReached = "Maximum number of users reached for your current license. Please contact the administrator to upgrade your plan or add more seats."
 mfaCode = "Authentication Code"
-mfaPromptBody = "Enter the authentication code from your authenticator app to continue."
-mfaPromptTitle = "Two-factor authentication"
 mfaRequired = "Two-factor code required"
-oauth2AccessDenied = "Access Denied"
-oAuth2AdminBlockedUser = "Registration or logging in of non-registered users is currently blocked. Please contact the administrator."
-oAuth2AutoCreateDisabled = "OAUTH2 Auto-Create User Disabled"
-oauth2InvalidIdToken = "Invalid Id Token"
-oauth2invalidRequest = "Invalid Request"
-oauth2InvalidTokenResponse = "Invalid Token Response"
-oauth2InvalidUserInfoResponse = "Invalid User Info Response"
-oauth2RequestNotFound = "Authorization request not found"
-oAuth2RequiresLicense = "OAuth/SSO login requires a Server or Enterprise license. Please contact the administrator to upgrade your plan."
 or = "Or"
 password = "Password"
 passwordChangedSuccess = "Password changed successfully! Please sign in with your new password."
@@ -5038,11 +4487,8 @@ passwordResetSent = "Password reset link sent to {{email}}! Check your email and
 passwordUpdatedSuccess = "Your password has been updated successfully."
 pleaseEnterBoth = "Please enter both email and password"
 pleaseEnterEmail = "Please enter your email address"
-relyingPartyRegistrationNotFound = "No relying party registration found"
-rememberme = "Remember me"
 resetHelp = "Enter your email to receive a secure link to reset your password. If the link has expired, please request a new one."
 resetYourPassword = "Reset your password"
-saml2RequiresLicense = "SAML login requires an Enterprise license. Please contact the administrator to upgrade your plan."
 sending = "Sending…"
 sendMagicLink = "Send Magic Link"
 sendResetLink = "Send reset link"
@@ -5050,21 +4496,14 @@ sessionExpired = "Your session has expired. Please sign in again."
 signin = "Sign in"
 signInAnonymously = "Sign Up as a Guest"
 signingIn = "Signing in..."
-signinTitle = "Please sign in"
 signInWith = "Sign in with"
-signOut = "Sign Out"
-ssoSignIn = "Login via Single Sign-on"
 subtitle = "Sign back in to Stirling PDF"
 title = "Sign in"
-toManySessions = "You have too many active sessions"
 unexpectedError = "Unexpected error: {{message}}"
 updatePassword = "Update password"
 useEmailInstead = "Login with email"
 useMagicLink = "Use magic link instead"
-userIsDisabled = "User is deactivated, login is currently blocked with this username. Please contact the administrator."
 username = "Username"
-verifyingMfa = "Verifying..."
-verifyMfa = "Verify code"
 youAreLoggedIn = "You are logged in!"
 
 [login.slides.edit]
@@ -5089,10 +4528,7 @@ small = "Small"
 xLarge = "Extra Large"
 
 [MarkdownToPDF]
-credit = "Uses WeasyPrint"
 header = "Markdown To PDF"
-help = "Work in progress"
-submit = "Convert"
 tags = "markup,web-content,transformation,convert,md"
 title = "Markdown To PDF"
 
@@ -5143,8 +4579,6 @@ capture = "Capture Photo"
 chooseMethod = "Choose Upload Method"
 chooseMethodDescription = "Select how you want to scan and upload documents"
 clearBatch = "Clear"
-connected = "Connected"
-connecting = "Connecting..."
 edgeDetection = "Edge Detection"
 fileDescription = "Upload existing photos or documents from your device"
 fileUpload = "File Upload"
@@ -5153,7 +4587,6 @@ flashlight = "Flashlight"
 httpsRequired = "Camera access requires HTTPS or localhost. Please use HTTPS or access via localhost."
 noSession = "Invalid Session"
 noSessionMessage = "Please scan a valid QR code to access this page."
-preview = "Preview"
 processing = "Processing..."
 retake = "Retake"
 selectFilesPrompt = "Select files to upload"
@@ -5162,7 +4595,6 @@ sessionExpired = "This session has expired. Please refresh and try again."
 sessionInvalid = "Session Error"
 sessionNotFound = "Session not found. Please refresh and try again."
 sessionValidationError = "Unable to verify session. Please try again."
-settings = "Settings"
 title = "Mobile Scanner"
 upload = "Upload"
 uploadAll = "Upload All"
@@ -5173,7 +4605,6 @@ uploadSuccessMessage = "Your images have been transferred."
 validating = "Validating session..."
 
 [mobileUpload]
-connected = "Mobile device connected"
 description = "Scan to upload photos. Images auto-convert to PDF."
 descriptionNoConvert = "Scan to upload photos from your mobile device."
 error = "Connection Error"
@@ -5184,55 +4615,14 @@ instructions = "Scan with your phone camera. Images convert to PDF automatically
 instructionsNoConvert = "Scan with your phone camera to upload files."
 pollingError = "Error checking for files"
 sessionCreateError = "Failed to create session"
-sessionId = "Session ID"
 title = "Upload from Mobile"
 
 [multiTool]
-addFile = "Add File"
-delete = "Delete"
-deleteSelected = "Delete Selected"
-deselectAll = "Deselect All"
-downloadAll = "Export"
-downloadSelected = "Export Selected"
-dragDropMessage = "Page(s) Selected"
-header = "PDF Multi Tool"
-insertPageBreak = "Insert Page Break"
-moveLeft = "Move Left"
-moveRight = "Move Right"
-page = "Page"
-redo = "Redo (CTRL + Y)"
-rotateLeft = "Rotate Left"
-rotateRight = "Rotate Right"
-selectAll = "Select All"
-selectedPages = "Selected Pages"
-selectPages = "Page Select"
-split = "Split"
 tags = "Multi Tool,Multi operation,UI,click drag,front end,client side,interactive,intractable,move,delete,migrate,divide"
 title = "PDF Multi Tool"
-undo = "Undo (CTRL + Z)"
-uploadPrompts = "File Name"
-
-[multiTool-advert]
-message = "This feature is also available in our <a href=\"{0}\">multi-tool page</a>. Check it out for enhanced page-by-page UI and additional features!"
 
 [navbar]
-allTools = "Tools"
-darkmode = "Dark Mode"
-favorite = "Favorites"
-language = "Languages"
-multiTool = "Multi Tool"
-recent = "New and recently updated"
 search = "Search"
-settings = "Settings"
-
-[navbar.sections]
-advance = "Advanced"
-convertFrom = "Convert from PDF"
-convertTo = "Convert to PDF"
-edit = "View & Edit"
-organize = "Organize"
-popular = "Popular"
-security = "Sign & Security"
 
 [oauth.error]
 message = "Authentication was not successful. You can close this window and try again."
@@ -5243,11 +4633,7 @@ message = "You can close this window and return to Stirling PDF."
 title = "Authentication Successful"
 
 [ocr]
-credit = "This service uses qpdf and Tesseract for OCR."
 desc = "Cleanup scans and detects text from images within a PDF and re-adds it as text."
-header = "Cleanup Scans / OCR (Optical Character Recognition)"
-help = "Please read this documentation on how to use this for other languages and/or use not in docker"
-submit = "Process PDF with OCR"
 tags = "recognition,text,image,scan,read,identify,detection,editable"
 title = "OCR / Scan Cleanup"
 
@@ -5264,20 +4650,6 @@ submit = "Process OCR and Review"
 
 [ocr.results]
 title = "OCR Results"
-
-[ocr.selectText]
-1 = "Select languages that are to be detected within the PDF (Ones listed are the ones currently detected):"
-10 = "OCR Mode"
-11 = "Remove images after OCR (Removes ALL images, only useful if part of conversion step)"
-12 = "Render Type (Advanced)"
-2 = "Produce text file containing OCR text alongside the OCR'ed PDF"
-3 = "Correct pages were scanned at a skewed angle by rotating them back into place"
-4 = "Clean page so its less likely that OCR will find text in background noise. (No output change)"
-5 = "Clean page so its less likely that OCR will find text in background noise, maintains cleanup in output."
-6 = "Ignores pages that have interactive text on them, only OCRs pages that are images"
-7 = "Force OCR, will OCR Every page removing all original text elements"
-8 = "Normal (Will error if PDF contains text)"
-9 = "Additional Settings"
 
 [ocr.settings]
 title = "Settings"
@@ -5356,18 +4728,11 @@ filesButton = "The <strong>Files</strong> button on the Quick Access bar allows 
 fileSources = "You can upload new files or access recent files from here. For the tour, we'll just use a sample file."
 finish = "Finish"
 next = "Next"
-pageEditor = "The <strong>Page Editor</strong> allows you to do various operations on the pages within your PDFs, such as reordering, rotating and deleting."
 pinButton = "You can use the <strong>Pin</strong> button if you'd rather your files stay active after running tools on them."
-previous = "Previous"
 results = "After the tool has finished running, the <strong>Review</strong> step will show a preview of the results in this panel, and allow you to undo the operation or download the file. "
 runButton = "Once the tool has been configured, this button allows you to run the tool on all the selected PDFs."
-selectControls = "The <strong>Right Rail</strong> contains buttons to quickly select/deselect all of your active PDFs, along with buttons to change the app's theme or language."
 selectCropTool = "Let's select the <strong>Crop</strong> tool to demonstrate how to use one of the tools."
-startTour = "Start Tour"
-startTourDescription = "Take a guided tour of Stirling PDF's key features"
 toolInterface = "This is the <strong>Crop</strong> tool interface. As you can see, there's not much there because we haven't added any PDF files to work with yet."
-viewer = "The <strong>Viewer</strong> lets you read and annotate your PDFs."
-viewSwitcher = "Use these controls to select how you want to view your PDFs."
 workbench = "This is the <strong>Workbench</strong> - the main area where you view and edit your PDFs."
 wrapUp = "You're all set! You can replay this tour anytime - just open <strong>Settings</strong> and find it here in the <strong>Tours</strong> section under Help."
 
@@ -5416,20 +4781,11 @@ freeTitle = "Server License"
 overLimitBody = "Our licensing permits up to <strong>{{freeTierLimit}}</strong> users for free per server. You have <strong>{{overLimitUserCopy}}</strong> Stirling users. To continue uninterrupted, upgrade to the Stirling Server plan - <strong>unlimited seats</strong>, PDF text editing, and full admin control for $99/server/mo."
 overLimitTitle = "Server License Needed"
 seePlans = "See Plans →"
-skip = "Skip for now"
 upgrade = "Upgrade now →"
 
 [onboarding.tourOverview]
 body = "Stirling PDF V2 ships with dozens of tools and a refreshed layout. Take a quick tour to see what changed and where to find the features you need."
 title = "Tour Overview"
-
-[onboarding.welcomeModal]
-description = "Would you like to take a quick 1-minute tour to learn the key features and how to get started?"
-dontShowAgain = "Don't Show Again"
-helpHint = "You can always access this tour later from the <strong>Help</strong> button in the bottom left."
-maybeLater = "Maybe Later"
-startTour = "Start Tour"
-title = "Welcome to Stirling PDF!"
 
 [onboarding.welcomeSlide]
 body = "Stirling PDF is now ready for teams of all sizes. This update includes a new layout, powerful new admin capabilities, and our most requested feature - <strong>Edit Text</strong>."
@@ -5446,19 +4802,14 @@ wrapUp = "That is what is new in V2. Open the <strong>Tours</strong> menu anytim
 
 [overlay-pdfs]
 desc = "Overlay one PDF on top of another"
-header = "Overlay PDF Files"
 submit = "Submit"
 tags = "Overlay"
 title = "Overlay PDFs"
-
-[overlay-pdfs.baseFile]
-label = "Select Base PDF File"
 
 [overlay-pdfs.counts]
 item = "Count for file"
 label = "Overlay Counts (for Fixed Repeat Mode)"
 noFiles = "Add overlay files to configure counts"
-placeholder = "Enter comma-separated counts (e.g., 2,3,1)"
 
 [overlay-pdfs.error]
 failed = "An error occurred while overlaying PDFs."
@@ -5516,23 +4867,7 @@ deselectAll = "None"
 selectAll = "Check All"
 
 [pageEditor]
-actualSize = "Actual Size"
-addFileNotImplemented = "Add file not implemented in demo"
-closePdf = "Close PDF"
-deleted = "Deleted:"
-fitToWidth = "Fit to Width"
-insertedPageBreak = "Inserted page break at:"
-movedLeft = "Moved left:"
-movedRight = "Moved right:"
-noPdfLoaded = "No PDF loaded. Please upload a PDF to edit."
-reset = "Reset Changes"
-rotatedLeft = "Rotated left:"
-rotatedRight = "Rotated right:"
-save = "Save Changes"
-splitAt = "Split at:"
 title = "Page Editor"
-zoomIn = "Zoom In"
-zoomOut = "Zoom Out"
 
 [pageEditor.emptyState]
 body = "Add files to start editing pages"
@@ -5546,9 +4881,6 @@ rotateRight = "Rotate Selected Right"
 undo = "Undo"
 
 [pageExtracter]
-header = "Extract Pages"
-placeholder = "(e.g. 1,2,8 or 4,7,12-16 or 2n-1)"
-submit = "Extract"
 title = "Extract Pages"
 
 [pageLayout]
@@ -5557,7 +4889,6 @@ borderWidth = "Border Thickness"
 bottom = "Bottom Margin"
 cols = "Columns"
 colsPlaceholder = "Enter columns"
-header = "Multi Page Layout"
 innerMargin = "Inner Margin"
 left = "Left Margin"
 pagesPerSheet = "Pages per sheet:"
@@ -5647,16 +4978,6 @@ label = "Reading Direction:"
 ltr = "Left to Right"
 rtl = "Right to Left"
 
-[pageLayout.tooltip.addBorder]
-text = "Draws border lines around each page cell for cutting guides or visual separation."
-title = "Add Borders"
-
-[pageLayout.tooltip.arrangement]
-bullet1 = "By Rows: Fill row by row (left-to-right or right-to-left)."
-bullet2 = "By Columns: Fill top-to-bottom, column by column."
-text = "Controls the order pages fill the grid:"
-title = "Page Arrangement"
-
 [pageLayout.tooltip.header]
 title = "Page Layout Guide"
 
@@ -5666,12 +4987,6 @@ bullet2 = "Custom: Set rows and columns manually."
 text = "Choose how the grid is configured:"
 title = "Mode"
 
-[pageLayout.tooltip.orientation]
-bullet1 = "Portrait: Taller than wide."
-bullet2 = "Landscape: Wider than tall."
-text = "Sets the output sheet orientation:"
-title = "Orientation"
-
 [pageLayout.tooltip.overview]
 text = "Fit multiple pages onto a single sheet for handouts or to save paper."
 title = "What is Page Layout?"
@@ -5680,44 +4995,21 @@ title = "What is Page Layout?"
 text = "Choose how many pages per sheet (e.g. 4 → 2×2, 9 → 3×3)."
 title = "Pages per Sheet (Default Mode)"
 
-[pageLayout.tooltip.readingDirection]
-bullet1 = "LTR: Left to right."
-bullet2 = "RTL: Right to left."
-text = "Controls the horizontal order of pages:"
-title = "Reading Direction"
-
 [pageLayout.tooltip.rowsCols]
 text = "Set exact grid dimensions. Total pages per sheet = rows × columns."
 title = "Rows & Columns (Custom Mode)"
 
 [pageRemover]
-header = "PDF Page remover"
-pagesToDelete = "Pages to delete (Enter a comma-separated list of page numbers) :"
-placeholder = "(e.g. 1,2,6 or 1-10,15-30)"
-submit = "Delete Pages"
 title = "Page Remover"
 
 [pageSelection.tooltip]
 description = "Choose which pages to use for the operation. Supports single pages, ranges, formulas, and the all keyword."
-
-[pageSelection.tooltip.advanced]
-title = "Advanced Features"
-
-[pageSelection.tooltip.basic]
-bullet1 = "Individual pages: 1,3,5"
-bullet2 = "Page ranges: 3-6 or 10-15"
-bullet3 = "All pages: all"
-text = "Select specific pages from your PDF document using simple syntax."
-title = "Basic Usage"
 
 [pageSelection.tooltip.complex]
 bullet1 = "<strong>1,3-5,8,2n</strong> → pages 1, 3–5, 8, plus evens"
 bullet2 = "<strong>10-,2n-1</strong> → from page 10 to end + odd pages"
 description = "Mix different types."
 title = "Complex Combinations"
-
-[pageSelection.tooltip.examples]
-title = "Examples"
 
 [pageSelection.tooltip.header]
 title = "Page Selection Guide"
@@ -5736,13 +5028,6 @@ bullet4 = "<strong>4n-1</strong> → pages 3, 7, 11, 15…"
 description = "Use n in formulas for patterns."
 title = "Mathematical Functions"
 
-[pageSelection.tooltip.operators]
-and = "AND: & or \"and\" - require both conditions (e.g., 1-50 & even)"
-comma = "Comma: , or | - combine selections (e.g., 1-10, 20)"
-not = "NOT: ! or \"not\" - exclude pages (e.g., 3n & not 30)"
-text = "AND has higher precedence than comma. NOT applies within the document range."
-title = "Operators"
-
 [pageSelection.tooltip.ranges]
 bullet1 = "<strong>3-6</strong> → selects pages 3–6"
 bullet2 = "<strong>10-15</strong> → selects pages 10–15"
@@ -5754,53 +5039,28 @@ title = "Page Ranges"
 bullet1 = "<strong>all</strong> → selects all pages"
 title = "Special Keywords"
 
-[pageSelection.tooltip.syntax]
-text = "Use numbers, ranges, keywords, and progressions (n starts at 0). Parentheses are supported."
-title = "Syntax Basics"
-
-[pageSelection.tooltip.syntax.bullets]
-keywords = "Keywords: odd, even"
-numbers = "Numbers/ranges: 5, 10-20"
-progressions = "Progressions: 3n, 4n+1"
-
-[pageSelection.tooltip.tips]
-bullet1 = "Page numbers start from 1 (not 0)"
-bullet2 = "Spaces are automatically removed"
-bullet3 = "Invalid expressions are ignored"
-text = "Keep these guidelines in mind:"
-title = "Tips"
-
 [payment]
 autoClose = "This window will close automatically..."
-billingPeriod = "Billing Period"
 canCloseWindow = "You can now close this window."
 checkoutInstructions = "Complete your purchase in the browser window that just opened. After payment is complete, return here and click the button below to refresh your billing information."
 checkoutOpened = "Checkout Opened in Browser"
 closeLater = "I'll Do This Later"
-emailInvalid = "Please enter a valid email address"
-enterpriseNote = "Seats can be adjusted in checkout (1-1000)."
 error = "Payment Error"
 generatingLicense = "Generating your license key..."
-installationId = "Installation ID"
 licenseActivated = "License activated! Your license key has been saved. A confirmation email has been sent to your registered email address."
 licenseDelayed = "Payment successful! Your license is being generated. You will receive an email with your license key shortly. If you don't receive it within 10 minutes, please contact support."
 licenseDelayedMessage = "Your license key is being generated. Please check your email shortly or contact support."
 licenseInstructions = "This has been added to your installation. You will receive a copy in your email as well."
 licenseKey = "Your License Key"
-licenseKeyProcessing = "License Key Processing"
 licensePollingError = "Payment successful but we couldn't retrieve your license key automatically. Please check your email or contact support with your payment confirmation."
 licenseRetrievalError = "Payment successful but license retrieval failed. You will receive your license key via email. Please contact support if you don't receive it within 10 minutes."
 licenseSaveError = "Failed to save license key. Please contact support with your license key to complete activation."
 monthly = "Monthly"
 paymentCanceled = "Payment was canceled. No charges were made."
-paymentSuccess = "Payment successful! Retrieving your license key..."
 perMonth = "/month"
-perYear = "/year"
 preparing = "Preparing your checkout..."
 redirecting = "Redirecting to secure checkout..."
 refreshBilling = "I've Completed Payment - Refresh Billing"
-stripeNotConfigured = "Stripe Not Configured"
-stripeNotConfiguredMessage = "Stripe payment integration is not configured. Please contact your administrator."
 success = "Payment Successful!"
 successMessage = "Your subscription has been activated successfully. You will receive a confirmation email shortly."
 syncError = "Payment successful but license sync failed. Your license will be updated shortly. Please contact support if issues persist."
@@ -5817,25 +5077,17 @@ description = "We'll use this to send your license key and receipts."
 emailLabel = "Email Address"
 emailPlaceholder = "your@email.com"
 modalTitle = "Get Started - {{planName}}"
-title = "Enter Your Email"
 
 [payment.paymentStage]
-backToPlan = "Back to Plan Selection"
 modalTitle = "Complete Payment - {{planName}}"
-selectedPlan = "Selected Plan"
 
 [payment.planStage]
-basePrice = "Base Price"
 billedYearly = "Billed yearly at {{currency}}{{amount}}"
 modalTitle = "Select Billing Period - {{planName}}"
 savePercent = "Save {{percent}}%"
 savingsAmount = "You save {{amount}}"
-savingsNote = "Save {{percent}}% with annual billing"
-seatPrice = "Per Seat"
 selectMonthly = "Select Monthly"
 selectYearly = "Select Yearly"
-title = "Choose Your Billing Period"
-totalForSeats = "Total ({{count}} seats)"
 
 [pdfCommentAgent]
 submit = "Generate comments"
@@ -5856,24 +5108,9 @@ title = "Commented PDF"
 title = "Comment instructions"
 
 [pdfOrganiser]
-header = "PDF Page Organiser"
 placeholder = "(e.g. 1,3,2 or 4-8,2,10-12 or 2n-1)"
-submit = "Rearrange Pages"
 tags = "duplex,even,odd,sort,move"
 title = "Page Organiser"
-
-[pdfOrganiser.desc]
-BOOKLET_SORT = "Arrange pages for booklet printing (last, first, second, second last, …)."
-CUSTOM = "Use a custom sequence of page numbers or expressions to define a new order."
-DUPLEX_SORT = "Interleave fronts then backs as if a duplex scanner scanned all fronts, then all backs (1, n, 2, n-1, …)."
-DUPLICATE = "Duplicate each page according to the custom order count (e.g., 4 duplicates each page 4×)."
-ODD_EVEN_MERGE = "Merge two PDFs by alternating pages: odd from the first, even from the second."
-ODD_EVEN_SPLIT = "Split the document into two outputs: all odd pages and all even pages."
-REMOVE_FIRST = "Remove the first page from the document."
-REMOVE_FIRST_AND_LAST = "Remove both the first and last pages from the document."
-REMOVE_LAST = "Remove the last page from the document."
-REVERSE_ORDER = "Flip the document so the last page becomes first and so on."
-SIDE_STITCH_BOOKLET_SORT = "Arrange pages for side‑stitch booklet printing (optimised for binding on the side)."
 
 [pdfOrganiser.mode]
 1 = "Custom Page Order"
@@ -5917,26 +5154,15 @@ viewLabel = "PDF Editor"
 [pdfTextEditor.actions]
 applyChanges = "Apply Changes"
 downloadCopy = "Download Copy"
-downloadJson = "Download JSON"
-generatePdf = "Generate PDF"
 reset = "Reset Changes"
-saveChanges = "Save Changes"
 
 [pdfTextEditor.badges]
 earlyAccess = "Early Access"
 modified = "Edited"
-unsaved = "Edited"
-
-[pdfTextEditor.disclaimer]
-alpha = "This alpha viewer is still evolving-certain fonts, colours, transparency effects, and layout details may shift slightly. Please double-check the generated PDF before sharing."
-heading = "Preview Limitations"
-previewVariance = "Some visuals (such as table borders, shapes, or annotation appearances) may not display exactly in the preview. The exported PDF keeps the original drawing commands whenever possible."
-textFocus = "This workspace focuses on editing text and repositioning embedded images. Complex page artwork, form widgets, and layered graphics are preserved for export but are not fully editable here."
 
 [pdfTextEditor.empty]
 dropzone = "Drag and drop a PDF here, or click to browse"
 dropzoneWithFiles = "Select a file from the Files tab, or drag and drop a PDF here, or click to browse"
-subtitle = "Load a PDF or JSON file to begin editing text content."
 title = "No document loaded"
 
 [pdfTextEditor.errors]
@@ -5998,9 +5224,6 @@ paragraphDescription = "Groups aligned lines into multi-line paragraph text boxe
 singleLineDescription = "Keeps each PDF text line as a separate text box."
 title = "Text Grouping Mode"
 
-[pdfTextEditor.options.manualGrouping]
-descriptionInline = "Tip: Hold Ctrl (Cmd) or Shift to multi-select text boxes. A floating toolbar will appear above the selection so you can merge, ungroup, or adjust widths."
-
 [pdfTextEditor.pageType]
 paragraph = "Paragraph page"
 sparse = "Sparse text"
@@ -6052,68 +5275,35 @@ title = "Welcome to PDF Text Editor (Early Access)"
 
 [PDFToCSV]
 header = "PDF to CSV"
-prompt = "Choose page to extract table"
-submit = "Extract"
 title = "PDF to CSV"
 
 [PDFToHTML]
-credit = "This service uses pdftohtml for file conversion."
 header = "PDF to HTML"
-submit = "Convert"
 tags = "web content,browser friendly"
 title = "PDF to HTML"
 
 [pdfToImage]
-blackwhite = "Black and White (May lose data!)"
-color = "Colour"
-colorType = "Colour type"
-grey = "Greyscale"
-header = "PDF to Image"
-info = "Python is not installed. Required for WebP conversion."
-multi = "Multiple Images, one image per page"
-placeholder = "(e.g. 1,2,8 or 4,7,12-16 or 2n-1)"
-selectText = "Image Format"
-single = "Single Big Image Combing all pages"
-singleOrMultiple = "Page to Image result type"
-submit = "Convert"
 tags = "conversion,img,jpg,picture,photo"
 title = "PDF to Image"
 
 [PDFToMarkdown]
 header = "PDF To Markdown"
-submit = "Convert"
 tags = "markup,web-content,transformation,convert,md"
 title = "PDF To Markdown"
 
 [pdfToPDFA]
-credit = "This service uses libreoffice for PDF/A conversion"
 header = "PDF To PDF/A"
-outputFormat = "Output format"
-pdfWithDigitalSignature = "The PDF contains a digital signature. This will be removed in the next step."
-submit = "Convert"
 tags = "archive,long-term,standard,conversion,storage,preservation"
-tip = "Currently does not work for multiple inputs at once"
 title = "PDF To PDF/A"
 
 [pdfToPDFX]
-credit = "This service uses Ghostscript for PDF/X conversion"
-header = "PDF To PDF/X"
-outputFormat = "Output format"
-pdfWithDigitalSignature = "The PDF contains a digital signature. This will be removed in the next step."
-submit = "Convert"
 tags = "print,standard,conversion,production,prepress,archive"
-tip = "Currently does not work for multiple inputs at once"
 title = "PDF To PDF/X"
 
 [PDFToPresentation]
-credit = "This service uses LibreOffice for file conversion."
 header = "PDF to Presentation"
-submit = "Convert"
 tags = "slides,show,office,microsoft"
 title = "PDF to Presentation"
-
-[PDFToPresentation.selectText]
-1 = "Output file format"
 
 [PdfToSinglePage]
 tags = "single page"
@@ -6121,96 +5311,42 @@ tags = "single page"
 [pdfToSinglePage]
 tags = "combine,merge,single,single page,one page,merge to single,combine all,stitch pages,concatenate vertical,long page,poster"
 description = "This tool will merge all pages of your PDF into one large single page. The width will remain the same as the original pages, but the height will be the sum of all page heights."
-filenamePrefix = "single_page"
-header = "PDF To Single Page"
 submit = "Convert To Single Page"
 title = "PDF To Single Page"
 
 [pdfToSinglePage.error]
 failed = "An error occurred whilst converting to single page."
 
-[pdfToSinglePage.files]
-placeholder = "Select a PDF file in the main view to get started"
-
 [pdfToSinglePage.results]
 title = "Single Page Results"
 
 [PDFToText]
-credit = "This service uses LibreOffice for file conversion."
 header = "PDF to RTF (Text)"
-submit = "Convert"
 tags = "richformat,richtextformat,rich text format"
 title = "PDF to RTF (Text)"
 
-[PDFToText.selectText]
-1 = "Output file format"
-
 [PDFToWord]
-credit = "This service uses LibreOffice for file conversion."
 header = "PDF to Word"
-submit = "Convert"
 tags = "doc,docx,odt,word,transformation,format,conversion,office,microsoft,docfile"
 title = "PDF to Word"
 
-[PDFToWord.selectText]
-1 = "Output file format"
-
 [PDFToXLSX]
 header = "PDF to Excel"
-prompt = "Choose pages to extract tables"
-submit = "Convert"
 tags = "spreadsheet,excel,xlsx,table,extract,convert"
 title = "PDF to Excel (XLSX)"
 
 [PDFToXML]
-credit = "This service uses LibreOffice for file conversion."
 header = "PDF to XML"
-submit = "Convert"
 tags = "data-extraction,structured-content,interop,transformation,convert"
 title = "PDF to XML"
 
 [permissions]
-header = "Change Permissions"
-submit = "Change"
 tags = "read,write,edit,print"
 title = "Change Permissions"
-warning = "Warning to have these permissions be unchangeable it is recommended to set them with a password via the add-password page"
-
-[permissions.selectText]
-1 = "Select PDF to change permissions"
-10 = "Prevent printing different formats"
-2 = "Permissions to set"
-3 = "Prevent assembly of document"
-4 = "Prevent content extraction"
-5 = "Prevent extraction for accessibility"
-6 = "Prevent filling in form"
-7 = "Prevent modification"
-8 = "Prevent annotation modification"
-9 = "Prevent printing"
 
 [pipeline]
-configureButton = "Configure"
-defaultOption = "Custom"
-deletePrompt = "Are you sure you want to delete pipeline"
-header = "Pipeline Menu (Beta)"
-help = "Pipeline Help"
-scanHelp = "Folder Scanning Help"
-submitButton = "Submit"
 tags = "automate,sequence,scripted,batch-process"
 title = "Pipeline"
-uploadButton = "Upload Custom"
-
-[pipelineOptions]
-addOperationButton = "Add operation"
-header = "Pipeline Configuration"
-pipelineHeader = "Pipeline:"
-pipelineNameLabel = "Pipeline Name"
-pipelineNamePrompt = "Enter pipeline name here"
-saveButton = "Download"
-saveForFolderScanning = "Save for Folder Scanning"
-saveSettings = "Save Operation Settings"
-selectOperation = "Select Operation"
-validateButton = "Validate"
 
 [plan]
 contact = "Contact Us"
@@ -6221,7 +5357,6 @@ featureComparison = "Feature Comparison"
 from = "From"
 hideComparison = "Hide Feature Comparison"
 included = "Included"
-includedInCurrent = "Included in Your Plan"
 licensedSeats = "Licensed: {{count}} seats"
 manage = "Manage"
 perMonth = "/month"
@@ -6322,12 +5457,8 @@ cta = "See plans"
 overLimit = "more than {{limit}}"
 title = "Free self-hosted limit reached"
 
-[plan.manageSubscription]
-description = "Manage your subscription, billing, and payment methods"
-
 [plan.period]
 month = "month"
-perUserPerMonth = "/user/month"
 
 [plan.pro]
 highlight1 = "Unlimited Tool Usage"
@@ -6337,16 +5468,10 @@ name = "Pro"
 
 [plan.static]
 activateLicense = "Activate Your License"
-checkoutInstructions = "Complete your purchase in the Stripe tab. After payment, return here and refresh the page to activate your license. You will also receive an email with your license key."
-checkoutOpened = "Checkout Opened"
-contactSales = "Contact Sales"
 contactToUpgrade = "Contact us to upgrade or customize your plan"
 getLicense = "Get Server License"
-maxUsers = "Max Users"
-message = "Online billing is not currently configured. To upgrade your plan or manage subscriptions, please contact us directly."
 monthlyBilling = "Monthly Billing"
 selectPeriod = "Select Billing Period"
-title = "Billing Information"
 upgradeToEnterprise = "Upgrade to Enterprise"
 upTo = "Up to"
 yearlyBilling = "Yearly Billing"
@@ -6367,7 +5492,6 @@ successMessage = "Your license has been successfully activated. You can now clos
 
 [plan.team]
 name = "Team"
-siteLicense = "Site License"
 
 [plan.trial]
 badge = "Trial"
@@ -6384,13 +5508,7 @@ subscriptionScheduled = "Subscription scheduled - starts {{date}}"
 title = "Free Trial Active"
 
 [printFile]
-header = "Print File to Printer"
-submit = "Print"
 title = "Print File"
-
-[printFile.selectText]
-1 = "Select File to Print"
-2 = "Enter Printer Name"
 
 [provider.googledrive]
 name = "Google Drive"
@@ -6617,12 +5735,9 @@ accessSelectedFile = "Selected file"
 accessSendInvite = "Send Invite"
 accessTitle = "Document Access"
 accessYou = "You"
-account = "Account"
 activeSessions = "Active Sessions"
 activeTab = "Active"
 activity = "Activity"
-adminSettings = "Admin Settings"
-allSessions = "All Sessions"
 allTools = "Tools"
 automate = "Automate"
 back = "Back"
@@ -6631,7 +5746,6 @@ certSign = "Certificate Sign"
 completedSessions = "Completed Sessions"
 completedTab = "Completed"
 config = "Config"
-createNew = "Create New Request"
 createSession = "Create Signing Request"
 dueDate = "Due date (optional)"
 files = "Files"
@@ -6655,7 +5769,6 @@ selectUsers = "Select users to sign"
 selectUsersPlaceholder = "Choose participants..."
 sendingRequest = "Sending..."
 settings = "Settings"
-showMeAround = "Show me around"
 sign = "Sign"
 signatureRequests = "Signature Requests"
 signYourself = "Sign Yourself"
@@ -6683,7 +5796,6 @@ title = "Redact"
 colorLabel = "Box Colour"
 convertPDFToImageLabel = "Convert PDF to PDF-Image"
 customPaddingLabel = "Custom Extra Padding"
-header = "Auto Redact"
 useRegexLabel = "Use Regex"
 wholeWordSearchLabel = "Whole Word Search"
 
@@ -6701,54 +5813,17 @@ title = "Words to Redact"
 failed = "An error occurred while redacting the PDF."
 
 [redact.manual]
-activate = "Activate Redaction Tool"
-active = "Redaction Mode Active"
 apply = "Apply"
-applyChanges = "Apply Changes"
-applyRedactions = "Apply Redactions"
 applyWarning = "⚠️ Permanent application, cannot be undone and the data underneath will be deleted"
-boxRedaction = "Box draw redaction"
 colorLabel = "Redaction Colour"
-colourPicker = "Colour Picker"
 controlsTitle = "Manual Redaction Controls"
-convertPDFToImageLabel = "Convert PDF to PDF-Image (Used to remove text behind the box)"
-export = "Export"
-findCurrentOutlineItem = "Find current outline item"
-header = "Manual Redaction"
 instructions = "Select text or draw areas on the PDF to mark content for redaction."
-markArea = "Mark Area"
-markText = "Mark Text"
-nextPage = "Next Page"
-noMarks = "No redaction marks. Use the tools above to mark content for redaction."
-pageBasedRedaction = "Page-based Redaction"
-pendingLabel = "Pending:"
-previousPage = "Previous Page"
-showAttachments = "Show Attachments"
-showDocumentOutline = "Show Document Outline (double-click to expand/collapse all items)"
-showLayers = "Show Layers (double-click to reset all layers to the default state)"
-showThumbnails = "Show Thumbnails"
-textBasedRedaction = "Text-based Redaction"
 title = "Redaction Tools"
-toggleSidebar = "Toggle Sidebar"
-upload = "Upload"
-zoom = "Zoom"
-zoomIn = "Zoom in"
-zoomOut = "Zoom out"
-
-[redact.manual.pageRedactionNumbers]
-placeholder = "(e.g. 1,2,8 or 4,7,12-16 or 2n-1)"
-title = "Pages"
-
-[redact.manual.redactionColor]
-title = "Redaction Colour"
 
 [redact.modeSelector]
 automatic = "Automatic"
-automaticDesc = "Redact text based on search terms"
 automaticDisabledTooltip = "Select files in the file manager to redact multiple files at once"
 manual = "Manual"
-manualComingSoon = "Manual redaction coming soon"
-manualDesc = "Click and drag to redact specific areas"
 mode = "Mode"
 title = "Redaction Method"
 
@@ -6819,16 +5894,9 @@ title = "Common Examples"
 title = "Words to Redact"
 
 [releases]
-footer = "Releases"
-header = "Release Notes"
-note = "Release notes are only available in English"
 title = "Release Notes"
 
-[releases.current]
-version = "Current Release"
-
 [removeAnnotations]
-header = "Remove Annotations"
 submit = "Remove"
 tags = "comments,highlight,notes,markup,remove"
 title = "Remove Annotations"
@@ -6838,7 +5906,6 @@ failed = "An error occurred while removing annotations from the PDF."
 
 [removeAnnotations.info]
 description = "This tool will remove all annotations (comments, highlights, notes, etc.) from your PDF documents."
-title = "About Remove Annotations"
 
 [removeAnnotations.settings]
 title = "Settings"
@@ -6851,7 +5918,6 @@ title = "About Remove Annotations"
 
 [removeBlanks]
 tags = "delete,clean,empty,remove blank,delete blank pages,empty pages,white pages,remove empty,clean up,cleanup blank"
-header = "Remove Blank Pages"
 submit = "Remove blank pages"
 title = "Remove Blanks"
 
@@ -6896,13 +5962,9 @@ title = "White Percentage Threshold"
 
 [removeBlanks.whitePercent]
 label = "White Percentage Threshold"
-unit = "%"
 
 [removeCertSign]
 description = "This tool will remove digital certificate signatures from your PDF document."
-filenamePrefix = "unsigned"
-header = "Remove the digital certificate from the PDF"
-selectPDF = "Select a PDF file:"
 submit = "Remove Signature"
 tags = "authenticate,PEM,P12,official,decrypt"
 title = "Remove Certificate Signature"
@@ -6910,16 +5972,11 @@ title = "Remove Certificate Signature"
 [removeCertSign.error]
 failed = "An error occurred whilst removing certificate signatures."
 
-[removeCertSign.files]
-placeholder = "Select a PDF file in the main view to get started"
-
 [removeCertSign.results]
 title = "Certificate Removal Results"
 
 [removeImage]
 tags = "remove,delete,clean,remove image,delete image,strip images,remove pictures,delete photos,clean images,reduce size,remove graphics"
-header = "Remove image"
-removeImage = "Remove image"
 submit = "Remove image"
 title = "Remove image"
 
@@ -6932,20 +5989,13 @@ title = "Remove Images Results"
 [removeImagePdf]
 tags = "Remove Image,Page operations,Back end,server side"
 
-[removeMetadata]
-submit = "Remove Metadata"
-
 [removePages]
-filenamePrefix = "pages_removed"
 submit = "Remove Pages"
 tags = "Remove pages,delete pages"
 title = "Remove Pages"
 
 [removePages.error]
 failed = "An error occurred whilst removing pages."
-
-[removePages.files]
-placeholder = "Select a PDF file in the main view to get started"
 
 [removePages.pageNumbers]
 error = "Invalid page number format. Use numbers, ranges (1-5), or mathematical expressions (2n+1)"
@@ -6977,17 +6027,8 @@ bullet4 = "Open ranges: 5- (removes from page 5 to end)"
 text = "Specify which pages to remove from your PDF. You can select individual pages, ranges, or use mathematical expressions."
 title = "Page Selection"
 
-[removePages.tooltip.safety]
-bullet1 = "Always preview your selection before processing"
-bullet2 = "Keep a backup of your original file"
-bullet3 = "Page numbers start from 1, not 0"
-bullet4 = "Invalid page numbers will be ignored"
-text = "Important considerations when removing pages:"
-title = "Safety Tips"
-
 [removePassword]
 desc = "Remove password protection from your PDF document."
-filenamePrefix = "decrypted"
 submit = "Remove Password"
 tags = "secure,Decrypt,security,unpassword,delete password"
 title = "Remove Password"
@@ -6996,7 +6037,6 @@ title = "Remove Password"
 failed = "An error occurred while removing the password from the PDF."
 
 [removePassword.password]
-completed = "Password configured"
 label = "Current Password"
 placeholder = "Enter current password"
 stepTitle = "Remove Password"
@@ -7022,8 +6062,6 @@ title = "Settings"
 
 [repair]
 description = "This tool will attempt to repair corrupted or damaged PDF files. No additional settings are required."
-filenamePrefix = "repaired"
-header = "Repair PDFs"
 submit = "Repair"
 tags = "fix,restore,correction,recover"
 title = "Repair"
@@ -7031,32 +6069,17 @@ title = "Repair"
 [repair.error]
 failed = "An error occurred whilst repairing the PDF."
 
-[repair.files]
-placeholder = "Select a PDF file in the main view to get started"
-
 [repair.results]
 title = "Repair Results"
 
 [replace-color]
-previewOverlayOpacity = "Preview overlay opacity"
-previewOverlayTransparency = "Preview overlay transparency"
-previewOverlayVisibility = "Show preview overlay"
 submit = "Replace"
 title = "Replace-Invert-Color"
-
-[replace-color.options]
-fill = "Fill colour"
-gradient = "Gradient"
 
 [replace-color.selectText]
 1 = "Replace or invert colour options"
 10 = "Choose text Color"
 11 = "Choose background Color"
-12 = "Choose start colour"
-13 = "Choose end colour"
-2 = "Default (preset high contrast colours)"
-3 = "Custom (choose your own colours)"
-4 = "Full invert (invert all colours)"
 5 = "High contrast color options"
 6 = "White text on black background"
 7 = "Black text on white background"
@@ -7134,19 +6157,13 @@ title = "Rotate Settings Overview"
 
 [sanitize]
 tags = "clean,purge,remove,sanitize,sanitise,remove scripts,remove javascript,remove metadata,strip metadata,security,clean document,remove hidden data,privacy"
-completed = "Sanitisation completed successfully"
 desc = "Remove potentially harmful elements from PDF files."
-filenamePrefix = "sanitised"
 sanitizationResults = "Sanitisation Results"
 submit = "Sanitise PDF"
 title = "Sanitise"
 
 [sanitize.error]
 failed = "An error occurred while sanitising the PDF."
-generic = "Sanitisation failed"
-
-[sanitize.files]
-placeholder = "Select a PDF file in the main view to get started"
 
 [sanitize.options]
 note = "Select the elements you want to remove from the PDF. At least one option must be selected."
@@ -7177,37 +6194,17 @@ desc = "Remove XMP metadata from the PDF"
 label = "Remove XMP Metadata"
 
 [sanitize.steps]
-files = "Files"
-results = "Results"
 settings = "Settings"
 
 [sanitizePdf]
 tags = "clean,secure,safe,remove-threats"
 
 [sanitizePDF]
-header = "Sanitise a PDF file"
-submit = "Sanitize PDF"
 title = "Sanitise PDF"
-
-[sanitizePDF.selectText]
-1 = "Remove JavaScript actions"
-2 = "Remove embedded files"
-3 = "Remove XMP metadata"
-4 = "Remove links"
-5 = "Remove fonts"
-6 = "Remove Document Info Metadata"
 
 [scalePages]
 tags = "resize,adjust,scale,page size,resize page,scale page,change size,adjust size,enlarge,shrink page,fit to page,A4,letter size"
-header = "Adjust page-scale"
-keepPageSize = "Original Size"
-pageSize = "Size of a page of the document."
-scaleFactor = "Zoom level (crop) of a page."
-submit = "Submit"
 title = "Adjust page-scale"
-
-[ScannerImageSplit]
-info = "Python is not installed. It is required to run."
 
 [ScannerImageSplit.selectText]
 1 = "Angle Threshold:"
@@ -7258,8 +6255,6 @@ placeholder = "Enter search term..."
 searching = "Searching..."
 title = "Search PDF"
 
-[selfHosted]
-
 [selfHosted.offline]
 hideTools = "Hide unavailable tools ▴"
 messageNoFallback = "Tools are unavailable until your server comes back online."
@@ -7270,7 +6265,6 @@ toolNotAvailableLocally = "Your Stirling-PDF server is offline and \"{{endpoint}
 
 [session]
 expired = "Your session has expired. Please refresh the page and try again."
-refreshPage = "Refresh Page"
 
 [sessionManagement.tooltip]
 header = "Managing Signing Sessions"
@@ -7567,31 +6561,13 @@ people = "People"
 teams = "Teams"
 title = "Workspace"
 
-[setup]
-description = "Get started by choosing how you want to use Stirling PDF"
-welcome = "Welcome to Stirling PDF"
-
 [setup.login]
 connectingTo = "Connecting to:"
-hideInstructions = "Hide instructions"
-instructions = "To enable login on your Stirling PDF server:"
-instructionsEnvVar = "Set the environment variable:"
-instructionsOrYml = "Or in settings.yml:"
-instructionsRestart = "Then restart your server for the changes to take effect."
 oauthPending = "Opening browser for authentication..."
 orContinueWith = "Or continue with email"
-serverRequirement = "Note: The server must have login enabled."
-showInstructions = "How to enable?"
-signInWith = "Sign in with"
 skipSignIn = "Continue without signing in"
 sso = "Single Sign-On"
 submit = "Login"
-subtitle = "Enter your credentials to continue"
-title = "Sign In"
-
-[setup.login.email]
-label = "Email"
-placeholder = "Enter your email"
 
 [setup.login.error]
 emptyEmail = "Please enter your email"
@@ -7599,24 +6575,7 @@ emptyPassword = "Please enter your password"
 emptyUsername = "Please enter your username"
 oauthFailed = "OAuth login failed. Please try again."
 
-[setup.login.password]
-label = "Password"
-placeholder = "Enter your password"
-
-[setup.login.username]
-label = "Username"
-placeholder = "Enter your username"
-
-[setup.mode.saas]
-description = "Sign in with your Stirling account"
-title = "Stirling Cloud"
-
-[setup.mode.selfhosted]
-description = "Connect to your own Stirling PDF server with your personal account"
-title = "Self-Hosted Server"
-
 [setup.saas]
-subtitle = "Sign in with your Stirling account"
 title = "Sign in to Stirling"
 
 [setup.selfhosted]
@@ -7628,7 +6587,6 @@ title = "Sign in to Server"
 
 [setup.selfhosted.unreachable]
 changeServer = "Connect to a different server"
-changeServerLocked = "Your organisation has restricted this app to a specific server"
 continueOffline = "Use local tools instead"
 message = "Could not reach {{url}}. Check that the server is running and accessible."
 retry = "Retry"
@@ -7655,42 +6613,20 @@ step2 = "Or set security.enableLogin=true in settings.yml"
 step3 = "Restart the server"
 title = "Login Not Enabled"
 
-[setup.server.type]
-saas = "Stirling PDF SaaS"
-selfhosted = "Self-hosted server"
-
 [setup.server.url]
 description = "Enter the full URL of your self-hosted Stirling PDF server"
 label = "Server URL"
 
-[setup.step1]
-description = "Offline or Server"
-label = "Choose Mode"
-
-[setup.step2]
-description = "Self-hosted server"
-label = "Select Server"
-
-[setup.step3]
-description = "Enter credentials"
-label = "Login"
-
 [showJS]
 done = "JavaScript extracted"
-downloadJS = "Download Javascript"
-header = "Show Javascript"
 processing = "Extracting JavaScript..."
 results = "Result"
-singleFileWarning = "This tool only supports one file at a time. Please select a single file."
 submit = "Show"
 tags = "JS"
 title = "Show Javascript"
 
 [showJS.view]
 title = "Extracted JavaScript"
-
-[sidebar]
-toggle = "Toggle Sidebar"
 
 [sign]
 tags = "signature,autograph,e-sign,electronic signature,digital signature,sign document,approval,signoff,authorize,endorse,ink signature,handwriting"
@@ -7866,7 +6802,6 @@ createFailed = "Failed to create signing request"
 
 [signup]
 accountCreatedSuccessfully = "Account created successfully! You can now sign in."
-alreadyHaveAccount = "Already have an account? Sign in"
 checkEmailConfirmation = "Check your email for a confirmation link to complete your registration."
 confirmPassword = "Confirm password"
 confirmPasswordPlaceholder = "Confirm password"
@@ -7900,67 +6835,44 @@ x-large = "X-Large"
 
 [split]
 tags = "divide,separate,break,split,extract pages,separate pages,divide document,break apart,separate files,unbind,split by page,divide by chapter"
-header = "Split PDF"
 resultsTitle = "Split Results"
 selectMethod = "Select a split method"
 splitPages = "Enter pages to split on:"
 submit = "Split"
 title = "Split PDF"
 
-[split.desc]
-1 = "The numbers you select are the page number you wish to do a split on"
-2 = "As such selecting 1,3,7-9 would split a 10 page document into 6 separate PDFS with:"
-3 = "Document #1: Page 1"
-4 = "Document #2: Page 2 and 3"
-5 = "Document #3: Page 4, 5, 6 and 7"
-6 = "Document #4: Page 8"
-7 = "Document #5: Page 9"
-8 = "Document #6: Page 10"
-
 [split.error]
 failed = "An error occurred while splitting the PDF."
 
-[split.method]
-label = "Choose split method"
-placeholder = "Select how to split the PDF"
-
 [split.methods.byChapters]
-desc = "Split at bookmark boundaries"
 name = "Chapters"
 tooltip = "Uses PDF bookmarks to determine split points"
 
 [split.methods.byDocCount]
-desc = "Create specific number of files"
 name = "Document Count"
 tooltip = "Enter how many files you want to create"
 
 [split.methods.byPageCount]
-desc = "Fixed pages per file"
 name = "Page Count"
 tooltip = "Enter the number of pages for each split file"
 
 [split.methods.byPageDivider]
-desc = "Auto-split with divider sheets"
 name = "Page Divider"
 tooltip = "Use QR code divider sheets between documents when scanning"
 
 [split.methods.byPages]
-desc = "Extract specific pages (1,3,5-10)"
 name = "Page Numbers"
 tooltip = "Enter page numbers separated by commas or ranges with hyphens"
 
 [split.methods.byPoster]
-desc = "Split large pages into printable sizes"
 name = "Printable Chunks"
 tooltip = "Divide oversized pages into smaller chunks suitable for printing on standard paper (A4, Letter, etc.)"
 
 [split.methods.bySections]
-desc = "Divide pages into grid sections"
 name = "Sections"
 tooltip = "Split each page into horizontal and vertical sections"
 
 [split.methods.bySize]
-desc = "Limit maximum file size"
 name = "File Size"
 tooltip = "Specify maximum file size (e.g. 10MB, 500KB)"
 
@@ -8008,13 +6920,6 @@ bullet2 = "Include Metadata: Preserve document properties"
 bullet3 = "Allow Duplicates: Handle repeated bookmark names"
 text = "Use PDF bookmarks to automatically split at chapter boundaries. Requires PDFs with bookmark structure."
 title = "Split by Chapters"
-
-[split.tooltip.byCount]
-bullet1 = "Page Count: Fixed number of pages per file"
-bullet2 = "Document Count: Fixed number of output files"
-bullet3 = "Useful for batch processing workflows"
-text = "Create multiple PDFs with a specific number of pages or documents each."
-title = "Split by Count"
 
 [split.tooltip.byDocCount]
 bullet1 = "Enter the number of output files you want"
@@ -8068,9 +6973,6 @@ bullet3 = "System will split at page boundaries"
 text = "Create multiple PDFs that don't exceed a specified file size. Ideal for file size limitations or email attachments."
 title = "Split by File Size"
 
-[split.tooltip.header]
-title = "Split Methods Overview"
-
 [split.value.docCount]
 label = "Number of Files"
 placeholder = "e.g. 3, 5"
@@ -8084,9 +6986,7 @@ label = "Pages per File"
 placeholder = "e.g. 5, 10"
 
 [split-by-sections]
-header = "Split PDF into Sections"
 merge = "Merge Into One PDF"
-submit = "Split PDF"
 tags = "Section Split, Divide, Customize,Customise"
 title = "Split PDF by Sections"
 
@@ -8112,15 +7012,7 @@ label = "Vertical Divisions"
 placeholder = "Enter number of vertical divisions"
 
 [split-by-size-or-count]
-header = "Split PDF by Size or Count"
-submit = "Submit"
 title = "Split PDF by Size or Count"
-
-[split-by-size-or-count.type]
-docCount = "By Document Count"
-label = "Select Split Type"
-pageCount = "By Page Count"
-size = "By Size"
 
 [split-by-size-or-count.value]
 label = "Enter Value"
@@ -8129,28 +7021,11 @@ placeholder = "Enter size (e.g., 2MB or 3KB) or count (e.g., 5)"
 [splitByChapters]
 allowDuplicates = "Allow Duplicates"
 bookmarkLevel = "Bookmark Level"
-header = "Split PDF by Chapters"
 includeMetadata = "Include Metadata"
-submit = "Split PDF"
 title = "Split PDF by Chapters"
-
-[splitByChapters.desc]
-1 = "This tool splits a PDF file into multiple PDFs based on its chapter structure."
-2 = "Bookmark Level: Choose the level of bookmarks to use for splitting (0 for top-level, 1 for second-level, etc.)."
-3 = "Include Metadata: If checked, the original PDF's metadata will be included in each split PDF."
-4 = "Allow Duplicates: If checked, allows multiple bookmarks on the same page to create separate PDFs."
 
 [splitPdfByChapters]
 tags = "split,chapters,bookmarks,organize"
-
-[storage]
-approximateSize = "Approximate size"
-fileTooLarge = "File too large. Maximum size per file is"
-storageFull = "Storage is nearly full. Consider removing some files."
-storageLimit = "Storage limit"
-storageQuotaExceeded = "Storage quota exceeded. Please remove some files before uploading more."
-storageUsed = "Temporary Storage used"
-temporaryNotice = "Files are stored temporarily in your browser and may be cleared automatically"
 
 [storageShare]
 accessDenied = "You do not have access to this shared file. Ask the owner to share it with you."
@@ -8253,43 +7128,11 @@ title = "Upload to Server"
 updateButton = "Update on Server"
 uploadButton = "Upload to Server"
 
-[subscription]
-cancelsOn = "Cancels on {{date}}"
-renewsOn = "Renews on {{date}}"
-
-[subscription.status]
-active = "Active"
-canceled = "Canceled"
-incomplete = "Incomplete"
-none = "No Subscription"
-pastDue = "Past Due"
-trialing = "Trial"
-
 [survey]
-button = "Take Survey"
-changes = "Stirling-PDF has changed since the last survey! To find out more please check our blog post here:"
-changes2 = "With these changes we are getting paid business support and funding"
-description = "Stirling-PDF has no tracking so we want to hear from our users to improve Stirling-PDF!"
-disabled = "(Survey popup will be disabled in following updates but available at foot of page)"
-dontShowAgain = "Don't show again"
 nav = "Survey"
-please = "Please consider taking our survey to have input on the future of Stirling-PDF!"
 title = "Stirling-PDF Survey"
 
-[survey.meeting]
-1 = "If you're using Stirling PDF at work, we'd love to speak to you. We're offering technical support sessions in exchange for a 15 minute user discovery session."
-2 = "This is a chance to:"
-3 = "Get help with deployment, integrations, or troubleshooting"
-4 = "Provide direct feedback on performance, edge cases, and feature gaps"
-5 = "Help us refine Stirling PDF for real-world enterprise use"
-6 = "If you're interested, you can book time with our team directly. (English speaking only)"
-7 = "Looking forward to digging into your use cases and making Stirling PDF even better!"
-button = "Book meeting"
-notInterested = "Not a business and/or interested in a meeting?"
-
 [swagger]
-desc = "View and test the Stirling PDF API endpoints"
-header = "API Documentation"
 tags = "api,documentation,swagger,endpoints,development"
 title = "API Documentation"
 
@@ -8375,9 +7218,6 @@ right = "Right"
 [textInput]
 clear = "Clear input"
 
-[theme]
-toggle = "Toggle Theme"
-
 [time.relative]
 daysAgo = "{{count}}d ago"
 hoursAgo = "{{count}}h ago"
@@ -8386,19 +7226,13 @@ minutesAgo = "{{count}}m ago"
 
 [timestampPdf]
 tags = "timestamp,RFC 3161,TSA,time stamp authority,document timestamp,proof of existence,timestamp token,trusted timestamp,sign timestamp,notarise"
-completed = "PDF timestamped successfully"
 desc = "Add an RFC 3161 document timestamp to your PDF using a trusted Time Stamp Authority (TSA) server."
-filenamePrefix = "timestamped"
 results = "Timestamp Results"
 submit = "Apply Timestamp"
 title = "Timestamp PDF"
 
 [timestampPdf.error]
 failed = "An error occurred while timestamping the PDF."
-generic = "Timestamping failed"
-
-[timestampPdf.files]
-placeholder = "Select a PDF file in the main view to get started"
 
 [timestampPdf.options]
 note = "Only a SHA-256 hash of your document is sent to the TSA server; the PDF file itself is never sent to the TSA server."
@@ -8429,18 +7263,13 @@ singleFileScope = "Only applying to: {{fileName}}"
 viewerMode = "Switch to the file editor to add multiple files."
 
 [toolPanel]
-allTools = "All tools"
 alpha = "Alpha"
 backToAllTools = "Back to all tools"
-backToDefault = "Back"
-backToTools = "Back to tools"
 collapse = "Collapse panel"
-comingSoon = "Coming soon:"
 expand = "Expand panel"
 goBack = "Go back"
 placeholder = "Choose a tool to get started"
 premiumFeature = "Premium feature:"
-search = "Search tools"
 toolsHeader = "Tools"
 viewAllTools = "View all tools"
 
@@ -8468,10 +7297,6 @@ recommended = "Recommended"
 sidebarDescription = "Keep tools alongside your workspace for quick switching."
 sidebarTitle = "Sidebar mode"
 title = "Choose how you browse tools"
-
-[toolPanel.toggle]
-fullscreen = "Switch to fullscreen mode"
-sidebar = "Switch to sidebar mode"
 
 [toolPicker]
 allTools = "ALL TOOLS"
@@ -8506,8 +7331,6 @@ close = "Close tooltip"
 
 [unlockPDFForms]
 description = "This tool will remove read-only restrictions from PDF form fields, making them editable and fillable."
-filenamePrefix = "unlocked_forms"
-header = "Unlock PDF Forms"
 submit = "Unlock Forms"
 tags = "remove,delete,form,field,readonly"
 title = "Remove Read-Only from Form Fields"
@@ -8515,15 +7338,11 @@ title = "Remove Read-Only from Form Fields"
 [unlockPDFForms.error]
 failed = "An error occurred whilst unlocking PDF forms."
 
-[unlockPDFForms.files]
-placeholder = "Select a PDF file in the main view to get started"
-
 [unlockPDFForms.results]
 title = "Unlocked Forms Results"
 
 [update]
 allReleases = "All Releases"
-availableUpdates = "Available Updates"
 breaking = "Breaking"
 breakingChanges = "Breaking Changes"
 breakingChangesDefault = "This version contains breaking changes."
@@ -8536,7 +7355,6 @@ defaultRecommendation = "This update contains important fixes and improvements."
 downloadLatest = "Download Latest"
 later = "Later"
 latest = "Latest Version"
-latestStable = "Latest Stable"
 loadingDetailedInfo = "Loading detailed information..."
 migrationGuide = "Migration Guide"
 migrationGuides = "Migration Guides"
@@ -8544,18 +7362,14 @@ migrationGuidesDesc = "Review important changes before updating."
 modalSubtitle = "A new version of Stirling PDF is ready to install."
 modalTitle = "Update Available"
 notes = "Notes"
-priorityLabel = "Priority"
-recommendedAction = "Recommended Action"
 releaseNotes = "Release Notes"
 showLess = "Show fewer versions"
 showMore = "Show all {{count}} versions"
 stable = "STABLE"
-unableToLoadDetails = "Unable to load detailed information."
 updateAvailable = "Update Available"
 urgentUpdateAvailable = "Urgent Update"
 version = "Version"
 versionHistory = "Version History"
-viewAllReleases = "View All Releases"
 viewGuide = "View Guide"
 whatsNewIn = "What's new in"
 
@@ -8569,16 +7383,12 @@ urgent = "Urgent"
 attentionBody = "Your admin needs to sign in to see more info. Please contact them immediately."
 attentionBodyAdmin = "Review the license requirements to keep this server compliant."
 attentionTitle = "This server needs admin attention"
-dismiss = "Dismiss banner"
 message = "Get the most out of Stirling PDF with unlimited users and advanced features"
 seeInfo = "See info"
 title = "Upgrade to Server Plan"
 upgradeButton = "Upgrade Now"
 
 [URLToPDF]
-credit = "Uses WeasyPrint"
-header = "URL To PDF"
-submit = "Convert"
 tags = "web-capture,save-page,web-to-doc,archive"
 title = "URL To PDF"
 
@@ -8631,7 +7441,6 @@ downloadCsv = "Download CSV"
 downloadJson = "Download JSON"
 downloadPdf = "Download PDF Report"
 finalizing = "Preparing downloads..."
-header = "Validate Digital Signatures"
 location = "Location"
 noResults = "Run the validation to generate a report."
 noSignatures = "No digital signatures found in this document"
@@ -8640,7 +7449,6 @@ processing = "Validating signatures..."
 reason = "Reason"
 results = "Validation Results"
 selectCustomCert = "Custom Certificate File X.509 (Optional)"
-selectPDF = "Select signed PDF file"
 signatureDate = "Signature Date"
 signer = "Signer"
 submit = "Validate Signatures"
@@ -8652,21 +7460,15 @@ totalSignatures = "Total Signatures"
 algorithm = "Algorithm"
 bits = "bits"
 details = "Certificate Details"
-expired = "Certificate has expired"
-info = "Certificate Details"
 issuer = "Issuer"
 keySize = "Key Size"
 keyUsage = "Key Usage"
-revoked = "Certificate has been revoked"
 selfSigned = "Self-Signed"
 serialNumber = "Serial Number"
 subject = "Subject"
 validFrom = "Valid From"
 validUntil = "Valid Until"
 version = "Version"
-
-[validateSignature.chain]
-invalid = "Certificate chain validation failed - cannot verify signer's identity"
 
 [validateSignature.downloadType]
 csv = "CSV"
@@ -8714,22 +7516,11 @@ title = "Validation Settings"
 
 [validateSignature.signature]
 _value = "Signature"
-info = "Signature Information"
-mathValid = "Signature is mathematically valid BUT:"
 
 [validateSignature.status]
-_value = "Status"
 complete = "Validation complete"
 invalid = "Invalid"
 valid = "Valid"
-
-[validateSignature.trust]
-invalid = "Certificate not in trust store - source cannot be verified"
-
-[view]
-fileManager = "File Manager"
-pageEditor = "Page Editor"
-viewer = "Viewer"
 
 [viewer]
 cannotPreviewFile = "Cannot Preview File"
@@ -8772,10 +7563,8 @@ moreActions = "More actions"
 nComments = "{{count}} comments"
 oneComment = "1 comment"
 pageLabel = "Page {{page}}"
-placeholder = "Type your comment..."
 removeCommentOnly = "Remove comment only"
 saveReply = "Save reply"
-send = "Send"
 title = "Comments"
 typeComment = "Comment"
 typeInsertText = "Insert Text"
@@ -8802,7 +7591,6 @@ columnDefault = "Column {{index}}"
 convertToPdf = "Convert to PDF"
 csvStats = "{{rows}} rows · {{columns}} columns · {{size}}"
 emptyFile = "Empty file"
-fileTypeBadge = "{{type}} File"
 htmlPreview = "HTML preview"
 htmlPreviewWarning = "HTML preview - external resources may not load · {{size}}"
 invalidJson = "Invalid JSON - showing raw content"
@@ -8826,7 +7614,6 @@ resultsOf = "of {{total}}"
 delete = "Delete signature"
 
 [viewPdf]
-header = "View PDF"
 tags = "view,read,annotate,text,image,highlight,edit"
 title = "View/Edit PDF"
 
@@ -8835,19 +7622,9 @@ tooltipTitle = "Warning"
 
 [watermark]
 tags = "stamp,mark,overlay,watermark,branding,logo,confidential,draft,copyright,trademark,text overlay,image overlay,background text"
-completed = "Watermark added"
 desc = "Add text or image watermarks to PDF files"
-filenamePrefix = "watermarked"
 submit = "Add Watermark"
 title = "Add Watermark"
-
-[watermark.alphabet]
-arabic = "Arabic"
-chinese = "Chinese"
-japanese = "Japanese"
-korean = "Korean"
-roman = "Roman/Latin"
-thai = "Thai"
 
 [watermark.error]
 failed = "An error occurred while adding watermark to the PDF."
@@ -8859,16 +7636,12 @@ title = "Watermark Results"
 alphabet = "Font/Language"
 color = "Watermark Colour"
 convertToImage = "Flatten PDF pages to images"
-fontSize = "Font Size"
 opacity = "Opacity (%)"
 rotation = "Rotation (degrees)"
 size = "Size"
-type = "Watermark Type"
 
 [watermark.settings.image]
 choose = "Choose Image"
-label = "Watermark Image"
-selected = "Selected: {{filename}}"
 
 [watermark.settings.spacing]
 height = "Height Spacing"
@@ -8877,7 +7650,6 @@ vertical = "Vertical Spacing"
 width = "Width Spacing"
 
 [watermark.settings.text]
-label = "Watermark Text"
 placeholder = "Enter watermark text"
 
 [watermark.steps]
@@ -8911,13 +7683,6 @@ bullet3 = "Higher resolution images maintain quality better"
 text = "Upload an image file to use as your watermark."
 title = "Image Selection"
 
-[watermark.tooltip.formatting.appearance]
-bullet1 = "Rotation: -360° to 360° for angled watermarks"
-bullet2 = "Opacity: 0-100% for transparency control"
-bullet3 = "Lower opacity creates subtle watermarks"
-text = "Control how your watermark looks and blends with the document."
-title = "Appearance Settings"
-
 [watermark.tooltip.formatting.header]
 title = "Formatting & Layout"
 
@@ -8933,13 +7698,6 @@ title = "Security Option"
 bullet1 = "Larger sizes create more prominent watermarks"
 text = "Adjust the size of your watermark (text or image)."
 title = "Size Control"
-
-[watermark.tooltip.formatting.spacing]
-bullet1 = "Horizontal spacing: Distance between watermarks left to right"
-bullet2 = "Vertical spacing: Distance between watermarks top to bottom"
-bullet3 = "Higher values create more spread out patterns"
-text = "Adjust the spacing between repeated watermarks across the page."
-title = "Spacing Control"
 
 [watermark.tooltip.language]
 text = "Choose the appropriate language setting to ensure proper font rendering for your text."
@@ -8961,10 +7719,6 @@ title = "Colour Selection"
 
 [watermark.tooltip.textStyle.header]
 title = "Text Style"
-
-[watermark.tooltip.textStyle.language]
-text = "Choose the appropriate language setting to ensure proper font rendering."
-title = "Language Support"
 
 [watermark.tooltip.type.description]
 text = "Select between text or image watermarks based on your needs."
@@ -9035,17 +7789,13 @@ annotations = "Annotations"
 applyRedactionsFirst = "Apply redactions first"
 closeAll = "Close All Files"
 closePdf = "Close PDF"
-closeSelected = "Close Selected Files"
 deleteSelected = "Delete Selected Pages"
 deselectAll = "Deselect All"
 downloadAll = "Download All"
-downloadSelected = "Download Selected Files"
-draw = "Draw"
 exitRedaction = "Exit Redaction Mode"
 exportAll = "Export PDF"
 exportSelected = "Export Selected Pages"
 formFill = "Fill Form"
-language = "Language"
 multiTool = "Multi-Tool"
 panMode = "Pan Mode"
 print = "Print PDF"
@@ -9064,14 +7814,12 @@ search = "Search PDF"
 selectAll = "Select All"
 selectByNumber = "Select by Page Numbers"
 selectLanguage = "Select language"
-share = "Share"
 toggleAnnotations = "Toggle Annotations Visibility"
 toggleAttachments = "Toggle Attachments"
 toggleBookmarks = "Toggle Bookmarks"
 toggleComments = "Comments"
 toggleLayers = "Toggle Layers"
 toggleSidebar = "Toggle Sidebar"
-toggleTheme = "Toggle Theme"
 viewer = "Viewer"
 
 [workflow.participant]
@@ -9131,7 +7879,6 @@ member = "Member"
 noMembersFound = "No members found"
 role = "Role"
 searchMembers = "Search members..."
-status = "Status"
 team = "Team"
 title = "People"
 unlockAccount = "Unlock Account"
@@ -9140,25 +7887,21 @@ unlockUserSuccess = "User account unlocked successfully"
 user = "User"
 
 [workspace.people.actions]
-label = "Actions"
 upgrade = "Upgrade"
 
 [workspace.people.addMember]
 authType = "Authentication Type"
-cancel = "Cancel"
 error = "Failed to create user"
 forceMFA = "Force MFA setup on next login"
 forcePasswordChange = "Force password change on first login"
 password = "Password"
 passwordPlaceholder = "Enter password"
 passwordRequired = "Password is required"
-passwordTooShort = "Password must be at least 6 characters"
 role = "Role"
 submit = "Add Member"
 success = "User created successfully"
 team = "Team (Optional)"
 teamPlaceholder = "Select a team"
-title = "Add Member"
 username = "Username (Email)"
 usernamePlaceholder = "user@example.com"
 usernameRequired = "Username and password are required"
@@ -9194,15 +7937,7 @@ subtitle = "Update the password for"
 success = "Password updated successfully"
 title = "Change password"
 
-[workspace.people.delete]
-error = "Failed to delete user"
-success = "User deleted successfully"
-
-[workspace.people.directInvite]
-tab = "Direct Create"
-
 [workspace.people.editMember]
-cancel = "Cancel"
 editing = "Editing:"
 error = "Failed to update user"
 role = "Role"
@@ -9214,7 +7949,6 @@ title = "Edit Member"
 
 [workspace.people.emailInvite]
 allFailed = "Failed to invite users"
-description = "Type or paste in emails below, separated by commas. Users will receive login credentials via email."
 emails = "Email Addresses"
 emailsPlaceholder = "user1@example.com, user2@example.com"
 emailsRequired = "At least one email address is required"
@@ -9222,34 +7956,20 @@ error = "Failed to send invites"
 partialFailure = "Some invites failed"
 submit = "Send Invites"
 success = "user(s) invited successfully"
-tab = "Email Invite"
 
 [workspace.people.inviteLink]
 copied = "Link copied to clipboard"
-description = "Generate a secure link that allows the user to set their own password"
 email = "Email Address"
 emailDescription = "Optional - leave blank for a general invite link that can be used by anyone"
-emailFailed = "Invite link generated, but email failed"
-emailFailedDetails = "Error: {0}. Please share the invite link manually."
-emailOptional = "Optional - leave blank for a general invite link"
 emailPlaceholder = "user@example.com (optional)"
-emailRequired = "Email address is required"
-emailRequiredForSend = "Email address is required to send email notification"
 emailSent = "Invite link generated and sent via email"
 error = "Failed to generate invite link"
-expiryDescription = "How many hours until the link expires"
 expiryHours = "Expiry Hours"
 generate = "Generate Link"
 generated = "Invite Link Generated"
 sendEmail = "Send invite link via email"
 sendEmailDescription = "If enabled, the invite link will be sent to the specified email address"
-smtpRequired = "SMTP not configured"
 submit = "Generate Invite Link"
-success = "Invite link generated successfully"
-successWithEmail = "Invite link generated and sent via email"
-
-[workspace.people.inviteLinkTab]
-tab = "Invite Link"
 
 [workspace.people.inviteMembers]
 label = "Invite Members"
@@ -9262,7 +7982,6 @@ link = "Link"
 username = "Username"
 
 [workspace.people.license]
-availableSlots = "Available Slots"
 currentUsage = "Currently using {{current}} of {{max}} user licences"
 fromLicense = "from license"
 grandfathered = "Grandfathered"
@@ -9286,12 +8005,10 @@ error = "Failed to update user status"
 success = "User status updated successfully"
 
 [workspace.teams]
-actions = "Actions"
 addMember = "Add Member"
 backToTeams = "Back to Teams"
 cannotAddToInternal = "Cannot add members to the Internal team"
 cannotDeleteInternal = "Cannot delete the Internal team"
-cannotRemoveFromSystemTeam = "Cannot remove from system team"
 cannotRenameInternal = "Cannot rename the Internal team"
 confirmDelete = "Are you sure you want to delete this team? This team must be empty to delete."
 confirmRemove = "Remove user from this team?"
@@ -9317,7 +8034,6 @@ viewTeam = "View Team"
 
 [workspace.teams.addMemberToTeam]
 addingTo = "Adding to"
-cancel = "Cancel"
 currentlyIn = "currently in"
 error = "Failed to add member to team"
 selectUser = "Select User"
@@ -9341,7 +8057,6 @@ success = "Team changed successfully"
 title = "Change Team"
 
 [workspace.teams.createTeam]
-cancel = "Cancel"
 error = "Failed to create team"
 nameRequired = "Team name is required"
 submit = "Create Team"
@@ -9353,10 +8068,8 @@ title = "Create New Team"
 [workspace.teams.deleteTeam]
 error = "Failed to delete team. Make sure the team is empty."
 success = "Team deleted successfully"
-teamMustBeEmpty = "Team must be empty before deletion"
 
 [workspace.teams.renameTeam]
-cancel = "Cancel"
 error = "Failed to rename team"
 nameRequired = "Team name is required"
 newTeamName = "New Team Name"
@@ -9395,4 +8108,3 @@ tags = "view,open,display,read,viewer,PDF viewer,PDF reader,open PDF,view PDF,di
 
 [scannerEffect]
 tags = "scan,simulate,create,fake scan,look scanned,scanner effect,make look scanned,photocopy effect,simulate scanner,realistic scan"
-

--- a/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
+++ b/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
@@ -1083,7 +1083,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
           () =>
             import("@app/components/tools/scannerImageSplit/ScannerImageSplitSettings"),
         ),
-        synonyms: getSynonyms(t, "ScannerImageSplit"),
+        synonyms: getSynonyms(t, "scannerImageSplit"),
       },
       overlayPdfs: {
         icon: (

--- a/frontend/editor/src/core/i18n.ts
+++ b/frontend/editor/src/core/i18n.ts
@@ -67,8 +67,6 @@ export enum LanguageSource {
   User = 3,
 }
 
-const isDev = process.env.NODE_ENV === "development";
-
 i18n
   .use(TomlBackend)
   .use(LanguageDetector)
@@ -78,23 +76,7 @@ i18n
     supportedLngs: Object.keys(supportedLanguages),
     load: "currentOnly",
     nonExplicitSupportedLngs: false,
-    debug: isDev,
-
-    // Dev-only: surface translation lookups that fall through to the key as
-    // a console.error so we can spot dynamic t() calls whose constructed
-    // key isn't in the en-GB file. Gated to development so end users never
-    // see this noise — they just get the standard fallback behaviour.
-    saveMissing: isDev,
-    missingKeyHandler: isDev
-      ? (lngs, ns, key, fallbackValue) => {
-          console.error(
-            `[i18n] Missing translation: "${key}" ` +
-              `(language=${lngs.join(",")}, namespace=${ns}` +
-              (fallbackValue ? `, fallback="${fallbackValue}"` : "") +
-              `)`,
-          );
-        }
-      : undefined,
+    debug: process.env.NODE_ENV === "development",
 
     // Ensure synchronous loading to prevent timing issues
     initImmediate: false,

--- a/frontend/editor/src/core/i18n.ts
+++ b/frontend/editor/src/core/i18n.ts
@@ -67,6 +67,8 @@ export enum LanguageSource {
   User = 3,
 }
 
+const isDev = process.env.NODE_ENV === "development";
+
 i18n
   .use(TomlBackend)
   .use(LanguageDetector)
@@ -76,7 +78,23 @@ i18n
     supportedLngs: Object.keys(supportedLanguages),
     load: "currentOnly",
     nonExplicitSupportedLngs: false,
-    debug: process.env.NODE_ENV === "development",
+    debug: isDev,
+
+    // Dev-only: surface translation lookups that fall through to the key as
+    // a console.error so we can spot dynamic t() calls whose constructed
+    // key isn't in the en-GB file. Gated to development so end users never
+    // see this noise — they just get the standard fallback behaviour.
+    saveMissing: isDev,
+    missingKeyHandler: isDev
+      ? (lngs, ns, key, fallbackValue) => {
+          console.error(
+            `[i18n] Missing translation: "${key}" ` +
+              `(language=${lngs.join(",")}, namespace=${ns}` +
+              (fallbackValue ? `, fallback="${fallbackValue}"` : "") +
+              `)`,
+          );
+        }
+      : undefined,
 
     // Ensure synchronous loading to prevent timing issues
     initImmediate: false,

--- a/frontend/editor/src/core/tests/unusedTranslations.test.ts
+++ b/frontend/editor/src/core/tests/unusedTranslations.test.ts
@@ -1,0 +1,206 @@
+import fs from "fs";
+import path from "path";
+import ts from "typescript";
+import { describe, expect, test } from "vitest";
+import { parse } from "smol-toml";
+
+const REPO_ROOT = path.join(__dirname, "../../../..");
+const SRC_ROOT = path.join(__dirname, "../..");
+const EN_GB_FILE = path.join(
+  __dirname,
+  "../../../public/locales/en-GB/translation.toml",
+);
+
+const IGNORED_DIRS = new Set(["tests", "__mocks__"]);
+const IGNORED_FILE_PATTERNS = [
+  /\.d\.ts$/,
+  /\.test\./,
+  /\.spec\./,
+  /\.stories\./,
+];
+
+/**
+ * Keys that look unused to the heuristic but are genuinely used: keep them.
+ * Prefer fixing the usage to be detectable; only add here as a last resort.
+ */
+const IGNORED_KEYS = new Set<string>([]);
+
+/**
+ * Whole key subtrees to skip. Useful when a feature builds keys entirely from
+ * runtime data (e.g. enum values) such that no static fragment ever appears
+ * in source code. Match is by literal prefix: include the trailing dot to
+ * restrict to children only, or omit it to also match the prefix itself.
+ */
+const IGNORED_KEY_PREFIXES: string[] = [];
+
+const flattenKeys = (
+  node: unknown,
+  prefix = "",
+  acc = new Set<string>(),
+): Set<string> => {
+  if (!node || typeof node !== "object" || Array.isArray(node)) {
+    if (prefix) {
+      acc.add(prefix);
+    }
+    return acc;
+  }
+
+  for (const [childKey, value] of Object.entries(
+    node as Record<string, unknown>,
+  )) {
+    const next = prefix ? `${prefix}.${childKey}` : childKey;
+    flattenKeys(value, next, acc);
+  }
+
+  return acc;
+};
+
+const listSourceFiles = (): string[] => {
+  const files = ts.sys.readDirectory(
+    SRC_ROOT,
+    [".ts", ".tsx", ".js", ".jsx"],
+    undefined,
+    ["**/*"],
+  );
+
+  return files
+    .filter(
+      (file) =>
+        !file.split(path.sep).some((segment) => IGNORED_DIRS.has(segment)),
+    )
+    .filter((file) => !IGNORED_FILE_PATTERNS.some((re) => re.test(file)));
+};
+
+const getScriptKind = (file: string): ts.ScriptKind => {
+  if (file.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (file.endsWith(".ts")) return ts.ScriptKind.TS;
+  if (file.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  return ts.ScriptKind.JS;
+};
+
+/**
+ * Walk each file's AST and collect every template literal whose static parts
+ * could plausibly form a dotted translation key. Each shape replaces ${...}
+ * interpolations with `*`, e.g. `tools.${id}.title` becomes `tools.*.title`.
+ *
+ * We deliberately collect *all* template literals (not just those at t()
+ * call sites), because keys are often built up in helpers, constants or
+ * config objects and only passed to t() somewhere far away. A shape only
+ * counts if it carries at least one identifier-like static fragment though,
+ * so generic templates like `${name}.${ext}` (shape `*.*`) are discarded.
+ *
+ * Using the AST (rather than a backtick-pair regex) is important: source
+ * files contain large multi-line templates with embedded CSS/HTML and
+ * nested interpolations that confuse regex-based pairing.
+ */
+const extractTemplateShapesFromFile = (
+  file: string,
+  acc: Set<string>,
+): void => {
+  const code = fs.readFileSync(file, "utf8");
+  if (!code.includes("${")) return;
+
+  const sourceFile = ts.createSourceFile(
+    file,
+    code,
+    ts.ScriptTarget.Latest,
+    false,
+    getScriptKind(file),
+  );
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isTemplateExpression(node)) {
+      let shape = node.head.text;
+      for (const span of node.templateSpans) {
+        shape += "*";
+        shape += span.literal.text;
+      }
+      if (
+        shape.includes(".") &&
+        /[A-Za-z0-9_-]/.test(shape.replace(/\*/g, ""))
+      ) {
+        acc.add(shape);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sourceFile, visit);
+};
+
+const shapeToMatcher = (shape: string): RegExp => {
+  // Each * stands in for one runtime-supplied path segment. We use `[^.]+`
+  // (not `.+`) so a one-variable interpolation doesn't accidentally span
+  // multiple key levels. If a real interpolation does carry a multi-segment
+  // string, the IGNORED_KEYS / IGNORED_KEY_PREFIXES lists are the escape
+  // hatch.
+  const escaped = shape
+    .split("*")
+    .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
+    .join("[^.]+");
+  return new RegExp(`^${escaped}$`);
+};
+
+const isIgnored = (key: string): boolean => {
+  if (IGNORED_KEYS.has(key)) return true;
+  return IGNORED_KEY_PREFIXES.some(
+    (p) => key === p.replace(/\.$/, "") || key.startsWith(p),
+  );
+};
+
+describe("Unused translation coverage", () => {
+  test(
+    "fails if any en-GB translation key has no source references",
+    { timeout: 30_000 },
+    () => {
+      expect(fs.existsSync(EN_GB_FILE)).toBe(true);
+
+      const enGb = parse(fs.readFileSync(EN_GB_FILE, "utf8"));
+      const availableKeys = Array.from(flattenKeys(enGb));
+      expect(availableKeys.length).toBeGreaterThan(100); // sanity check
+
+      const sourceFiles = listSourceFiles();
+      expect(sourceFiles.length).toBeGreaterThan(0);
+
+      const source = sourceFiles
+        .map((file) => fs.readFileSync(file, "utf8"))
+        .join("\n");
+
+      const shapes = new Set<string>();
+      for (const file of sourceFiles) {
+        extractTemplateShapesFromFile(file, shapes);
+      }
+      const shapeMatchers = Array.from(shapes).map(shapeToMatcher);
+
+      const unused = availableKeys.filter((key) => {
+        if (isIgnored(key)) return false;
+        // Direct: the full key text appears anywhere in source (catches
+        // static t() calls, i18nKey props, constants, and any other place
+        // the literal string sits in code or comments).
+        if (source.includes(key)) return false;
+        // Dynamic: the key matches a template-literal shape from source.
+        return !shapeMatchers.some((re) => re.test(key));
+      });
+
+      const localeRelative = path
+        .relative(REPO_ROOT, EN_GB_FILE)
+        .replace(/\\/g, "/");
+
+      // GitHub Annotations format so unused keys show up tagged on the
+      // translation file in CI.
+      for (const key of unused) {
+        process.stderr.write(
+          `::error file=${localeRelative}::Unused en-GB translation: ${key}\n`,
+        );
+      }
+
+      expect(
+        unused,
+        `Found ${unused.length} unused en-GB translation key(s). ` +
+          `Remove them from ${localeRelative}, or (if the usage is too ` +
+          `dynamic for the heuristic to spot) add to IGNORED_KEYS / ` +
+          `IGNORED_KEY_PREFIXES in this test.`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/frontend/editor/src/core/tests/unusedTranslations.test.ts
+++ b/frontend/editor/src/core/tests/unusedTranslations.test.ts
@@ -21,17 +21,22 @@ const IGNORED_FILE_PATTERNS = [
 
 /**
  * Keys that look unused to the heuristic but are genuinely used: keep them.
- * Prefer fixing the usage to be detectable; only add here as a last resort.
+ * These are families assembled at runtime, so no static fragment ever reaches
+ * source code for the literal/template matching to catch. Add a regex here
+ * (with a comment naming the runtime usage) rather than teaching the test
+ * about specific component internals. For a single key, anchor it: /^a\.b$/.
  */
-const IGNORED_KEYS = new Set<string>([]);
-
-/**
- * Whole key subtrees to skip. Useful when a feature builds keys entirely from
- * runtime data (e.g. enum values) such that no static fragment ever appears
- * in source code. Match is by literal prefix: include the trailing dot to
- * restrict to children only, or omit it to also match the prefix itself.
- */
-const IGNORED_KEY_PREFIXES: string[] = [];
+const IGNORED_KEY_PATTERNS: RegExp[] = [
+  // SignSettings / SavedSignaturesSection look up every key as
+  // t(`${translationScope}.${key}`); the scope ("sign" | "addText" |
+  // "addImage") and the relative key only ever exist as separate literals.
+  /^(sign|addText|addImage)\./,
+  // SettingsSearchBar builds its search index by loading whole subtrees via
+  // t(prefix, { returnObjects: true }); the leaf keys never appear in source.
+  /^admin\.settings\./,
+  /^settings\./,
+  /^account\./,
+];
 
 const flattenKeys = (
   node: unknown,
@@ -142,10 +147,7 @@ const shapeToMatcher = (shape: string): RegExp => {
 };
 
 const isIgnored = (key: string): boolean => {
-  if (IGNORED_KEYS.has(key)) return true;
-  return IGNORED_KEY_PREFIXES.some(
-    (p) => key === p.replace(/\.$/, "") || key.startsWith(p),
-  );
+  return IGNORED_KEY_PATTERNS.some((re) => re.test(key));
 };
 
 describe("Unused translation coverage", () => {
@@ -198,8 +200,8 @@ describe("Unused translation coverage", () => {
         unused,
         `Found ${unused.length} unused en-GB translation key(s). ` +
           `Remove them from ${localeRelative}, or (if the usage is too ` +
-          `dynamic for the heuristic to spot) add to IGNORED_KEYS / ` +
-          `IGNORED_KEY_PREFIXES in this test.`,
+          `dynamic for the heuristic to spot) add to IGNORED_KEY_PATTERNS ` +
+          `in this test.`,
       ).toEqual([]);
     },
   );

--- a/frontend/editor/src/core/tests/unusedTranslations.test.ts
+++ b/frontend/editor/src/core/tests/unusedTranslations.test.ts
@@ -137,8 +137,7 @@ const shapeToMatcher = (shape: string): RegExp => {
   // Each * stands in for one runtime-supplied path segment. We use `[^.]+`
   // (not `.+`) so a one-variable interpolation doesn't accidentally span
   // multiple key levels. If a real interpolation does carry a multi-segment
-  // string, the IGNORED_KEYS / IGNORED_KEY_PREFIXES lists are the escape
-  // hatch.
+  // string, the IGNORED_KEY_PATTERNS list is the escape hatch.
   const escaped = shape
     .split("*")
     .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))


### PR DESCRIPTION
# Description of Changes
Adds all the missing translations that I could find (they're all dynamic ones that the existing test can't detect are required) and adds a new test to find as many unused translations as possible. The test has an ignore list for translations that are used, but dynamically so the test can't find them (most of the settings UI translations are built up dynamically like that). 

This PR is scoped to just include en-GB translation changes, since that's the main supported language. We'll need to do a translation PR to trim all the dead keys from the other languages, and add the missing ones.