### PR TITLE
Cache Rust build to improve Tauri build job times

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -115,6 +115,15 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.platform == 'macos-15' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      # Cache the Cargo registry and compiled dependency crates so the build
+      # only recompiles the app crate. Written on main; PRs and the merge queue
+      # restore from it.
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: frontend/editor/src-tauri
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Set up x86_64 JDK 25 (macOS universal JRE)
         if: matrix.platform == 'macos-15'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0


### PR DESCRIPTION
# Description of Changes
The Tauri jobs are very slow, especially the Linux ones, which can take >1hr to build all the necessary code. A lot of that is because of the actual Rust compilation, which isn't cached at all as far as I can tell. This introduces a cache step for the Rust dependencies, so PRs will just reuse the compiled Rust from the last build of main (if it's safe to do so). 