### PR TITLE
fix(pre-commit): replace New-TemporaryFile with GetTempFileName on Windows

### DIFF
--- a/scripts/pre-commit/install-gitleaks.ps1
+++ b/scripts/pre-commit/install-gitleaks.ps1
@@ -17,7 +17,7 @@ if (-not $Sha) {
 
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Dest) | Out-Null
 
-$archive = New-TemporaryFile
+$archive = [System.IO.Path]::GetTempFileName()
 $extract = Join-Path $env:TEMP 'gitleaks-extract'
 try {
     Invoke-WebRequest -Uri $Url -OutFile $archive


### PR DESCRIPTION
## Summary

Fixes #6723. Running `task pre-commit` on Windows fails during the `pre-commit:gitleaks-bin` step because `New-TemporaryFile` is not available in all PowerShell environments.

## Changes

- Replaced `New-TemporaryFile` with `[System.IO.Path]::GetTempFileName()` in `scripts/pre-commit/install-gitleaks.ps1`
- `GetTempFileName()` is universally available across all PowerShell versions and Windows configurations

## Testing

- Verified the script runs successfully on Windows PowerShell 5.1 and PowerShell 7+