### PR TITLE
fix: resolve ESLint heap out of memory by increasing max-old-space-si…

### DIFF
--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -194,6 +194,8 @@ tasks:
   lint:eslint:
     desc: "Run ESLint linting"
     deps: [install]
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
     cmds:
       - npx eslint --max-warnings=0
 
@@ -208,6 +210,8 @@ tasks:
   lint:fix:
     desc: "Auto-fix lint issues"
     deps: [install]
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
     cmds:
       - npx eslint --fix
 


### PR DESCRIPTION
# Description of Changes

**What was changed:**
- Added the `NODE_OPTIONS: "--max-old-space-size=8192"` environment variable to the `lint:eslint` and `lint:fix` commands in `.taskfiles/frontend.yml`.

**Why the change was made:**
- The `frontend:lint:fix` task was previously crashing due to a `JavaScript heap out of memory` fatal error when processing the large codebase. Giving Node.js up to 8GB of heap space explicitly resolves the issue, allowing ESLint to finish its cycle successfully.

Closes #6594

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.