### PR TITLE
Fix rearrange-pages DUPLICATE producing shared page nodes (pypdf cyclic-references CI break)

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/RearrangePagesPDFController.java
@@ -3,9 +3,12 @@ package stirling.software.SPDF.controller.api;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
+import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
@@ -261,10 +264,19 @@ public class RearrangePagesPDFController {
                 log.info("newPageOrder = {}", newPageOrder);
                 log.info("totalPages = {}", totalPages);
 
-                // Snapshot the desired pages before mutating the source document's page tree.
+                // Snapshot desired pages before mutating the tree; clone repeats (e.g. DUPLICATE)
+                // so each slot is a distinct node, not one PDPage under multiple /Kids.
                 List<PDPage> newPages = new ArrayList<>(newPageOrder.size());
+                Set<Integer> seenIndices = new HashSet<>();
                 for (Integer idx : newPageOrder) {
-                    newPages.add(document.getPage(idx));
+                    PDPage page = document.getPage(idx);
+                    if (!seenIndices.add(idx)) {
+                        // Duplicate index: distinct page node sharing content/resources.
+                        COSDictionary clonedDict = new COSDictionary();
+                        clonedDict.addAll(page.getCOSObject());
+                        page = new PDPage(clonedDict);
+                    }
+                    newPages.add(page);
                 }
 
                 // Rearrange in-place on the source document rather than copying pages into a

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/RearrangePagesPDFControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/RearrangePagesPDFControllerTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.pdfbox.Loader;
@@ -302,6 +303,11 @@ class RearrangePagesPDFControllerTest {
             assertNotNull(response);
             // 2 pages * 3 duplicates = 6 final pages
             assertEquals(6, realDoc.getNumberOfPages());
+            // Each duplicate must be a distinct page node in the saved output; a shared
+            // node under multiple /Kids is an invalid tree readers reject as cyclic.
+            List<Object> savedPages = reloadAndSnapshot(response);
+            assertEquals(6, savedPages.size());
+            assertEquals(6, new HashSet<>(savedPages).size());
         }
     }
 

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/RearrangePagesPDFControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/RearrangePagesPDFControllerTest.java
@@ -329,4 +329,29 @@ class RearrangePagesPDFControllerTest {
             assertEquals(4, realDoc.getNumberOfPages());
         }
     }
+
+    @Test
+    void testRearrangePages_SideStitchBooklet_RepeatedPaddingPagesAreDistinctNodes()
+            throws IOException {
+        MockMultipartFile file = createMockPdf();
+        RearrangePagesRequest request = new RearrangePagesRequest();
+        request.setFileInput(file);
+        request.setPageNumbers("");
+        request.setCustomMode("SIDE_STITCH_BOOKLET_SORT");
+
+        // 6 pages is not a multiple of 4, so booklet padding repeats the last page index
+        // several times; each repeat must be a distinct page node, not one shared node.
+        try (PDDocument realDoc = buildRealPdf(6)) {
+            when(pdfDocumentFactory.load(file)).thenReturn(realDoc);
+
+            ResponseEntity<Resource> response = controller.rearrangePages(request);
+
+            assertNotNull(response);
+            assertEquals(200, response.getStatusCode().value());
+            assertEquals(8, realDoc.getNumberOfPages());
+            List<Object> savedPages = reloadAndSnapshot(response);
+            assertEquals(8, savedPages.size());
+            assertEquals(8, new HashSet<>(savedPages).size());
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`docker-compose-tests` is red on `main` (and on every open PR rebased past it) since #6831 bumped the cucumber test `pypdf` to 6.13.3. The single failing scenario is:

```
features/general_new.feature:91  rearrange-pages customMode=DUPLICATE  (4 pages -> 8)
  pypdf.errors.PdfReadError: Detected cyclic page references.
```

pypdf 6.13.3 tightened its page-tree walk to reject a page node that appears more than once in the tree. `rearrange-pages` DUPLICATE mode produced exactly that: after the in-place-rearrange refactor (the PDFBOX-6203 cross-doc-copy workaround), it added the **same** `PDPage` object multiple times, so one page dictionary sat under multiple `/Kids`. PDFBox tolerated it on write; pypdf 6.13.3 no longer does. This is not a regression in any feature PR - it is broken-on-main, surfaced by the dependency bump (the `pypdf-6.13.3` dependabot run failed this same job before it was merged).

## Fix

When a page index repeats, clone its dictionary (`new COSDictionary` + `addAll`) so each occurrence is a distinct page node that still shares the underlying content/resources - no data bloat, spec-valid output. Non-duplicate rearrange paths are byte-for-byte unchanged (the clone only fires on a repeated index).

## Test

Extended `testRearrangePages_Duplicate` to reload the saved PDF and assert all 6 page objects are distinct - the exact invariant pypdf enforces.

## Verification

- With fix: `:stirling-pdf:test` -> 11 tests, 0 failures.
- Reverted the controller fix: the new assertion fails at line 310, proving the guard has teeth.
- `spotlessApply` + `spotlessCheck` clean.