### PR TITLE
MCP token rejection reason and stop logging the raw tokens

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/config/CustomAuditEventRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/config/CustomAuditEventRepository.java
@@ -61,17 +61,34 @@ public class CustomAuditEventRepository implements AuditEventRepository {
 
             PersistentAuditEvent ent =
                     PersistentAuditEvent.builder()
-                            .principal(ev.getPrincipal())
+                            .principal(safePrincipal(ev.getPrincipal()))
                             .type(ev.getType())
                             .data(auditEventData)
                             .timestamp(ev.getTimestamp())
                             .build();
             repo.save(ent);
         } catch (Exception e) {
-            log.error(
-                    "Failed to persist audit event (fail-open); principal={}",
-                    ev.getPrincipal(),
-                    e);
+            log.error("Failed to persist audit event (fail-open); type={}", ev.getType(), e);
         }
+    }
+
+    /**
+     * Width of the {@code principal} column; values are capped so an oversized one can't fail the
+     * insert.
+     */
+    private static final int PRINCIPAL_MAX_LENGTH = 255;
+
+    /**
+     * A rejected MCP bearer auth surfaces the raw JWT as the Spring principal; never persist a
+     * credential (or anything wider than the column) into the audit log.
+     */
+    private static String safePrincipal(String principal) {
+        if (principal == null || principal.isBlank()) {
+            return "anonymous";
+        }
+        if (principal.startsWith("eyJ") || principal.length() > PRINCIPAL_MAX_LENGTH) {
+            return "[redacted-token]";
+        }
+        return principal;
     }
 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/config/CustomAuditEventRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/config/CustomAuditEventRepository.java
@@ -80,24 +80,20 @@ public class CustomAuditEventRepository implements AuditEventRepository {
     private static final int PRINCIPAL_MAX_LENGTH = 255;
 
     /**
-     * Keep the principal within the column width and never store a token-shaped value verbatim;
-     * hash those so distinct callers stay distinguishable in the audit trail without persisting a
-     * secret.
+     * Hash JWT-shaped or over-long principals so the insert fits the column and stores no secret.
      */
     static String safePrincipal(String principal) {
         if (principal == null || principal.isBlank()) {
             return "anonymous";
         }
-        // A JWT ("eyJ..."), or any over-long value, is hashed rather than stored as-is.
+        // Hash JWTs ("eyJ...") and any over-long value rather than store verbatim.
         if (principal.startsWith("eyJ") || principal.length() > PRINCIPAL_MAX_LENGTH) {
             return "token:" + sha256Prefix(principal);
         }
         return principal;
     }
 
-    /**
-     * First 8 bytes of the SHA-256 digest as hex: stable per value, one-way, collision-safe enough.
-     */
+    /** First 8 bytes of SHA-256 as hex: stable, one-way, collision-safe enough. */
     private static String sha256Prefix(String value) {
         try {
             byte[] digest =

--- a/app/proprietary/src/main/java/stirling/software/proprietary/config/CustomAuditEventRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/config/CustomAuditEventRepository.java
@@ -1,6 +1,10 @@
 package stirling.software.proprietary.config;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -72,23 +76,36 @@ public class CustomAuditEventRepository implements AuditEventRepository {
         }
     }
 
-    /**
-     * Width of the {@code principal} column; values are capped so an oversized one can't fail the
-     * insert.
-     */
+    /** Width of the {@code principal} column; longer values are hashed so the insert can't fail. */
     private static final int PRINCIPAL_MAX_LENGTH = 255;
 
     /**
-     * A rejected MCP bearer auth surfaces the raw JWT as the Spring principal; never persist a
-     * credential (or anything wider than the column) into the audit log.
+     * Keep the principal within the column width and never store a token-shaped value verbatim;
+     * hash those so distinct callers stay distinguishable in the audit trail without persisting a
+     * secret.
      */
-    private static String safePrincipal(String principal) {
+    static String safePrincipal(String principal) {
         if (principal == null || principal.isBlank()) {
             return "anonymous";
         }
+        // A JWT ("eyJ..."), or any over-long value, is hashed rather than stored as-is.
         if (principal.startsWith("eyJ") || principal.length() > PRINCIPAL_MAX_LENGTH) {
-            return "[redacted-token]";
+            return "token:" + sha256Prefix(principal);
         }
         return principal;
+    }
+
+    /**
+     * First 8 bytes of the SHA-256 digest as hex: stable per value, one-way, collision-safe enough.
+     */
+    private static String sha256Prefix(String value) {
+        try {
+            byte[] digest =
+                    MessageDigest.getInstance("SHA-256")
+                            .digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            return "unhashable";
+        }
     }
 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpAudienceValidator.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpAudienceValidator.java
@@ -43,8 +43,8 @@ public class McpAudienceValidator implements OAuth2TokenValidator<Jwt> {
             return OAuth2TokenValidatorResult.failure(
                     new OAuth2Error(
                             "invalid_token",
-                            "MCP server has no resource id configured; rejecting all tokens"
-                                    + " until mcp.auth.resource-id is set.",
+                            "MCP audience binding is not configured; rejecting all tokens until"
+                                    + " mcp.auth.resource-id or mcp.auth.accepted-audiences is set.",
                             null));
         }
         List<String> aud = token.getAudience();

--- a/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpAuthenticationEntryPoint.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpAuthenticationEntryPoint.java
@@ -14,10 +14,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Emits 401 + {@code WWW-Authenticate: Bearer resource_metadata="..."} (RFC 9728), preferring
- * X-Forwarded-* headers to build the public-facing metadata URL. When a token is actually presented
- * and rejected, logs the concrete OAuth2 reason (audience/issuer/expiry) and echoes it back as
- * {@code error_description} so admins and MCP clients see why instead of a bare 401.
+ * Emits 401 + {@code WWW-Authenticate: Bearer resource_metadata="..."} (RFC 9728) from
+ * X-Forwarded-* headers. A rejected token also logs the OAuth2 reason and echoes it as {@code
+ * error_description}.
  */
 @Slf4j
 public class McpAuthenticationEntryPoint implements AuthenticationEntryPoint {
@@ -35,8 +34,7 @@ public class McpAuthenticationEntryPoint implements AuthenticationEntryPoint {
             HttpServletResponse response,
             AuthenticationException authException)
             throws IOException {
-        // A tokenless 401 is the normal discovery handshake (client fetches metadata, then retries
-        // with a token); only a present-but-rejected token is a real failure worth a warning.
+        // Tokenless 401 is the normal discovery handshake; only a rejected token is a real failure.
         boolean tokenPresented = request.getHeader("Authorization") != null;
         String reason = rejectionReason(authException);
         if (tokenPresented) {
@@ -59,8 +57,7 @@ public class McpAuthenticationEntryPoint implements AuthenticationEntryPoint {
     }
 
     /**
-     * OAuth2 error as {@code "code - description"} for a rejected token, sanitized so it is safe in
-     * a header value and a single log line; {@code null} when there is no structured OAuth2 error.
+     * OAuth2 error as {@code "code - description"}, sanitized for a header/log line; null if none.
      */
     private static String rejectionReason(AuthenticationException ex) {
         if (!(ex instanceof OAuth2AuthenticationException oae)) {

--- a/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpAuthenticationEntryPoint.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpAuthenticationEntryPoint.java
@@ -4,15 +4,22 @@ import java.io.IOException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Emits 401 + {@code WWW-Authenticate: Bearer resource_metadata="..."} (RFC 9728), preferring
- * X-Forwarded-* headers to build the public-facing metadata URL.
+ * X-Forwarded-* headers to build the public-facing metadata URL. When a token is actually presented
+ * and rejected, logs the concrete OAuth2 reason (audience/issuer/expiry) and echoes it back as
+ * {@code error_description} so admins and MCP clients see why instead of a bare 401.
  */
+@Slf4j
 public class McpAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final String metadataPath;
@@ -28,13 +35,47 @@ public class McpAuthenticationEntryPoint implements AuthenticationEntryPoint {
             HttpServletResponse response,
             AuthenticationException authException)
             throws IOException {
+        // A tokenless 401 is the normal discovery handshake (client fetches metadata, then retries
+        // with a token); only a present-but-rejected token is a real failure worth a warning.
+        boolean tokenPresented = request.getHeader("Authorization") != null;
+        String reason = rejectionReason(authException);
+        if (tokenPresented) {
+            log.warn("MCP rejected bearer token: {}", reason != null ? reason : "invalid_token");
+        } else {
+            log.debug("MCP 401: no bearer token; returning protected-resource metadata pointer");
+        }
+
         String scheme = firstForwarded(request, "X-Forwarded-Proto", request.getScheme());
         String authority = forwardedHost(request, scheme);
         String metadataUrl = scheme + "://" + authority + metadataPath;
-        response.setHeader(
-                "WWW-Authenticate",
-                "Bearer error=\"invalid_token\", resource_metadata=\"" + metadataUrl + "\"");
+
+        StringBuilder header = new StringBuilder("Bearer error=\"invalid_token\"");
+        if (tokenPresented && reason != null) {
+            header.append(", error_description=\"").append(reason).append('"');
+        }
+        header.append(", resource_metadata=\"").append(metadataUrl).append('"');
+        response.setHeader("WWW-Authenticate", header.toString());
         response.sendError(HttpStatus.UNAUTHORIZED.value(), "Unauthorized");
+    }
+
+    /**
+     * OAuth2 error as {@code "code - description"} for a rejected token, sanitized so it is safe in
+     * a header value and a single log line; {@code null} when there is no structured OAuth2 error.
+     */
+    private static String rejectionReason(AuthenticationException ex) {
+        if (!(ex instanceof OAuth2AuthenticationException oae)) {
+            return null;
+        }
+        OAuth2Error error = oae.getError();
+        if (error == null) {
+            return null;
+        }
+        String description = error.getDescription();
+        String combined =
+                (description == null || description.isBlank())
+                        ? error.getErrorCode()
+                        : error.getErrorCode() + " - " + description;
+        return combined == null ? null : combined.replaceAll("[\\r\\n\"]", " ").trim();
     }
 
     /** host[:port] from forwarded headers when present, else the servlet host/port. */

--- a/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpConfigValidator.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpConfigValidator.java
@@ -37,6 +37,18 @@ public final class McpConfigValidator {
             return findings;
         }
 
+        // Anything that isn't exactly "apikey" runs the OAuth chain (mirrors isApiKeyMode()).
+        String mode = auth.getMode();
+        if (mode != null && !mode.isBlank() && !"oauth".equalsIgnoreCase(mode.trim())) {
+            findings.add(
+                    warn(
+                            "mcp.auth.mode='"
+                                    + mode
+                                    + "' is not recognized (expected 'oauth' or 'apikey'); it falls"
+                                    + " back to the OAuth chain, which rejects every token unless"
+                                    + " issuer-uri and resource-id are set. A near-miss like"
+                                    + " 'api-key' is NOT treated as API-key mode."));
+        }
         findings.add(info("auth mode = oauth - running as an OAuth2 resource server for /mcp."));
 
         if (isBlank(auth.getIssuerUri())) {
@@ -54,19 +66,52 @@ public final class McpConfigValidator {
                                     + "' does not look like an http(s) URL."));
         }
 
-        if (isBlank(auth.getResourceId())) {
+        boolean hasResourceId = !isBlank(auth.getResourceId());
+        boolean hasAcceptedAudiences =
+                auth.getAcceptedAudiences().stream().anyMatch(a -> !isBlank(a));
+
+        if (!hasResourceId && !hasAcceptedAudiences) {
             findings.add(
                     warn(
-                            "mcp.auth.resource-id is not set: the audience validator rejects every"
-                                    + " token (RFC 8707). Set it to this server's public /mcp URL (e.g."
-                                    + " https://your-host/mcp)."));
-        } else if (!auth.getResourceId().endsWith("/mcp")) {
-            findings.add(
-                    warn(
-                            "mcp.auth.resource-id='"
-                                    + auth.getResourceId()
-                                    + "' does not end in /mcp: it must match the public URL clients"
-                                    + " call and the audience your IdP puts in the token."));
+                            "neither mcp.auth.resource-id nor mcp.auth.accepted-audiences is set: the"
+                                    + " audience validator fails closed and rejects every token (RFC"
+                                    + " 8707). Set resource-id to this server's public /mcp URL, or"
+                                    + " accepted-audiences to the audience your IdP actually mints."));
+        } else {
+            if (hasResourceId && !looksLikeUrl(auth.getResourceId())) {
+                findings.add(
+                        warn(
+                                "mcp.auth.resource-id='"
+                                        + auth.getResourceId()
+                                        + "' is not an http(s) URL: the token aud must match it"
+                                        + " exactly (scheme, host and port included)."));
+            } else if (hasResourceId && !auth.getResourceId().endsWith("/mcp")) {
+                findings.add(
+                        warn(
+                                "mcp.auth.resource-id='"
+                                        + auth.getResourceId()
+                                        + "' does not end in /mcp: it must match the public URL"
+                                        + " clients call and the audience your IdP puts in the"
+                                        + " token."));
+            }
+            if (hasAcceptedAudiences) {
+                findings.add(
+                        info(
+                                "mcp.auth.accepted-audiences="
+                                        + auth.getAcceptedAudiences()
+                                        + " - tokens whose aud matches any of these are accepted, the"
+                                        + " escape hatch for IdPs that can't mint a resource-specific"
+                                        + " audience (e.g. an Entra ID app id, or Supabase's"
+                                        + " aud=authenticated)."));
+            } else {
+                findings.add(
+                        info(
+                                "audience binding is strict (token aud must equal"
+                                        + " mcp.auth.resource-id). If your IdP can't mint that - e.g."
+                                        + " Entra ID issues aud=<client-id> - set"
+                                        + " mcp.auth.accepted-audiences to the audience it actually"
+                                        + " emits."));
+            }
         }
 
         if (isBlank(auth.getJwksUri())) {
@@ -85,6 +130,15 @@ public final class McpConfigValidator {
                                     + " or 'preferred_username', or provision accounts keyed by sub."));
         }
 
+        if (!auth.isRequireExistingAccount()) {
+            findings.add(
+                    warn(
+                            "mcp.auth.require-existing-account=false: any token your IdP signs can"
+                                    + " invoke MCP tools even if its subject has no Stirling account. Set"
+                                    + " it true unless you intend open access for every IdP-valid"
+                                    + " token."));
+        }
+
         if (mcp.isScopesEnabled()) {
             findings.add(
                     info(
@@ -93,8 +147,31 @@ public final class McpConfigValidator {
                                     + " mcp.scopes-enabled=false if it can only issue coarse tokens."));
         }
 
+        List<String> allowed = mcp.getAllowedOperations();
+        List<String> blocked = mcp.getBlockedOperations();
+        if (allowed != null && !allowed.isEmpty()) {
+            findings.add(
+                    info(
+                            "mcp.allowed-operations is a strict allow-list of "
+                                    + allowed.size()
+                                    + " operation(s); every other tool is hidden, so a wrong or"
+                                    + " typo'd id silently exposes nothing."));
+            List<String> shadowed =
+                    blocked == null
+                            ? List.of()
+                            : allowed.stream().filter(blocked::contains).toList();
+            if (!shadowed.isEmpty()) {
+                findings.add(
+                        warn(
+                                "mcp operation(s) "
+                                        + shadowed
+                                        + " are in both allowed-operations and blocked-operations;"
+                                        + " blocked wins, so they are hidden."));
+            }
+        }
+
         if (findings.stream().noneMatch(f -> f.severity() == Severity.WARN)) {
-            findings.add(info("OAuth settings look complete (issuer + resource-id set)."));
+            findings.add(info("OAuth settings look complete."));
         }
 
         return findings;

--- a/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpConfigValidator.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpConfigValidator.java
@@ -7,9 +7,8 @@ import java.util.Locale;
 import stirling.software.common.model.ApplicationProperties;
 
 /**
- * Startup sanity-checks for MCP configuration. Produces human-readable findings that {@link
- * McpSecurityConfig} logs once at boot, so a misconfigured /mcp endpoint is obvious from the logs
- * before a client ever connects - instead of only surfacing later as a rejected-token 401.
+ * Startup sanity-checks for MCP config; {@link McpSecurityConfig} logs the findings at boot so a
+ * misconfigured /mcp endpoint shows up in the logs instead of as a later rejected-token 401.
  */
 public final class McpConfigValidator {
 

--- a/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpConfigValidator.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpConfigValidator.java
@@ -1,0 +1,119 @@
+package stirling.software.proprietary.mcp.security;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import stirling.software.common.model.ApplicationProperties;
+
+/**
+ * Startup sanity-checks for MCP configuration. Produces human-readable findings that {@link
+ * McpSecurityConfig} logs once at boot, so a misconfigured /mcp endpoint is obvious from the logs
+ * before a client ever connects - instead of only surfacing later as a rejected-token 401.
+ */
+public final class McpConfigValidator {
+
+    public enum Severity {
+        WARN,
+        INFO
+    }
+
+    public record Finding(Severity severity, String message) {}
+
+    private McpConfigValidator() {}
+
+    /** Inspect the resolved MCP config and return ordered findings (most actionable first). */
+    public static List<Finding> validate(ApplicationProperties.Mcp mcp) {
+        List<Finding> findings = new ArrayList<>();
+        ApplicationProperties.Mcp.Auth auth = mcp.getAuth();
+
+        if ("apikey".equalsIgnoreCase(auth.getMode())) {
+            findings.add(
+                    info(
+                            "auth mode = apikey - clients send a Stirling API key via X-API-KEY (or"
+                                    + " Authorization: Bearer <key>); no external IdP needed. The key"
+                                    + " must belong to a provisioned, enabled account (Account -> API"
+                                    + " Keys)."));
+            return findings;
+        }
+
+        findings.add(info("auth mode = oauth - running as an OAuth2 resource server for /mcp."));
+
+        if (isBlank(auth.getIssuerUri())) {
+            findings.add(
+                    warn(
+                            "mcp.auth.issuer-uri is not set: the JWT decoder fails closed and rejects"
+                                    + " every token. Set it to your IdP issuer that publishes"
+                                    + " /.well-known/openid-configuration (e.g."
+                                    + " https://login.microsoftonline.com/<tenant>/v2.0)."));
+        } else if (!looksLikeUrl(auth.getIssuerUri())) {
+            findings.add(
+                    warn(
+                            "mcp.auth.issuer-uri='"
+                                    + auth.getIssuerUri()
+                                    + "' does not look like an http(s) URL."));
+        }
+
+        if (isBlank(auth.getResourceId())) {
+            findings.add(
+                    warn(
+                            "mcp.auth.resource-id is not set: the audience validator rejects every"
+                                    + " token (RFC 8707). Set it to this server's public /mcp URL (e.g."
+                                    + " https://your-host/mcp)."));
+        } else if (!auth.getResourceId().endsWith("/mcp")) {
+            findings.add(
+                    warn(
+                            "mcp.auth.resource-id='"
+                                    + auth.getResourceId()
+                                    + "' does not end in /mcp: it must match the public URL clients"
+                                    + " call and the audience your IdP puts in the token."));
+        }
+
+        if (isBlank(auth.getJwksUri())) {
+            findings.add(
+                    info(
+                            "mcp.auth.jwks-uri not set - signing keys are auto-discovered from the"
+                                    + " issuer's OpenID configuration."));
+        }
+
+        if ("sub".equalsIgnoreCase(auth.getUsernameClaim()) && auth.isRequireExistingAccount()) {
+            findings.add(
+                    warn(
+                            "mcp.auth.username-claim='sub' with require-existing-account=true: many"
+                                    + " IdPs (e.g. Entra ID, Google) set 'sub' to an opaque id that won't"
+                                    + " match a Stirling username. Set mcp.auth.username-claim to 'email'"
+                                    + " or 'preferred_username', or provision accounts keyed by sub."));
+        }
+
+        if (mcp.isScopesEnabled()) {
+            findings.add(
+                    info(
+                            "mcp.scopes-enabled=true - the IdP must mint 'mcp.tools.read' and"
+                                    + " 'mcp.tools.write' scopes or clients are rejected; set"
+                                    + " mcp.scopes-enabled=false if it can only issue coarse tokens."));
+        }
+
+        if (findings.stream().noneMatch(f -> f.severity() == Severity.WARN)) {
+            findings.add(info("OAuth settings look complete (issuer + resource-id set)."));
+        }
+
+        return findings;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static boolean looksLikeUrl(String value) {
+        String lower = value.toLowerCase(Locale.ROOT);
+        return lower.startsWith("http://") || lower.startsWith("https://");
+    }
+
+    private static Finding warn(String message) {
+        return new Finding(Severity.WARN, message);
+    }
+
+    private static Finding info(String message) {
+        return new Finding(Severity.INFO, message);
+    }
+}

--- a/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpSecurityConfig.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/mcp/security/McpSecurityConfig.java
@@ -77,24 +77,14 @@ public class McpSecurityConfig {
     }
 
     @PostConstruct
-    void warnIfMisconfigured() {
-        ApplicationProperties.Mcp mcp = applicationProperties.getMcp();
-        if (isApiKeyMode()) {
-            log.info(
-                    "MCP auth mode = apikey: clients authenticate with a Stirling per-user API key"
-                            + " (X-API-KEY header). No OAuth issuer required.");
-        } else {
-            if (mcp.getAuth().getIssuerUri().isBlank()) {
-                log.warn(
-                        "MCP enabled but mcp.auth.issuer-uri is blank - JWT decoder will reject"
-                                + " every token (fail-closed). Set mcp.auth.issuer-uri and"
-                                + " mcp.auth.resource-id before exposing /mcp to clients.");
-            }
-            if (mcp.getAuth().getResourceId().isBlank()) {
-                log.warn(
-                        "MCP enabled but mcp.auth.resource-id is blank - audience validator will"
-                                + " reject every token. Set this to the public URL of the MCP"
-                                + " endpoint (RFC 8707).");
+    void validateConfigOnStartup() {
+        log.info("MCP server enabled - validating configuration:");
+        for (McpConfigValidator.Finding finding :
+                McpConfigValidator.validate(applicationProperties.getMcp())) {
+            if (finding.severity() == McpConfigValidator.Severity.WARN) {
+                log.warn("MCP config: {}", finding.message());
+            } else {
+                log.info("MCP config: {}", finding.message());
             }
         }
     }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/config/CustomAuditEventRepositoryTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/config/CustomAuditEventRepositoryTest.java
@@ -1,0 +1,52 @@
+package stirling.software.proprietary.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CustomAuditEventRepositoryTest {
+
+    @Test
+    void shortPrincipalPassesThroughUnchanged() {
+        assertEquals(
+                "alice@example.com", CustomAuditEventRepository.safePrincipal("alice@example.com"));
+    }
+
+    @Test
+    void blankOrNullPrincipalBecomesAnonymous() {
+        assertEquals("anonymous", CustomAuditEventRepository.safePrincipal(null));
+        assertEquals("anonymous", CustomAuditEventRepository.safePrincipal("   "));
+    }
+
+    @Test
+    void tokenShapedPrincipalIsHashedNotStoredVerbatim() {
+        String jwt = "eyJhbGciOiJSUzI1NiJ9." + "x".repeat(1400);
+
+        String safe = CustomAuditEventRepository.safePrincipal(jwt);
+
+        assertNotEquals(jwt, safe);
+        assertFalse(safe.contains(jwt), "raw token must not be stored");
+        assertTrue(safe.startsWith("token:"));
+        assertTrue(safe.length() <= 255, "must fit the principal column");
+    }
+
+    @Test
+    void distinctTokensStayDistinguishable() {
+        String a = CustomAuditEventRepository.safePrincipal("eyJ" + "a".repeat(400));
+        String b = CustomAuditEventRepository.safePrincipal("eyJ" + "b".repeat(400));
+
+        assertNotEquals(a, b, "different tokens must map to different audit principals");
+    }
+
+    @Test
+    void sameTokenHashesStably() {
+        String token = "eyJ" + "c".repeat(400);
+
+        assertEquals(
+                CustomAuditEventRepository.safePrincipal(token),
+                CustomAuditEventRepository.safePrincipal(token));
+    }
+}

--- a/app/proprietary/src/test/java/stirling/software/proprietary/mcp/security/McpAuthenticationEntryPointTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/mcp/security/McpAuthenticationEntryPointTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -57,5 +59,31 @@ class McpAuthenticationEntryPointTest {
         ArgumentCaptor<String> header = ArgumentCaptor.forClass(String.class);
         verify(resp).setHeader(eq("WWW-Authenticate"), header.capture());
         assertTrue(header.getValue().contains("http://localhost:8080" + META), header.getValue());
+    }
+
+    @Test
+    void surfacesRejectionReasonWhenTokenPresented() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getScheme()).thenReturn("https");
+        when(req.getServerName()).thenReturn("mcp.example.com");
+        when(req.getServerPort()).thenReturn(443);
+        when(req.getHeader("Authorization")).thenReturn("Bearer bad.token");
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+
+        OAuth2Error error =
+                new OAuth2Error(
+                        "invalid_token",
+                        "Token audience does not include this server's resource id"
+                                + " (https://mcp.example.com/mcp).",
+                        null);
+
+        entryPoint.commence(req, resp, new OAuth2AuthenticationException(error));
+
+        ArgumentCaptor<String> header = ArgumentCaptor.forClass(String.class);
+        verify(resp).setHeader(eq("WWW-Authenticate"), header.capture());
+        String www = header.getValue();
+        assertTrue(
+                www.contains("error_description=\"invalid_token - Token audience does not include"),
+                "must surface the rejection reason, got: " + www);
     }
 }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/mcp/security/McpConfigValidatorTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/mcp/security/McpConfigValidatorTest.java
@@ -1,0 +1,72 @@
+package stirling.software.proprietary.mcp.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import stirling.software.common.model.ApplicationProperties;
+
+class McpConfigValidatorTest {
+
+    private static ApplicationProperties.Mcp newMcp() {
+        return new ApplicationProperties.Mcp();
+    }
+
+    private static boolean hasWarn(List<McpConfigValidator.Finding> findings, String needle) {
+        return findings.stream()
+                .anyMatch(
+                        f ->
+                                f.severity() == McpConfigValidator.Severity.WARN
+                                        && f.message().contains(needle));
+    }
+
+    @Test
+    void apiKeyModeSkipsOAuthChecks() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setMode("apikey");
+
+        List<McpConfigValidator.Finding> findings = McpConfigValidator.validate(mcp);
+
+        assertEquals(1, findings.size());
+        assertEquals(McpConfigValidator.Severity.INFO, findings.get(0).severity());
+        assertTrue(findings.get(0).message().contains("apikey"));
+    }
+
+    @Test
+    void blankIssuerAndResourceProduceWarnings() {
+        // Defaults: oauth mode, blank issuer-uri and resource-id.
+        List<McpConfigValidator.Finding> findings = McpConfigValidator.validate(newMcp());
+
+        assertTrue(hasWarn(findings, "issuer-uri"), "blank issuer must warn");
+        assertTrue(hasWarn(findings, "resource-id"), "blank resource-id must warn");
+    }
+
+    @Test
+    void subClaimWithRequireAccountWarns() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setIssuerUri("https://issuer.example.com");
+        mcp.getAuth().setResourceId("https://host.example.com/mcp");
+        // Defaults username-claim=sub, require-existing-account=true.
+
+        assertTrue(hasWarn(McpConfigValidator.validate(mcp), "username-claim='sub'"));
+    }
+
+    @Test
+    void completeConfigReportsReadyWithNoWarnings() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setIssuerUri("https://issuer.example.com");
+        mcp.getAuth().setResourceId("https://host.example.com/mcp");
+        mcp.getAuth().setUsernameClaim("email");
+        mcp.setScopesEnabled(false);
+
+        List<McpConfigValidator.Finding> findings = McpConfigValidator.validate(mcp);
+
+        assertTrue(
+                findings.stream().noneMatch(f -> f.severity() == McpConfigValidator.Severity.WARN),
+                "complete config must have no warnings");
+        assertTrue(findings.stream().anyMatch(f -> f.message().contains("look complete")));
+    }
+}

--- a/app/proprietary/src/test/java/stirling/software/proprietary/mcp/security/McpConfigValidatorTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/mcp/security/McpConfigValidatorTest.java
@@ -1,6 +1,7 @@
 package stirling.software.proprietary.mcp.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -68,5 +69,83 @@ class McpConfigValidatorTest {
                 findings.stream().noneMatch(f -> f.severity() == McpConfigValidator.Severity.WARN),
                 "complete config must have no warnings");
         assertTrue(findings.stream().anyMatch(f -> f.message().contains("look complete")));
+    }
+
+    @Test
+    void acceptedAudiencesCoverBlankResourceId() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setIssuerUri("https://issuer.example.com");
+        mcp.getAuth().setResourceId("");
+        mcp.getAuth().setAcceptedAudiences(List.of("authenticated"));
+        mcp.getAuth().setUsernameClaim("email");
+        mcp.setScopesEnabled(false);
+
+        List<McpConfigValidator.Finding> findings = McpConfigValidator.validate(mcp);
+
+        assertFalse(
+                hasWarn(findings, "fails closed"),
+                "accepted-audiences must satisfy audience binding without a resource id");
+        assertTrue(
+                findings.stream().anyMatch(f -> f.message().contains("accepted-audiences=")),
+                "configured accepted-audiences should be surfaced");
+    }
+
+    @Test
+    void strictAudienceHintsAtAcceptedAudiencesEscapeHatch() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setIssuerUri("https://issuer.example.com");
+        mcp.getAuth().setResourceId("https://host.example.com/mcp");
+        mcp.getAuth().setUsernameClaim("email");
+        mcp.setScopesEnabled(false);
+
+        List<McpConfigValidator.Finding> findings = McpConfigValidator.validate(mcp);
+
+        assertTrue(
+                findings.stream().anyMatch(f -> f.message().contains("accepted-audiences")),
+                "should point coarse-audience IdPs at accepted-audiences");
+    }
+
+    @Test
+    void unrecognizedModeWarnsAboutOAuthFallback() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setMode("api-key"); // near-miss typo that silently runs the OAuth chain
+
+        assertTrue(hasWarn(McpConfigValidator.validate(mcp), "is not recognized"));
+    }
+
+    @Test
+    void requireExistingAccountFalseWarnsAboutOpenAccess() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setIssuerUri("https://issuer.example.com");
+        mcp.getAuth().setResourceId("https://host.example.com/mcp");
+        mcp.getAuth().setUsernameClaim("email");
+        mcp.getAuth().setRequireExistingAccount(false);
+
+        assertTrue(hasWarn(McpConfigValidator.validate(mcp), "require-existing-account=false"));
+    }
+
+    @Test
+    void nonUrlResourceIdWarns() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setIssuerUri("https://issuer.example.com");
+        mcp.getAuth().setResourceId("localhost:8080/mcp"); // missing scheme
+
+        assertTrue(hasWarn(McpConfigValidator.validate(mcp), "is not an http(s) URL"));
+    }
+
+    @Test
+    void allowListIsFlaggedAndOverlapWithBlockListWarns() {
+        ApplicationProperties.Mcp mcp = newMcp();
+        mcp.getAuth().setIssuerUri("https://issuer.example.com");
+        mcp.getAuth().setResourceId("https://host.example.com/mcp");
+        mcp.setAllowedOperations(List.of("merge-pdfs", "split-pdf"));
+        mcp.setBlockedOperations(List.of("split-pdf"));
+
+        List<McpConfigValidator.Finding> findings = McpConfigValidator.validate(mcp);
+
+        assertTrue(
+                findings.stream().anyMatch(f -> f.message().contains("strict allow-list")),
+                "an allow-list should be surfaced");
+        assertTrue(hasWarn(findings, "blocked wins"), "allowed+blocked overlap should warn");
     }
 }


### PR DESCRIPTION

- Surface the real reason an MCP token is rejected: the 401's WWW-Authenticate header now includes error_description (audience/issuer/expiry), and a present-but-rejected token logs the concrete OAuth2 reason. Tokenless 401s (the normal discovery handshake) stay at debug.
- Add McpConfigValidator that sanity-checks MCP config at startup and logs actionable warnings (missing issuer-uri/resource-id, unrecognized auth mode, sub + require-existing-account, open access, scopes, allow/block overlap) so misconfig shows up in the logs before a client ever connects.
- Align the audience-rejection message to mention both resource-id and accepted-audiences.
- Harden audit writes: hash JWT-shaped or over-long principals (token:<sha256-prefix>) so the insert fits the column and never stores a raw bearer token, and stop logging the raw principal on persist failure.
---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
