### PR TITLE
Fix tooltip positioning on Add Page Numbers

### DIFF
--- a/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings.tsx
@@ -27,6 +27,7 @@ const AddPageNumbersAppearanceSettings = ({
   return (
     <Stack gap="md">
       <Tooltip
+        position="left"
         content={t(
           "marginTooltip",
           "Distance between the page number and the edge of the page.",
@@ -56,6 +57,7 @@ const AddPageNumbersAppearanceSettings = ({
       </Tooltip>
 
       <Tooltip
+        position="left"
         content={t(
           "fontSizeTooltip",
           "Size of the page number text in points. Larger numbers create bigger text.",
@@ -73,6 +75,7 @@ const AddPageNumbersAppearanceSettings = ({
       </Tooltip>
 
       <Tooltip
+        position="left"
         content={t(
           "addPageNumbers.zeroPadTooltip",
           "Zero-pad (Bates Stamp) page numbers to this width (e.g. 3 => 001). Set 0 to disable.",
@@ -90,6 +93,7 @@ const AddPageNumbersAppearanceSettings = ({
       </Tooltip>
 
       <Tooltip
+        position="left"
         content={t(
           "fontTypeTooltip",
           "Font family for the page numbers. Choose based on your document style.",
@@ -118,6 +122,7 @@ const AddPageNumbersAppearanceSettings = ({
       </Tooltip>
 
       <Tooltip
+        position="left"
         content={t(
           "customTextTooltip",
           'Optional custom format for page numbers. Use {n} as placeholder for the number. Example: "Page {n}" will show "Page 1", "Page 2", etc.',

--- a/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersPositionSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersPositionSettings.tsx
@@ -49,6 +49,7 @@ const AddPageNumbersPositionSettings = ({
         </Text>
 
         <Tooltip
+          position="left"
           content={t(
             "pageSelectionPrompt",
             "Custom Page Selection (Enter a comma-separated list of page numbers 1,5,6 or Functions like 2n+1)",
@@ -69,6 +70,7 @@ const AddPageNumbersPositionSettings = ({
         </Tooltip>
 
         <Tooltip
+          position="left"
           content={t(
             "startingNumberTooltip",
             "The first number to display. Subsequent pages will increment from this number.",


### PR DESCRIPTION
# Description of Changes
## Before

<img width="483" height="227" alt="image" src="https://github.com/user-attachments/assets/4bf86eec-a9cc-4f63-84f0-4eb2bd535bab" />

## After

<img width="732" height="235" alt="image" src="https://github.com/user-attachments/assets/101d2ea4-36e8-4e8f-990a-d72b33fa0ac2" />
