### PR TITLE
fix(payg): land usage-limit modal CTAs on the Plan section

### DIFF
--- a/frontend/editor/src/saas/components/shared/AppConfigModal.tsx
+++ b/frontend/editor/src/saas/components/shared/AppConfigModal.tsx
@@ -8,7 +8,7 @@ import LocalIcon from "@app/components/shared/LocalIcon";
 import Overview from "@app/components/shared/config/configSections/Overview";
 import { createSaasConfigNavSections } from "@app/components/shared/config/saasConfigNavSections";
 import { NavKey } from "@app/components/shared/config/types";
-import { withBasePath } from "@app/constants/app";
+import { stripBasePath, withBasePath } from "@app/constants/app";
 import { COOKIE_CONSENT_SCROLL_SHARD } from "@app/hooks/useCookieConsent";
 import "@app/components/shared/AppConfigModal.css";
 import {
@@ -46,6 +46,21 @@ const AppConfigModal: React.FC<AppConfigModalProps> = ({ opened, onClose }) => {
         handler as EventListener,
       );
   }, []);
+
+  // When the modal opens via a /settings/<section> deep link (navigateToSettings — e.g. the
+  // usage-limit modal CTAs, which need to land on the Plan section), select that section. The
+  // opener (QuickAccessBar) opens the modal whenever the path is /settings/*, but doesn't carry
+  // the section, and `active` defaults to "overview" — so without this a deep link would open on
+  // Overview rather than the linked section.
+  useEffect(() => {
+    if (!opened) return;
+    const match = stripBasePath(window.location.pathname).match(
+      /^\/settings\/([^/?#]+)/,
+    );
+    if (match) {
+      setActive(match[1] as NavKey);
+    }
+  }, [opened]);
 
   // Listen for notice updates (e.g., "Not enough credits..." next to Plan title)
   useEffect(() => {

--- a/frontend/editor/src/saas/components/shared/FreeLimitReachedModal.tsx
+++ b/frontend/editor/src/saas/components/shared/FreeLimitReachedModal.tsx
@@ -5,7 +5,7 @@ import CelebrationIcon from "@mui/icons-material/CelebrationOutlined";
 import AnimatedSlideBackground from "@app/components/onboarding/slides/AnimatedSlideBackground";
 import styles from "@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css";
 import { Z_INDEX_OVER_FULLSCREEN_SURFACE } from "@app/styles/zIndex";
-import { openPlanSettings } from "@app/utils/appSettings";
+import { navigateToSettings } from "@app/utils/settingsNavigation";
 import {
   FreeMeterPanel,
   freeSnapshotFromWallet,
@@ -69,11 +69,7 @@ export function FreeLimitReachedModal({ onClose }: FreeLimitReachedModalProps) {
 
   const handleUpgrade = () => {
     onClose();
-    // Open the App Config modal AND select the Plan section. navigateToSettings("plan") only
-    // pushes a /settings/plan URL, which in SaaS opens config at its default section rather than
-    // the Plan page; openPlanSettings dispatches the appConfig:open + appConfig:navigate events the
-    // config modal actually listens for.
-    openPlanSettings();
+    navigateToSettings("plan");
   };
 
   return (

--- a/frontend/editor/src/saas/components/shared/SpendCapReachedModal.tsx
+++ b/frontend/editor/src/saas/components/shared/SpendCapReachedModal.tsx
@@ -5,7 +5,7 @@ import TrendingUpIcon from "@mui/icons-material/TrendingUpOutlined";
 import AnimatedSlideBackground from "@app/components/onboarding/slides/AnimatedSlideBackground";
 import styles from "@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css";
 import { Z_INDEX_OVER_FULLSCREEN_SURFACE } from "@app/styles/zIndex";
-import { openPlanSettings } from "@app/utils/appSettings";
+import { navigateToSettings } from "@app/utils/settingsNavigation";
 import {
   SpendCapMeterPanel,
   spendCapSnapshotFromWallet,
@@ -69,11 +69,7 @@ export function SpendCapReachedModal({ onClose }: SpendCapReachedModalProps) {
 
   const handleRaiseCap = () => {
     onClose();
-    // Open the App Config modal AND select the Plan section. navigateToSettings("plan") only
-    // pushes a /settings/plan URL, which in SaaS opens config at its default section rather than
-    // the Plan page; openPlanSettings dispatches the appConfig:open + appConfig:navigate events the
-    // config modal actually listens for.
-    openPlanSettings();
+    navigateToSettings("plan");
   };
 
   return (


### PR DESCRIPTION
## What

The usage-limit modals' CTA buttons ("View Processor Plan" / "View Spending Limit") now open App Config **on the Plan section**, instead of opening it on Overview.

Follow-up to #6626 (merged), which wired the modals up but left the CTA landing on the wrong section.

## Why it was broken

The config opener (`QuickAccessBar`) opens the modal whenever the path is `/settings/*`, but it never carried the *section*, and `AppConfigModal` defaults `active` to `"overview"`. So `navigateToSettings("plan")` opened config — but on Overview, not Plan.

(A brief detour through `openPlanSettings()` was worse: `openAppSettings` dispatches an `appConfig:open` event that nothing listens for, so the modal didn't open at all.)

## Fix

- Both modal CTAs use `navigateToSettings("plan")` (which reliably opens the modal via the URL).
- The saas `AppConfigModal` now reads the section from the `/settings/<section>` path when it opens, and selects it. Fixes the CTAs at the source — any `/settings/<section>` deep link now lands correctly, with no event-timing race.

## Test plan

- [x] `eslint --max-warnings=0` clean
- [x] saas typecheck clean
- [ ] Manual: hit free/cap limit → modal → CTA opens config on **Plan**