### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Then open: http://localhost:8080
 
 For full installation options (including desktop and Kubernetes), see our [Documentation Guide](https://docs.stirlingpdf.com/#documentation-guide).
 
+## Managed Hosting
+
+Prefer not to self-host? Deploy a managed instance in one click:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/stirling-pdf)
+
+> One-click managed Stirling-PDF: storage, backups, email and a free subdomain included. A share of every subscription goes back to Stirling-PDF.
+
 ## Resources
 
 - [**Documentation**](https://docs.stirlingpdf.com)


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Stirling-PDF to our marketplace, so this PR adds a small "Deploy with Zenith" badge under a new Managed Hosting section (links to https://zenith.hosting/host/stirling-pdf).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Testing (if applicable)

- N/A docs-only change (README addition); no linters, typechecks, or tests affected.