### PR TITLE
Policies: drop the Pro-license gate from the policy API

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/policy/controller/PolicyController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/policy/controller/PolicyController.java
@@ -52,7 +52,6 @@ import stirling.software.proprietary.policy.model.PolicyRunStatus;
 import stirling.software.proprietary.policy.model.PolicyRunView;
 import stirling.software.proprietary.policy.progress.PolicyProgressListener;
 import stirling.software.proprietary.policy.store.PolicyStore;
-import stirling.software.proprietary.security.config.PremiumEndpoint;
 
 /**
  * Policy CRUD plus pipeline runs (stored or ad-hoc). Runs are async: returns a run id, poll {@code
@@ -62,7 +61,6 @@ import stirling.software.proprietary.security.config.PremiumEndpoint;
 @RestController
 @RequestMapping("/api/v1/policies")
 @Hidden
-@PremiumEndpoint
 @RequiredArgsConstructor
 @Tag(name = "Policies", description = "Run tool pipelines on the backend")
 public class PolicyController {


### PR DESCRIPTION
`PolicyController` was annotated `@PremiumEndpoint` (requires a Pro-or-higher server license). Policies don't need a server-license gate:

- On SaaS the server runs in Pro mode, so the check is always satisfied anyway — it gates nothing in practice.
- Access is already governed by team scoping (#6632) plus the per-user / guest gates.

So the annotation is dead weight and misleading. This removes it (and its import) — a 2-line change.

## Verification
- `:proprietary:compileJava` succeeds; spotless clean. No other premium gate on policy classes.