### PR TITLE
Improve type safety of tool definitions

### DIFF
--- a/frontend/editor/src/core/components/tools/addPageNumbers/useAddPageNumbersOperation.ts
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/useAddPageNumbersOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -73,7 +74,7 @@ export const buildAddPageNumbersFormData = (
 ): FormData =>
   objectToFormData(addPageNumbersToApiParams(parameters), { fileInput: file });
 
-export const addPageNumbersOperationConfig = {
+export const addPageNumbersOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildAddPageNumbersFormData,
   toApiParams: addPageNumbersToApiParams,
@@ -81,7 +82,7 @@ export const addPageNumbersOperationConfig = {
   operationType: "addPageNumbers",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useAddPageNumbersOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/components/tools/addPageNumbers/useAddPageNumbersOperation.ts
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/useAddPageNumbersOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -75,7 +74,6 @@ export const buildAddPageNumbersFormData = (
   objectToFormData(addPageNumbersToApiParams(parameters), { fileInput: file });
 
 export const addPageNumbersOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildAddPageNumbersFormData,
   toApiParams: addPageNumbersToApiParams,
   fromApiParams: addPageNumbersFromApiParams,

--- a/frontend/editor/src/core/components/tools/addStamp/useAddStampOperation.ts
+++ b/frontend/editor/src/core/components/tools/addStamp/useAddStampOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -87,7 +88,7 @@ export const buildAddStampFormData = (
       : { fileInput: file },
   );
 
-export const addStampOperationConfig = {
+export const addStampOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildAddStampFormData,
   toApiParams: addStampToApiParams,
@@ -95,7 +96,7 @@ export const addStampOperationConfig = {
   operationType: "addStamp",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useAddStampOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/components/tools/addStamp/useAddStampOperation.ts
+++ b/frontend/editor/src/core/components/tools/addStamp/useAddStampOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -89,7 +88,6 @@ export const buildAddStampFormData = (
   );
 
 export const addStampOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildAddStampFormData,
   toApiParams: addStampToApiParams,
   fromApiParams: addStampFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/addAttachments/useAddAttachmentsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/addAttachments/useAddAttachmentsOperation.ts
@@ -1,8 +1,7 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolOperationConfig,
-  ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -48,16 +47,14 @@ const buildFormData = (
   });
 
 // Operation configuration for automation
-export const addAttachmentsOperationConfig: ToolOperationConfig<AddAttachmentsParameters> =
-  {
-    toolType: ToolType.singleFile,
-    buildFormData,
-    toApiParams: addAttachmentsToApiParams,
-    fromApiParams: addAttachmentsFromApiParams,
-    operationType: "addAttachments",
-    endpoint: ENDPOINT,
-    defaultParameters: DEFAULT_ADD_ATTACHMENTS_PARAMETERS,
-  };
+export const addAttachmentsOperationConfig = defineSingleFileTool({
+  buildFormData,
+  toApiParams: addAttachmentsToApiParams,
+  fromApiParams: addAttachmentsFromApiParams,
+  operationType: "addAttachments",
+  endpoint: ENDPOINT,
+  defaultParameters: DEFAULT_ADD_ATTACHMENTS_PARAMETERS,
+});
 
 export const useAddAttachmentsOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/addPassword/useAddPasswordOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/addPassword/useAddPasswordOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -87,7 +86,6 @@ const fullDefaultParameters: AddPasswordFullParameters = {
 
 // Static configuration object
 export const addPasswordOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildAddPasswordFormData,
   toApiParams: addPasswordToApiParams,
   fromApiParams: addPasswordFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/addPassword/useAddPasswordOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/addPassword/useAddPasswordOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -85,7 +86,7 @@ const fullDefaultParameters: AddPasswordFullParameters = {
 };
 
 // Static configuration object
-export const addPasswordOperationConfig = {
+export const addPasswordOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildAddPasswordFormData,
   toApiParams: addPasswordToApiParams,
@@ -93,7 +94,7 @@ export const addPasswordOperationConfig = {
   operationType: "addPassword",
   endpoint: ENDPOINT,
   defaultParameters: fullDefaultParameters,
-} as const;
+});
 
 export const useAddPasswordOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/addWatermark/useAddWatermarkOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/addWatermark/useAddWatermarkOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -89,7 +88,6 @@ export const buildAddWatermarkFormData = (
 
 // Static configuration object
 export const addWatermarkOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildAddWatermarkFormData,
   toApiParams: addWatermarkToApiParams,
   fromApiParams: addWatermarkFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/addWatermark/useAddWatermarkOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/addWatermark/useAddWatermarkOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -87,7 +88,7 @@ export const buildAddWatermarkFormData = (
   );
 
 // Static configuration object
-export const addWatermarkOperationConfig = {
+export const addWatermarkOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildAddWatermarkFormData,
   toApiParams: addWatermarkToApiParams,
@@ -95,7 +96,7 @@ export const addWatermarkOperationConfig = {
   operationType: "watermark",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useAddWatermarkOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/adjustContrast/useAdjustContrastOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/adjustContrast/useAdjustContrastOperation.ts
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
+  defineCustomTool,
   useToolOperation,
   CustomProcessorResult,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -195,14 +195,11 @@ async function processPdfClientSide(
   };
 }
 
-export const adjustContrastOperationConfig = {
-  toolType: ToolType.custom,
+export const adjustContrastOperationConfig = defineCustomTool({
   customProcessor: processPdfClientSide,
   operationType: "adjustContrast",
   defaultParameters,
-  settingsComponentPath:
-    "components/tools/adjustContrast/AdjustContrastSingleStepSettings",
-} as const;
+});
 
 export const useAdjustContrastOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/adjustPageScale/useAdjustPageScaleOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/adjustPageScale/useAdjustPageScaleOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import { createStandardErrorHandler } from "@app/utils/toolErrorHandler";
@@ -23,7 +22,6 @@ export {
 };
 
 export const adjustPageScaleOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildAdjustPageScaleFormData,
   toApiParams: adjustPageScaleToApiParams,
   fromApiParams: adjustPageScaleFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/adjustPageScale/useAdjustPageScaleOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/adjustPageScale/useAdjustPageScaleOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import { createStandardErrorHandler } from "@app/utils/toolErrorHandler";
 import {
@@ -21,7 +22,7 @@ export {
   adjustPageScaleFromApiParams,
 };
 
-export const adjustPageScaleOperationConfig = {
+export const adjustPageScaleOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildAdjustPageScaleFormData,
   toApiParams: adjustPageScaleToApiParams,
@@ -29,7 +30,7 @@ export const adjustPageScaleOperationConfig = {
   operationType: "scalePages",
   endpoint: ADJUST_PAGE_SCALE_ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useAdjustPageScaleOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/autoRename/useAutoRenameOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/autoRename/useAutoRenameOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -44,7 +45,7 @@ export const buildAutoRenameFormData = (
   objectToFormData(autoRenameToApiParams(parameters), { fileInput: file });
 
 // Static configuration object
-export const autoRenameOperationConfig = {
+export const autoRenameOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildAutoRenameFormData,
   toApiParams: autoRenameToApiParams,
@@ -53,7 +54,7 @@ export const autoRenameOperationConfig = {
   endpoint: ENDPOINT,
   preserveBackendFilename: true, // Use filename from backend response headers
   defaultParameters,
-} as const;
+});
 
 export const useAutoRenameOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/autoRename/useAutoRenameOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/autoRename/useAutoRenameOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -46,7 +45,6 @@ export const buildAutoRenameFormData = (
 
 // Static configuration object
 export const autoRenameOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildAutoRenameFormData,
   toApiParams: autoRenameToApiParams,
   fromApiParams: autoRenameFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/automate/useAutomateOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/automate/useAutomateOperation.ts
@@ -1,5 +1,5 @@
 import {
-  ToolType,
+  defineCustomTool,
   useToolOperation,
 } from "@app/hooks/tools/shared/useToolOperation";
 import { useCallback } from "react";
@@ -55,10 +55,11 @@ export function useAutomateOperation() {
     [toolRegistry],
   );
 
-  return useToolOperation<AutomateParameters>({
-    toolType: ToolType.custom,
-    operationType: "automate",
-    customProcessor,
-    consumesAllInputs: true,
-  });
+  return useToolOperation<AutomateParameters>(
+    defineCustomTool({
+      operationType: "automate",
+      customProcessor,
+      consumesAllInputs: true,
+    }),
+  );
 }

--- a/frontend/editor/src/core/hooks/tools/bookletImposition/useBookletImpositionOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/bookletImposition/useBookletImpositionOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -59,7 +60,7 @@ export const buildBookletImpositionFormData = (
   });
 
 // Static configuration object
-export const bookletImpositionOperationConfig = {
+export const bookletImpositionOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildBookletImpositionFormData,
   toApiParams: bookletImpositionToApiParams,
@@ -67,7 +68,7 @@ export const bookletImpositionOperationConfig = {
   operationType: "bookletImposition",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useBookletImpositionOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/bookletImposition/useBookletImpositionOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/bookletImposition/useBookletImpositionOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -61,7 +60,6 @@ export const buildBookletImpositionFormData = (
 
 // Static configuration object
 export const bookletImpositionOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildBookletImpositionFormData,
   toApiParams: bookletImpositionToApiParams,
   fromApiParams: bookletImpositionFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/certSign/useCertSignOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/certSign/useCertSignOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -136,16 +137,15 @@ export const buildCertSignFormData = (
   });
 
 // Static configuration object
-export const certSignOperationConfig = {
+export const certSignOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildCertSignFormData,
   toApiParams: certSignToApiParams,
   fromApiParams: certSignFromApiParams,
   operationType: "certSign",
   endpoint: ENDPOINT,
-  multiFileEndpoint: false,
   defaultParameters,
-} as const;
+});
 
 export const useCertSignOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/certSign/useCertSignOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/certSign/useCertSignOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -138,7 +137,6 @@ export const buildCertSignFormData = (
 
 // Static configuration object
 export const certSignOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildCertSignFormData,
   toApiParams: certSignToApiParams,
   fromApiParams: certSignFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/changeMetadata/useChangeMetadataOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/changeMetadata/useChangeMetadataOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import { createStandardErrorHandler } from "@app/utils/toolErrorHandler";
@@ -77,7 +76,6 @@ export const buildChangeMetadataFormData = (
 
 // Static configuration object
 export const changeMetadataOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildChangeMetadataFormData,
   operationType: "changeMetadata",
   endpoint: "/api/v1/misc/update-metadata",

--- a/frontend/editor/src/core/hooks/tools/changeMetadata/useChangeMetadataOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/changeMetadata/useChangeMetadataOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import { createStandardErrorHandler } from "@app/utils/toolErrorHandler";
 import {
@@ -75,13 +76,13 @@ export const buildChangeMetadataFormData = (
 };
 
 // Static configuration object
-export const changeMetadataOperationConfig = {
+export const changeMetadataOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildChangeMetadataFormData,
   operationType: "changeMetadata",
   endpoint: "/api/v1/misc/update-metadata",
   defaultParameters,
-} as const;
+});
 
 export const useChangeMetadataOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/changePermissions/useChangePermissionsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/changePermissions/useChangePermissionsOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -73,7 +72,6 @@ export const buildChangePermissionsFormData = (
 
 // Static configuration object
 export const changePermissionsOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildChangePermissionsFormData,
   toApiParams: changePermissionsToApiParams,
   fromApiParams: changePermissionsFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/changePermissions/useChangePermissionsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/changePermissions/useChangePermissionsOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -71,7 +72,7 @@ export const buildChangePermissionsFormData = (
   });
 
 // Static configuration object
-export const changePermissionsOperationConfig = {
+export const changePermissionsOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildChangePermissionsFormData,
   toApiParams: changePermissionsToApiParams,
@@ -79,7 +80,7 @@ export const changePermissionsOperationConfig = {
   operationType: "changePermissions",
   endpoint: ENDPOINT, // Change Permissions is a fake endpoint for the Add Password tool
   defaultParameters,
-} as const;
+});
 
 export const useChangePermissionsOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/compress/useCompressOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/compress/useCompressOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -92,7 +91,6 @@ export const buildCompressFormData = (
 
 // Static configuration object
 export const compressOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildCompressFormData,
   toApiParams: compressToApiParams,
   fromApiParams: compressFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/compress/useCompressOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/compress/useCompressOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -90,7 +91,7 @@ export const buildCompressFormData = (
   objectToFormData(compressToApiParams(parameters), { fileInput: file });
 
 // Static configuration object
-export const compressOperationConfig = {
+export const compressOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildCompressFormData,
   toApiParams: compressToApiParams,
@@ -98,7 +99,7 @@ export const compressOperationConfig = {
   operationType: "compress",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useCompressOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/convert/useConvertOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/convert/useConvertOperation.ts
@@ -8,7 +8,7 @@ import {
 import { createFileFromApiResponse } from "@app/utils/fileResponseUtils";
 import {
   useToolOperation,
-  ToolType,
+  defineCustomTool,
   CustomProcessorResult,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -300,8 +300,7 @@ export const convertProcessor = async (
 };
 
 // Static configuration object
-export const convertOperationConfig = {
-  toolType: ToolType.custom,
+export const convertOperationConfig = defineCustomTool({
   customProcessor: convertProcessor, // Can't use callback version here
   operationType: "convert",
   defaultParameters,
@@ -311,7 +310,7 @@ export const convertOperationConfig = {
       params.toExtension === "pdfx" ? "pdfa" : params.toExtension;
     return getEndpointUrl(params.fromExtension, actualToExtension) ?? undefined;
   },
-} as const;
+});
 
 export const useConvertOperation = (parameters?: ConvertParameters) => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/crop/useCropOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/crop/useCropOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -59,7 +60,7 @@ export const buildCropFormData = (
   objectToFormData(cropToApiParams(parameters), { fileInput: file });
 
 // Static configuration object
-export const cropOperationConfig = {
+export const cropOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildCropFormData,
   toApiParams: cropToApiParams,
@@ -67,7 +68,7 @@ export const cropOperationConfig = {
   operationType: "crop",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useCropOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/crop/useCropOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/crop/useCropOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -61,7 +60,6 @@ export const buildCropFormData = (
 
 // Static configuration object
 export const cropOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildCropFormData,
   toApiParams: cropToApiParams,
   fromApiParams: cropFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/editTableOfContents/useEditTableOfContentsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/editTableOfContents/useEditTableOfContentsOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
-  type ToolOperationConfig,
+  defineSingleFileTool,
   useToolOperation,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -64,15 +63,13 @@ const buildFormData = (
     fileInput: file,
   });
 
-export const editTableOfContentsOperationConfig: ToolOperationConfig<EditTableOfContentsParameters> =
-  {
-    toolType: ToolType.singleFile,
-    operationType: "editTableOfContents",
-    endpoint: ENDPOINT,
-    buildFormData,
-    toApiParams: editTableOfContentsToApiParams,
-    fromApiParams: editTableOfContentsFromApiParams,
-  };
+export const editTableOfContentsOperationConfig = defineSingleFileTool({
+  operationType: "editTableOfContents",
+  endpoint: ENDPOINT,
+  buildFormData,
+  toApiParams: editTableOfContentsToApiParams,
+  fromApiParams: editTableOfContentsFromApiParams,
+});
 
 export const useEditTableOfContentsOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/extractImages/useExtractImagesOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/extractImages/useExtractImagesOperation.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -41,7 +42,7 @@ export const buildExtractImagesFormData = (
   objectToFormData(extractImagesToApiParams(parameters), { fileInput: file });
 
 // Static configuration object (without response handler - will be added in hook)
-export const extractImagesOperationConfig = {
+export const extractImagesOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildExtractImagesFormData,
   toApiParams: extractImagesToApiParams,
@@ -49,7 +50,7 @@ export const extractImagesOperationConfig = {
   operationType: "extractImages",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useExtractImagesOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/extractImages/useExtractImagesOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/extractImages/useExtractImagesOperation.ts
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -43,7 +42,6 @@ export const buildExtractImagesFormData = (
 
 // Static configuration object (without response handler - will be added in hook)
 export const extractImagesOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildExtractImagesFormData,
   toApiParams: extractImagesToApiParams,
   fromApiParams: extractImagesFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/extractPages/useExtractPagesOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/extractPages/useExtractPagesOperation.ts
@@ -1,7 +1,7 @@
 import apiClient from "@app/services/apiClient";
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
+  defineCustomTool,
   useToolOperation,
   CustomProcessorResult,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -33,8 +33,7 @@ async function resolveSelectionToCsv(
   }
 }
 
-export const extractPagesOperationConfig = {
-  toolType: ToolType.custom,
+export const extractPagesOperationConfig = defineCustomTool({
   operationType: "extractPages",
   customProcessor: async (
     parameters: ExtractPagesParameters,
@@ -71,7 +70,7 @@ export const extractPagesOperationConfig = {
     };
   },
   defaultParameters,
-} as const;
+});
 
 export const useExtractPagesOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/flatten/useFlattenOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/flatten/useFlattenOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -61,7 +60,6 @@ export const buildFlattenFormData = (
 
 // Static configuration object
 export const flattenOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildFlattenFormData,
   toApiParams: flattenToApiParams,
   fromApiParams: flattenFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/flatten/useFlattenOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/flatten/useFlattenOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -59,16 +60,15 @@ export const buildFlattenFormData = (
   objectToFormData(flattenToApiParams(parameters), { fileInput: file });
 
 // Static configuration object
-export const flattenOperationConfig = {
+export const flattenOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildFlattenFormData,
   toApiParams: flattenToApiParams,
   fromApiParams: flattenFromApiParams,
   operationType: "flatten",
   endpoint: ENDPOINT,
-  multiFileEndpoint: false,
   defaultParameters,
-} as const;
+});
 
 export const useFlattenOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/merge/useMergeOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/merge/useMergeOperation.ts
@@ -3,6 +3,7 @@ import {
   useToolOperation,
   ToolOperationConfig,
   ToolType,
+  defineMultiFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -56,16 +57,17 @@ const buildFormData = (
 };
 
 // Operation configuration for automation
-export const mergeOperationConfig: ToolOperationConfig<MergeParameters> = {
-  toolType: ToolType.multiFile,
-  buildFormData,
-  toApiParams: mergeToApiParams,
-  fromApiParams: mergeFromApiParams,
-  operationType: "merge",
-  endpoint: ENDPOINT,
-  filePrefix: "merged_",
-  defaultParameters,
-};
+export const mergeOperationConfig: ToolOperationConfig<MergeParameters> =
+  defineMultiFileTool({
+    toolType: ToolType.multiFile,
+    buildFormData,
+    toApiParams: mergeToApiParams,
+    fromApiParams: mergeFromApiParams,
+    operationType: "merge",
+    endpoint: ENDPOINT,
+    filePrefix: "merged_",
+    defaultParameters,
+  });
 
 export const useMergeOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/merge/useMergeOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/merge/useMergeOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolOperationConfig,
   defineMultiFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -56,16 +55,15 @@ const buildFormData = (
 };
 
 // Operation configuration for automation
-export const mergeOperationConfig: ToolOperationConfig<MergeParameters> =
-  defineMultiFileTool({
-    buildFormData,
-    toApiParams: mergeToApiParams,
-    fromApiParams: mergeFromApiParams,
-    operationType: "merge",
-    endpoint: ENDPOINT,
-    filePrefix: "merged_",
-    defaultParameters,
-  });
+export const mergeOperationConfig = defineMultiFileTool({
+  buildFormData,
+  toApiParams: mergeToApiParams,
+  fromApiParams: mergeFromApiParams,
+  operationType: "merge",
+  endpoint: ENDPOINT,
+  filePrefix: "merged_",
+  defaultParameters,
+});
 
 export const useMergeOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/merge/useMergeOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/merge/useMergeOperation.ts
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolOperationConfig,
-  ToolType,
   defineMultiFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -59,7 +58,6 @@ const buildFormData = (
 // Operation configuration for automation
 export const mergeOperationConfig: ToolOperationConfig<MergeParameters> =
   defineMultiFileTool({
-    toolType: ToolType.multiFile,
     buildFormData,
     toApiParams: mergeToApiParams,
     fromApiParams: mergeFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/ocr/useOCROperation.ts
+++ b/frontend/editor/src/core/hooks/tools/ocr/useOCROperation.ts
@@ -8,6 +8,7 @@ import {
   useToolOperation,
   ToolOperationConfig,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -151,7 +152,7 @@ export const ocrResponseHandler = async (
 };
 
 // Static configuration object (without t function dependencies)
-export const ocrOperationConfig = {
+export const ocrOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildOCRFormData,
   toApiParams: ocrToApiParams,
@@ -159,7 +160,7 @@ export const ocrOperationConfig = {
   operationType: "ocr",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useOCROperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/ocr/useOCROperation.ts
+++ b/frontend/editor/src/core/hooks/tools/ocr/useOCROperation.ts
@@ -7,7 +7,6 @@ import {
 import {
   useToolOperation,
   ToolOperationConfig,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -153,7 +152,6 @@ export const ocrResponseHandler = async (
 
 // Static configuration object (without t function dependencies)
 export const ocrOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildOCRFormData,
   toApiParams: ocrToApiParams,
   fromApiParams: ocrFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/overlayPdfs/useOverlayPdfsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/overlayPdfs/useOverlayPdfsOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   type ToolOperationConfig,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -62,7 +61,6 @@ const buildFormData = (
 
 export const overlayPdfsOperationConfig: ToolOperationConfig<OverlayPdfsParameters> =
   defineSingleFileTool({
-    toolType: ToolType.singleFile,
     buildFormData,
     toApiParams: overlayPdfsToApiParams,
     fromApiParams: overlayPdfsFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/overlayPdfs/useOverlayPdfsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/overlayPdfs/useOverlayPdfsOperation.ts
@@ -3,6 +3,7 @@ import {
   useToolOperation,
   ToolType,
   type ToolOperationConfig,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -60,14 +61,14 @@ const buildFormData = (
   });
 
 export const overlayPdfsOperationConfig: ToolOperationConfig<OverlayPdfsParameters> =
-  {
+  defineSingleFileTool({
     toolType: ToolType.singleFile,
     buildFormData,
     toApiParams: overlayPdfsToApiParams,
     fromApiParams: overlayPdfsFromApiParams,
     operationType: "overlayPdfs",
     endpoint: ENDPOINT,
-  };
+  });
 
 export const useOverlayPdfsOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/pageLayout/usePageLayoutOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/pageLayout/usePageLayoutOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -69,7 +68,6 @@ export const buildPageLayoutFormData = (
   objectToFormData(pageLayoutToApiParams(parameters), { fileInput: file });
 
 export const pageLayoutOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildPageLayoutFormData,
   toApiParams: pageLayoutToApiParams,
   fromApiParams: pageLayoutFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/pageLayout/usePageLayoutOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/pageLayout/usePageLayoutOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -67,7 +68,7 @@ export const buildPageLayoutFormData = (
 ): FormData =>
   objectToFormData(pageLayoutToApiParams(parameters), { fileInput: file });
 
-export const pageLayoutOperationConfig = {
+export const pageLayoutOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildPageLayoutFormData,
   toApiParams: pageLayoutToApiParams,
@@ -75,7 +76,7 @@ export const pageLayoutOperationConfig = {
   operationType: "pageLayout",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const usePageLayoutOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/redact/useRedactOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/redact/useRedactOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -66,7 +65,6 @@ export const buildRedactFormData = (
 
 // Static configuration object
 export const redactOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildRedactFormData,
   toApiParams: redactToApiParams,
   fromApiParams: redactFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/redact/useRedactOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/redact/useRedactOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -64,7 +65,7 @@ export const buildRedactFormData = (
 };
 
 // Static configuration object
-export const redactOperationConfig = {
+export const redactOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildRedactFormData,
   toApiParams: redactToApiParams,
@@ -73,7 +74,7 @@ export const redactOperationConfig = {
   endpoint: (parameters: RedactParameters) =>
     parameters.mode === "automatic" ? AUTO_ENDPOINT : null,
   defaultParameters,
-} as const;
+});
 
 export const useRedactOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/removeAnnotations/useRemoveAnnotationsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removeAnnotations/useRemoveAnnotationsOperation.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
+  defineCustomTool,
   CustomProcessorResult,
 } from "@app/hooks/tools/shared/useToolOperation";
 import { createStandardErrorHandler } from "@app/utils/toolErrorHandler";
@@ -78,12 +78,11 @@ const removeAnnotationsProcessor = async (
 };
 
 // Static configuration object
-export const removeAnnotationsOperationConfig = {
-  toolType: ToolType.custom,
+export const removeAnnotationsOperationConfig = defineCustomTool({
   operationType: "removeAnnotations",
   customProcessor: removeAnnotationsProcessor,
   defaultParameters,
-} as const;
+});
 
 export const useRemoveAnnotationsOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/removeBlanks/useRemoveBlanksOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removeBlanks/useRemoveBlanksOperation.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -42,7 +41,6 @@ export const buildRemoveBlanksFormData = (
   objectToFormData(removeBlanksToApiParams(parameters), { fileInput: file });
 
 export const removeBlanksOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildRemoveBlanksFormData,
   toApiParams: removeBlanksToApiParams,
   fromApiParams: removeBlanksFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/removeBlanks/useRemoveBlanksOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removeBlanks/useRemoveBlanksOperation.ts
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
-  ToolOperationConfig,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -41,7 +41,7 @@ export const buildRemoveBlanksFormData = (
 ): FormData =>
   objectToFormData(removeBlanksToApiParams(parameters), { fileInput: file });
 
-export const removeBlanksOperationConfig = {
+export const removeBlanksOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildRemoveBlanksFormData,
   toApiParams: removeBlanksToApiParams,
@@ -49,7 +49,7 @@ export const removeBlanksOperationConfig = {
   operationType: "removeBlanks",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const satisfies ToolOperationConfig<RemoveBlanksParameters>;
+});
 
 export const useRemoveBlanksOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -27,7 +26,6 @@ export const buildRemoveCertificateSignFormData = (
 
 // Static configuration object
 export const removeCertificateSignOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildRemoveCertificateSignFormData,
   toApiParams,
   fromApiParams,

--- a/frontend/editor/src/core/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removeCertificateSign/useRemoveCertificateSignOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   fileOnlyMapping,
@@ -25,7 +26,7 @@ export const buildRemoveCertificateSignFormData = (
 ): FormData => objectToFormData(toApiParams(), { fileInput: file });
 
 // Static configuration object
-export const removeCertificateSignOperationConfig = {
+export const removeCertificateSignOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildRemoveCertificateSignFormData,
   toApiParams,
@@ -33,7 +34,7 @@ export const removeCertificateSignOperationConfig = {
   operationType: "removeCertSign",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useRemoveCertificateSignOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/removeImage/useRemoveImageOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removeImage/useRemoveImageOperation.ts
@@ -1,8 +1,7 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolOperationConfig,
-  ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   fileOnlyMapping,
@@ -22,15 +21,13 @@ export const buildRemoveImageFormData = (
   file: File,
 ): FormData => objectToFormData(toApiParams(), { fileInput: file });
 
-export const removeImageOperationConfig: ToolOperationConfig<RemoveImageParameters> =
-  {
-    toolType: ToolType.singleFile,
-    buildFormData: buildRemoveImageFormData,
-    toApiParams,
-    fromApiParams,
-    operationType: "removeImage",
-    endpoint: ENDPOINT,
-  };
+export const removeImageOperationConfig = defineSingleFileTool({
+  buildFormData: buildRemoveImageFormData,
+  toApiParams,
+  fromApiParams,
+  operationType: "removeImage",
+  endpoint: ENDPOINT,
+});
 
 export const useRemoveImageOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/removePages/useRemovePagesOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removePages/useRemovePagesOperation.ts
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
-  ToolOperationConfig,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -42,7 +42,7 @@ export const buildRemovePagesFormData = (
 ): FormData =>
   objectToFormData(removePagesToApiParams(parameters), { fileInput: file });
 
-export const removePagesOperationConfig = {
+export const removePagesOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildRemovePagesFormData,
   toApiParams: removePagesToApiParams,
@@ -50,7 +50,7 @@ export const removePagesOperationConfig = {
   operationType: "removePages",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const satisfies ToolOperationConfig<RemovePagesParameters>;
+});
 
 export const useRemovePagesOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/removePages/useRemovePagesOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removePages/useRemovePagesOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -43,7 +42,6 @@ export const buildRemovePagesFormData = (
   objectToFormData(removePagesToApiParams(parameters), { fileInput: file });
 
 export const removePagesOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildRemovePagesFormData,
   toApiParams: removePagesToApiParams,
   fromApiParams: removePagesFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/removePassword/useRemovePasswordOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removePassword/useRemovePasswordOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import { createStandardErrorHandler } from "@app/utils/toolErrorHandler";
 import {
@@ -19,7 +20,7 @@ import {
 export { buildRemovePasswordFormData };
 
 // Static configuration object
-export const removePasswordOperationConfig = {
+export const removePasswordOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildRemovePasswordFormData,
   toApiParams: removePasswordToApiParams,
@@ -27,7 +28,7 @@ export const removePasswordOperationConfig = {
   operationType: "removePassword",
   endpoint: REMOVE_PASSWORD_ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useRemovePasswordOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/removePassword/useRemovePasswordOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/removePassword/useRemovePasswordOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -21,7 +20,6 @@ export { buildRemovePasswordFormData };
 
 // Static configuration object
 export const removePasswordOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildRemovePasswordFormData,
   toApiParams: removePasswordToApiParams,
   fromApiParams: removePasswordFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/reorganizePages/useReorganizePagesOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/reorganizePages/useReorganizePagesOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolOperationConfig,
-  ToolType,
+  defineSingleFileTool,
   useToolOperation,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -54,15 +53,13 @@ const buildFormData = (
     fileInput: file,
   });
 
-export const reorganizePagesOperationConfig: ToolOperationConfig<ReorganizePagesParameters> =
-  {
-    toolType: ToolType.singleFile,
-    buildFormData,
-    toApiParams: reorganizePagesToApiParams,
-    fromApiParams: reorganizePagesFromApiParams,
-    operationType: "reorganizePages",
-    endpoint: ENDPOINT,
-  };
+export const reorganizePagesOperationConfig = defineSingleFileTool({
+  buildFormData,
+  toApiParams: reorganizePagesToApiParams,
+  fromApiParams: reorganizePagesFromApiParams,
+  operationType: "reorganizePages",
+  endpoint: ENDPOINT,
+});
 
 export const useReorganizePagesOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/repair/useRepairOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/repair/useRepairOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   fileOnlyMapping,
@@ -25,7 +26,7 @@ export const buildRepairFormData = (
 ): FormData => objectToFormData(toApiParams(), { fileInput: file });
 
 // Static configuration object
-export const repairOperationConfig = {
+export const repairOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildRepairFormData,
   toApiParams,
@@ -33,7 +34,7 @@ export const repairOperationConfig = {
   operationType: "repair",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useRepairOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/repair/useRepairOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/repair/useRepairOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -27,7 +26,6 @@ export const buildRepairFormData = (
 
 // Static configuration object
 export const repairOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildRepairFormData,
   toApiParams,
   fromApiParams,

--- a/frontend/editor/src/core/hooks/tools/replaceColor/useReplaceColorOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/replaceColor/useReplaceColorOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -62,16 +63,15 @@ export const buildReplaceColorFormData = (
 ): FormData =>
   objectToFormData(replaceColorToApiParams(parameters), { fileInput: file });
 
-export const replaceColorOperationConfig = {
+export const replaceColorOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildReplaceColorFormData,
   toApiParams: replaceColorToApiParams,
   fromApiParams: replaceColorFromApiParams,
   operationType: "replaceColor",
   endpoint: ENDPOINT,
-  multiFileEndpoint: false,
   defaultParameters,
-} as const;
+});
 
 export const useReplaceColorOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/replaceColor/useReplaceColorOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/replaceColor/useReplaceColorOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -64,7 +63,6 @@ export const buildReplaceColorFormData = (
   objectToFormData(replaceColorToApiParams(parameters), { fileInput: file });
 
 export const replaceColorOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildReplaceColorFormData,
   toApiParams: replaceColorToApiParams,
   fromApiParams: replaceColorFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/rotate/useRotateOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/rotate/useRotateOperation.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
-  ToolType,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
@@ -45,7 +44,6 @@ export const buildRotateFormData = (
 
 // Static configuration object
 export const rotateOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildRotateFormData,
   toApiParams: rotateToApiParams,
   fromApiParams: rotateFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/rotate/useRotateOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/rotate/useRotateOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -43,7 +44,7 @@ export const buildRotateFormData = (
   objectToFormData(rotateToApiParams(parameters), { fileInput: file });
 
 // Static configuration object
-export const rotateOperationConfig = {
+export const rotateOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildRotateFormData,
   toApiParams: rotateToApiParams,
@@ -51,7 +52,7 @@ export const rotateOperationConfig = {
   operationType: "rotate",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useRotateOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/sanitize/useSanitizeOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/sanitize/useSanitizeOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -57,7 +56,6 @@ export const buildSanitizeFormData = (
 
 // Static configuration object
 export const sanitizeOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildSanitizeFormData,
   toApiParams: sanitizeToApiParams,
   fromApiParams: sanitizeFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/sanitize/useSanitizeOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/sanitize/useSanitizeOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -55,16 +56,15 @@ export const buildSanitizeFormData = (
   objectToFormData(sanitizeToApiParams(parameters), { fileInput: file });
 
 // Static configuration object
-export const sanitizeOperationConfig = {
+export const sanitizeOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildSanitizeFormData,
   toApiParams: sanitizeToApiParams,
   fromApiParams: sanitizeFromApiParams,
   operationType: "sanitize",
   endpoint: ENDPOINT,
-  multiFileEndpoint: false,
   defaultParameters,
-} as const;
+});
 
 export const useSanitizeOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/scannerImageSplit/useScannerImageSplitOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/scannerImageSplit/useScannerImageSplitOperation.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   ToolOperationConfig,
   defineSingleFileTool,
@@ -56,7 +55,6 @@ export const buildScannerImageSplitFormData = (
 
 // Static configuration object
 export const scannerImageSplitOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildScannerImageSplitFormData,
   toApiParams: scannerImageSplitToApiParams,
   fromApiParams: scannerImageSplitFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/scannerImageSplit/useScannerImageSplitOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/scannerImageSplit/useScannerImageSplitOperation.ts
@@ -4,6 +4,7 @@ import {
   ToolType,
   useToolOperation,
   ToolOperationConfig,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -54,7 +55,7 @@ export const buildScannerImageSplitFormData = (
   });
 
 // Static configuration object
-export const scannerImageSplitOperationConfig = {
+export const scannerImageSplitOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildScannerImageSplitFormData,
   toApiParams: scannerImageSplitToApiParams,
@@ -62,7 +63,7 @@ export const scannerImageSplitOperationConfig = {
   operationType: "scannerImageSplit",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useScannerImageSplitOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/shared/migratedToolMappers.test.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/migratedToolMappers.test.ts
@@ -117,7 +117,7 @@ describe("migrated tool mappers (sweep)", () => {
 
 describe("redact mappers", () => {
   test("toApiParams builds the auto-redact body from UI parameters", () => {
-    const api = redactOperationConfig.toApiParams({
+    const api = redactOperationConfig.toApiParams!({
       mode: "automatic",
       wordsToRedact: ["foo", "bar"],
       useRegex: true,
@@ -138,7 +138,7 @@ describe("redact mappers", () => {
   });
 
   test("round-trips through fromApiParams", () => {
-    const api = redactOperationConfig.toApiParams({
+    const api = redactOperationConfig.toApiParams!({
       mode: "automatic",
       wordsToRedact: ["secret"],
       useRegex: false,
@@ -147,7 +147,7 @@ describe("redact mappers", () => {
       customPadding: 0.1,
       convertPDFToImage: true,
     });
-    const roundTripped = redactOperationConfig.toApiParams({
+    const roundTripped = redactOperationConfig.toApiParams!({
       mode: "automatic",
       wordsToRedact: [],
       useRegex: false,
@@ -155,7 +155,7 @@ describe("redact mappers", () => {
       redactColor: "#000000",
       customPadding: 0,
       convertPDFToImage: false,
-      ...redactOperationConfig.fromApiParams(api),
+      ...redactOperationConfig.fromApiParams!(api),
     });
 
     expect(roundTripped).toEqual(api);

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationTypes.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationTypes.ts
@@ -183,16 +183,15 @@ export type ToolOperationConfig<
 /**
  * Define a single-file tool's operation config. Infers the endpoint literal from
  * `endpoint` and binds toApiParams/fromApiParams to that endpoint's request
- * model, so a mapper cannot silently drift from the generated spec. Prefer this
- * over a bare object literal when authoring a tool.
+ * model, so a mapper cannot silently drift from the generated spec.
  */
 export function defineSingleFileTool<
   TParams,
   const TEndpoint extends ToolEndpoint,
 >(
-  config: SingleFileToolOperationConfig<TParams, TEndpoint>,
+  config: Omit<SingleFileToolOperationConfig<TParams, TEndpoint>, "toolType">,
 ): SingleFileToolOperationConfig<TParams, TEndpoint> {
-  return config;
+  return { ...config, toolType: ToolType.singleFile };
 }
 
 /** Multi-file counterpart of {@link defineSingleFileTool}. */
@@ -200,9 +199,9 @@ export function defineMultiFileTool<
   TParams,
   const TEndpoint extends ToolEndpoint,
 >(
-  config: MultiFileToolOperationConfig<TParams, TEndpoint>,
+  config: Omit<MultiFileToolOperationConfig<TParams, TEndpoint>, "toolType">,
 ): MultiFileToolOperationConfig<TParams, TEndpoint> {
-  return config;
+  return { ...config, toolType: ToolType.multiFile };
 }
 
 /**

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationTypes.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationTypes.ts
@@ -205,6 +205,18 @@ export function defineMultiFileTool<
 }
 
 /**
+ * Custom-processor counterpart of {@link defineSingleFileTool}, for tools whose
+ * customProcessor owns the API calls and file handling. Rejects fields that
+ * belong to the file-based patterns (e.g. buildFormData) and any property not on
+ * the config, so a stray or stale field is a build error rather than dead weight.
+ */
+export function defineCustomTool<TParams>(
+  config: Omit<CustomToolOperationConfig<TParams>, "toolType">,
+): CustomToolOperationConfig<TParams> {
+  return { ...config, toolType: ToolType.custom };
+}
+
+/**
  * One generic source-of-truth for the props every automation settings component
  * accepts: the tool's parameters plus a typed change handler.
  */

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationTypes.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationTypes.ts
@@ -3,7 +3,7 @@ import { StirlingFile } from "@app/types/fileContext";
 import type { ResponseHandler } from "@app/utils/toolResponseProcessor";
 import { ToolId } from "@app/types/toolId";
 import type { ProcessingProgress } from "@app/hooks/tools/shared/useToolState";
-import type { ToolApiRequest, ToolEndpoint } from "@app/types/toolApiTypes";
+import type { ToolApiParams, ToolEndpoint } from "@app/types/toolApiTypes";
 
 export type { ProcessingProgress, ResponseHandler };
 
@@ -53,7 +53,7 @@ export interface CustomProcessorResult {
  * 2. Multi-file tools: toolType: multiFile, single API call with all files
  * 3. Complex tools: toolType: custom, customProcessor handles all processing logic
  */
-interface BaseToolOperationConfig<TParams> {
+interface BaseToolOperationConfig<TParams, TEndpoint extends ToolEndpoint> {
   /** Operation identifier for tracking and logging */
   operationType: ToolId;
 
@@ -82,15 +82,16 @@ interface BaseToolOperationConfig<TParams> {
   /**
    * Typed frontend params -> backend request model. When a tool provides this,
    * it is the spec-checked source of truth for the request body and its
-   * buildFormData is derived from it via objectToFormData.
+   * buildFormData is derived from it via objectToFormData. Bound to the tool's
+   * endpoint, so a spec rename of that endpoint's model breaks the build here.
    */
-  toApiParams?(params: TParams): ToolApiRequest;
+  toApiParams?(params: TParams): ToolApiParams[TEndpoint];
 
   /**
    * Backend request model -> partial frontend params, so a stored API call
    * can be re-hydrated into this tool's settings UI.
    */
-  fromApiParams?(apiParams: ToolApiRequest): Partial<TParams>;
+  fromApiParams?(apiParams: ToolApiParams[TEndpoint]): Partial<TParams>;
 
   /**
    * For custom tools: if true, success implies all input files were successfully processed.
@@ -102,7 +103,8 @@ interface BaseToolOperationConfig<TParams> {
 
 export interface SingleFileToolOperationConfig<
   TParams,
-> extends BaseToolOperationConfig<TParams> {
+  TEndpoint extends ToolEndpoint = ToolEndpoint,
+> extends BaseToolOperationConfig<TParams, TEndpoint> {
   /** This tool processes one file at a time. */
   toolType: ToolType.singleFile;
 
@@ -110,18 +112,18 @@ export interface SingleFileToolOperationConfig<
   buildFormData: (params: TParams, file: File) => FormData;
 
   /**
-   * API endpoint for the operation. Can be static or a function for dynamic routing.
+   * API endpoint for the operation, or a function for dynamic routing. `null`
+   * when the operation has no backend endpoint (see {@link ToolOperationEndpoint}).
    */
-  endpoint:
-    | ToolOperationEndpoint
-    | ((params: TParams) => ToolOperationEndpoint);
+  endpoint: TEndpoint | null | ((params: TParams) => TEndpoint | null);
 
   customProcessor?: undefined;
 }
 
 export interface MultiFileToolOperationConfig<
   TParams,
-> extends BaseToolOperationConfig<TParams> {
+  TEndpoint extends ToolEndpoint = ToolEndpoint,
+> extends BaseToolOperationConfig<TParams, TEndpoint> {
   /** This tool processes multiple files at once. */
   toolType: ToolType.multiFile;
 
@@ -132,18 +134,17 @@ export interface MultiFileToolOperationConfig<
   buildFormData: (params: TParams, files: File[]) => FormData;
 
   /**
-   * API endpoint for the operation. Can be static or a function for dynamic routing.
+   * API endpoint for the operation, or a function for dynamic routing. `null`
+   * when the operation has no backend endpoint (see {@link ToolOperationEndpoint}).
    */
-  endpoint:
-    | ToolOperationEndpoint
-    | ((params: TParams) => ToolOperationEndpoint);
+  endpoint: TEndpoint | null | ((params: TParams) => TEndpoint | null);
 
   customProcessor?: undefined;
 }
 
 export interface CustomToolOperationConfig<
   TParams,
-> extends BaseToolOperationConfig<TParams> {
+> extends BaseToolOperationConfig<TParams, ToolEndpoint> {
   /** This tool has custom behaviour. */
   toolType: ToolType.custom;
 
@@ -171,10 +172,38 @@ export interface CustomToolOperationConfig<
   ) => Promise<CustomProcessorResult>;
 }
 
-export type ToolOperationConfig<TParams = void> =
-  | SingleFileToolOperationConfig<TParams>
-  | MultiFileToolOperationConfig<TParams>
+export type ToolOperationConfig<
+  TParams = void,
+  TEndpoint extends ToolEndpoint = ToolEndpoint,
+> =
+  | SingleFileToolOperationConfig<TParams, TEndpoint>
+  | MultiFileToolOperationConfig<TParams, TEndpoint>
   | CustomToolOperationConfig<TParams>;
+
+/**
+ * Define a single-file tool's operation config. Infers the endpoint literal from
+ * `endpoint` and binds toApiParams/fromApiParams to that endpoint's request
+ * model, so a mapper cannot silently drift from the generated spec. Prefer this
+ * over a bare object literal when authoring a tool.
+ */
+export function defineSingleFileTool<
+  TParams,
+  const TEndpoint extends ToolEndpoint,
+>(
+  config: SingleFileToolOperationConfig<TParams, TEndpoint>,
+): SingleFileToolOperationConfig<TParams, TEndpoint> {
+  return config;
+}
+
+/** Multi-file counterpart of {@link defineSingleFileTool}. */
+export function defineMultiFileTool<
+  TParams,
+  const TEndpoint extends ToolEndpoint,
+>(
+  config: MultiFileToolOperationConfig<TParams, TEndpoint>,
+): MultiFileToolOperationConfig<TParams, TEndpoint> {
+  return config;
+}
 
 /**
  * One generic source-of-truth for the props every automation settings component

--- a/frontend/editor/src/core/hooks/tools/shared/useToolOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/useToolOperation.ts
@@ -42,6 +42,7 @@ import {
   ToolType,
   defineSingleFileTool,
   defineMultiFileTool,
+  defineCustomTool,
   ToolOperationConfig,
   ToolOperationHook,
   CustomProcessorResult,
@@ -52,7 +53,7 @@ import {
   ResponseHandler,
 } from "@app/hooks/tools/shared/toolOperationTypes";
 
-export { ToolType, defineSingleFileTool, defineMultiFileTool };
+export { ToolType, defineSingleFileTool, defineMultiFileTool, defineCustomTool };
 export type {
   ToolOperationConfig,
   ToolOperationHook,

--- a/frontend/editor/src/core/hooks/tools/shared/useToolOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/useToolOperation.ts
@@ -53,7 +53,12 @@ import {
   ResponseHandler,
 } from "@app/hooks/tools/shared/toolOperationTypes";
 
-export { ToolType, defineSingleFileTool, defineMultiFileTool, defineCustomTool };
+export {
+  ToolType,
+  defineSingleFileTool,
+  defineMultiFileTool,
+  defineCustomTool,
+};
 export type {
   ToolOperationConfig,
   ToolOperationHook,

--- a/frontend/editor/src/core/hooks/tools/shared/useToolOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/useToolOperation.ts
@@ -40,6 +40,8 @@ import {
 } from "@app/hooks/tools/shared/toolOperationHelpers";
 import {
   ToolType,
+  defineSingleFileTool,
+  defineMultiFileTool,
   ToolOperationConfig,
   ToolOperationHook,
   CustomProcessorResult,
@@ -50,7 +52,7 @@ import {
   ResponseHandler,
 } from "@app/hooks/tools/shared/toolOperationTypes";
 
-export { ToolType };
+export { ToolType, defineSingleFileTool, defineMultiFileTool };
 export type {
   ToolOperationConfig,
   ToolOperationHook,
@@ -69,10 +71,10 @@ export { createStandardErrorHandler } from "@app/utils/toolErrorHandler";
  * Shared hook for tool operations providing consistent error handling, progress tracking,
  * and FileContext integration. Eliminates boilerplate while maintaining flexibility.
  *
- * Supports three tool patterns:
- * 1. Single-file tools: Set multiFileEndpoint: false, processes files individually
- * 2. Multi-file tools: Set multiFileEndpoint: true, single API call with all files
- * 3. Complex tools: Provide customProcessor for full control over processing logic
+ * Supports three tool patterns, selected by the config's toolType:
+ * 1. Single-file tools (ToolType.singleFile): processes files individually
+ * 2. Multi-file tools (ToolType.multiFile): single API call with all files
+ * 3. Complex tools (ToolType.custom): customProcessor takes full control
  *
  * @param config - Tool operation configuration
  * @returns Hook interface with state and execution methods

--- a/frontend/editor/src/core/hooks/tools/sign/useSignOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/sign/useSignOperation.ts
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   useToolOperation,
   ToolOperationHook,
-  ToolType,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   SignParameters,
@@ -50,8 +50,7 @@ export const buildSignFormData = (
 };
 
 // Static configuration object
-export const signOperationConfig = {
-  toolType: ToolType.singleFile,
+export const signOperationConfig = defineSingleFileTool({
   buildFormData: buildSignFormData,
   operationType: "sign",
   // Signing is applied client-side in the viewer (see createStampTool ->
@@ -60,7 +59,7 @@ export const signOperationConfig = {
   endpoint: null,
   filePrefix: "signed_",
   defaultParameters: DEFAULT_PARAMETERS,
-} as const;
+});
 
 export const useSignOperation = (): ToolOperationHook<SignParameters> => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   fileOnlyMapping,
@@ -26,7 +27,7 @@ export const buildSingleLargePageFormData = (
 ): FormData => objectToFormData(toApiParams(), { fileInput: file });
 
 // Static configuration object
-export const singleLargePageOperationConfig = {
+export const singleLargePageOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildSingleLargePageFormData,
   toApiParams,
@@ -34,7 +35,7 @@ export const singleLargePageOperationConfig = {
   operationType: "pdfToSinglePage",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useSingleLargePageOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/singleLargePage/useSingleLargePageOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -28,7 +27,6 @@ export const buildSingleLargePageFormData = (
 
 // Static configuration object
 export const singleLargePageOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildSingleLargePageFormData,
   toApiParams,
   fromApiParams,

--- a/frontend/editor/src/core/hooks/tools/split/useSplitOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/split/useSplitOperation.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   ToolOperationConfig,
   defineSingleFileTool,
@@ -173,7 +172,6 @@ export const getSplitEndpoint = (parameters: SplitParameters): SplitEndpoint =>
 
 // Static configuration object
 export const splitOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildSplitFormData,
   toApiParams: splitToApiParams,
   fromApiParams: splitFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/split/useSplitOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/split/useSplitOperation.ts
@@ -4,6 +4,7 @@ import {
   ToolType,
   useToolOperation,
   ToolOperationConfig,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -33,7 +34,8 @@ const SPLIT_ENDPOINTS = {
   [SPLIT_METHODS.BY_POSTER]: "/api/v1/general/split-for-poster-print",
 } as const satisfies Record<SplitMethod, ToolEndpoint>;
 
-type SplitApiParams = ToolApiParams[(typeof SPLIT_ENDPOINTS)[SplitMethod]];
+type SplitEndpoint = (typeof SPLIT_ENDPOINTS)[SplitMethod];
+type SplitApiParams = ToolApiParams[SplitEndpoint];
 type SectionsApiParams =
   ToolApiParams[(typeof SPLIT_ENDPOINTS)[typeof SPLIT_METHODS.BY_SECTIONS]];
 type PosterApiParams =
@@ -165,12 +167,12 @@ export const buildSplitFormData = (
 ): FormData =>
   objectToFormData(splitToApiParams(parameters), { fileInput: file });
 
-export const getSplitEndpoint = (parameters: SplitParameters): ToolEndpoint =>
+export const getSplitEndpoint = (parameters: SplitParameters): SplitEndpoint =>
   // Default to BY_PAGES when no method is selected yet.
   SPLIT_ENDPOINTS[parameters.method ?? SPLIT_METHODS.BY_PAGES];
 
 // Static configuration object
-export const splitOperationConfig = {
+export const splitOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildSplitFormData,
   toApiParams: splitToApiParams,
@@ -178,7 +180,7 @@ export const splitOperationConfig = {
   operationType: "split",
   endpoint: getSplitEndpoint,
   defaultParameters,
-} as const;
+});
 
 export const useSplitOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/timestampPdf/useTimestampPdfOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/timestampPdf/useTimestampPdfOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -37,7 +36,6 @@ export const buildTimestampPdfFormData = (
   objectToFormData(timestampPdfToApiParams(parameters), { fileInput: file });
 
 export const timestampPdfOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildTimestampPdfFormData,
   toApiParams: timestampPdfToApiParams,
   fromApiParams: timestampPdfFromApiParams,

--- a/frontend/editor/src/core/hooks/tools/timestampPdf/useTimestampPdfOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/timestampPdf/useTimestampPdfOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   objectToFormData,
@@ -35,16 +36,15 @@ export const buildTimestampPdfFormData = (
 ): FormData =>
   objectToFormData(timestampPdfToApiParams(parameters), { fileInput: file });
 
-export const timestampPdfOperationConfig = {
+export const timestampPdfOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildTimestampPdfFormData,
   toApiParams: timestampPdfToApiParams,
   fromApiParams: timestampPdfFromApiParams,
   operationType: "timestampPdf",
   endpoint: ENDPOINT,
-  multiFileEndpoint: false,
   defaultParameters,
-} as const;
+});
 
 export const useTimestampPdfOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/core/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import {
-  ToolType,
   useToolOperation,
   defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
@@ -28,7 +27,6 @@ export const buildUnlockPdfFormsFormData = (
 
 // Static configuration object
 export const unlockPdfFormsOperationConfig = defineSingleFileTool({
-  toolType: ToolType.singleFile,
   buildFormData: buildUnlockPdfFormsFormData,
   toApiParams,
   fromApiParams,

--- a/frontend/editor/src/core/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/unlockPdfForms/useUnlockPdfFormsOperation.ts
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   ToolType,
   useToolOperation,
+  defineSingleFileTool,
 } from "@app/hooks/tools/shared/useToolOperation";
 import {
   fileOnlyMapping,
@@ -26,7 +27,7 @@ export const buildUnlockPdfFormsFormData = (
 ): FormData => objectToFormData(toApiParams(), { fileInput: file });
 
 // Static configuration object
-export const unlockPdfFormsOperationConfig = {
+export const unlockPdfFormsOperationConfig = defineSingleFileTool({
   toolType: ToolType.singleFile,
   buildFormData: buildUnlockPdfFormsFormData,
   toApiParams,
@@ -34,7 +35,7 @@ export const unlockPdfFormsOperationConfig = {
   operationType: "unlockPDFForms",
   endpoint: ENDPOINT,
   defaultParameters,
-} as const;
+});
 
 export const useUnlockPdfFormsOperation = () => {
   const { t } = useTranslation();

--- a/frontend/editor/src/prototypes/hooks/tools/pdfCommentAgent/pdfCommentAgentOperationConfig.ts
+++ b/frontend/editor/src/prototypes/hooks/tools/pdfCommentAgent/pdfCommentAgentOperationConfig.ts
@@ -1,7 +1,6 @@
 import apiClient from "@app/services/apiClient";
 import {
-  ToolType,
-  CustomToolOperationConfig,
+  defineCustomTool,
   CustomProcessorResult,
 } from "@app/hooks/tools/shared/toolOperationTypes";
 import {
@@ -104,10 +103,10 @@ const processPdfCommentAgent = async (
   return { files: [resultFile] };
 };
 
-export const pdfCommentAgentOperationConfig = {
-  toolType: ToolType.custom,
-  operationType: "pdfCommentAgent",
-  endpoint: PDF_COMMENT_AGENT_ENDPOINT,
-  customProcessor: processPdfCommentAgent,
-  defaultParameters,
-} as const satisfies CustomToolOperationConfig<PdfCommentAgentParameters>;
+export const pdfCommentAgentOperationConfig =
+  defineCustomTool<PdfCommentAgentParameters>({
+    operationType: "pdfCommentAgent",
+    endpoint: PDF_COMMENT_AGENT_ENDPOINT,
+    customProcessor: processPdfCommentAgent,
+    defaultParameters,
+  });


### PR DESCRIPTION
# Description of Changes
Followup work requested in review of #6867. Currently, there is nothing enforcing that the endpoint chosen in the tool config is the correct mapping for `toApiParams`, so theoretically it's possible for a tool to be set up to call an endpoint with the wrong API params for it. There's also nothing currently enforcing that `toApiParams` and `fromApiParams` are compatible with each other (using the same types). This PR changes it so that instead of creating the config object directly, tools create it via a generic function, which enforces that all of the relevant mappings are using compatible types.