### PR TITLE
Scope ADMINS_AND_TEAM_LEADS default access to the resource's owning team

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/access/service/OwnershipService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/access/service/OwnershipService.java
@@ -37,6 +37,7 @@ public class OwnershipService {
                 type,
                 String.valueOf(resource.getId()),
                 resource.getOwnerUserId(),
+                resource.getOwnerTeamId(),
                 resource.getDefaultAccess(),
                 user);
     }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/access/service/ResourceAccessService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/access/service/ResourceAccessService.java
@@ -37,7 +37,8 @@ public class ResourceAccessService {
 
     /** Whether the user may use the portal / processor. */
     public boolean canAccessPortal(User user) {
-        return canUseResource(ResourceType.PORTAL, "", null, portalDefaultPolicy, user);
+        // Server-wide resource: no owning team, so the team-lead default admits any lead.
+        return canUseResource(ResourceType.PORTAL, "", null, null, portalDefaultPolicy, user);
     }
 
     /** Whether the user may use a resource, falling back to its default policy. */
@@ -45,6 +46,7 @@ public class ResourceAccessService {
             ResourceType type,
             String resourceId,
             Long ownerUserId,
+            Long ownerTeamId,
             DefaultAccessPolicy defaultPolicy,
             User user) {
         if (user == null) {
@@ -56,7 +58,7 @@ public class ResourceAccessService {
         if (hasGrant(type, normalize(resourceId), user, AccessPermission.USE)) {
             return true;
         }
-        return matchesDefault(defaultPolicy, user);
+        return matchesDefault(defaultPolicy, ownerTeamId, user);
     }
 
     /** Whether the user may manage (edit/delete/share) a resource. No default-policy fallback. */
@@ -161,14 +163,19 @@ public class ResourceAccessService {
         return held == AccessPermission.MANAGE;
     }
 
-    private boolean matchesDefault(DefaultAccessPolicy policy, User user) {
+    private boolean matchesDefault(DefaultAccessPolicy policy, Long ownerTeamId, User user) {
         if (policy == null) {
             return false;
         }
         return switch (policy) {
             case ORG_ALL -> true;
-            // Admins already pass above; only team leads here.
-            case ADMINS_AND_TEAM_LEADS -> teamLeadLookup.isAnyTeamLeader(user);
+            // Admins already pass above. For a team-owned resource only a lead OF THAT team
+            // qualifies — "any team leader" would let team A's lead use team B's resource. A
+            // resource with no owning team (portal / server-scoped) admits any team lead.
+            case ADMINS_AND_TEAM_LEADS ->
+                    ownerTeamId == null
+                            ? teamLeadLookup.isAnyTeamLeader(user)
+                            : teamLeadLookup.isLeaderOfTeam(user, ownerTeamId);
             case EXPLICIT_ONLY -> false;
         };
     }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/access/service/OwnershipServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/access/service/OwnershipServiceTest.java
@@ -120,7 +120,8 @@ class OwnershipServiceTest {
     void enabledResourceUseDelegatesToTheAcl() {
         TestResource r = new TestResource(1L);
         User user = user(7);
-        when(accessService.canUseResource(any(), any(), any(), any(), any())).thenReturn(true);
+        when(accessService.canUseResource(any(), any(), any(), any(), any(), any()))
+                .thenReturn(true);
 
         assertThat(ownership.canUse(TYPE, r, user)).isTrue();
     }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/access/service/ResourceAccessServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/access/service/ResourceAccessServiceTest.java
@@ -47,7 +47,7 @@ class ResourceAccessServiceTest {
     void adminMayUseEvenWithExplicitOnlyAndNoGrants() {
         assertThat(
                         service.canUseResource(
-                                TYPE, RID, null, DefaultAccessPolicy.EXPLICIT_ONLY, admin(1)))
+                                TYPE, RID, null, null, DefaultAccessPolicy.EXPLICIT_ONLY, admin(1)))
                 .isTrue();
     }
 
@@ -55,13 +55,13 @@ class ResourceAccessServiceTest {
     void ownerMayUseEvenWithExplicitOnly() {
         assertThat(
                         service.canUseResource(
-                                TYPE, RID, 5L, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
+                                TYPE, RID, 5L, null, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
                 .isTrue();
     }
 
     @Test
     void nullUserIsAlwaysDenied() {
-        assertThat(service.canUseResource(TYPE, RID, 5L, DefaultAccessPolicy.ORG_ALL, null))
+        assertThat(service.canUseResource(TYPE, RID, 5L, null, DefaultAccessPolicy.ORG_ALL, null))
                 .isFalse();
         assertThat(service.canManageResource(TYPE, RID, 5L, null)).isFalse();
     }
@@ -73,7 +73,7 @@ class ResourceAccessServiceTest {
         stubGrants(grant(PrincipalType.USER, 5L, AccessPermission.USE));
         assertThat(
                         service.canUseResource(
-                                TYPE, RID, null, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
+                                TYPE, RID, null, null, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
                 .isTrue();
     }
 
@@ -84,6 +84,7 @@ class ResourceAccessServiceTest {
                         service.canUseResource(
                                 TYPE,
                                 RID,
+                                null,
                                 null,
                                 DefaultAccessPolicy.EXPLICIT_ONLY,
                                 userInTeam(5, 7)))
@@ -98,6 +99,7 @@ class ResourceAccessServiceTest {
                                 TYPE,
                                 RID,
                                 null,
+                                null,
                                 DefaultAccessPolicy.EXPLICIT_ONLY,
                                 userInTeam(5, 99)))
                 .isFalse();
@@ -108,7 +110,7 @@ class ResourceAccessServiceTest {
         stubGrants(grant(PrincipalType.USER, 5L, AccessPermission.MANAGE));
         assertThat(
                         service.canUseResource(
-                                TYPE, RID, null, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
+                                TYPE, RID, null, null, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
                 .isTrue();
     }
 
@@ -129,7 +131,9 @@ class ResourceAccessServiceTest {
     @Test
     void orgAllDefaultAllowsAnyUser() {
         stubGrants();
-        assertThat(service.canUseResource(TYPE, RID, null, DefaultAccessPolicy.ORG_ALL, user(5)))
+        assertThat(
+                        service.canUseResource(
+                                TYPE, RID, null, null, DefaultAccessPolicy.ORG_ALL, user(5)))
                 .isTrue();
     }
 
@@ -138,7 +142,7 @@ class ResourceAccessServiceTest {
         stubGrants();
         assertThat(
                         service.canUseResource(
-                                TYPE, RID, null, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
+                                TYPE, RID, null, null, DefaultAccessPolicy.EXPLICIT_ONLY, user(5)))
                 .isFalse();
     }
 
@@ -149,7 +153,12 @@ class ResourceAccessServiceTest {
         when(teamLeadLookup.isAnyTeamLeader(leader)).thenReturn(true);
         assertThat(
                         service.canUseResource(
-                                TYPE, RID, null, DefaultAccessPolicy.ADMINS_AND_TEAM_LEADS, leader))
+                                TYPE,
+                                RID,
+                                null,
+                                null,
+                                DefaultAccessPolicy.ADMINS_AND_TEAM_LEADS,
+                                leader))
                 .isTrue();
 
         stubGrants();
@@ -158,8 +167,40 @@ class ResourceAccessServiceTest {
                                 TYPE,
                                 RID,
                                 null,
+                                null,
                                 DefaultAccessPolicy.ADMINS_AND_TEAM_LEADS,
                                 user(6)))
+                .isFalse();
+    }
+
+    @Test
+    void teamLeadDefaultOnTeamResourceAdmitsOnlyThatTeamsLead() {
+        // Team-owned resource: only a lead OF THE OWNING TEAM qualifies — a lead of some
+        // other team must not cross the boundary.
+        stubGrants();
+        User owningTeamLead = user(5);
+        when(teamLeadLookup.isLeaderOfTeam(owningTeamLead, 7L)).thenReturn(true);
+        assertThat(
+                        service.canUseResource(
+                                TYPE,
+                                RID,
+                                null,
+                                7L,
+                                DefaultAccessPolicy.ADMINS_AND_TEAM_LEADS,
+                                owningTeamLead))
+                .isTrue();
+
+        stubGrants();
+        User foreignTeamLead = user(6);
+        when(teamLeadLookup.isLeaderOfTeam(foreignTeamLead, 7L)).thenReturn(false);
+        assertThat(
+                        service.canUseResource(
+                                TYPE,
+                                RID,
+                                null,
+                                7L,
+                                DefaultAccessPolicy.ADMINS_AND_TEAM_LEADS,
+                                foreignTeamLead))
                 .isFalse();
     }
 


### PR DESCRIPTION
## The bug, simply

`ResourceAccessService` is the permission checker for shared resources (today: integration configs, the portal). When someone tries to use a resource it asks a chain of questions: are you the **owner**? an **admin**? do you have an **explicit grant**? Otherwise, what's the resource's **default sharing level**?

The bug lives in that last step. One of the sharing levels is `ADMINS_AND_TEAM_LEADS` — the intent is "admins and the leads of *the team that owns this resource*." But it was implemented as:

```java
case ADMINS_AND_TEAM_LEADS -> teamLeadLookup.isAnyTeamLeader(user);
```

`isAnyTeamLeader` asks "does this user lead *a* team?" — any team, anywhere. It never looks at *which* team owns the resource. Since teams are flat, top-level tenants (there is no org grouping), a leader of a completely unrelated team — on SaaS, a different customer — would pass the check and be able to **view** a team resource shared at that level. It's a read leak, not a takeover: `canManageResource` has no default-policy fallback, so edit/delete were never exposed.

Think of it like a building where the rule "team leads can enter the team room" was implemented as "anyone holding *a* key can enter *every* team room."

## The fix

Teach the check which team owns the resource:

```java
case ADMINS_AND_TEAM_LEADS ->
        ownerTeamId == null
                ? teamLeadLookup.isAnyTeamLeader(user)                 // server-scoped (portal): any lead, intended
                : teamLeadLookup.isLeaderOfTeam(user, ownerTeamId);    // team resource: lead of THAT team only
```

Plus threading `ownerTeamId` through `canUseResource` and its call site in `OwnershipService`. The `null` branch matters: the portal is a server-wide resource with no owning team, and there "any team leader" is the *correct* meaning — the fix only tightens team-owned resources.

Added a test pinning the boundary (owning team's lead admitted, foreign team's lead denied) and updated the existing call sites for the new parameter.

## Is anything at risk today? No — verified

This is **not currently exploitable**, on two independent grounds:

1. The only `TeamLeadLookup` implementation in the codebase is the no-op `DefaultTeamLeadLookup` (always `false`), wired via `@ConditionalOnMissingBean` — no SaaS bean exists yet. So the vulnerable branch currently denies everyone, and `ADMINS_AND_TEAM_LEADS` effectively means admins-only everywhere.
2. Even where the level is settable (`IntegrationConfigRequest.defaultAccess`), it therefore grants nothing beyond owner/admin/grants.

This is **future-proofing**: the interface exists precisely so a real team-lead lookup gets wired later, and the moment that bean lands, the unscoped check would become a live cross-tenant read leak. Fixing it now, while the gun is unloaded, is free.

## Test plan
- `:proprietary:test --tests "stirling.software.proprietary.access.*"` — green, including the new `teamLeadDefaultOnTeamResourceAdmitsOnlyThatTeamsLead`.
- Spotless applied.