### PR TITLE
Show top-level Info and XMP custom metadata in Change Metadata

### DIFF
--- a/frontend/editor/src/core/services/pdfMetadataService.test.ts
+++ b/frontend/editor/src/core/services/pdfMetadataService.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  extractCustomMetadata,
+  extractPDFMetadata,
+} from "@app/services/pdfMetadataService";
+import { TrappedStatus } from "@app/types/metadata";
+
+const { createDocumentMock, destroyDocumentMock } = vi.hoisted(() => ({
+  createDocumentMock: vi.fn(),
+  destroyDocumentMock: vi.fn(),
+}));
+
+vi.mock("@app/services/fileAnalyzer", () => ({
+  FileAnalyzer: {
+    isValidPDF: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock("@app/services/pdfWorkerManager", () => ({
+  pdfWorkerManager: {
+    createDocument: createDocumentMock,
+    destroyDocument: destroyDocumentMock,
+  },
+}));
+
+describe("extractCustomMetadata", () => {
+  test("extracts custom metadata from the PDF.js Custom object", () => {
+    const customMetadata = extractCustomMetadata({
+      Custom: {
+        Department: "Engineering",
+        Project: "Stirling",
+      },
+    });
+
+    expect(customMetadata).toStrictEqual([
+      { key: "Department", value: "Engineering", id: "custom1" },
+      { key: "Project", value: "Stirling", id: "custom2" },
+    ]);
+  });
+
+  test("extracts non-standard top-level info fields as custom metadata", () => {
+    const customMetadata = extractCustomMetadata({
+      Title: "Document title",
+      Author: "Document author",
+      Creator: "Microsoft Word 2019",
+      Company: "Example Ltd",
+      Manager: "Jane Doe",
+    });
+
+    expect(customMetadata).toStrictEqual([
+      { key: "Company", value: "Example Ltd", id: "custom1" },
+      { key: "Manager", value: "Jane Doe", id: "custom2" },
+    ]);
+  });
+
+  test("keeps Custom entries when the same key also appears at the top level", () => {
+    const customMetadata = extractCustomMetadata({
+      Custom: {
+        Company: "Custom Company",
+      },
+      Company: "Top-level Company",
+    });
+
+    expect(customMetadata).toStrictEqual([
+      { key: "Company", value: "Custom Company", id: "custom1" },
+    ]);
+  });
+
+  test("skips empty custom metadata values", () => {
+    const customMetadata = extractCustomMetadata({
+      Custom: {
+        Empty: "",
+        Missing: null,
+        Present: "value",
+      },
+      AnotherEmpty: "",
+    });
+
+    expect(customMetadata).toStrictEqual([
+      { key: "Present", value: "value", id: "custom1" },
+    ]);
+  });
+
+  test("extracts non-standard XMP metadata entries", () => {
+    const xmpMetadata = new Map<string, unknown>([
+      ["dc:title", "Document title"],
+      ["pdf:Producer", "PDF Producer"],
+      ["pdfx:Company", "Example Ltd"],
+      ["pdfx:Manager", "Jane Doe"],
+    ]);
+
+    const customMetadata = extractCustomMetadata({}, xmpMetadata);
+
+    expect(customMetadata).toStrictEqual([
+      { key: "pdfx:Company", value: "Example Ltd", id: "custom1" },
+      { key: "pdfx:Manager", value: "Jane Doe", id: "custom2" },
+    ]);
+  });
+});
+
+describe("extractPDFMetadata", () => {
+  test("falls back to XMP metadata for standard fields and custom entries", async () => {
+    const pdfDocument = {
+      getMetadata: vi.fn().mockResolvedValue({
+        info: {},
+        metadata: new Map<string, unknown>([
+          ["dc:title", "XMP title"],
+          ["dc:creator", "XMP author"],
+          ["dc:description", "XMP subject"],
+          ["pdf:Keywords", "xmp, keywords"],
+          ["xmp:CreatorTool", "Microsoft Word 2019"],
+          ["pdf:Producer", "PDF Producer"],
+          ["xmp:CreateDate", "2024-01-02T03:04:05"],
+          ["xmp:ModifyDate", "2024-01-03T04:05:06"],
+          ["pdfx:Company", "Example Ltd"],
+        ]),
+      }),
+    };
+    createDocumentMock.mockResolvedValue(pdfDocument);
+
+    const result = await extractPDFMetadata(
+      new File(["%PDF-1.7"], "metadata.pdf", { type: "application/pdf" }),
+    );
+
+    expect(result).toStrictEqual({
+      success: true,
+      metadata: {
+        title: "XMP title",
+        author: "XMP author",
+        subject: "XMP subject",
+        keywords: "xmp, keywords",
+        creator: "Microsoft Word 2019",
+        producer: "PDF Producer",
+        creationDate: "2024/01/02 03:04:05",
+        modificationDate: "2024/01/03 04:05:06",
+        trapped: TrappedStatus.UNKNOWN,
+        customMetadata: [
+          { key: "pdfx:Company", value: "Example Ltd", id: "custom1" },
+        ],
+      },
+    });
+    expect(destroyDocumentMock).toHaveBeenCalledWith(pdfDocument);
+  });
+});

--- a/frontend/editor/src/core/services/pdfMetadataService.ts
+++ b/frontend/editor/src/core/services/pdfMetadataService.ts
@@ -79,26 +79,86 @@ function convertTrappedStatus(trapped: unknown): TrappedStatus {
   return TrappedStatus.UNKNOWN;
 }
 
+const STANDARD_METADATA_KEYS = new Set([
+  "PDFFormatVersion",
+  "Language",
+  "EncryptFilterName",
+  "IsLinearized",
+  "IsAcroFormPresent",
+  "IsXFAPresent",
+  "IsCollectionPresent",
+  "IsSignaturesPresent",
+  "Title",
+  "Author",
+  "Subject",
+  "Keywords",
+  "Creator",
+  "Producer",
+  "CreationDate",
+  "ModDate",
+  "Trapped",
+  "Custom",
+]);
+
+const STANDARD_XMP_KEYS = new Set([
+  "dc:title",
+  "dc:creator",
+  "dc:description",
+  "pdf:Keywords",
+  "pdf:Producer",
+  "xmp:CreateDate",
+  "xmp:CreatorTool",
+  "xmp:MetadataDate",
+  "xmp:ModifyDate",
+]);
+
+type PDFJSMetadata = Iterable<[string, unknown]>;
+
 /**
- * Extract custom metadata fields from PDF.js info object
- * Custom metadata is nested under the "Custom" key
+ * Extract custom metadata fields from PDF.js metadata objects.
+ * PDF.js may expose custom metadata under info.Custom, as extra top-level info fields,
+ * or as XMP metadata entries.
  */
-function extractCustomMetadata(custom: unknown): CustomMetadataEntry[] {
+export function extractCustomMetadata(
+  info: Record<string, unknown>,
+  xmpMetadata?: PDFJSMetadata | null,
+): CustomMetadataEntry[] {
   const customMetadata: CustomMetadataEntry[] = [];
+  const seenKeys = new Set<string>();
   let customIdCounter = 1;
 
-  // Check if there's a Custom object containing the custom metadata
-  if (typeof custom === "object" && custom !== null) {
-    const customObj = custom as Record<string, unknown>;
+  const addMetadataEntry = (key: string, value: unknown) => {
+    const normalizedKey = key.toLowerCase();
+    if (seenKeys.has(normalizedKey) || value == null || value === "") {
+      return;
+    }
 
-    Object.entries(customObj).forEach(([key, value]) => {
-      if (value != null && value !== "") {
-        const entry = {
-          key,
-          value: String(value),
-          id: `custom${customIdCounter++}`,
-        };
-        customMetadata.push(entry);
+    customMetadata.push({
+      key,
+      value: String(value),
+      id: `custom${customIdCounter++}`,
+    });
+    seenKeys.add(normalizedKey);
+  };
+
+  if (typeof info.Custom === "object" && info.Custom !== null) {
+    Object.entries(info.Custom as Record<string, unknown>).forEach(
+      ([key, value]) => {
+        addMetadataEntry(key, value);
+      },
+    );
+  }
+
+  Object.entries(info).forEach(([key, value]) => {
+    if (!STANDARD_METADATA_KEYS.has(key)) {
+      addMetadataEntry(key, value);
+    }
+  });
+
+  if (xmpMetadata) {
+    Array.from(xmpMetadata).forEach(([key, value]) => {
+      if (!STANDARD_XMP_KEYS.has(key)) {
+        addMetadataEntry(key, value);
       }
     });
   }
@@ -119,12 +179,35 @@ function cleanupPdfDocument(pdfDoc: PDFDocumentProxy | null): void {
   }
 }
 
-function getStringMetadata(info: Record<string, unknown>, key: string): string {
-  if (typeof info[key] === "string") {
-    return info[key];
-  } else {
+function getXmpStringMetadata(
+  xmpMetadata: PDFJSMetadata | null | undefined,
+  keys: string[],
+): string {
+  if (!xmpMetadata) {
     return "";
   }
+
+  const keySet = new Set(keys);
+  for (const [key, value] of xmpMetadata) {
+    if (keySet.has(key) && typeof value === "string") {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+function getStringMetadata(
+  info: Record<string, unknown>,
+  key: string,
+  xmpMetadata?: PDFJSMetadata | null,
+  xmpKeys: string[] = [],
+): string {
+  if (typeof info[key] === "string") {
+    return info[key];
+  }
+
+  return getXmpStringMetadata(xmpMetadata, xmpKeys);
 }
 
 /**
@@ -165,19 +248,32 @@ export async function extractPDFMetadata(
   }
 
   const info = metadata.info as Record<string, unknown>;
+  const xmpMetadata = metadata.metadata;
 
   // Safely extract metadata with proper type checking
   const extractedMetadata: ExtractedPDFMetadata = {
-    title: getStringMetadata(info, "Title"),
-    author: getStringMetadata(info, "Author"),
-    subject: getStringMetadata(info, "Subject"),
-    keywords: getStringMetadata(info, "Keywords"),
-    creator: getStringMetadata(info, "Creator"),
-    producer: getStringMetadata(info, "Producer"),
-    creationDate: formatPDFDate(getStringMetadata(info, "CreationDate")),
-    modificationDate: formatPDFDate(getStringMetadata(info, "ModDate")),
+    title: getStringMetadata(info, "Title", xmpMetadata, ["dc:title"]),
+    author: getStringMetadata(info, "Author", xmpMetadata, ["dc:creator"]),
+    subject: getStringMetadata(info, "Subject", xmpMetadata, [
+      "dc:description",
+    ]),
+    keywords: getStringMetadata(info, "Keywords", xmpMetadata, [
+      "pdf:Keywords",
+    ]),
+    creator: getStringMetadata(info, "Creator", xmpMetadata, [
+      "xmp:CreatorTool",
+    ]),
+    producer: getStringMetadata(info, "Producer", xmpMetadata, [
+      "pdf:Producer",
+    ]),
+    creationDate: formatPDFDate(
+      getStringMetadata(info, "CreationDate", xmpMetadata, ["xmp:CreateDate"]),
+    ),
+    modificationDate: formatPDFDate(
+      getStringMetadata(info, "ModDate", xmpMetadata, ["xmp:ModifyDate"]),
+    ),
     trapped: convertTrappedStatus(info.Trapped),
-    customMetadata: extractCustomMetadata(info.Custom),
+    customMetadata: extractCustomMetadata(info, xmpMetadata),
   };
 
   cleanupPdfDocument(pdfDoc);


### PR DESCRIPTION
## Summary

- Extract custom metadata from PDF.js top-level `info` fields in addition to `info.Custom`.
- Use XMP metadata as a fallback for standard fields such as title, author, creator, producer, dates, and keywords.
- Include non-standard XMP entries in the custom metadata list while avoiding duplicates for standard fields.
- Add unit tests for custom metadata extraction and XMP fallback behavior.

## Why

The Change Metadata tool could miss metadata fields that are visible in tools such as ExifTool or Adobe Acrobat, especially for PDFs exported from Microsoft Word. PDF.js can expose those values as top-level `info` fields or XMP metadata entries rather than only under `info.Custom`.

## Testing

- `../node_modules/.bin/vitest run src/core/services/pdfMetadataService.test.ts --project core`
- `npx prettier --check editor/src/core/services/pdfMetadataService.ts editor/src/core/services/pdfMetadataService.test.ts`
- `git diff --check`

Fixes #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)