### PR TITLE
drop type-aware ESLint to stop the lint OOM

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -143,7 +143,9 @@ export default defineConfig(
       ],
     },
   },
-  // Stricter rules that not all sub-folders are conformant to yet
+  // Stricter rules that not all sub-folders are conformant to yet.
+  // Keep this non-type-aware: `parserOptions.project`/`projectService` here OOMs
+  // the lint step (builds the whole TS program); tsc covers type correctness.
   {
     files: srcGlobs,
     ignores: [
@@ -158,15 +160,8 @@ export default defineConfig(
       "editor/src/core/types/**/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/utils/**/*.{js,mjs,jsx,ts,tsx}",
     ],
-    languageOptions: {
-      parserOptions: {
-        project: true,
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
-      "@typescript-eslint/no-unnecessary-type-assertion": "error",
     },
   },
   // Config for browser scripts


### PR DESCRIPTION
parserOptions.project:true made typescript-eslint build the whole tree's TS program (~4 GB peak) to lint, OOM-ing the eslint step (exit 134) in CI and locally. That entire program existed to power one type-aware rule, no-unnecessary-type-assertion. tsc already enforces type correctness in the typecheck step, so drop the type-aware program and that rule and keep the syntactic no-explicit-any. Full lint now runs in ~18s under 1 GB (was >4 GB).
