### PR TITLE
feat(ocr): add rotatePages option for automatic page orientation correction

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/OCRController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/OCRController.java
@@ -102,6 +102,7 @@ public class OCRController {
         List<String> selectedLanguages = request.getLanguages();
         boolean sidecar = request.isSidecar();
         Boolean deskew = request.isDeskew();
+        Boolean rotatePages = request.isRotatePages();
         Boolean clean = request.isClean();
         Boolean cleanFinal = request.isCleanFinal();
         String ocrType = request.getOcrType();
@@ -142,6 +143,7 @@ public class OCRController {
                         selectedLanguages,
                         sidecar,
                         deskew,
+                        rotatePages,
                         clean,
                         cleanFinal,
                         ocrType,
@@ -224,6 +226,7 @@ public class OCRController {
             List<String> selectedLanguages,
             Boolean sidecar,
             Boolean deskew,
+            Boolean rotatePages,
             Boolean clean,
             Boolean cleanFinal,
             String ocrType,
@@ -255,6 +258,10 @@ public class OCRController {
 
         if (deskew != null && deskew) {
             command.add("--deskew");
+        }
+        if (rotatePages != null && rotatePages) {
+            // Tesseract OSD-based automatic page orientation correction (90/180/270)
+            command.add("--rotate-pages");
         }
         if (clean != null && clean) {
             command.add("--clean");

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ProcessPdfWithOcrRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/misc/ProcessPdfWithOcrRequest.java
@@ -25,6 +25,11 @@ public class ProcessPdfWithOcrRequest extends PDFFile {
     @Schema(description = "Deskew the input file if set to true")
     private boolean deskew;
 
+    @Schema(
+            description =
+                    "Auto-correct page orientation (90/180/270) using Tesseract OSD if set to true")
+    private boolean rotatePages;
+
     @Schema(description = "Clean the input file if set to true")
     private boolean clean;
 


### PR DESCRIPTION
# Description of Changes

**What was changed**

Added a new boolean request parameter `rotatePages` to the OCR endpoint
(`POST /api/v1/misc/ocr-pdf`). When set to `true`, the OCRmyPDF command now
gets `--rotate-pages` appended, mirroring how the existing `deskew` / `clean`
flags are handled.

- `ProcessPdfWithOcrRequest` — new `rotatePages` field with a Swagger description.
- `OCRController` — reads `request.isRotatePages()`, threads it through the
  command-builder method signature, and appends `--rotate-pages` when set.

**Why**

Stirling's OCR is built on OCRmyPDF + Tesseract, which already ships
`--rotate-pages`. It uses Tesseract OSD (Orientation & Script Detection) to
auto-correct the *cardinal* orientation (90/180/270) of each page — the standard
fix for scanned documents that arrive sideways or upside-down. Until now there
was no way to trigger it from Stirling:

- `rotate-pdf` only takes a single `angle` applied to the whole document (no
  per-page, no auto-detect).
- `ocr-pdf` exposed `deskew`, but `--deskew` only corrects *small* skew, not
  90/180/270 rotation, so it does not cover this case.

This is a long-standing gap — see #725, where users asked for automatic
orientation/skew correction on scans back in 2024.

**Scope**

12 lines across 2 files, no new dependencies, no behavior change unless the
caller opts in by sending `rotatePages=true`.

**Verified**

Built locally (`./gradlew bootJar`), ran the server, and called `ocr-pdf` with
`rotatePages=true` on a real 20-page scan with mixed 0°/180° pages. The
upside-down pages came out upright, already-upright pages were left untouched,
and the resulting OCR text layer was correct.

**Possible follow-up (not in this PR):** bare `--rotate-pages` uses OCRmyPDF's
conservative default `--rotate-pages-threshold` (15). For noisy/sparse scans a
more aggressive threshold catches more low-confidence pages. That could be
exposed as an additional optional param if maintainers want it — happy to add.

Relates to #725

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
