### PR TITLE
Per-arch JPDFium natives in Docker + musl ultra-lite (jpdfium 1.1.0)

### DIFF
--- a/app/common/build.gradle
+++ b/app/common/build.gradle
@@ -60,22 +60,26 @@ dependencies {
         exclude group: 'com.google.code.gson', module: 'gson'
     }
 
-    api 'com.stirling:jpdfium:1.0.2'
+    api 'com.stirling:jpdfium:1.1.0'
 
-    // -PjpdfiumPlatforms=all|<csv of linux-x64,linux-arm64,darwin-x64,darwin-arm64,windows-x64>
+    // -PjpdfiumPlatforms=all|<csv of linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,darwin-x64,darwin-arm64,windows-x64>
+    // 'all' = the standard glibc/mac/windows set. musl (Alpine) natives are
+    // opt-in only (the ultra-lite Docker build selects them per-arch), so they
+    // are valid values but excluded from 'all'.
     def jpdfiumPlatformsProp = (project.findProperty('jpdfiumPlatforms') ?: 'all').toString().trim()
     def jpdfiumAllPlatforms = ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64', 'windows-x64']
+    def jpdfiumValidPlatforms = jpdfiumAllPlatforms + ['linux-musl-x64', 'linux-musl-arm64']
     def jpdfiumPlatforms = jpdfiumPlatformsProp == 'all'
             ? jpdfiumAllPlatforms
             : jpdfiumPlatformsProp.split(',').collect { it.trim() }.findAll { it }
-    def jpdfiumInvalid = jpdfiumPlatforms.findAll { !jpdfiumAllPlatforms.contains(it) }
+    def jpdfiumInvalid = jpdfiumPlatforms.findAll { !jpdfiumValidPlatforms.contains(it) }
     if (jpdfiumInvalid) {
         throw new GradleException("Unknown jpdfiumPlatforms value(s): ${jpdfiumInvalid.join(', ')}. " +
-                "Valid: ${jpdfiumAllPlatforms.join(', ')} or 'all'.")
+                "Valid: ${jpdfiumValidPlatforms.join(', ')} or 'all'.")
     }
     logger.lifecycle("JPDFium native platforms: ${jpdfiumPlatforms.join(', ')}")
     jpdfiumPlatforms.each { platform ->
-        runtimeOnly "com.stirling:jpdfium-natives-${platform}:1.0.2"
+        runtimeOnly "com.stirling:jpdfium-natives-${platform}:1.1.0"
     }
 
     // Bucket4j (local in-process token bucket for RateLimitStore default impl)

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -31,9 +31,13 @@ ARG STIRLING_FLAVOR=proprietary
 ENV STIRLING_FLAVOR=${STIRLING_FLAVOR}
 
 # buildWithFrontend=false → backend-only JAR with API landing page.
-RUN STIRLING_FLAVOR=${STIRLING_FLAVOR} \
+# Bundle only the JPDFium native for this image's target arch (glibc).
+ARG TARGETARCH
+RUN JPDFIUM_PLATFORM="$([ "$TARGETARCH" = arm64 ] && echo linux-arm64 || echo linux-x64)" && \
+    STIRLING_FLAVOR=${STIRLING_FLAVOR} \
     gradle clean build \
       -PbuildWithFrontend=false \
+      -PjpdfiumPlatforms="$JPDFIUM_PLATFORM" \
       -PprototypesMode=${PROTOTYPES_BUILD} \
       -x spotlessApply -x spotlessCheck -x test -x sonarqube \
       --no-daemon

--- a/docker/embedded/Dockerfile
+++ b/docker/embedded/Dockerfile
@@ -43,9 +43,13 @@ ARG PROTOTYPES_BUILD=false
 ARG STIRLING_FLAVOR=proprietary
 ENV STIRLING_FLAVOR=${STIRLING_FLAVOR}
 
-RUN STIRLING_FLAVOR=${STIRLING_FLAVOR} \
+# Bundle only the JPDFium native for this image's target arch (glibc).
+ARG TARGETARCH
+RUN JPDFIUM_PLATFORM="$([ "$TARGETARCH" = arm64 ] && echo linux-arm64 || echo linux-x64)" && \
+    STIRLING_FLAVOR=${STIRLING_FLAVOR} \
     gradle clean build \
       -PbuildWithFrontend=true \
+      -PjpdfiumPlatforms="$JPDFIUM_PLATFORM" \
       -PprototypesMode=${PROTOTYPES_BUILD} \
       -x spotlessApply -x spotlessCheck -x test -x sonarqube \
       --no-daemon

--- a/docker/embedded/Dockerfile.fat
+++ b/docker/embedded/Dockerfile.fat
@@ -40,9 +40,13 @@ RUN gradle dependencies --no-daemon || true
 
 COPY . .
 
-RUN DISABLE_ADDITIONAL_FEATURES=false \
+# Bundle only the JPDFium native for this image's target arch (glibc).
+ARG TARGETARCH
+RUN JPDFIUM_PLATFORM="$([ "$TARGETARCH" = arm64 ] && echo linux-arm64 || echo linux-x64)" && \
+    DISABLE_ADDITIONAL_FEATURES=false \
     gradle clean build \
       -PbuildWithFrontend=true \
+      -PjpdfiumPlatforms="$JPDFIUM_PLATFORM" \
       -x spotlessApply -x spotlessCheck -x test -x sonarqube \
       --no-daemon
 

--- a/docker/embedded/Dockerfile.ultra-lite
+++ b/docker/embedded/Dockerfile.ultra-lite
@@ -39,10 +39,14 @@ RUN ./gradlew dependencies --no-daemon || true
 # Copy entire project
 COPY . .
 
-# Build ultra-lite JAR with embedded frontend (minimal features)
-RUN DISABLE_ADDITIONAL_FEATURES=true \
+# Build ultra-lite JAR with embedded frontend (minimal features).
+# Bundle only the JPDFium musl native for this image's target arch (Alpine).
+ARG TARGETARCH
+RUN JPDFIUM_PLATFORM="$([ "$TARGETARCH" = arm64 ] && echo linux-musl-arm64 || echo linux-musl-x64)" && \
+    DISABLE_ADDITIONAL_FEATURES=true \
     ./gradlew clean build \
       -PbuildWithFrontend=true \
+      -PjpdfiumPlatforms="$JPDFIUM_PLATFORM" \
       -x spotlessApply -x spotlessCheck -x test -x sonarqube \
       --no-daemon
 
@@ -98,7 +102,9 @@ RUN echo "@main https://dl-cdn.alpinelinux.org/alpine/edge/main" | tee -a /etc/a
     bash \
     curl \
     shadow \
-    util-linux && \
+    util-linux \
+    libstdc++ \
+    libgcc && \
     mkdir -p $HOME /configs /logs /customFiles /pipeline/watchedFolders /pipeline/finishedFolders /storage /tmp/stirling-pdf /tmp/stirling-pdf/heap_dumps && \
     mkdir -p /usr/share/fonts/opentype/noto && \
     # User permissions


### PR DESCRIPTION
## ⚠️ Held — blocked on JPDFium 1.1.0

This bumps the JPDFium dependency to **1.1.0**, which is not released yet (tracking: Stirling-Tools/JPDFium#16 adds the musl natives). **Do not merge until JPDFium 1.1.0 is on Maven Central** — the build can't resolve the dependency until then. Keeping it as a draft.

## What this does

**Per-arch native selection in all Docker images (size win).** Today every image bundles all 5 platforms' JPDFium natives (~57 MB) even though a Linux container only uses one. Each Dockerfile now reads Docker's `TARGETARCH` and passes `-PjpdfiumPlatforms=<one platform>` so the image carries only its own arch's native (~11.7 MB). One multi-arch `buildx` command still builds both arches — BuildKit runs them as separate passes and injects `TARGETARCH` per pass.

- `backend`, `embedded` (normal), `embedded.fat` (glibc): `amd64 → linux-x64`, `arm64 → linux-arm64`.
- `ultra-lite` (Alpine/musl): `amd64 → linux-musl-x64`, `arm64 → linux-musl-arm64`, and adds `libstdc++`/`libgcc` for the natives. This is how ultra-lite gets fixed without leaving Alpine (supersedes the abandoned noble-base stopgap).

**`app/common/build.gradle`:** jpdfium `1.0.2 → 1.1.0`; `linux-musl-x64`/`linux-musl-arm64` added as valid `-PjpdfiumPlatforms` values (kept out of `all` so desktop/local builds don't pull musl).

## Validation

- Validated locally: `-PjpdfiumPlatforms` accepts the musl values and rejects unknown ones; the `TARGETARCH → platform` shell mapping is correct for amd64/arm64/empty.
- Full image builds are **pending JPDFium 1.1.0** (dependency can't resolve yet). Once it's released, run `task check` and build each image before merging.
