### PR TITLE
Make image stamp clamp account for stamp rotation

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/StampController.java
@@ -493,20 +493,72 @@ public class StampController {
             y = calculateImagePositionY(pageSize, position, desiredPhysicalHeight, margin);
         }
 
-        float llx = pageSize.getLowerLeftX();
-        float lly = pageSize.getLowerLeftY();
-        float urx = pageSize.getUpperRightX();
-        float ury = pageSize.getUpperRightY();
-        float xMax = Math.max(llx, urx - desiredPhysicalWidth);
-        float yMax = Math.max(lly, ury - desiredPhysicalHeight);
-        x = Math.min(xMax, Math.max(llx, x));
-        y = Math.min(yMax, Math.max(lly, y));
+        // Clamp against the image's actual rotated footprint. The stamp is drawn as
+        // translate(x, y) -> rotate(rotation) -> drawImage(0, 0, w, h), so the bitmap does not
+        // occupy an axis-aligned w x h box when a stamp rotation is applied. Clamping with the raw
+        // w/h (as if rotation were 0) snapped explicit overrideX/overrideY coordinates on rotated
+        // stamps to the wrong corner (issue #6784). For rotation == 0 this reduces to the previous
+        // clamp.
+        float[] clamped =
+                clampImagePosition(
+                        pageSize, x, y, desiredPhysicalWidth, desiredPhysicalHeight, rotation);
+        x = clamped[0];
+        y = clamped[1];
 
         contentStream.saveGraphicsState();
         contentStream.transform(Matrix.getTranslateInstance(x, y));
         contentStream.transform(Matrix.getRotateInstance(Math.toRadians(rotation), 0, 0));
         contentStream.drawImage(xobject, 0, 0, desiredPhysicalWidth, desiredPhysicalHeight);
         contentStream.restoreGraphicsState();
+    }
+
+    /**
+     * Clamp the lower-left stamp anchor so the image stays inside the page bounds, accounting for
+     * the stamp rotation that is applied at draw time.
+     *
+     * <p>The image is rendered as {@code translate(x, y) -> rotate(rotation) -> drawImage(0, 0, w,
+     * h)}, so its footprint in page space is the rotated rectangle, not an axis-aligned {@code w x
+     * h} box. The clamp bounds are derived from the rotated footprint relative to the anchor, then
+     * the anchor is constrained so the whole footprint fits between the media-box edges. When
+     * {@code rotation} is 0 this reduces to clamping {@code [llx, urx - w] x [lly, ury - h]},
+     * matching the previous behaviour.
+     */
+    private float[] clampImagePosition(
+            PDRectangle pageSize, float x, float y, float width, float height, float rotation) {
+        double radians = Math.toRadians(rotation);
+        double cos = Math.cos(radians);
+        double sin = Math.sin(radians);
+
+        float[] cornerX = {0f, width, width, 0f};
+        float[] cornerY = {0f, 0f, height, height};
+        float minX = Float.MAX_VALUE;
+        float maxX = -Float.MAX_VALUE;
+        float minY = Float.MAX_VALUE;
+        float maxY = -Float.MAX_VALUE;
+        for (int i = 0; i < cornerX.length; i++) {
+            float rx = (float) (cornerX[i] * cos - cornerY[i] * sin);
+            float ry = (float) (cornerX[i] * sin + cornerY[i] * cos);
+            minX = Math.min(minX, rx);
+            maxX = Math.max(maxX, rx);
+            minY = Math.min(minY, ry);
+            maxY = Math.max(maxY, ry);
+        }
+
+        float llx = pageSize.getLowerLeftX();
+        float lly = pageSize.getLowerLeftY();
+        float urx = pageSize.getUpperRightX();
+        float ury = pageSize.getUpperRightY();
+
+        // Anchor range that keeps the rotated footprint inside the page. xLo/yLo dominate when the
+        // footprint is wider/taller than the page so the stamp is not pushed off the opposite edge.
+        float xLo = llx - minX;
+        float xHi = urx - maxX;
+        float yLo = lly - minY;
+        float yHi = ury - maxY;
+
+        float clampedX = Math.min(Math.max(x, xLo), Math.max(xLo, xHi));
+        float clampedY = Math.min(Math.max(y, yLo), Math.max(yLo, yHi));
+        return new float[] {clampedX, clampedY};
     }
 
     private float calculatePositionX(

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/misc/StampControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/misc/StampControllerTest.java
@@ -48,6 +48,7 @@ class StampControllerTest {
     private Method processStampTextMethod;
     private Method processCustomDateFormatMethod;
     private Method calculateImagePositionYMethod;
+    private Method clampImagePositionMethod;
 
     @BeforeEach
     void setUp() throws NoSuchMethodException {
@@ -74,6 +75,29 @@ class StampControllerTest {
                         float.class,
                         float.class);
         calculateImagePositionYMethod.setAccessible(true);
+
+        clampImagePositionMethod =
+                StampController.class.getDeclaredMethod(
+                        "clampImagePosition",
+                        PDRectangle.class,
+                        float.class,
+                        float.class,
+                        float.class,
+                        float.class,
+                        float.class);
+        clampImagePositionMethod.setAccessible(true);
+    }
+
+    private float[] invokeClampImagePosition(
+            PDRectangle pageSize, float x, float y, float width, float height, float rotation)
+            throws Exception {
+        try {
+            return (float[])
+                    clampImagePositionMethod.invoke(
+                            stampController, pageSize, x, y, width, height, rotation);
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
     }
 
     private float invokeCalculateImagePositionY(
@@ -144,6 +168,74 @@ class StampControllerTest {
             assertEquals(240f, yMid, 0.001f);
             float yTop = invokeCalculateImagePositionY(page, 3, 20f, 5f);
             assertEquals(375f, yTop, 0.001f);
+        }
+    }
+
+    @Nested
+    @DisplayName("Image stamp clamp (rotation-aware)")
+    class ImageClampTests {
+
+        @Test
+        @DisplayName("Unrotated override is clamped to [llx, urx-w] x [lly, ury-h] as before")
+        void unrotatedClampMatchesPreviousBehaviour() throws Exception {
+            PDRectangle page = new PDRectangle(0, 0, 600, 800);
+            // Inside bounds: left untouched.
+            float[] inside = invokeClampImagePosition(page, 100f, 200f, 50f, 60f, 0f);
+            assertEquals(100f, inside[0], 0.001f);
+            assertEquals(200f, inside[1], 0.001f);
+            // Past top-right: clamped to urx-w / ury-h.
+            float[] outside = invokeClampImagePosition(page, 590f, 790f, 50f, 60f, 0f);
+            assertEquals(550f, outside[0], 0.001f);
+            assertEquals(740f, outside[1], 0.001f);
+            // Below origin: clamped up to llx / lly.
+            float[] below = invokeClampImagePosition(page, -10f, -10f, 50f, 60f, 0f);
+            assertEquals(0f, below[0], 0.001f);
+            assertEquals(0f, below[1], 0.001f);
+        }
+
+        @Test
+        @DisplayName(
+                "Issue #6784 reproduction: 270-degree stamp is not snapped off the bottom edge")
+        void rotated270OverrideIsNotSnapped() throws Exception {
+            // MediaBox 792x612, square 300x300 stamp, overrideX=0 overrideY=612, rotation=270.
+            PDRectangle page = new PDRectangle(0, 0, 792, 612);
+            float[] clamped = invokeClampImagePosition(page, 0f, 612f, 300f, 300f, 270f);
+            // Before the fix y was snapped from 612 down to 312 (ury - h), placing the stamp at the
+            // wrong corner. The rotated footprint actually fits, so the anchor must stay at 612.
+            assertEquals(0f, clamped[0], 0.001f);
+            assertEquals(612f, clamped[1], 0.001f);
+        }
+
+        @Test
+        @DisplayName("90-degree stamp footprint stays inside the page bounds")
+        void rotated90KeepsFootprintOnPage() throws Exception {
+            PDRectangle page = new PDRectangle(0, 0, 600, 800);
+            // rotate(90) maps the rectangle so its footprint relative to the anchor is
+            // x in [-h, 0] and y in [0, w]. Anchor at (0, 800) overflows the left and top edges, so
+            // both axes are pulled in to keep the bitmap on-page.
+            float[] clamped = invokeClampImagePosition(page, 0f, 800f, 100f, 40f, 90f);
+            assertEquals(40f, clamped[0], 0.001f); // llx - minX = 0 - (-40)
+            assertEquals(700f, clamped[1], 0.001f); // ury - maxY = 800 - 100
+        }
+
+        @Test
+        @DisplayName("180-degree stamp footprint stays inside the page bounds")
+        void rotated180KeepsFootprintOnPage() throws Exception {
+            PDRectangle page = new PDRectangle(0, 0, 600, 800);
+            // rotate(180): footprint relative to anchor is x in [-w, 0], y in [-h, 0].
+            float[] clamped = invokeClampImagePosition(page, 10f, 10f, 100f, 40f, 180f);
+            assertEquals(100f, clamped[0], 0.001f); // llx - minX = 0 - (-100)
+            assertEquals(40f, clamped[1], 0.001f); // lly - minY = 0 - (-40)
+        }
+
+        @Test
+        @DisplayName("Honours non-zero media-box origin")
+        void respectsMediaBoxOrigin() throws Exception {
+            PDRectangle page = new PDRectangle(50f, 100f, 400f, 300f);
+            // Far past the upper-right; unrotated clamp -> urx - w, ury - h.
+            float[] clamped = invokeClampImagePosition(page, 1000f, 1000f, 30f, 20f, 0f);
+            assertEquals(420f, clamped[0], 0.001f); // 450 - 30
+            assertEquals(380f, clamped[1], 0.001f); // 400 - 20
         }
     }
 


### PR DESCRIPTION
# Description of Changes

## Summary

Image stamps with explicit `overrideX`/`overrideY` coordinates are no longer snapped to the wrong corner when a stamp rotation is applied. The bounds check that keeps a stamp inside the page now uses the image's actual rotated footprint instead of an axis-aligned box, so rotated stamps land where the requested coordinates put them.

## Why this matters

Reported in #6784: on `POST /api/v1/misc/add-stamp`, an image stamp with `rotation=270`, `overrideX=0`, `overrideY=612` on a 792x612 page should appear at the visual bottom-left, but instead lands near the bottom-right. This worked at `<= v2.8.x` and regressed at `>= v2.9.0`, breaking coordinate-based automation for rotated documents.

Root cause: PR #6013 added a clamp that keeps the stamp inside the media box. The image is drawn as `translate(x, y) -> rotate(rotation) -> drawImage(0, 0, w, h)`, so when a rotation is applied the bitmap occupies a rotated rectangle, not an axis-aligned `w x h` box. The clamp computed its bounds from the raw `w`/`h` as if rotation were zero. For the reported case it treated the image as extending up from `y=612` by 300pt (off-page), so it pushed `y` down from `612` to `312` (`ury - h`), moving the stamp to the wrong corner. The rotated footprint actually fits, so no adjustment was needed.

The fix derives the clamp range from the rotated footprint of the image relative to its anchor, then constrains the anchor so the whole footprint stays between the media-box edges. When `rotation == 0` this reduces to the previous `[llx, urx - w] x [lly, ury - h]` clamp, so unrotated placement is unchanged.

## Testing

`./gradlew :stirling-pdf:test --tests "stirling.software.SPDF.controller.api.misc.StampControllerTest"` (BUILD SUCCESSFUL).

New `ImageClampTests` cover:
- Unrotated overrides clamp to `[llx, urx - w] x [lly, ury - h]` exactly as before (regression guard).
- Issue #6784 reproduction: the `rotation=270` stamp keeps `y=612` instead of being snapped to `312`.
- `rotation=90` and `rotation=180` footprints are pulled back inside the page bounds.
- Non-zero media-box origin is honoured.

Closes #6784

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [x] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
