### PR TITLE
Add message when running `task` with no arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For full installation options (including desktop and Kubernetes), see our [Docum
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-This project uses [Task](https://taskfile.dev/) as a unified command runner for all build, dev, and test commands. Run `task install` to get started, or see the [Developer Guide](DeveloperGuide.md) for full details.
+This project uses [Task](https://taskfile.dev/) as a unified command runner for all build, dev, and test commands. Run `task dev` to get started running the editor, run `task` to see the most common commands, or see the [Developer Guide](DeveloperGuide.md) for full details.
 
 For adding translations, see the [Translation Guide](devGuide/HowToAddNewLanguage.md).
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,6 +31,23 @@ includes:
 
 tasks:
   # ============================================================
+  # Help (shown when you run `task` with no arguments)
+  # ============================================================
+
+  default:
+    desc: "List the most common commands"
+    silent: true
+    cmds:
+      - |
+        echo "Common commands (run 'task --list' to see all):"
+        echo ""
+        echo "  task dev            Start backend & frontend on free ports"
+        echo "  task backend:dev    Start backend on default port"
+        echo "  task frontend:dev   Start frontend on default port"
+        echo "  task desktop:dev    Start desktop app"
+        echo "  task check          Quality gate (lint, typecheck, test, etc.)"
+
+  # ============================================================
   # Setup & Prerequisites
   # ============================================================
 


### PR DESCRIPTION
# Description of Changes
Add message describing the most common tasks when running `task` with no arguments. I think this should help newcomers because `task --list` is massive at this point and nobody's going to read through it all. Let me know if you think any other commands should be in the default message.