### PR TITLE
fix(settings): resolve interpolation placeholders in settings search results

### DIFF
--- a/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
+++ b/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
@@ -80,13 +80,15 @@ const getTranslationPrefixesForNavKey = (key: string): string[] => {
 };
 
 const normalizeSearchString = (value: string): string => {
-  return value.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_match, rawKey: string) => {
-    const replacement = rawKey.trim();
-    if (typeof replacement === "string" || typeof replacement === "number") {
-      return String(replacement);
-    }
-    return replacement;
-  });
+  return value
+    .replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_match, rawKey: string) => {
+      const replacement = rawKey.trim();
+      if (typeof replacement === "string" || typeof replacement === "number") {
+        return String(replacement);
+      }
+      return replacement;
+    })
+    .replace(/<\/?\d+>/g, "");
 };
 
 const flattenTranslationStrings = (value: unknown): string[] => {

--- a/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
+++ b/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
@@ -82,11 +82,7 @@ const getTranslationPrefixesForNavKey = (key: string): string[] => {
 const normalizeSearchString = (value: string): string => {
   return value
     .replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_match, rawKey: string) => {
-      const replacement = rawKey.trim();
-      if (typeof replacement === "string" || typeof replacement === "number") {
-        return String(replacement);
-      }
-      return replacement;
+      return rawKey.trim();
     })
     .replace(/<\/?\d+>/g, "");
 };

--- a/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
+++ b/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
@@ -79,19 +79,29 @@ const getTranslationPrefixesForNavKey = (key: string): string[] => {
   return Array.from(new Set([...explicitPrefixes, ...inferredPrefixes]));
 };
 
+const normalizeSearchString = (value: string): string => {
+  return value.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_match, rawKey: string) => {
+    const replacement = rawKey.trim();
+    if (typeof replacement === "string" || typeof replacement === "number") {
+      return String(replacement);
+    }
+    return replacement;
+  });
+};
+
 const flattenTranslationStrings = (value: unknown): string[] => {
   if (typeof value === "string") {
-    const trimmed = value.trim();
+    const trimmed = normalizeSearchString(value).trim();
     return trimmed ? [trimmed] : [];
   }
 
   if (Array.isArray(value)) {
-    return value.flatMap(flattenTranslationStrings);
+    return value.flatMap((entry) => flattenTranslationStrings(entry));
   }
 
   if (value && typeof value === "object") {
-    return Object.values(value as Record<string, unknown>).flatMap(
-      flattenTranslationStrings,
+    return Object.values(value as Record<string, unknown>).flatMap((entry) =>
+      flattenTranslationStrings(entry),
     );
   }
 
@@ -138,7 +148,10 @@ export const SettingsSearchBar: React.FC<SettingsSearchBarProps> = ({
           const translationPrefixes = getTranslationPrefixesForNavKey(item.key);
           const translationContent = translationPrefixes.flatMap((prefix) =>
             flattenTranslationStrings(
-              t(prefix, { returnObjects: true, defaultValue: {} } as any),
+              t(prefix, {
+                returnObjects: true,
+                defaultValue: {},
+              } as any),
             ),
           );
 


### PR DESCRIPTION
# Description of Changes

This PR updates the settings search index so translated strings with interpolation markers are turned into readable text instead of showing raw template placeholders.

- What was changed
  - `SettingsSearchBar` now normalizes `{{...}}` markers while flattening translation strings for the search index.
  - Nested translation objects and arrays are still traversed recursively.
  - The search UI itself is unchanged; only the indexed text used for matching is affected.
  - `SettingsSearchBar` reads the active language directly from `useTranslation()` and uses it while normalizing the indexed strings.

- Why the change was made
  - Settings search was surfacing raw translation templates for entries that include interpolation values.
  - This made search results harder to read and made dynamic translation text look broken.
  - The new behavior keeps search useful while preserving the existing translation structure.

before:

<img width="348" height="292" alt="image" src="https://github.com/user-attachments/assets/639c4bf3-426b-4f67-9d3f-482ede0c17db" />

after:
<img width="327" height="271" alt="image" src="https://github.com/user-attachments/assets/042007b8-4264-49f7-a351-d16e3cbb3243" />


---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
