### PR TITLE
Remove ffmpeg from published Docker images

### DIFF
--- a/.github/aur/stirling-pdf-desktop/PKGBUILD
+++ b/.github/aur/stirling-pdf-desktop/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Stirling PDF Inc <contact@stirlingpdf.com>
 pkgname=stirling-pdf-desktop
-pkgver=2.13.1
+pkgver=2.13.2
 pkgrel=1
 pkgdesc="Locally hosted, web-based PDF manipulation tool (Tauri desktop app, official Stirling PDF Inc build)"
 arch=('x86_64')

--- a/.github/aur/stirling-pdf-server-bin/PKGBUILD
+++ b/.github/aur/stirling-pdf-server-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Stirling PDF Inc <contact@stirlingpdf.com>
 pkgname=stirling-pdf-server-bin
-pkgver=2.13.1
+pkgver=2.13.2
 pkgrel=1
 pkgdesc="Locally hosted, web-based PDF manipulation tool (server JAR, prebuilt)"
 arch=('any')

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -155,9 +155,10 @@ jobs:
           cache-to: type=gha,mode=max,scope=stirling-pdf-latest
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Overrides the Dockerfile ARG default; 1.0.2 base drops the ffmpeg binary (CVEs).
           build-args: |
             VERSION_TAG=${{ steps.versionNumber.outputs.versionNumber }}
-            BASE_VERSION=1.0.0
+            BASE_VERSION=1.0.2
           platforms: linux/amd64,linux/arm64/v8
           provenance: true
           sbom: true

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -155,10 +155,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=stirling-pdf-latest
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Overrides the Dockerfile ARG default; 1.0.2 base drops the ffmpeg binary (CVEs).
+          # No BASE_VERSION pin: inherit the Dockerfile ARG default (single source of truth).
           build-args: |
             VERSION_TAG=${{ steps.versionNumber.outputs.versionNumber }}
-            BASE_VERSION=1.0.2
           platforms: linux/amd64,linux/arm64/v8
           provenance: true
           sbom: true

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ springBoot {
 
 allprojects {
     group = 'stirling.software'
-    version = '2.13.1'
+    version = '2.13.2'
 
     configurations.configureEach {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-tomcat"

--- a/frontend/editor/src-tauri/tauri.conf.json
+++ b/frontend/editor/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Stirling-PDF",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "identifier": "stirling.pdf.dev",
   "build": {
     "frontendDist": "../dist",

--- a/frontend/editor/src/core/testing/serverExperienceSimulations.ts
+++ b/frontend/editor/src/core/testing/serverExperienceSimulations.ts
@@ -38,7 +38,7 @@ const FREE_LICENSE_INFO: LicenseInfo = {
 
 const BASE_NO_LOGIN_CONFIG: AppConfig = {
   enableAnalytics: true,
-  appVersion: "2.13.1",
+  appVersion: "2.13.2",
   serverCertificateEnabled: false,
   enableAlphaFunctionality: false,
   serverPort: 8080,

--- a/frontend/editor/src/proprietary/testing/serverExperienceSimulations.ts
+++ b/frontend/editor/src/proprietary/testing/serverExperienceSimulations.ts
@@ -48,7 +48,7 @@ const FREE_LICENSE_INFO: LicenseInfo = {
 
 const BASE_NO_LOGIN_CONFIG: AppConfig = {
   enableAnalytics: true,
-  appVersion: "2.13.1",
+  appVersion: "2.13.2",
   serverCertificateEnabled: false,
   enableAlphaFunctionality: false,
   enableDesktopInstallSlide: true,


### PR DESCRIPTION
## Summary

Published Docker images (`stirling-pdf:latest`, `:2.13.1`) still shipped the full `ffmpeg` package even though it was disabled in source back in #6053.

**Root cause:** `push-docker.yml` passed a hardcoded `BASE_VERSION=1.0.0` build-arg for the regular image, overriding the Dockerfile's `ARG BASE_VERSION=1.0.2` default. Base `1.0.0` is the original base that still does the explicit `ffmpeg` apt install, so the published image never picked up the removal.
