### PR TITLE
Always use the modern logo in the SaaS build

### DIFF
--- a/frontend/editor/src/saas/hooks/useLogoVariant.ts
+++ b/frontend/editor/src/saas/hooks/useLogoVariant.ts
@@ -1,0 +1,18 @@
+import type { LogoVariant } from "@app/services/preferencesService";
+
+/**
+ * SaaS ships only the modern logo — the classic variant is never shown.
+ *
+ * This shadows the core hook (which resolves the variant from the stored user
+ * preference / server `logoStyle`) so that every logo asset in the SaaS bundle
+ * resolves to the `modern-logo` folder. All logo rendering funnels through this
+ * hook via `useLogoAssets` / `useLogoPath` (favicon, web manifest, apple-touch
+ * icon, wordmark, logo icon, tooltip logo) and the login-carousel slides, so
+ * forcing the variant here is sufficient to keep the classic logo out of SaaS.
+ *
+ * The core variant system is intentionally left intact for the OSS and
+ * proprietary builds.
+ */
+export function useLogoVariant(): LogoVariant {
+  return "modern";
+}


### PR DESCRIPTION
## What

Make the **SaaS** build always use the modern logo, so the classic logo can no longer appear anywhere in the SaaS app.

This is a minimal, SaaS-only alternative to the full classic-logo removal PR (~80 files). **OSS (`core`) and proprietary builds are untouched** — they keep the full modern/classic variant system, including the admin _Logo Style_ picker.

## How

A single SaaS-layer override shadows the core hook:

- `frontend/editor/src/saas/hooks/useLogoVariant.ts` → returns `"modern"` unconditionally.

In the SaaS build the `@app/*` alias cascade resolves `@app/hooks/useLogoVariant` to `src/saas/*` before `src/core/*`, so this shadows the core implementation (which otherwise resolves the variant from the stored user preference or the server `logoStyle`).

## Why one file is enough

All logo rendering funnels through `useLogoVariant()`:

- `useLogoAssets()` → favicon, web manifest, apple-touch icon, wordmark, `logo512`, tooltip logo — consumed by `BrandingAssetManager` (which sets `<link rel="icon|manifest|apple-touch-icon">`), `Wordmark`, `LogoIcon`, `Tooltip`.
- `useLogoPath()` → the no-text logo SVGs.
- The login-carousel slides (`buildLoginSlides`) receive the variant from `AuthLayout`, which calls the hook.

Everything else that references a logo in SaaS already hardcodes `modern-logo` (`index.html`, the SaaS `Login`/`Signup`/`AuthCallback`/`OAuthConsent` routes, cloud onboarding, account/MFA QR logos).

The only hardcoded `classic-logo` reference — the admin _Logo Style_ picker in `AdminGeneralSection` — is **not shipped in SaaS**: `createSaasConfigNavSections` builds from the core nav sections and never includes the proprietary admin sections.

`manifest-classic.json` and the classic assets remain in the shared `public/` folder (served by all builds) but are never referenced in the SaaS bundle.

## Test plan

- [x] `task frontend:typecheck:saas` — clean
- [x] `eslint` on the new file — clean
