### PR TITLE
Actually build the frontend for Playwright nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Install all Playwright browsers
         run: task e2e:install
 
+      - name: Build frontend (production bundle for vite preview)
+        env:
+          VITE_BUILD_FOR_PREVIEW: "1"
+        run: task frontend:build
+
       - name: Run E2E tests (all browsers)
         run: task e2e:cross-browser
 


### PR DESCRIPTION
# Description of Changes
[Our nightlies have literally never passed before](https://github.com/Stirling-Tools/Stirling-PDF/actions/workflows/nightly.yml). As far as I can tell, that's because the frontend was never being built, so the Playwright tests would just never start up. 

I've forced a nightly run from this branch, and the Playwright tests still fail, but for legitimate failures now. It's a separate job to track down why they're actually failing, so I'm leaving that for followup work.