### PR TITLE
fix: Gitleaks Powershell script on new versions of Powershell

### DIFF
--- a/scripts/pre-commit/install-gitleaks.ps1
+++ b/scripts/pre-commit/install-gitleaks.ps1
@@ -11,17 +11,34 @@ param(
 )
 $ErrorActionPreference = 'Stop'
 
+function Get-Sha256 {
+    param([Parameter(Mandatory)] [string]$Path)
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $hash = $sha256.ComputeHash($stream)
+            return [System.BitConverter]::ToString($hash).Replace('-', '').ToLowerInvariant()
+        } finally {
+            $sha256.Dispose()
+        }
+    } finally {
+        $stream.Dispose()
+    }
+}
+
 if (-not $Sha) {
     throw 'No pinned gitleaks checksum for this platform'
 }
 
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Dest) | Out-Null
 
-$archive = New-TemporaryFile
+$archive = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName() + '.zip')
 $extract = Join-Path $env:TEMP 'gitleaks-extract'
 try {
     Invoke-WebRequest -Uri $Url -OutFile $archive
-    if ((Get-FileHash $archive -Algorithm SHA256).Hash -ne $Sha) {
+    if ((Get-Sha256 $archive) -ne $Sha.ToLowerInvariant()) {
         throw 'gitleaks checksum mismatch'
     }
     Expand-Archive -Force -Path $archive -DestinationPath $extract


### PR DESCRIPTION
# Description of Changes

Closes #6724
Fix #6723

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
