### PR TITLE
Policies: centre the collapsed-rail policy button between its dividers

### DIFF
--- a/frontend/editor/src/proprietary/components/policies/Policies.css
+++ b/frontend/editor/src/proprietary/components/policies/Policies.css
@@ -424,6 +424,11 @@
   align-items: center;
   gap: var(--space-1);
   flex-shrink: 0;
+  /* The collapsed-rail dividers carry 8px of space below them only, so the
+     divider above gives the row 8px of headroom while the one below (rendered
+     straight after) hugs it. Match that 8px underneath so the row sits centred
+     between the two dividers. */
+  margin-bottom: 8px;
 }
 .pol-crail-btn {
   position: relative;


### PR DESCRIPTION
In the collapsed right rail, the policy icon sat ~4px too low — not centred in the space between the two dividers bracketing it.

## Cause
`.tool-panel__collapsed-divider` carries vertical spacing **below** it only (`margin: 0 0.5rem 8px`). So the divider above the policy row gives it 8px of headroom, while the divider rendered immediately after `.pol-crail` hugs its bottom (0px) — leaving the button low.

## Fix
Add a matching `margin-bottom: 8px` to `.pol-crail` so the row gets 8px below as well → centred between the dividers.

## Verification (measured live)
Before: gap above 8.5px / below 0.5px (offset +4px). After: **8.5px / 8.5px, offset 0** — button centre = midpoint between the two dividers.