### PR TITLE
Generate frontend license report on push

### DIFF
--- a/.github/workflows/frontend-backend-licenses-update.yml
+++ b/.github/workflows/frontend-backend-licenses-update.yml
@@ -98,6 +98,13 @@ jobs:
 
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+
+      - name: Generate frontend license report (Push only)
+        if: github.event_name == 'push'
+        env:
+          PR_IS_FORK: "false"
+        run: task frontend:licenses:generate
+
       - name: Generate frontend license report (internal PR)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         env:
@@ -353,6 +360,7 @@ jobs:
 
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+
       - name: Check licenses and generate report
         id: license-check
         run: task backend:licenses:generate || echo "LICENSE_CHECK_FAILED=true" >> $GITHUB_ENV

--- a/app/allowed-licenses.json
+++ b/app/allowed-licenses.json
@@ -174,6 +174,14 @@
     },
     {
       "moduleName": ".*",
+      "moduleLicense": "EPL-2.0"
+    },
+    {
+      "moduleName": ".*",
+      "moduleLicense": "LGPL-2.1-only"
+    },
+    {
+      "moduleName": ".*",
       "moduleLicense": "Ubuntu Font Licence 1.0"
     },
     {

--- a/app/allowed-licenses.json
+++ b/app/allowed-licenses.json
@@ -82,6 +82,10 @@
     },
     {
       "moduleName": ".*",
+      "moduleLicense": "Apache License version 2.0"
+    },
+    {
+      "moduleName": ".*",
       "moduleLicense": "Apache License, Version 2.0"
     },
     {
@@ -107,6 +111,10 @@
     {
       "moduleName": ".*",
       "moduleLicense": "Mozilla Public License 2.0 (MPL-2.0)"
+    },
+    {
+      "moduleName": ".*",
+      "moduleLicense": "Mozilla Public License Version 2.0"
     },
     {
       "moduleName": ".*",

--- a/app/allowed-licenses.json
+++ b/app/allowed-licenses.json
@@ -90,6 +90,10 @@
     },
     {
       "moduleName": ".*",
+      "moduleLicense": "Apache License, version 2.0"
+    },
+    {
+      "moduleName": ".*",
       "moduleLicense": "The Apache License, Version 2.0"
     },
     {


### PR DESCRIPTION
# Description of Changes

`app/allowed-licenses.json` has been modified in preparation for when "org.springframework.boot" is upgraded to version "4.0.7".

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
