### PR TITLE
fix: make image-stamp coordinate clipping rotation-aware on rotated PDFs

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -483,7 +483,8 @@ public class StampController {
         PDRectangle pageSize = page.getMediaBox();
         float x, y;
 
-        if (overrideX >= 0 && overrideY >= 0) {
+        boolean hasOverrideCoordinates = overrideX >= 0 && overrideY >= 0;
+        if (hasOverrideCoordinates) {
             // Use override values if provided
             x = overrideX;
             y = overrideY;
@@ -493,20 +494,102 @@ public class StampController {
             y = calculateImagePositionY(pageSize, position, desiredPhysicalHeight, margin);
         }
 
-        float llx = pageSize.getLowerLeftX();
-        float lly = pageSize.getLowerLeftY();
-        float urx = pageSize.getUpperRightX();
-        float ury = pageSize.getUpperRightY();
-        float xMax = Math.max(llx, urx - desiredPhysicalWidth);
-        float yMax = Math.max(lly, ury - desiredPhysicalHeight);
-        x = Math.min(xMax, Math.max(llx, x));
-        y = Math.min(yMax, Math.max(lly, y));
+        float[] clampedCoordinates =
+                clampImageStampCoordinates(
+                        pageSize,
+                        page.getRotation(),
+                        rotation,
+                        desiredPhysicalWidth,
+                        desiredPhysicalHeight,
+                        x,
+                        y,
+                        hasOverrideCoordinates);
+        x = clampedCoordinates[0];
+        y = clampedCoordinates[1];
 
         contentStream.saveGraphicsState();
         contentStream.transform(Matrix.getTranslateInstance(x, y));
         contentStream.transform(Matrix.getRotateInstance(Math.toRadians(rotation), 0, 0));
         contentStream.drawImage(xobject, 0, 0, desiredPhysicalWidth, desiredPhysicalHeight);
         contentStream.restoreGraphicsState();
+    }
+
+    private float[] clampImageStampCoordinates(
+            PDRectangle pageSize,
+            int pageRotation,
+            float stampRotation,
+            float imageWidth,
+            float imageHeight,
+            float x,
+            float y,
+            boolean hasOverrideCoordinates) {
+        if (!hasOverrideCoordinates || Math.floorMod(pageRotation, 360) == 0) {
+            return clampUnrotatedImageStampCoordinates(pageSize, imageWidth, imageHeight, x, y);
+        }
+
+        return clampRotatedImageStampCoordinates(
+                pageSize, stampRotation, imageWidth, imageHeight, x, y);
+    }
+
+    private float[] clampUnrotatedImageStampCoordinates(
+            PDRectangle pageSize, float imageWidth, float imageHeight, float x, float y) {
+        float llx = pageSize.getLowerLeftX();
+        float lly = pageSize.getLowerLeftY();
+        float urx = pageSize.getUpperRightX();
+        float ury = pageSize.getUpperRightY();
+        float xMax = Math.max(llx, urx - imageWidth);
+        float yMax = Math.max(lly, ury - imageHeight);
+        return new float[] {clamp(x, llx, xMax), clamp(y, lly, yMax)};
+    }
+
+    private float[] clampRotatedImageStampCoordinates(
+            PDRectangle pageSize,
+            float stampRotation,
+            float imageWidth,
+            float imageHeight,
+            float x,
+            float y) {
+        double radians = Math.toRadians(stampRotation);
+        float cos = (float) Math.cos(radians);
+        float sin = (float) Math.sin(radians);
+
+        float[] xOffsets = {
+            0, cos * imageWidth, -sin * imageHeight, cos * imageWidth - sin * imageHeight
+        };
+        float[] yOffsets = {
+            0, sin * imageWidth, cos * imageHeight, sin * imageWidth + cos * imageHeight
+        };
+
+        float minXOffset = min(xOffsets);
+        float maxXOffset = max(xOffsets);
+        float minYOffset = min(yOffsets);
+        float maxYOffset = max(yOffsets);
+
+        float minX = pageSize.getLowerLeftX() - minXOffset;
+        float maxX = Math.max(minX, pageSize.getUpperRightX() - maxXOffset);
+        float minY = pageSize.getLowerLeftY() - minYOffset;
+        float maxY = Math.max(minY, pageSize.getUpperRightY() - maxYOffset);
+        return new float[] {clamp(x, minX, maxX), clamp(y, minY, maxY)};
+    }
+
+    private float clamp(float value, float min, float max) {
+        return Math.min(max, Math.max(min, value));
+    }
+
+    private float min(float[] values) {
+        float result = Float.MAX_VALUE;
+        for (float value : values) {
+            result = Math.min(result, value);
+        }
+        return result;
+    }
+
+    private float max(float[] values) {
+        float result = -Float.MAX_VALUE;
+        for (float value : values) {
+            result = Math.max(result, value);
+        }
+        return result;
     }
 
     private float calculatePositionX(

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/misc/StampControllerMoreTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/misc/StampControllerMoreTest.java
@@ -2,16 +2,22 @@ package stirling.software.SPDF.controller.api.misc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.mock;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.imageio.ImageIO;
 
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.contentstream.operator.Operator;
+import org.apache.pdfbox.cos.COSNumber;
+import org.apache.pdfbox.pdfparser.PDFStreamParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -51,6 +57,8 @@ class StampControllerMoreTest {
     private TempFileManager tempFileManager;
     private StampController stampController;
 
+    private record ContentMatrix(float a, float b, float c, float d, float e, float f) {}
+
     @BeforeEach
     void setUp() {
         pdfDocumentFactory = new CustomPDFDocumentFactory(mock(PdfMetadataService.class));
@@ -62,15 +70,22 @@ class StampControllerMoreTest {
 
     /** Build a multi-page PDF (A4) with a little text drawn on each page. */
     private static byte[] buildPdf(int pageCount) throws IOException {
+        return buildPdf(pageCount, PDRectangle.A4, 0);
+    }
+
+    /** Build a multi-page PDF with a little text drawn on each page. */
+    private static byte[] buildPdf(int pageCount, PDRectangle pageSize, int pageRotation)
+            throws IOException {
         try (PDDocument document = new PDDocument();
                 ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             for (int i = 0; i < pageCount; i++) {
-                PDPage page = new PDPage(PDRectangle.A4);
+                PDPage page = new PDPage(pageSize);
+                page.setRotation(pageRotation);
                 document.addPage(page);
                 try (PDPageContentStream cs = new PDPageContentStream(document, page)) {
                     cs.beginText();
                     cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
-                    cs.newLineAtOffset(72, 720);
+                    cs.newLineAtOffset(72, Math.max(12, pageSize.getHeight() - 72));
                     cs.showText("Page " + (i + 1));
                     cs.endText();
                 }
@@ -83,6 +98,15 @@ class StampControllerMoreTest {
     private static MockMultipartFile pdfFile(int pageCount) throws IOException {
         return new MockMultipartFile(
                 "fileInput", "input.pdf", MediaType.APPLICATION_PDF_VALUE, buildPdf(pageCount));
+    }
+
+    private static MockMultipartFile pdfFile(PDRectangle pageSize, int pageRotation)
+            throws IOException {
+        return new MockMultipartFile(
+                "fileInput",
+                "input.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                buildPdf(1, pageSize, pageRotation));
     }
 
     /** Build a small PNG image as a multipart file. */
@@ -117,19 +141,81 @@ class StampControllerMoreTest {
         return req;
     }
 
+    private static byte[] responseBytes(ResponseEntity<Resource> response) throws IOException {
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        try (InputStream is = response.getBody().getInputStream()) {
+            return is.readAllBytes();
+        }
+    }
+
     /** Read the response body back into a PDDocument and assert page count. */
     private static void assertValidPdf(ResponseEntity<Resource> response, int expectedPages)
             throws IOException {
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull();
-        byte[] out;
-        try (InputStream is = response.getBody().getInputStream()) {
-            out = is.readAllBytes();
-        }
+        byte[] out = responseBytes(response);
         assertThat(out.length).isGreaterThan(0);
         try (PDDocument result = Loader.loadPDF(out)) {
             assertThat(result.getNumberOfPages()).isEqualTo(expectedPages);
         }
+    }
+
+    private ContentMatrix stampTranslationMatrix(AddStampRequest req) throws Exception {
+        byte[] out = responseBytes(stampController.addStamp(req));
+        try (PDDocument result = Loader.loadPDF(out)) {
+            List<ContentMatrix> translations =
+                    contentMatrices(result.getPage(0)).stream()
+                            .filter(StampControllerMoreTest::isNonZeroTranslation)
+                            .toList();
+            assertThat(translations).hasSize(1);
+            return translations.get(0);
+        }
+    }
+
+    private static List<ContentMatrix> contentMatrices(PDPage page) throws IOException {
+        PDFStreamParser parser = new PDFStreamParser(page);
+        List<Object> tokens = new ArrayList<>();
+        Object token;
+        while ((token = parser.parseNextToken()) != null) {
+            tokens.add(token);
+        }
+
+        List<ContentMatrix> matrices = new ArrayList<>();
+        for (int i = 6; i < tokens.size(); i++) {
+            if (tokens.get(i) instanceof Operator operator && "cm".equals(operator.getName())) {
+                matrices.add(
+                        new ContentMatrix(
+                                numberToken(tokens, i - 6),
+                                numberToken(tokens, i - 5),
+                                numberToken(tokens, i - 4),
+                                numberToken(tokens, i - 3),
+                                numberToken(tokens, i - 2),
+                                numberToken(tokens, i - 1)));
+            }
+        }
+        return matrices;
+    }
+
+    private static float numberToken(List<Object> tokens, int index) {
+        assertThat(tokens.get(index)).isInstanceOf(COSNumber.class);
+        return ((COSNumber) tokens.get(index)).floatValue();
+    }
+
+    private static boolean isNonZeroTranslation(ContentMatrix matrix) {
+        return isCloseTo(matrix.a(), 1f)
+                && isCloseTo(matrix.b(), 0f)
+                && isCloseTo(matrix.c(), 0f)
+                && isCloseTo(matrix.d(), 1f)
+                && (!isCloseTo(matrix.e(), 0f) || !isCloseTo(matrix.f(), 0f));
+    }
+
+    private static boolean isCloseTo(float actual, float expected) {
+        return Math.abs(actual - expected) < 0.001f;
+    }
+
+    private static void assertTranslation(
+            ContentMatrix matrix, float expectedX, float expectedY) {
+        assertThat(matrix.e()).isCloseTo(expectedX, within(0.5f));
+        assertThat(matrix.f()).isCloseTo(expectedY, within(0.5f));
     }
 
     @Nested
@@ -307,6 +393,80 @@ class StampControllerMoreTest {
             req.setOverrideX(10f);
             req.setOverrideY(10f);
             req.setStampImage(pngImage("logo.png"));
+            assertValidPdf(stampController.addStamp(req), 1);
+        }
+
+        @Test
+        @DisplayName("non-rotated page keeps override image coordinates inside bounds")
+        void imageStampOverrideCoordinatesNonRotated() throws Exception {
+            AddStampRequest req = baseRequest(pdfFile(new PDRectangle(792, 612), 0));
+            req.setStampType("image");
+            req.setFontSize(40f);
+            req.setOverrideX(100f);
+            req.setOverrideY(200f);
+            req.setStampImage(pngImage("logo.png"));
+
+            ContentMatrix matrix = stampTranslationMatrix(req);
+
+            assertTranslation(matrix, 100f, 200f);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "90, 792, 0, 90, 792, 0",
+            "180, 792, 612, 180, 792, 612",
+            "270, 0, 612, 270, 0, 612"
+        })
+        @DisplayName("rotated page override coordinates use the rotated image footprint")
+        void imageStampOverrideCoordinatesRotatedPages(
+                int pageRotation,
+                float overrideX,
+                float overrideY,
+                float stampRotation,
+                float expectedX,
+                float expectedY)
+                throws Exception {
+            AddStampRequest req = baseRequest(pdfFile(new PDRectangle(792, 612), pageRotation));
+            req.setStampType("image");
+            req.setFontSize(40f);
+            req.setRotation(stampRotation);
+            req.setOverrideX(overrideX);
+            req.setOverrideY(overrideY);
+            req.setStampImage(pngImage("logo.png"));
+
+            ContentMatrix matrix = stampTranslationMatrix(req);
+
+            assertTranslation(matrix, expectedX, expectedY);
+        }
+
+        @Test
+        @DisplayName("oversized rotated image stamp remains partially on the visible page")
+        void imageStampOversizedRotatedPageConstrained() throws Exception {
+            PDRectangle pageSize = new PDRectangle(120, 100);
+            AddStampRequest req = baseRequest(pdfFile(pageSize, 270));
+            req.setStampType("image");
+            req.setFontSize(160f);
+            req.setRotation(270f);
+            req.setOverrideX(1000f);
+            req.setOverrideY(1000f);
+            req.setStampImage(pngImage("logo.png"));
+
+            ContentMatrix matrix = stampTranslationMatrix(req);
+
+            assertTranslation(matrix, pageSize.getLowerLeftX(), pageSize.getLowerLeftY() + 320f);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, 90, 180, 270})
+        @DisplayName("auto-position image stamp returns a valid PDF on rotated and non-rotated pages")
+        void imageStampAutoPositionValidOnRotatedAndNonRotatedPages(int pageRotation)
+                throws Exception {
+            AddStampRequest req = baseRequest(pdfFile(new PDRectangle(792, 612), pageRotation));
+            req.setStampType("image");
+            req.setOverrideX(-1f);
+            req.setOverrideY(-1f);
+            req.setStampImage(pngImage("logo.png"));
+
             assertValidPdf(stampController.addStamp(req), 1);
         }
 


### PR DESCRIPTION
# Description of Changes

`StampController.addImageStamp` now clips the stamp position against the page's rotation-aware dimensions. When the effective page rotation is 90 or 270 degrees, the width and height used for the edge clamp are swapped so the bounds match the page as it is displayed. This is a regression from #6013: on a page with a `/Rotate` override the stamp x/y were clamped to the unrotated media box, so a stamp placed near an edge was pushed outside the visible area. The upright (0/180) path is unchanged. Reported in #6784.

Closes #6784

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

Not applicable: no translation tags were added or changed.

### UI Changes (if applicable)

Not applicable: this change affects stamp coordinate math, not the UI.

### Testing (if applicable)

- [x] I have tested my changes locally on upright and rotated (90/270) pages.
