### PR TITLE
fix(chat): prevent focus from landing inside hidden FAB panel

### DIFF
--- a/frontend/editor/src/proprietary/components/chat/ChatFAB.tsx
+++ b/frontend/editor/src/proprietary/components/chat/ChatFAB.tsx
@@ -49,6 +49,7 @@ export function ChatFAB() {
   // Scope the panel's nested MantineProvider to this ref; unscoped it writes
   // its color scheme onto <html> and overrides the whole app's theme.
   const panelThemeRootRef = useRef<HTMLDivElement>(null);
+  const triggerButtonRef = useRef<HTMLButtonElement>(null);
   const { colorScheme } = useMantineColorScheme();
   const panelColorScheme = colorScheme === "dark" ? "dark" : "light";
 
@@ -92,6 +93,22 @@ export function ChatFAB() {
     const el = overlayRef.current;
     if (!el) return null;
     return defaultPanelPos(el.offsetWidth, el.offsetHeight);
+  };
+
+  const closePanel = () => {
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof HTMLElement &&
+      activeElement !== document.body
+    ) {
+      activeElement.blur();
+    }
+
+    setIsOpen(false);
+
+    requestAnimationFrame(() => {
+      triggerButtonRef.current?.focus();
+    });
   };
 
   useLayoutEffect(() => {
@@ -172,6 +189,7 @@ export function ChatFAB() {
     >
       {/* Trigger button — fades out while panel is open */}
       <ChatFABButton
+        ref={triggerButtonRef}
         className={`chat-fab-trigger${isOpen ? " chat-fab-trigger--hidden" : ""}`}
         onClick={() => {
           // Fallback: ensure a position exists before opening, in case the
@@ -232,18 +250,20 @@ export function ChatFAB() {
           }}
         >
           <ChatFABWindow open={isOpen} onDoubleClick={handleHeaderDoubleClick}>
-            <MantineProvider
-              theme={FAB_PANEL_THEME}
-              getRootElement={() => panelThemeRootRef.current ?? undefined}
-              forceColorScheme={panelColorScheme}
-            >
-              <div ref={panelThemeRootRef} style={{ display: "contents" }}>
-                <ChatPanel
-                  onBack={() => setIsOpen(false)}
-                  backLabel={t("chat.fab.close", "Close chat")}
-                />
-              </div>
-            </MantineProvider>
+            {isOpen && (
+              <MantineProvider
+                theme={FAB_PANEL_THEME}
+                getRootElement={() => panelThemeRootRef.current ?? undefined}
+                forceColorScheme={panelColorScheme}
+              >
+                <div ref={panelThemeRootRef} style={{ display: "contents" }}>
+                  <ChatPanel
+                    onBack={closePanel}
+                    backLabel={t("chat.fab.close", "Close chat")}
+                  />
+                </div>
+              </MantineProvider>
+            )}
           </ChatFABWindow>
         </Rnd>
       )}

--- a/frontend/shared/components/ChatFABButton.tsx
+++ b/frontend/shared/components/ChatFABButton.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes } from "react";
+import { forwardRef, type ButtonHTMLAttributes } from "react";
 import "@shared/components/ChatFABButton.css";
 
 export interface ChatFABButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -8,59 +8,59 @@ export interface ChatFABButtonProps extends ButtonHTMLAttributes<HTMLButtonEleme
   showTick?: boolean;
 }
 
-export function ChatFABButton({
-  isLoading = false,
-  showTick = false,
-  className,
-  ...rest
-}: ChatFABButtonProps) {
-  const classes = [
-    "chat-fab-btn",
-    isLoading ? "chat-fab-btn--loading" : "",
-    showTick ? "chat-fab-btn--tick" : "",
-    className ?? "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+export const ChatFABButton = forwardRef<HTMLButtonElement, ChatFABButtonProps>(
+  function ChatFABButton(
+    { isLoading = false, showTick = false, className, ...rest },
+    ref,
+  ) {
+    const classes = [
+      "chat-fab-btn",
+      isLoading ? "chat-fab-btn--loading" : "",
+      showTick ? "chat-fab-btn--tick" : "",
+      className ?? "",
+    ]
+      .filter(Boolean)
+      .join(" ");
 
-  return (
-    <button type="button" className={classes} {...rest}>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width={28}
-        height={28}
-        viewBox="0 0 192 192"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          d="M68.48 102.4 L184.73 6.45 L184.73 96.05 L68.48 192 Z"
-          opacity="0.7"
-        />
-        <path d="M7.26 95.83 L123.37 0 L123.37 89.5 L7.26 185.33 Z" />
-      </svg>
-      {isLoading && !showTick && (
-        <span className="chat-fab-btn__pulse" aria-hidden="true" />
-      )}
-      {showTick && (
-        <span className="chat-fab-btn__tick" aria-hidden="true">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width={10}
-            height={10}
-            viewBox="0 0 10 10"
-            fill="none"
-          >
-            <path
-              d="M2 5l2 2 4-4"
-              stroke="#fff"
-              strokeWidth={1.6}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </span>
-      )}
-    </button>
-  );
-}
+    return (
+      <button ref={ref} type="button" className={classes} {...rest}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={28}
+          height={28}
+          viewBox="0 0 192 192"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M68.48 102.4 L184.73 6.45 L184.73 96.05 L68.48 192 Z"
+            opacity="0.7"
+          />
+          <path d="M7.26 95.83 L123.37 0 L123.37 89.5 L7.26 185.33 Z" />
+        </svg>
+        {isLoading && !showTick && (
+          <span className="chat-fab-btn__pulse" aria-hidden="true" />
+        )}
+        {showTick && (
+          <span className="chat-fab-btn__tick" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width={10}
+              height={10}
+              viewBox="0 0 10 10"
+              fill="none"
+            >
+              <path
+                d="M2 5l2 2 4-4"
+                stroke="#fff"
+                strokeWidth={1.6}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
+        )}
+      </button>
+    );
+  },
+);


### PR DESCRIPTION
# Description of Changes

- Changed the chat FAB so the panel content is mounted only while the window is open.
- Kept the floating window shell animated, but removed the hidden textarea from the DOM when closed.
- Added ref forwarding to `ChatFABButton` so focus can be returned to the trigger after closing the panel.
- Kept the close flow explicit so keyboard focus is moved out before the panel hides.

Why this change was made:

- The browser was warning that `aria-hidden` was being applied to a container while its textarea descendant still had focus.
- That broke accessibility expectations and created noisy console warnings during normal chat close/open interactions.
- Mounting the chat panel only when open removes the hidden-focused-descendant state entirely.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
