### PR TITLE
Build Rust cache on nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,3 +51,15 @@ jobs:
           name: playwright-nightly-${{ github.run_id }}
           path: frontend/editor/playwright-report/
           retention-days: 14
+
+  # Builds all desktop platforms on a schedule so the Rust dependency cache is
+  # written on main, where PR and merge-queue tauri builds can restore it.
+  warm-tauri-cache:
+    name: Warm Tauri Rust cache
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/tauri-build.yml
+    with:
+      platform: all
+    secrets: inherit

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -123,6 +123,8 @@ jobs:
         with:
           workspaces: frontend/editor/src-tauri
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Save the dependency cache even if a later step fails
+          cache-on-failure: true
 
       - name: Set up x86_64 JDK 25 (macOS universal JRE)
         if: matrix.platform == 'macos-15'

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -122,6 +122,9 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: frontend/editor/src-tauri
+          # Stable key shared across workflows so the nightly warmer. 
+          # rust-cache still appends OS + rustc + Cargo.lock.
+          shared-key: tauri-${{ matrix.name }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
           # Save the dependency cache even if a later step fails
           cache-on-failure: true


### PR DESCRIPTION
# Description of Changes
Rust cache added in #6732 never fired because `main` builds don't include building the desktop apps. We could build them on `main` builds, but that's fairly expensive, so just build them on nightlies instead to warm the cache for any desktop PRs the next day