### PR TITLE
Fix PDF text selection locked out on touch devices

### DIFF
--- a/frontend/editor/src/core/components/viewer/LocalEmbedPDF.tsx
+++ b/frontend/editor/src/core/components/viewer/LocalEmbedPDF.tsx
@@ -243,12 +243,12 @@ export function LocalEmbedPDF({
         drawBlackBoxes: false,
       }),
 
-      // Register pan plugin (depends on Viewport, InteractionManager)
-      createPluginRegistration(PanPluginPackage, {
-        defaultMode: "mobile", // Try mobile mode which might be more permissive
-      }),
-      // Register pan plugin (depends on Viewport, InteractionManager) - keep disabled to prevent drag panning
-      createPluginRegistration(PanPluginPackage, {}),
+      // Register pan plugin (depends on Viewport, InteractionManager).
+      // Keep the default mode ("never"). Do NOT set defaultMode: "mobile" - the pan
+      // react layer makes pan the default interaction on any touch-capable device
+      // (navigator.maxTouchPoints > 0), e.g. Windows touchscreen laptops, which then
+      // permanently locks the viewer in pan mode and blocks all text selection.
+      createPluginRegistration(PanPluginPackage),
 
       // Register zoom plugin with configuration
       createPluginRegistration(ZoomPluginPackage, {

--- a/frontend/editor/src/core/components/viewer/LocalEmbedPDFWithAnnotations.tsx
+++ b/frontend/editor/src/core/components/viewer/LocalEmbedPDFWithAnnotations.tsx
@@ -300,10 +300,11 @@ export const LocalEmbedPDFWithAnnotations = forwardRef<
           selectAfterCreate: true,
         }),
 
-        // Register pan plugin
-        createPluginRegistration(PanPluginPackage, {
-          defaultMode: "mobile",
-        }),
+        // Register pan plugin. Keep the default mode ("never"). Do NOT set
+        // defaultMode: "mobile" - it makes pan the default interaction on any
+        // touch-capable device (e.g. Windows touchscreen laptops) and blocks
+        // text selection.
+        createPluginRegistration(PanPluginPackage),
 
         // Register zoom plugin
         createPluginRegistration(ZoomPluginPackage, {


### PR DESCRIPTION
# Description of Changes

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
