### PR TITLE
feat: add PDF word count endpoint/tool

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/AnalysisController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/AnalysisController.java
@@ -12,6 +12,7 @@ import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.encryption.PDEncryption;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,11 +22,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 
 import stirling.software.SPDF.config.swagger.JsonDataResponse;
+import stirling.software.SPDF.model.api.analysis.WordCountRequest;
 import stirling.software.common.annotations.AutoJobPostMapping;
 import stirling.software.common.annotations.api.AnalysisApi;
 import stirling.software.common.enumeration.ResourceWeight;
 import stirling.software.common.model.api.PDFFile;
 import stirling.software.common.service.CustomPDFDocumentFactory;
+import stirling.software.common.util.RegexPatternUtils;
 
 @AnalysisApi
 @RequiredArgsConstructor
@@ -243,5 +246,57 @@ public class AnalysisController {
 
             return ResponseEntity.ok(securityInfo);
         }
+    }
+
+    @AutoJobPostMapping(
+            value = "/word-count",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            resourceWeight = ResourceWeight.SMALL_WEIGHT)
+    @JsonDataResponse
+    @Operation(
+            summary = "Get word, character, and line counts",
+            description =
+                    "Extracts text from the PDF and returns word count, character count, and line"
+                            + " count. Optionally includes a per-page breakdown."
+                            + " Input:PDF Output:JSON Type:SISO")
+    public ResponseEntity<?> getWordCount(@ModelAttribute WordCountRequest request)
+            throws IOException {
+        try (PDDocument document = pdfDocumentFactory.load(request.getFileInput(), true)) {
+            RegexPatternUtils patterns = RegexPatternUtils.getInstance();
+
+            PDFTextStripper stripper = new PDFTextStripper();
+            String fullText = stripper.getText(document);
+            Map<String, Object> result = buildCounts(fullText, patterns);
+
+            if (request.isIncludePerPage()) {
+                int pageCount = document.getNumberOfPages();
+                List<Map<String, Object>> pages = new ArrayList<>(pageCount);
+                for (int i = 1; i <= pageCount; i++) {
+                    PDFTextStripper pageStripper = new PDFTextStripper();
+                    pageStripper.setStartPage(i);
+                    pageStripper.setEndPage(i);
+                    pages.add(buildCounts(pageStripper.getText(document), patterns));
+                }
+                result.put("pages", pages);
+            }
+
+            return ResponseEntity.ok(result);
+        }
+    }
+
+    private static Map<String, Object> buildCounts(String text, RegexPatternUtils patterns) {
+        String trimmed = text.trim();
+        int wordCount =
+                trimmed.isEmpty() ? 0 : patterns.getWhitespacePattern().split(trimmed).length;
+        int lineCount =
+                trimmed.isEmpty()
+                        ? 0
+                        : patterns.getMultiFormatNewlinePattern().split(trimmed).length;
+        Map<String, Object> counts = new HashMap<>();
+        counts.put("wordCount", wordCount);
+        counts.put("characterCount", text.length());
+        counts.put("characterCountNoSpaces", text.replaceAll("\\s", "").length());
+        counts.put("lineCount", lineCount);
+        return counts;
     }
 }

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/analysis/WordCountRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/analysis/WordCountRequest.java
@@ -1,0 +1,18 @@
+package stirling.software.SPDF.model.api.analysis;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import stirling.software.common.model.api.PDFFile;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WordCountRequest extends PDFFile {
+
+    @Schema(
+            description = "Include a per-page breakdown of word and character counts",
+            defaultValue = "false")
+    private boolean includePerPage = false;
+}

--- a/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
+++ b/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
@@ -487,6 +487,28 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
         maxFiles: 1,
       },
+      wordCount: {
+        icon: (
+          <LocalIcon
+            icon="format-list-numbered-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
+        name: t("home.wordCount.title", "Word Count"),
+        component: lazy(() => import("@app/tools/WordCount")),
+        description: t(
+          "home.wordCount.desc",
+          "Count words, characters, and lines in a PDF, with optional per-page breakdown",
+        ),
+        categoryId: ToolCategoryId.STANDARD_TOOLS,
+        subcategoryId: SubcategoryId.VERIFICATION,
+        endpoints: ["word-count"],
+        synonyms: getSynonyms(t, "wordCount"),
+        supportsAutomate: false,
+        automationSettings: null,
+        maxFiles: 1,
+      },
       validateSignature: {
         icon: (
           <LocalIcon

--- a/frontend/editor/src/core/hooks/tools/wordCount/useWordCountOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/wordCount/useWordCountOperation.ts
@@ -1,0 +1,154 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import apiClient from "@app/services/apiClient";
+import { useFileContext } from "@app/contexts/file/fileHooks";
+import { ToolOperationHook } from "@app/hooks/tools/shared/useToolOperation";
+import type { StirlingFile } from "@app/types/fileContext";
+import { extractErrorMessage } from "@app/utils/toolErrorHandler";
+import type { WordCountParameters } from "@app/hooks/tools/wordCount/useWordCountParameters";
+
+export interface PageCounts {
+  wordCount: number;
+  characterCount: number;
+  characterCountNoSpaces: number;
+  lineCount: number;
+}
+
+export interface WordCountResult {
+  fileId: string;
+  fileName: string;
+  wordCount: number;
+  characterCount: number;
+  characterCountNoSpaces: number;
+  lineCount: number;
+  pages?: PageCounts[];
+  error: string | null;
+}
+
+export interface WordCountOperationHook
+  extends ToolOperationHook<WordCountParameters> {
+  results: WordCountResult[];
+}
+
+export const useWordCountOperation = (): WordCountOperationHook => {
+  const { t } = useTranslation();
+  const { selectors } = useFileContext();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [status, setStatus] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [results, setResults] = useState<WordCountResult[]>([]);
+
+  const resetResults = useCallback(() => {
+    setResults([]);
+    setStatus("");
+    setErrorMessage(null);
+  }, []);
+
+  const clearError = useCallback(() => setErrorMessage(null), []);
+
+  const cancelOperation = useCallback(() => {
+    if (isLoading) {
+      setIsLoading(false);
+      setStatus(t("operationCancelled", "Operation cancelled"));
+    }
+  }, [isLoading, t]);
+
+  const undoOperation = useCallback(async () => {
+    resetResults();
+  }, [resetResults]);
+
+  const executeOperation = useCallback(
+    async (params: WordCountParameters, selectedFiles: StirlingFile[]) => {
+      if (selectedFiles.length === 0) {
+        setErrorMessage(t("noFileSelected", "No file loaded"));
+        return;
+      }
+
+      setIsLoading(true);
+      setStatus(t("wordCount.processing", "Counting words..."));
+      setErrorMessage(null);
+      setResults([]);
+
+      try {
+        const aggregated: WordCountResult[] = [];
+
+        for (const file of selectedFiles) {
+          const formData = new FormData();
+          formData.append("fileInput", file);
+          formData.append("includePerPage", String(params.includePerPage));
+
+          try {
+            const response = await apiClient.post(
+              "/api/v1/analysis/word-count",
+              formData,
+            );
+            aggregated.push({
+              fileId: file.fileId,
+              fileName: file.name,
+              ...response.data,
+              error: null,
+            });
+          } catch (error) {
+            aggregated.push({
+              fileId: file.fileId,
+              fileName: file.name,
+              wordCount: 0,
+              characterCount: 0,
+              characterCountNoSpaces: 0,
+              lineCount: 0,
+              error: extractErrorMessage(error),
+            });
+          }
+        }
+
+        setResults(aggregated);
+        const anyError = aggregated.some((r) => r.error);
+        if (anyError) {
+          setErrorMessage(
+            t("wordCount.error.partial", "Some files could not be processed."),
+          );
+        }
+        setStatus(t("wordCount.status.complete", "Done"));
+      } catch (e) {
+        setErrorMessage(
+          t("wordCount.error.unexpected", "Unexpected error during word count."),
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [t],
+  );
+
+  return useMemo<WordCountOperationHook>(
+    () => ({
+      files: [],
+      thumbnails: [],
+      isGeneratingThumbnails: false,
+      downloadUrl: null,
+      downloadFilename: "",
+      isLoading,
+      status,
+      errorMessage,
+      progress: null,
+      executeOperation,
+      resetResults,
+      clearError,
+      cancelOperation,
+      undoOperation,
+      results,
+    }),
+    [
+      cancelOperation,
+      clearError,
+      errorMessage,
+      executeOperation,
+      isLoading,
+      resetResults,
+      results,
+      status,
+      undoOperation,
+    ],
+  );
+};

--- a/frontend/editor/src/core/hooks/tools/wordCount/useWordCountParameters.ts
+++ b/frontend/editor/src/core/hooks/tools/wordCount/useWordCountParameters.ts
@@ -1,0 +1,22 @@
+import { BaseParameters } from "@app/types/parameters";
+import {
+  useBaseParameters,
+  BaseParametersHook,
+} from "@app/hooks/tools/shared/useBaseParameters";
+
+export interface WordCountParameters extends BaseParameters {
+  includePerPage: boolean;
+}
+
+export const defaultParameters: WordCountParameters = {
+  includePerPage: false,
+};
+
+export type WordCountParametersHook = BaseParametersHook<WordCountParameters>;
+
+export const useWordCountParameters = (): WordCountParametersHook => {
+  return useBaseParameters({
+    defaultParameters,
+    endpointName: "word-count",
+  });
+};

--- a/frontend/editor/src/core/tools/WordCount.tsx
+++ b/frontend/editor/src/core/tools/WordCount.tsx
@@ -1,0 +1,215 @@
+import { useTranslation } from "react-i18next";
+import {
+  Stack,
+  Text,
+  Checkbox,
+  Table,
+  Badge,
+  Alert,
+  Divider,
+} from "@mantine/core";
+import { createToolFlow } from "@app/components/tools/shared/createToolFlow";
+import { useBaseTool } from "@app/hooks/tools/shared/useBaseTool";
+import { BaseToolProps, ToolComponent } from "@app/types/tool";
+import {
+  useWordCountParameters,
+  defaultParameters,
+} from "@app/hooks/tools/wordCount/useWordCountParameters";
+import {
+  useWordCountOperation,
+  WordCountOperationHook,
+} from "@app/hooks/tools/wordCount/useWordCountOperation";
+
+const WordCount = (props: BaseToolProps) => {
+  const { t } = useTranslation();
+
+  const base = useBaseTool(
+    "wordCount",
+    useWordCountParameters,
+    useWordCountOperation,
+    props,
+  );
+
+  const operation = base.operation as WordCountOperationHook;
+  const hasResults = operation.results.length > 0;
+
+  const resultsContent = hasResults ? (
+    <Stack gap="md">
+      {operation.results.map((result) => (
+        <Stack key={result.fileId} gap="xs">
+          <Text size="sm" fw={600} truncate="end">
+            {result.fileName}
+          </Text>
+
+          {result.error ? (
+            <Alert color="red" title={t("wordCount.error.title", "Error")}>
+              {result.error}
+            </Alert>
+          ) : (
+            <Stack gap="sm">
+              <Table withTableBorder withColumnBorders>
+                <Table.Tbody>
+                  <Table.Tr>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed">
+                        {t("wordCount.label.words", "Words")}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge variant="light" size="lg">
+                        {result.wordCount.toLocaleString()}
+                      </Badge>
+                    </Table.Td>
+                  </Table.Tr>
+                  <Table.Tr>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed">
+                        {t("wordCount.label.characters", "Characters")}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge variant="light" size="lg">
+                        {result.characterCount.toLocaleString()}
+                      </Badge>
+                    </Table.Td>
+                  </Table.Tr>
+                  <Table.Tr>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed">
+                        {t(
+                          "wordCount.label.charactersNoSpaces",
+                          "Characters (no spaces)",
+                        )}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge variant="light" size="lg">
+                        {result.characterCountNoSpaces.toLocaleString()}
+                      </Badge>
+                    </Table.Td>
+                  </Table.Tr>
+                  <Table.Tr>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed">
+                        {t("wordCount.label.lines", "Lines")}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge variant="light" size="lg">
+                        {result.lineCount.toLocaleString()}
+                      </Badge>
+                    </Table.Td>
+                  </Table.Tr>
+                </Table.Tbody>
+              </Table>
+
+              {result.pages && result.pages.length > 0 && (
+                <Stack gap="xs">
+                  <Divider
+                    label={t(
+                      "wordCount.perPage.title",
+                      "Per-Page Breakdown",
+                    )}
+                    labelPosition="center"
+                  />
+                  <Table withTableBorder withColumnBorders>
+                    <Table.Thead>
+                      <Table.Tr>
+                        <Table.Th>
+                          {t("wordCount.perPage.page", "Page")}
+                        </Table.Th>
+                        <Table.Th>
+                          {t("wordCount.label.words", "Words")}
+                        </Table.Th>
+                        <Table.Th>
+                          {t("wordCount.label.characters", "Characters")}
+                        </Table.Th>
+                        <Table.Th>
+                          {t("wordCount.label.lines", "Lines")}
+                        </Table.Th>
+                      </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                      {result.pages.map((page, idx) => (
+                        <Table.Tr key={idx}>
+                          <Table.Td>{idx + 1}</Table.Td>
+                          <Table.Td>{page.wordCount.toLocaleString()}</Table.Td>
+                          <Table.Td>
+                            {page.characterCount.toLocaleString()}
+                          </Table.Td>
+                          <Table.Td>{page.lineCount.toLocaleString()}</Table.Td>
+                        </Table.Tr>
+                      ))}
+                    </Table.Tbody>
+                  </Table>
+                </Stack>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      ))}
+    </Stack>
+  ) : null;
+
+  return createToolFlow({
+    files: {
+      selectedFiles: base.selectedFiles,
+      isCollapsed: hasResults,
+    },
+    steps: [
+      {
+        title: t("wordCount.options.title", "Options"),
+        isVisible: !hasResults,
+        isCollapsed: false,
+        content: (
+          <Stack gap="md">
+            <Divider ml="-md" />
+            <Checkbox
+              checked={base.params.parameters.includePerPage}
+              onChange={(e) =>
+                base.params.setParameters({
+                  ...base.params.parameters,
+                  includePerPage: e.currentTarget.checked,
+                })
+              }
+              label={t(
+                "wordCount.options.includePerPage",
+                "Include per-page breakdown",
+              )}
+              description={t(
+                "wordCount.options.includePerPageDesc",
+                "Shows word and character counts for each page individually",
+              )}
+            />
+          </Stack>
+        ),
+      },
+      {
+        title: t("wordCount.results.title", "Results"),
+        isVisible: hasResults,
+        isCollapsed: false,
+        content: resultsContent,
+      },
+    ],
+    executeButton: {
+      text: t("wordCount.submit", "Count Words"),
+      loadingText: t("loading", "Loading..."),
+      onClick: base.handleExecute,
+      endpointEnabled: base.endpointEnabled,
+      paramsValid: base.params.validateParameters(),
+      isVisible: !hasResults,
+    },
+    review: {
+      isVisible: false,
+      operation: base.operation,
+      title: t("wordCount.results.title", "Results"),
+      onUndo: base.handleUndo,
+    },
+  });
+};
+
+const WordCountTool = WordCount as ToolComponent;
+WordCountTool.tool = () => useWordCountOperation;
+WordCountTool.getDefaultParameters = () => ({ ...defaultParameters });
+
+export default WordCountTool;

--- a/frontend/editor/src/core/types/toolId.ts
+++ b/frontend/editor/src/core/types/toolId.ts
@@ -56,6 +56,7 @@ export const CORE_REGULAR_TOOL_IDS = [
   "changeMetadata",
   "overlayPdfs",
   "getPdfInfo",
+  "wordCount",
   "validateSignature",
   "timestampPdf",
   "replaceColor",


### PR DESCRIPTION
# Description of Changes

What was changed

Added a word-count endpoint to AnalysisController that returns word count, character count, character count excluding spaces, and line count for a PDF. Includes an optional per-page breakdown. Frontend follows the existing hook-based architecture with a parameters hook, operation hook, tool component, and registry entries.

Why the change was made

Gives users a lightweight way to get a quick text summary of a PDF without running the full "Get All Info" operation, which is slow on larger files.

Any challenges encountered

Since this endpoint returns JSON rather than a file, useToolOperation couldn't be used and a custom hook pattern was needed instead. A WordCountRequest model class was also added to keep the API consistent with other parameterized endpoints in the project.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
