### PR TITLE
Fix bookmarks and attachments not loading after file switch (#6813)

### DIFF
--- a/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mantine/core";
 import LocalIcon from "@app/components/shared/LocalIcon";
 import { useViewer } from "@app/contexts/ViewerContext";
+import { fetchWithReadyRetry } from "@app/components/viewer/fetchWithReadyRetry";
 import { PdfAttachmentObject } from "@embedpdf/models";
 import AttachmentIcon from "@mui/icons-material/AttachmentRounded";
 import DownloadIcon from "@mui/icons-material/DownloadRounded";
@@ -162,33 +163,7 @@ export const AttachmentSidebar = ({
       }),
     );
 
-    const fetchWithRetry = async () => {
-      const maxAttempts = 10;
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        try {
-          const result = await attachmentActions.getAttachments();
-          return Array.isArray(result) ? result : [];
-        } catch (error: any) {
-          const message =
-            typeof error?.message === "string"
-              ? error.message.toLowerCase()
-              : "";
-          const notReady =
-            message.includes("document") &&
-            message.includes("not") &&
-            message.includes("open");
-
-          if (!notReady || attempt === maxAttempts - 1) {
-            throw error;
-          }
-
-          await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-      }
-      return [];
-    };
-
-    fetchWithRetry()
+    fetchWithReadyRetry(() => attachmentActions.getAttachments())
       .then((attachments) => {
         if (cancelled) return;
         const entry = createEntry({

--- a/frontend/editor/src/core/components/viewer/BookmarkSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/BookmarkSidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mantine/core";
 import LocalIcon from "@app/components/shared/LocalIcon";
 import { useViewer } from "@app/contexts/ViewerContext";
+import { fetchWithReadyRetry } from "@app/components/viewer/fetchWithReadyRetry";
 import { PdfBookmarkObject, PdfActionType } from "@embedpdf/models";
 import BookmarksIcon from "@mui/icons-material/BookmarksRounded";
 import "@app/components/viewer/SidebarBase.css";
@@ -187,33 +188,7 @@ export const BookmarkSidebar = ({
       }),
     );
 
-    const fetchWithRetry = async () => {
-      const maxAttempts = 10;
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        try {
-          const result = await bookmarkActions.fetchBookmarks();
-          return Array.isArray(result) ? result : [];
-        } catch (error: any) {
-          const message =
-            typeof error?.message === "string"
-              ? error.message.toLowerCase()
-              : "";
-          const notReady =
-            message.includes("document") &&
-            message.includes("not") &&
-            message.includes("open");
-
-          if (!notReady || attempt === maxAttempts - 1) {
-            throw error;
-          }
-
-          await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-      }
-      return [];
-    };
-
-    fetchWithRetry()
+    fetchWithReadyRetry(() => bookmarkActions.fetchBookmarks())
       .then((bookmarks) => {
         if (cancelled) return;
         const entry = createEntry({

--- a/frontend/editor/src/core/components/viewer/fetchWithReadyRetry.test.ts
+++ b/frontend/editor/src/core/components/viewer/fetchWithReadyRetry.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for fetchWithReadyRetry.
+ *
+ * Regression coverage for issue #6813: bookmarks/attachments were silently
+ * shown as empty after switching files via the file sidebar. The root cause
+ * was that the viewer bridge returns `null` while the document is still
+ * transitioning, and the sidebars treated that `null` as "loaded, but empty",
+ * caching an empty success that hid the document's real data until a reload.
+ */
+
+import { describe, test, expect, vi } from "vitest";
+import { fetchWithReadyRetry } from "@app/components/viewer/fetchWithReadyRetry";
+
+// Retries with 0ms delay so tests don't wait on real timers.
+const NO_DELAY = { delayMs: 0 };
+
+describe("fetchWithReadyRetry", () => {
+  test("returns the resolved array without retrying when ready", async () => {
+    const fetch = vi.fn().mockResolvedValue([1, 2, 3]);
+
+    const result = await fetchWithReadyRetry(fetch, NO_DELAY);
+
+    expect(result).toEqual([1, 2, 3]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("treats an empty array as a genuine success (document open, no items)", async () => {
+    const fetch = vi.fn().mockResolvedValue([]);
+
+    const result = await fetchWithReadyRetry(fetch, NO_DELAY);
+
+    expect(result).toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries on null (bridge not ready) then returns real data", async () => {
+    // null, null = bridge still transitioning; then the real bookmarks arrive.
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(["bookmark"]);
+
+    const result = await fetchWithReadyRetry(fetch, NO_DELAY);
+
+    expect(result).toEqual(["bookmark"]);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  test("throws (does NOT return empty) when the bridge never becomes ready", async () => {
+    const fetch = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      fetchWithReadyRetry(fetch, { ...NO_DELAY, maxAttempts: 4 }),
+    ).rejects.toThrow();
+    expect(fetch).toHaveBeenCalledTimes(4);
+  });
+
+  test("retries on a 'document not open' error then succeeds", async () => {
+    const fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Document is not open yet"))
+      .mockResolvedValue(["bookmark"]);
+
+    const result = await fetchWithReadyRetry(fetch, NO_DELAY);
+
+    expect(result).toEqual(["bookmark"]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("rethrows non-transient errors immediately without retrying", async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(fetchWithReadyRetry(fetch, NO_DELAY)).rejects.toThrow("boom");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/editor/src/core/components/viewer/fetchWithReadyRetry.ts
+++ b/frontend/editor/src/core/components/viewer/fetchWithReadyRetry.ts
@@ -44,8 +44,8 @@ export async function fetchWithReadyRetry<T>(
   fetch: () => Promise<T[] | null>,
   options: FetchWithReadyRetryOptions = {},
 ): Promise<T[]> {
-  const maxAttempts = options.maxAttempts ?? 20;
-  const delayMs = options.delayMs ?? 50;
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 20);
+  const delayMs = Math.max(0, options.delayMs ?? 50);
   const isNotReadyError = options.isNotReadyError ?? defaultIsNotReadyError;
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {

--- a/frontend/editor/src/core/components/viewer/fetchWithReadyRetry.ts
+++ b/frontend/editor/src/core/components/viewer/fetchWithReadyRetry.ts
@@ -1,0 +1,74 @@
+/**
+ * Repeatedly invokes a viewer-bridge fetch until it returns real data.
+ *
+ * The viewer bridges (bookmarks, attachments) return `null` while a document is
+ * still transitioning — e.g. when switching files from the file sidebar, the
+ * EmbedPDF viewer remounts (its `key` changes) and the bridge briefly
+ * unregisters before the new document is ready. During that window the fetch
+ * resolves to `null`.
+ *
+ * A `null` result must NOT be treated as "loaded, but empty": doing so caches an
+ * empty success for the document and the sidebars never re-fetch, so the real
+ * bookmarks/attachments stay hidden until a full reload (issue #6813). Instead
+ * we retry until the bridge is ready, then return its data. If the bridge never
+ * becomes ready within the budget we throw, so the caller records a recoverable
+ * error (with a Retry affordance) rather than a misleading empty success.
+ *
+ * Transient "document not open" errors thrown by the underlying plugin are
+ * retried the same way; any other error is rethrown immediately.
+ */
+
+export interface FetchWithReadyRetryOptions {
+  /** Total number of attempts before giving up. */
+  maxAttempts?: number;
+  /** Delay between attempts, in milliseconds. */
+  delayMs?: number;
+  /** Classifies an error as a transient "not ready yet" error worth retrying. */
+  isNotReadyError?: (error: unknown) => boolean;
+}
+
+const defaultIsNotReadyError = (error: unknown): boolean => {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error ?? "");
+  return (
+    message.includes("document") &&
+    message.includes("not") &&
+    message.includes("open")
+  );
+};
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function fetchWithReadyRetry<T>(
+  fetch: () => Promise<T[] | null>,
+  options: FetchWithReadyRetryOptions = {},
+): Promise<T[]> {
+  const maxAttempts = options.maxAttempts ?? 20;
+  const delayMs = options.delayMs ?? 50;
+  const isNotReadyError = options.isNotReadyError ?? defaultIsNotReadyError;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const result = await fetch();
+
+      // `null` = bridge/document not ready yet. Retry instead of caching empty.
+      if (result === null) {
+        if (attempt === maxAttempts - 1) {
+          throw new Error("Viewer bridge not ready");
+        }
+        await delay(delayMs);
+        continue;
+      }
+
+      return result;
+    } catch (error) {
+      if (!isNotReadyError(error) || attempt === maxAttempts - 1) {
+        throw error;
+      }
+      await delay(delayMs);
+    }
+  }
+
+  return [];
+}


### PR DESCRIPTION
# Description of Changes

**What was changed**
- Fixed bookmarks and attachments showing as empty after switching files via the
  left file sidebar (they loaded correctly only via the "Active files" tab).
- Added a shared helper `fetchWithReadyRetry` (in `core/components/viewer/`) and
  refactored `BookmarkSidebar` and `AttachmentSidebar` to use it, removing the
  duplicated retry logic.

**Why**
The bookmark/attachment bridges live inside `<LocalEmbedPDF key={fileId}>`. When
you switch files while already in the viewer, `LocalEmbedPDF` remounts and the
bridge briefly unregisters. During that window `fetchBookmarks()/getAttachments()`
resolve to `null` ("not ready yet"). The sidebars coerced that `null` to an empty
array (`Array.isArray(result) ? result : []`) and cached it as a successful empty
result — and the re-fetch guard never retrieanels
stayed empty until a full page reload. The "Active files" path mounts the viewer
fresh and waits for the bridge, which is why it was unaffected.

The fix treats `null` (bridge not ready) distinctly from `[]` (document open, no
items): it retries until the bridge is ready, and if it never becomes ready within
the budget it throws, so the caller records r state
(with a Retry button) instead of a misleading empty success.

**Challenges**
The two navigation paths behaving differently was the key clue — it pointed to a
mount/timing race rather than a data problem.

Closes #6813

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

<img width="1607" height="578" alt="Screenshot 2026-06-29 030449" src="https://github.com/user-attachments/assets/5789d8a0-eb61-47b5-9cc9-f941d58f2cc5" />

<img width="1606" height="408" alt="Screenshot 2026-06-29 034054" src="https://github.com/user-attachments/assets/9d0ca925-3a76-4cc1-aeed-4e71f62b1224" />

<img width="1615" height="567" alt="Screenshot 2026-06-29 034149" src="https://github.com/user-attachments/assets/dcfc26e3-5b6e-4c47-8df5-69051b031a13" />
