### PR TITLE
docs: Document pluralization suffix usage for translations

### DIFF
--- a/scripts/translations/README.md
+++ b/scripts/translations/README.md
@@ -482,6 +482,46 @@ title = "Add Page Numbers"
 
 Keys use dot notation internally (e.g., `addPageNumbers.selectText.1`).
 
+### Pluralization Suffixes
+
+Pluralized i18n keys use the i18next/Intl plural suffixes:
+`_zero`, `_one`, `_two`, `_few`, `_many`, and `_other`.
+
+Define the shared base key plus one entry for each plural category the language
+needs. Always provide `_other`; i18next uses it as the fallback plural form.
+Use `{{count}}` as the count placeholder, and call the base key from code with a
+`count` value:
+
+```toml
+[common]
+fileCount_one = "{{count}} file"
+fileCount_other = "{{count}} files"
+fileCount_zero = "No files"
+```
+
+Languages with more plural categories can add their required forms. For example,
+Arabic-style plural rules distinguish `0`, `1`, `2`, small counts, large counts,
+and the fallback form:
+
+```toml
+[common]
+uploadCount_zero = "No files uploaded"              # count = 0
+uploadCount_one = "One file uploaded"               # count = 1
+uploadCount_two = "Two files uploaded"              # count = 2
+uploadCount_few = "{{count}} files uploaded"        # count = 3-10
+uploadCount_many = "{{count}} files uploaded"       # count = 11-99
+uploadCount_other = "{{count}} files uploaded"      # count = 100, fractions, fallback
+```
+
+```ts
+t("common.uploadCount", { count: files.length });
+```
+
+Do not translate the suffix names themselves. They are CLDR plural categories,
+not English words. Add only the forms required by the target language, but keep
+the plural key set aligned with `en-GB` unless the target language needs
+additional CLDR forms such as `_few` or `_many`.
+
 ## Key Features
 
 ### Placeholder Preservation

--- a/scripts/translations/README.md
+++ b/scripts/translations/README.md
@@ -519,7 +519,7 @@ t("common.uploadCount", { count: files.length });
 
 Do not translate the suffix names themselves. They are CLDR plural categories,
 not English words. Add only the forms required by the target language, but keep
-the plural key set aligned with `en-GB` unless the target language needs
+the plural key set aligned with `en-US` unless the target language needs
 additional CLDR forms such as `_few` or `_many`.
 
 ## Key Features


### PR DESCRIPTION
# Description of Changes

This PR updates the translation tooling README with guidance for pluralized i18n keys.

- Added documentation for i18next/Intl plural suffixes such as `_zero`, `_one`, `_two`, `_few`, `_many`, and `_other`
- Clarified that `_other` must always be provided as the fallback plural form
- Added TOML examples for simple English-style pluralization and languages with additional CLDR plural categories
- Added a TypeScript usage example showing how to call the shared base key with a `count` value
- Clarified that plural suffix names must not be translated and that target-language plural key sets should stay aligned with `en-US` unless additional CLDR forms are required


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
