### PR TITLE
Support translations in Storybook: initialize i18n with bundled resources

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -32,11 +32,15 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     // Wire @portal/* and @shared/* aliases directly on the Storybook bundler so
     // portal story imports resolve without needing the portal's vite config.
+    // @portal-locales and @editor-locales cover the public/locales directories
+    // used by preview.tsx to bundle translation TOML files via ?raw imports.
     config.resolve = config.resolve ?? {};
     config.resolve.alias = {
       ...(config.resolve.alias ?? {}),
       "@portal": resolve(__dirname, "../portal/src"),
       "@shared": resolve(__dirname, "../shared"),
+      "@portal-locales": resolve(__dirname, "../portal/public/locales"),
+      "@editor-locales": resolve(__dirname, "../editor/public/locales"),
     };
     // Editor stories import via @app/* (proprietary→core fallback), @core/* and
     // @proprietary/*. Resolve them exactly the way the editor's own build does —

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -20,10 +20,10 @@ void React;
 // This avoids HTTP fetches in Storybook (no backend URL needed) and sidesteps
 // the static-dir conflict that would arise from both portal and editor serving
 // files at the same /locales/ path.
-// @ts-ignore — ?raw is a Vite-only import suffix; tsc doesn't know the type.
-import portalEnUS from "../portal/public/locales/en-US/translation.toml?raw";
-// @ts-ignore
-import editorEnUS from "../editor/public/locales/en-US/translation.toml?raw";
+// @ts-expect-error — ?raw is a Vite-only import suffix; tsc doesn't know the type.
+import portalEnUS from "@portal-locales/en-US/translation.toml?raw";
+// @ts-expect-error — ?raw is a Vite-only import suffix; tsc doesn't know the type.
+import editorEnUS from "@editor-locales/en-US/translation.toml?raw";
 
 i18n.use(initReactI18next).init({
   lng: "en-US",

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -8,10 +8,38 @@ import { initialize, mswLoader } from "msw-storybook-addon";
 import { MemoryRouter } from "react-router-dom";
 import { withThemeByDataAttribute } from "@storybook/addon-themes";
 import { MantineProvider } from "@mantine/core";
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import { parse } from "smol-toml";
 
 // Reference React so the import isn't dropped as unused by the bundler — the
 // classic runtime needs it present even though it's not named in the JSX.
 void React;
+
+// Import translation files as raw strings so Vite bundles them at build time.
+// This avoids HTTP fetches in Storybook (no backend URL needed) and sidesteps
+// the static-dir conflict that would arise from both portal and editor serving
+// files at the same /locales/ path.
+// @ts-ignore — ?raw is a Vite-only import suffix; tsc doesn't know the type.
+import portalEnUS from "../portal/public/locales/en-US/translation.toml?raw";
+// @ts-ignore
+import editorEnUS from "../editor/public/locales/en-US/translation.toml?raw";
+
+i18n.use(initReactI18next).init({
+  lng: "en-US",
+  fallbackLng: "en-US",
+  resources: {
+    "en-US": {
+      translation: {
+        ...(parse(portalEnUS as string) as Record<string, unknown>),
+        ...(parse(editorEnUS as string) as Record<string, unknown>),
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+  // Resources are bundled synchronously — no async backend fetch.
+  react: { useSuspense: false },
+});
 
 import { TierProvider, type Tier } from "@portal/contexts/TierContext";
 import { LinkProvider, type LinkState } from "@portal/contexts/LinkContext";


### PR DESCRIPTION
## What

Initializes i18next in the Storybook preview with bundled en-US translations so portal and editor components render real strings instead of raw keys.

## Why

Portal and editor components use `useTranslation()` without inline fallback strings. Without an initialized i18next instance, stories rendered raw keys like `accountLink.card.eyebrow`, breaking layout and making stories visually useless.

## How

Import the en-US TOML files via Vite's `?raw` suffix so they are bundled at build time. Parse them with `smol-toml` and initialize i18next with inline resources — no HTTP fetch, no static-dir conflict between portal and editor both serving `/locales/`, and synchronous init so no Suspense boundary is needed.