### PR TITLE
fe(payg): remove em dashes from Plan page copy

### DIFF
--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -5160,7 +5160,7 @@ text = "Keep these guidelines in mind:"
 title = "Tips"
 
 [payg]
-subtitle = "Pay-as-you-go — you only pay for what you process. Billing period {{start}} – {{end}}."
+subtitle = "Pay-as-you-go: you only pay for what you process. Billing period {{start}} – {{end}}."
 
 [payg.activity]
 subtitle = "Only AI and automation draw from your budget. Everyday tools are free and aren't listed here."
@@ -5196,7 +5196,7 @@ errorTitle = "Stripe error"
 startFailed = "Couldn't start checkout session"
 
 [payg.checkout.mock]
-backend = "Backend is in mock mode — no real Stripe session was created."
+backend = "Backend is in mock mode; no real Stripe session was created."
 continue = "Continue with mock subscription"
 noKey = "VITE_STRIPE_PUBLISHABLE_KEY is unset. Real iframe mounts here once configured."
 title = "Stripe Embedded Checkout (mock mode)"
@@ -5227,15 +5227,15 @@ benefit3Body = "call any Stirling endpoint programmatically"
 benefit3Title = "API access"
 button = "Turn on Processor →"
 reassurance = "No minimum · Set a $0 cap to test · Cancel anytime"
-subtitle = "Keep going past your 500 free PDFs with automation, AI, and the API. Set a monthly ceiling — you stay in control."
+subtitle = "Keep going past your 500 free PDFs with automation, AI, and the API. Set a monthly ceiling, so you stay in control."
 title = "Turn on the Processor plan"
 
 [payg.free.editor]
 eyebrow = "Editor plan · Always free"
 
 [payg.free.explainer]
-alwaysFreeBody = "Manual tools — viewing, editing, merging, splitting, signing, watermarks, compression, conversion, manual OCR. Use them as much as you want, no matter where you trigger them from."
-alwaysFreeForYouBody = "Manual tools — viewing, editing, merging, splitting, signing, watermarks, compression, conversion, manual OCR. Use them as much as you want, never counted."
+alwaysFreeBody = "Manual tools: viewing, editing, merging, splitting, signing, watermarks, compression, conversion, manual OCR. Use them as much as you want, no matter where you trigger them from."
+alwaysFreeForYouBody = "Manual tools: viewing, editing, merging, splitting, signing, watermarks, compression, conversion, manual OCR. Use them as much as you want, never counted."
 alwaysFreeForYouLabel = "Always free for you"
 alwaysFreeLabel = "Always free"
 countsBody = "Automation pipelines (chained tools, scheduled runs), AI tools (summaries, classification, AI-OCR), and API calls (programmatic access). Past your free PDFs you'll need Processor."
@@ -5244,16 +5244,16 @@ sharedBody = "Automation pipelines, AI tools, and API calls share a single one-t
 sharedLabel = "Shared with the team"
 
 [payg.free.header]
-subtitle = "Editor plan — manual tools are always free. Pay only for automation, AI & API. Billing period {{period}}."
+subtitle = "Editor plan: manual tools are always free. Pay only for automation, AI & API. Billing period {{period}}."
 
 [payg.free.hero]
 capSuffix = "/ {{limit}} free PDFs"
 eyebrow = "Your free PDFs"
 metaCategories = "Automation · AI · API requests"
-neverResets = "One-time — never resets"
+neverResets = "One-time, never resets"
 
 [payg.free.member]
-body = "Your team owner can enable the Processor plan and set a monthly ceiling. Until then, manual tools are free for you to use as much as you like — automation, AI, and API access share the team's one-time allowance of 500 free PDFs."
+body = "Your team owner can enable the Processor plan and set a monthly ceiling. Until then, manual tools are free for you to use as much as you like. Automation, AI, and API access share the team's one-time allowance of 500 free PDFs."
 ownerOnly = "Only your team owner can turn on Processor. Manual tools stay free for you to use as much as you like."
 title = "Want to process more than your 500 free PDFs?"
 
@@ -5287,7 +5287,7 @@ leader = "Team owner"
 member = "Member"
 
 [payg.signupRequired]
-body = "Stirling PDF gives every signed-up account 500 free operations — enough to keep most workflows humming without paying a cent. You're currently using Stirling as a guest, which doesn't include billable tools like AI, automations, or hosted processing."
+body = "Stirling PDF gives every signed-up account 500 free operations, enough to keep most workflows humming without paying a cent. You're currently using Stirling as a guest, which doesn't include billable tools like AI, automations, or hosted processing."
 cancel = "Not now"
 cta = "Sign up free"
 subtext = "Creating an account is free and takes a few seconds. No credit card required."
@@ -5326,11 +5326,11 @@ finish = "Finish"
 customPlaceholder = "Or enter your own amount ($0 keeps it free)"
 help = "We'll never charge above this. Set $0 if you want to keep everything free while testing."
 noCapHint = "You can still cancel anytime from the customer portal."
-noCapLabel = "No cap — I'll manage spend manually"
+noCapLabel = "No cap, I'll manage spend manually"
 perMonthSuffix = "/ month"
 presetsAria = "Monthly cap preset"
 title = "Set your monthly spend ceiling"
-usdNote = "Estimated in USD. You can adjust your cap any time after subscribing — in your own currency."
+usdNote = "Estimated in USD. You can adjust your cap any time after subscribing, in your own currency."
 
 [payg.upgrade.checkout]
 capLabel = "Monthly ceiling:"
@@ -5343,7 +5343,7 @@ title = "Add your payment method"
 
 [payg.upgrade.footer]
 capHint = "You can change your cap any time later."
-checkoutHint = "Card details handled by Stripe — never touched by Stirling."
+checkoutHint = "Card details handled by Stripe, never touched by Stirling."
 confirmHint = "Your wallet will refresh automatically in a moment."
 
 [payg.upgrade.help]
@@ -5353,11 +5353,11 @@ apiBody = "programmatic access to any Stirling endpoint"
 apiTitle = "API calls"
 automationBody = "chained tools or scheduled runs that don't need clicks"
 automationTitle = "Automation pipelines"
-footnote = "Manual tools — viewing, editing, merging, splitting, watermarking, compressing, manual OCR — are always free, even past 500. The distinction is the type of work, not where you click."
+footnote = "Manual tools (viewing, editing, merging, splitting, watermarking, compressing, manual OCR) are always free, even past 500. The distinction is the type of work, not where you click."
 title = "What we count toward billing"
 
 [payg.upgrade.promise]
-body = "You only pay for automation pipelines, AI tools, and API calls — the work that goes beyond a single click. Edit, merge, split, sign, compress as much as you want, no charge."
+body = "You only pay for automation pipelines, AI tools, and API calls, the work that goes beyond a single click. Edit, merge, split, sign, compress as much as you want, no charge."
 highlight = "Manual tools stay free, always."
 
 [payg.upgrade.steps]

--- a/frontend/editor/src/saas/components/shared/config/configSections/Payg.tsx
+++ b/frontend/editor/src/saas/components/shared/config/configSections/Payg.tsx
@@ -708,7 +708,7 @@ const Payg: React.FC<PaygProps> = ({ role, wallet, onSaveCap, onOpenPortal }) =>
               <p className="payg-planhead__body">
                 {t(
                   "payg.header.freeBody",
-                  "View, edit, merge, split, sign, watermark, compress, convert and manual OCR — as much as you want, no matter where you trigger it.",
+                  "View, edit, merge, split, sign, watermark, compress, convert and manual OCR, as much as you want, no matter where you trigger it.",
                 )}
               </p>
             </div>

--- a/frontend/editor/src/saas/components/shared/config/configSections/PaygFree.tsx
+++ b/frontend/editor/src/saas/components/shared/config/configSections/PaygFree.tsx
@@ -123,7 +123,7 @@ function EditorPlanCard({ pill, leader }: EditorPlanCardProps) {
       <p className="payg-planhead__body">
         {t(
           "payg.free.header.freeBody",
-          "View, edit, merge, split, sign, watermark, compress, convert and manual OCR — as much as you want, no matter where you trigger it.",
+          "View, edit, merge, split, sign, watermark, compress, convert and manual OCR, as much as you want, no matter where you trigger it.",
         )}
       </p>
     </div>
@@ -174,7 +174,7 @@ function FreeMeterPanel({ snap }: { snap: FreeSnapshot }) {
           {t("payg.free.hero.metaCategories", "Automation · AI · API requests")}
         </span>
         <span className="payg-hero__meta-dot">•</span>
-        <span>{t("payg.free.hero.neverResets", "One-time — never resets")}</span>
+        <span>{t("payg.free.hero.neverResets", "One-time, never resets")}</span>
       </div>
     </div>
   );
@@ -207,7 +207,7 @@ function ProcessorCard({ snap, isLeader, onTurnOn }: ProcessorCardProps) {
           <p className="paygf-cta__subtitle">
             {t(
               "payg.free.cta.subtitle",
-              "Keep going past your {{limit}} free PDFs with automation, AI, and the API. Set a monthly ceiling — you stay in control.",
+              "Keep going past your {{limit}} free PDFs with automation, AI, and the API. Set a monthly ceiling, so you stay in control.",
               { limit: snap.billableLimit.toLocaleString() },
             )}
           </p>
@@ -219,7 +219,7 @@ function ProcessorCard({ snap, isLeader, onTurnOn }: ProcessorCardProps) {
                 <strong>
                   {t("payg.free.cta.benefit1Title", "Automation pipelines")}
                 </strong>
-                {" — "}
+                {": "}
                 {t(
                   "payg.free.cta.benefit1Body",
                   "chain tools, schedule runs, batch process",
@@ -230,7 +230,7 @@ function ProcessorCard({ snap, isLeader, onTurnOn }: ProcessorCardProps) {
               <CheckIcon className="paygf-cta__check" fontSize="small" />
               <span>
                 <strong>{t("payg.free.cta.benefit2Title", "AI tools")}</strong>
-                {" — "}
+                {": "}
                 {t(
                   "payg.free.cta.benefit2Body",
                   "summarise, classify, redact, AI-OCR",
@@ -241,7 +241,7 @@ function ProcessorCard({ snap, isLeader, onTurnOn }: ProcessorCardProps) {
               <CheckIcon className="paygf-cta__check" fontSize="small" />
               <span>
                 <strong>{t("payg.free.cta.benefit3Title", "API access")}</strong>
-                {" — "}
+                {": "}
                 {t(
                   "payg.free.cta.benefit3Body",
                   "call any Stirling endpoint programmatically",


### PR DESCRIPTION
## What

Removes all em dash (`—`) characters from the **user-facing text** on the Plan page (PAYG section), replacing them with colons, commas, or restructured punctuation so the copy reads naturally.

## Changes

- `frontend/editor/public/locales/en-GB/translation.toml` — all `payg.*` strings (this is what actually renders on the page)
- `PaygFree.tsx` — `t()` default fallbacks + the `{" — "}` JSX benefit-list separators (now `{": "}`)
- `Payg.tsx` — `t()` default fallback for the editor-plan body

## Notes

- The en-dash range separator (`{{start}} – {{end}}`) in the billing-period string is intentionally **kept** — only em dashes were targeted.
- JSDoc / code comments containing em dashes were **left unchanged**, since they aren't rendered text on the page.
<img width="990" height="502" alt="image" src="https://github.com/user-attachments/assets/13d89b0f-007c-4b4c-b72d-1d912f968bc7" />
