### PR TITLE
Fix SaaS mobile scanner being auth-gated under /app base path

### DIFF
--- a/frontend/editor/src/core/App.tsx
+++ b/frontend/editor/src/core/App.tsx
@@ -17,8 +17,9 @@ import "@app/styles/index.css";
 // Import file ID debugging helpers (development only)
 import "@app/utils/fileIdSafety";
 
-// Minimal providers for mobile scanner - no API calls, no authentication
-function MobileScannerProviders({ children }: { children: React.ReactNode }) {
+// Minimal providers for the public, no-auth mobile-scanner page - no API
+// calls, no authentication
+function PublicRouteProviders({ children }: { children: React.ReactNode }) {
   return (
     <PreferencesProvider>
       <RainbowThemeProvider>{children}</RainbowThemeProvider>
@@ -34,9 +35,9 @@ export default function App() {
         <Route
           path="/mobile-scanner"
           element={
-            <MobileScannerProviders>
+            <PublicRouteProviders>
               <MobileScannerPage />
-            </MobileScannerProviders>
+            </PublicRouteProviders>
           }
         />
 

--- a/frontend/editor/src/core/components/shared/MobileUploadModal.tsx
+++ b/frontend/editor/src/core/components/shared/MobileUploadModal.tsx
@@ -88,7 +88,8 @@ export default function MobileUploadModal({
   // /mobile-scanner route under the app's base path, otherwise the phone hits
   // the auth-gated catch-all route and is bounced to the login page.
   const mobileUrl = buildMobileScannerUrl({
-    configuredUrl: localStorage.getItem("server_url") || config?.frontendUrl || "",
+    configuredUrl:
+      localStorage.getItem("server_url") || config?.frontendUrl || "",
     sessionId,
     origin: window.location.origin,
     basePath: BASE_PATH,

--- a/frontend/editor/src/core/components/shared/MobileUploadModal.tsx
+++ b/frontend/editor/src/core/components/shared/MobileUploadModal.tsx
@@ -8,7 +8,8 @@ import ErrorRoundedIcon from "@mui/icons-material/ErrorRounded";
 import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 import { Z_INDEX_OVER_FILE_MANAGER_MODAL } from "@app/styles/zIndex";
-import { withBasePath } from "@app/constants/app";
+import { BASE_PATH } from "@app/constants/app";
+import { buildMobileScannerUrl } from "@app/utils/mobileScannerUrl";
 import { convertImageToPdf, isImageFile } from "@app/utils/imageToPdfUtils";
 import apiClient from "@app/services/apiClient";
 
@@ -83,27 +84,15 @@ export default function MobileUploadModal({
   const timerIntervalRef = useRef<number | null>(null);
   const processedFiles = useRef<Set<string>>(new Set());
 
-  // A configured server_url/frontendUrl already includes any subpath, so append
-  // the route directly; only the bare-origin fallback needs withBasePath.
-  const configuredUrl = (
-    localStorage.getItem("server_url") ||
-    config?.frontendUrl ||
-    ""
-  ).trim();
-  let mobileBase = "";
-  if (configuredUrl) {
-    try {
-      const parsed = new URL(configuredUrl);
-      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-        mobileBase = configuredUrl.replace(/\/$/, "");
-      }
-    } catch {
-      // invalid configured URL — fall back to origin
-    }
-  }
-  const mobileUrl = mobileBase
-    ? `${mobileBase}/mobile-scanner?session=${sessionId}`
-    : `${window.location.origin}${withBasePath("/mobile-scanner")}?session=${sessionId}`;
+  // Build the QR-code URL the phone opens. It must land on the public
+  // /mobile-scanner route under the app's base path, otherwise the phone hits
+  // the auth-gated catch-all route and is bounced to the login page.
+  const mobileUrl = buildMobileScannerUrl({
+    configuredUrl: localStorage.getItem("server_url") || config?.frontendUrl || "",
+    sessionId,
+    origin: window.location.origin,
+    basePath: BASE_PATH,
+  });
 
   // Create session on backend
   const createSession = useCallback(

--- a/frontend/editor/src/core/utils/mobileScannerUrl.test.ts
+++ b/frontend/editor/src/core/utils/mobileScannerUrl.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for buildMobileScannerUrl.
+ *
+ * Regression guard: the SaaS frontend is served under a base path (e.g.
+ * `/app`), and `/mobile-scanner` is a public route that only matches under that
+ * base path. The backend advertises `frontendUrl` as a bare origin (no
+ * subpath), so the generated QR URL must still carry the base path. Dropping it
+ * sent phones to the auth-gated catch-all route / login page.
+ */
+
+import { describe, test, expect } from "vitest";
+import { buildMobileScannerUrl } from "@app/utils/mobileScannerUrl";
+
+const sessionId = "abc-123";
+
+describe("buildMobileScannerUrl", () => {
+  test("origin-only frontendUrl keeps the app base path (SaaS web regression)", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "https://app.stirlingpdf.com",
+        sessionId,
+        origin: "https://app.stirlingpdf.com",
+        basePath: "/app",
+      }),
+    ).toBe("https://app.stirlingpdf.com/app/mobile-scanner?session=abc-123");
+  });
+
+  test("origin-only frontendUrl with a trailing slash keeps the app base path", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "https://app.stirlingpdf.com/",
+        sessionId,
+        origin: "https://app.stirlingpdf.com",
+        basePath: "/app",
+      }),
+    ).toBe("https://app.stirlingpdf.com/app/mobile-scanner?session=abc-123");
+  });
+
+  test("configured URL that already carries the subpath is used verbatim (no doubled base)", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "https://app.stirlingpdf.com/app",
+        sessionId,
+        origin: "https://elsewhere.example",
+        basePath: "/app",
+      }),
+    ).toBe("https://app.stirlingpdf.com/app/mobile-scanner?session=abc-123");
+  });
+
+  test("configured URL subpath with trailing slash is normalized", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "https://host.example/app/",
+        sessionId,
+        origin: "https://host.example",
+        basePath: "",
+      }),
+    ).toBe("https://host.example/app/mobile-scanner?session=abc-123");
+  });
+
+  test("no base path and no configured URL uses the current origin", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "",
+        sessionId,
+        origin: "http://localhost:5173",
+        basePath: "",
+      }),
+    ).toBe("http://localhost:5173/mobile-scanner?session=abc-123");
+  });
+
+  test("empty configured URL falls back to origin + base path", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "   ",
+        sessionId,
+        origin: "https://app.stirlingpdf.com",
+        basePath: "/app",
+      }),
+    ).toBe("https://app.stirlingpdf.com/app/mobile-scanner?session=abc-123");
+  });
+
+  test("custom port (LAN/desktop) is preserved", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "http://192.168.1.50:8080",
+        sessionId,
+        origin: "http://localhost:8080",
+        basePath: "",
+      }),
+    ).toBe("http://192.168.1.50:8080/mobile-scanner?session=abc-123");
+  });
+
+  test("invalid configured URL falls back to the current origin + base path", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "not a url",
+        sessionId,
+        origin: "https://app.stirlingpdf.com",
+        basePath: "/app",
+      }),
+    ).toBe("https://app.stirlingpdf.com/app/mobile-scanner?session=abc-123");
+  });
+
+  test("non-http(s) configured URL is ignored (no javascript: injection)", () => {
+    expect(
+      buildMobileScannerUrl({
+        configuredUrl: "javascript:alert(1)",
+        sessionId,
+        origin: "https://app.stirlingpdf.com",
+        basePath: "/app",
+      }),
+    ).toBe("https://app.stirlingpdf.com/app/mobile-scanner?session=abc-123");
+  });
+});

--- a/frontend/editor/src/core/utils/mobileScannerUrl.ts
+++ b/frontend/editor/src/core/utils/mobileScannerUrl.ts
@@ -1,0 +1,47 @@
+/**
+ * Build the URL a phone opens (via the QR code) to reach the SPA's
+ * `/mobile-scanner` route.
+ *
+ * That route is a public, top-level route. It lives under the app's base path,
+ * which is the router's `basename`. If the generated URL omits the base path,
+ * the phone loads a path the router can't match, falls through to the
+ * auth-gated catch-all route, and gets bounced to the login page. So the base
+ * path must always be present.
+ *
+ * A configured `server_url`/`frontendUrl` supplies the host the phone should
+ * reach (desktop / LAN / reverse proxy):
+ *   - origin only (no subpath): apply the app's base path. The backend's
+ *     `resolveFrontendUrl` advertises a bare origin with no subpath, so this is
+ *     the common SaaS web case (frontend served under e.g. `/app`).
+ *   - already carries a subpath: it points at the target SPA's base directly,
+ *     so use it verbatim and do not add the base path again (no doubled base).
+ *
+ * With no usable configured URL, fall back to the current origin + base path.
+ */
+export function buildMobileScannerUrl(params: {
+  configuredUrl: string;
+  sessionId: string;
+  origin: string;
+  basePath: string;
+}): string {
+  const { configuredUrl, sessionId, origin, basePath } = params;
+  const query = `?session=${sessionId}`;
+  const route = `${basePath}/mobile-scanner`;
+
+  const trimmed = configuredUrl.trim();
+  if (trimmed) {
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        const subpath = parsed.pathname.replace(/\/+$/, "");
+        return subpath
+          ? `${parsed.origin}${subpath}/mobile-scanner${query}`
+          : `${parsed.origin}${route}${query}`;
+      }
+    } catch {
+      // invalid configured URL — fall through to the current-origin default
+    }
+  }
+
+  return `${origin}${route}${query}`;
+}

--- a/frontend/editor/src/proprietary/App.tsx
+++ b/frontend/editor/src/proprietary/App.tsx
@@ -26,8 +26,9 @@ import "@app/styles/auth-theme.css";
 // Import file ID debugging helpers (development only)
 import "@app/utils/fileIdSafety";
 
-// Minimal providers for mobile scanner - no API calls, no authentication
-function MobileScannerProviders({ children }: { children: React.ReactNode }) {
+// Minimal providers for public, no-auth pages (mobile scanner, participant
+// signing) - no API calls, no authentication
+function PublicRouteProviders({ children }: { children: React.ReactNode }) {
   return (
     <PreferencesProvider>
       <RainbowThemeProvider>{children}</RainbowThemeProvider>
@@ -50,9 +51,9 @@ export default function App() {
         <Route
           path="/mobile-scanner"
           element={
-            <MobileScannerProviders>
+            <PublicRouteProviders>
               <MobileScannerPage />
-            </MobileScannerProviders>
+            </PublicRouteProviders>
           }
         />
 
@@ -60,9 +61,9 @@ export default function App() {
         <Route
           path="/workflow/sign/:token"
           element={
-            <MobileScannerProviders>
+            <PublicRouteProviders>
               <ParticipantViewPage />
-            </MobileScannerProviders>
+            </PublicRouteProviders>
           }
         />
 

--- a/frontend/editor/src/saas/App.tsx
+++ b/frontend/editor/src/saas/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, type ReactNode } from "react";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation, useParams } from "react-router-dom";
 import { isAuthRoute } from "@app/utils/pathUtils";
 import { AppProviders } from "@app/components/AppProviders";
 import { PreferencesProvider } from "@app/contexts/PreferencesContext";
@@ -15,6 +15,8 @@ import Signup from "@app/routes/Signup";
 import AuthCallback from "@app/routes/AuthCallback";
 import ResetPassword from "@app/routes/ResetPassword";
 import OAuthConsent from "@app/routes/OAuthConsent";
+import ShareLinkPage from "@app/routes/ShareLinkPage";
+import ParticipantView from "@app/components/workflow/ParticipantView";
 import MobileScannerPage from "@app/pages/MobileScannerPage";
 import OnboardingBootstrap from "@app/components/OnboardingBootstrap";
 import TrialExpiredBootstrap from "@app/components/TrialExpiredBootstrap";
@@ -43,6 +45,15 @@ function MobileScannerProviders({ children }: { children: ReactNode }) {
       <RainbowThemeProvider>{children}</RainbowThemeProvider>
     </PreferencesProvider>
   );
+}
+
+// Participant signing page - public, token-gated, no login required. The
+// participant API (/api/v1/workflow/participant/*) authenticates via the share
+// token, so it works without a Supabase session.
+function ParticipantViewPage() {
+  const { token } = useParams<{ token: string }>();
+  if (!token) return null;
+  return <ParticipantView token={token} />;
 }
 
 /**
@@ -81,6 +92,17 @@ export default function App() {
           }
         />
 
+        {/* Participant signing - public, token-gated, no login required. Same
+            reasoning as the mobile scanner (kept outside AppProviders). */}
+        <Route
+          path="/workflow/sign/:token"
+          element={
+            <MobileScannerProviders>
+              <ParticipantViewPage />
+            </MobileScannerProviders>
+          }
+        />
+
         {/* Everything else needs the auth/backend providers. */}
         <Route
           path="*"
@@ -96,6 +118,11 @@ export default function App() {
                   <Route path="/auth/callback" element={<AuthCallback />} />
                   <Route path="/auth/reset" element={<ResetPassword />} />
                   <Route path="/oauth/consent" element={<OAuthConsent />} />
+                  {/* Shared-file links. Team invites are NOT routed here: on
+                      SaaS they are accepted in-app via the Supabase team
+                      invitation banner, not the Spring password-based
+                      /invite/:token page used by the self-hosted build. */}
+                  <Route path="/share/:token" element={<ShareLinkPage />} />
                   <Route path="/*" element={<Landing />} />
                 </Routes>
                 <OnboardingTour />

--- a/frontend/editor/src/saas/App.tsx
+++ b/frontend/editor/src/saas/App.tsx
@@ -36,10 +36,10 @@ function handleConfigLoaded(config: AppConfig) {
   if (config.baseUrl) setBaseUrl(config.baseUrl);
 }
 
-// Minimal providers for the mobile scanner: no AppProviders, so no auth and no
-// backend bootstrap. The page is opened on a phone via a QR code and must work
-// without a logged-in session, the same way it does in the proprietary build.
-function MobileScannerProviders({ children }: { children: ReactNode }) {
+// Minimal providers for public, no-auth pages (the mobile-scanner QR page and
+// the participant signing page). Just theme + preferences, no AppProviders, so
+// no auth and no backend bootstrap - these render without a logged-in session.
+function PublicRouteProviders({ children }: { children: ReactNode }) {
   return (
     <PreferencesProvider>
       <RainbowThemeProvider>{children}</RainbowThemeProvider>
@@ -86,9 +86,9 @@ export default function App() {
         <Route
           path="/mobile-scanner"
           element={
-            <MobileScannerProviders>
+            <PublicRouteProviders>
               <MobileScannerPage />
-            </MobileScannerProviders>
+            </PublicRouteProviders>
           }
         />
 
@@ -97,9 +97,9 @@ export default function App() {
         <Route
           path="/workflow/sign/:token"
           element={
-            <MobileScannerProviders>
+            <PublicRouteProviders>
               <ParticipantViewPage />
-            </MobileScannerProviders>
+            </PublicRouteProviders>
           }
         />
 

--- a/frontend/editor/src/saas/App.tsx
+++ b/frontend/editor/src/saas/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, type ReactNode } from "react";
-import { Routes, Route, useLocation, useParams } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import { isAuthRoute } from "@app/utils/pathUtils";
 import { AppProviders } from "@app/components/AppProviders";
 import { PreferencesProvider } from "@app/contexts/PreferencesContext";
@@ -16,7 +16,6 @@ import AuthCallback from "@app/routes/AuthCallback";
 import ResetPassword from "@app/routes/ResetPassword";
 import OAuthConsent from "@app/routes/OAuthConsent";
 import ShareLinkPage from "@app/routes/ShareLinkPage";
-import ParticipantView from "@app/components/workflow/ParticipantView";
 import MobileScannerPage from "@app/pages/MobileScannerPage";
 import OnboardingBootstrap from "@app/components/OnboardingBootstrap";
 import TrialExpiredBootstrap from "@app/components/TrialExpiredBootstrap";
@@ -36,24 +35,15 @@ function handleConfigLoaded(config: AppConfig) {
   if (config.baseUrl) setBaseUrl(config.baseUrl);
 }
 
-// Minimal providers for public, no-auth pages (the mobile-scanner QR page and
-// the participant signing page). Just theme + preferences, no AppProviders, so
-// no auth and no backend bootstrap - these render without a logged-in session.
+// Minimal providers for the public, no-auth mobile-scanner page. Just theme +
+// preferences, no AppProviders, so no auth and no backend bootstrap - it
+// renders without a logged-in session.
 function PublicRouteProviders({ children }: { children: ReactNode }) {
   return (
     <PreferencesProvider>
       <RainbowThemeProvider>{children}</RainbowThemeProvider>
     </PreferencesProvider>
   );
-}
-
-// Participant signing page - public, token-gated, no login required. The
-// participant API (/api/v1/workflow/participant/*) authenticates via the share
-// token, so it works without a Supabase session.
-function ParticipantViewPage() {
-  const { token } = useParams<{ token: string }>();
-  if (!token) return null;
-  return <ParticipantView token={token} />;
 }
 
 /**
@@ -88,17 +78,6 @@ export default function App() {
           element={
             <PublicRouteProviders>
               <MobileScannerPage />
-            </PublicRouteProviders>
-          }
-        />
-
-        {/* Participant signing - public, token-gated, no login required. Same
-            reasoning as the mobile scanner (kept outside AppProviders). */}
-        <Route
-          path="/workflow/sign/:token"
-          element={
-            <PublicRouteProviders>
-              <ParticipantViewPage />
             </PublicRouteProviders>
           }
         />

--- a/frontend/editor/src/saas/App.tsx
+++ b/frontend/editor/src/saas/App.tsx
@@ -1,7 +1,9 @@
-import { Suspense } from "react";
+import { Suspense, type ReactNode } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { isAuthRoute } from "@app/utils/pathUtils";
 import { AppProviders } from "@app/components/AppProviders";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import { RainbowThemeProvider } from "@app/components/shared/RainbowThemeProvider";
 import { setBaseUrl } from "@app/constants/app";
 import type { AppConfig } from "@app/contexts/AppConfigContext";
 import { AppLayout } from "@app/components/AppLayout";
@@ -13,6 +15,7 @@ import Signup from "@app/routes/Signup";
 import AuthCallback from "@app/routes/AuthCallback";
 import ResetPassword from "@app/routes/ResetPassword";
 import OAuthConsent from "@app/routes/OAuthConsent";
+import MobileScannerPage from "@app/pages/MobileScannerPage";
 import OnboardingBootstrap from "@app/components/OnboardingBootstrap";
 import TrialExpiredBootstrap from "@app/components/TrialExpiredBootstrap";
 import SignupRequiredBootstrap from "@app/components/SignupRequiredBootstrap";
@@ -29,6 +32,17 @@ import "@app/utils/fileIdSafety";
 
 function handleConfigLoaded(config: AppConfig) {
   if (config.baseUrl) setBaseUrl(config.baseUrl);
+}
+
+// Minimal providers for the mobile scanner: no AppProviders, so no auth and no
+// backend bootstrap. The page is opened on a phone via a QR code and must work
+// without a logged-in session, the same way it does in the proprietary build.
+function MobileScannerProviders({ children }: { children: ReactNode }) {
+  return (
+    <PreferencesProvider>
+      <RainbowThemeProvider>{children}</RainbowThemeProvider>
+    </PreferencesProvider>
+  );
 }
 
 /**
@@ -54,22 +68,42 @@ function NonAuthBootstraps() {
 export default function App() {
   return (
     <Suspense fallback={<LoadingFallback />}>
-      <AppProviders
-        appConfigProviderProps={{ onConfigLoaded: handleConfigLoaded }}
-      >
-        <AppLayout>
-          <NonAuthBootstraps />
-          <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/signup" element={<Signup />} />
-            <Route path="/auth/callback" element={<AuthCallback />} />
-            <Route path="/auth/reset" element={<ResetPassword />} />
-            <Route path="/oauth/consent" element={<OAuthConsent />} />
-            <Route path="/*" element={<Landing />} />
-          </Routes>
-          <OnboardingTour />
-        </AppLayout>
-      </AppProviders>
+      <Routes>
+        {/* Mobile scanner - public, no auth. Opened on a phone via the QR code,
+            so it must render without a logged-in session. Kept outside
+            AppProviders or it falls through to the auth-gated catch-all. */}
+        <Route
+          path="/mobile-scanner"
+          element={
+            <MobileScannerProviders>
+              <MobileScannerPage />
+            </MobileScannerProviders>
+          }
+        />
+
+        {/* Everything else needs the auth/backend providers. */}
+        <Route
+          path="*"
+          element={
+            <AppProviders
+              appConfigProviderProps={{ onConfigLoaded: handleConfigLoaded }}
+            >
+              <AppLayout>
+                <NonAuthBootstraps />
+                <Routes>
+                  <Route path="/login" element={<Login />} />
+                  <Route path="/signup" element={<Signup />} />
+                  <Route path="/auth/callback" element={<AuthCallback />} />
+                  <Route path="/auth/reset" element={<ResetPassword />} />
+                  <Route path="/oauth/consent" element={<OAuthConsent />} />
+                  <Route path="/*" element={<Landing />} />
+                </Routes>
+                <OnboardingTour />
+              </AppLayout>
+            </AppProviders>
+          }
+        />
+      </Routes>
     </Suspense>
   );
 }


### PR DESCRIPTION
# Description of Changes

## Summary
- Fixes the mobile scanner requiring auth on SaaS: `saas/App.tsx` (written fresh in the editor restructure #6404) never registered the public `/mobile-scanner` route, so the QR URL fell through to the auth-gated catch-all (login for guests, workspace for signed-in users).
- Re-adds the public routes `saas/App.tsx` was missing vs `proprietary/App.tsx`: `/mobile-scanner`, `/share/:token`, `/workflow/sign/:token`.
- Hardens the QR URL builder to always include the app base path (`/app`); extracted to a tested `buildMobileScannerUrl` helper.
- `/invite/:token` intentionally not added (Spring password-account flow, incompatible with SaaS Supabase auth; SaaS uses its own team-invite system).
- SaaS-only regression; OSS / proprietary / desktop unaffected.
---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
