### PR TITLE
Fix pipeline update-metadata custom params

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessor.java
@@ -108,15 +108,7 @@ public class PipelineProcessor {
                             hasInputFileType = true;
                             MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
                             body.add("fileInput", file);
-                            for (Entry<String, Object> entry : parameters.entrySet()) {
-                                if (entry.getValue() instanceof List<?> entryList) {
-                                    for (Object item : entryList) {
-                                        body.add(entry.getKey(), item);
-                                    }
-                                } else {
-                                    body.add(entry.getKey(), entry.getValue());
-                                }
-                            }
+                            addParametersToBody(body, parameters);
                             ResponseEntity<Resource> response =
                                     internalApiClient.post(operation, body);
                             // If the operation is filter and the response body is null or empty,
@@ -193,15 +185,7 @@ public class PipelineProcessor {
                     for (Resource file : matchingFiles) {
                         body.add("fileInput", file);
                     }
-                    for (Entry<String, Object> entry : parameters.entrySet()) {
-                        if (entry.getValue() instanceof List<?> entryList) {
-                            for (Object item : entryList) {
-                                body.add(entry.getKey(), item);
-                            }
-                        } else {
-                            body.add(entry.getKey(), entry.getValue());
-                        }
-                    }
+                    addParametersToBody(body, parameters);
                     ResponseEntity<Resource> response = internalApiClient.post(operation, body);
                     if (response.getBody()
                             instanceof InternalApiClient.TempFileResource tempFileResource) {
@@ -256,6 +240,30 @@ public class PipelineProcessor {
         result.setFiltersApplied(filtersApplied);
         result.setOutputFiles(outputFiles);
         return result;
+    }
+
+    private void addParametersToBody(
+            MultiValueMap<String, Object> body, Map<String, Object> parameters) {
+        for (Entry<String, Object> entry : parameters.entrySet()) {
+            Object value = entry.getValue();
+            if ("allRequestParams".equals(entry.getKey()) && value instanceof Map<?, ?> mapValue) {
+                for (Entry<?, ?> mapEntry : mapValue.entrySet()) {
+                    body.add(
+                            "allRequestParams[" + mapEntry.getKey() + "]",
+                            mapEntry.getValue());
+                }
+            } else if ("allRequestParams".equals(entry.getKey())
+                    && value instanceof String stringValue
+                    && stringValue.isBlank()) {
+                continue;
+            } else if (value instanceof List<?> entryList) {
+                for (Object item : entryList) {
+                    body.add(entry.getKey(), item);
+                }
+            } else {
+                body.add(entry.getKey(), value);
+            }
+        }
     }
 
     private List<Resource> processOutputFiles(

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/pipeline/PipelineProcessorTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ByteArrayResource;
@@ -19,6 +20,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 
 import stirling.software.SPDF.model.PipelineConfig;
 import stirling.software.SPDF.model.PipelineOperation;
@@ -111,6 +113,89 @@ class PipelineProcessorTest {
         verify(internalApiClient).post(anyString(), any());
 
         assertFalse(result.isHasErrors());
+
+        Files.deleteIfExists(tempPath);
+    }
+
+    @Test
+    void skipsBlankAllRequestParamsForMultipartBinding() throws Exception {
+        PipelineOperation op = new PipelineOperation();
+        op.setOperation("/api/v1/misc/update-metadata");
+        op.setParameters(Map.of("title", "Updated title", "allRequestParams", ""));
+        PipelineConfig config = new PipelineConfig();
+        config.setOperations(List.of(op));
+
+        Path tempPath = Files.createTempFile("test-output", ".pdf");
+        Files.write(tempPath, "processed_data".getBytes());
+        Resource outputResource =
+                new FileSystemResource(tempPath.toFile()) {
+                    @Override
+                    public String getFilename() {
+                        return "processed.pdf";
+                    }
+                };
+
+        when(apiDocService.isMultiInput("/api/v1/misc/update-metadata")).thenReturn(false);
+        when(apiDocService.getExtensionTypes(false, "/api/v1/misc/update-metadata"))
+                .thenReturn(List.of("pdf"));
+        when(apiDocService.isValidOperation(eq("/api/v1/misc/update-metadata"), anyMap()))
+                .thenReturn(true);
+        when(internalApiClient.post(eq("/api/v1/misc/update-metadata"), any()))
+                .thenReturn(new ResponseEntity<>(outputResource, HttpStatus.OK));
+
+        pipelineProcessor.runPipelineAgainstFiles(List.of(new MyFileByteArrayResource()), config);
+
+        ArgumentCaptor<MultiValueMap> bodyCaptor = ArgumentCaptor.forClass(MultiValueMap.class);
+        verify(internalApiClient).post(eq("/api/v1/misc/update-metadata"), bodyCaptor.capture());
+        MultiValueMap<String, Object> body = bodyCaptor.getValue();
+
+        assertEquals("Updated title", body.getFirst("title"));
+        assertFalse(body.containsKey("allRequestParams"));
+
+        Files.deleteIfExists(tempPath);
+    }
+
+    @Test
+    void expandsAllRequestParamsMapForMultipartBinding() throws Exception {
+        PipelineOperation op = new PipelineOperation();
+        op.setOperation("/api/v1/misc/update-metadata");
+        op.setParameters(
+                Map.of(
+                        "title",
+                        "Updated title",
+                        "allRequestParams",
+                        Map.of("customKey1", "Department", "customValue1", "Engineering")));
+        PipelineConfig config = new PipelineConfig();
+        config.setOperations(List.of(op));
+
+        Path tempPath = Files.createTempFile("test-output", ".pdf");
+        Files.write(tempPath, "processed_data".getBytes());
+        Resource outputResource =
+                new FileSystemResource(tempPath.toFile()) {
+                    @Override
+                    public String getFilename() {
+                        return "processed.pdf";
+                    }
+                };
+
+        when(apiDocService.isMultiInput("/api/v1/misc/update-metadata")).thenReturn(false);
+        when(apiDocService.getExtensionTypes(false, "/api/v1/misc/update-metadata"))
+                .thenReturn(List.of("pdf"));
+        when(apiDocService.isValidOperation(eq("/api/v1/misc/update-metadata"), anyMap()))
+                .thenReturn(true);
+        when(internalApiClient.post(eq("/api/v1/misc/update-metadata"), any()))
+                .thenReturn(new ResponseEntity<>(outputResource, HttpStatus.OK));
+
+        pipelineProcessor.runPipelineAgainstFiles(List.of(new MyFileByteArrayResource()), config);
+
+        ArgumentCaptor<MultiValueMap> bodyCaptor = ArgumentCaptor.forClass(MultiValueMap.class);
+        verify(internalApiClient).post(eq("/api/v1/misc/update-metadata"), bodyCaptor.capture());
+        MultiValueMap<String, Object> body = bodyCaptor.getValue();
+
+        assertEquals("Updated title", body.getFirst("title"));
+        assertEquals("Department", body.getFirst("allRequestParams[customKey1]"));
+        assertEquals("Engineering", body.getFirst("allRequestParams[customValue1]"));
+        assertFalse(body.containsKey("allRequestParams"));
 
         Files.deleteIfExists(tempPath);
     }


### PR DESCRIPTION
## Summary

- Expand pipeline `allRequestParams` map values into multipart fields such as `allRequestParams[customKey1]`.
- Skip blank `allRequestParams` values so the metadata endpoint does not try to parse an empty JSON map.
- Reuse the same parameter-to-multipart handling for single-input and multi-input pipeline operations.
- Add `PipelineProcessorTest` coverage for map expansion and blank values.

## Why

The regular Change Metadata UI submits custom metadata as indexed multipart fields, but pipeline JSON can deserialize `allRequestParams` as a `Map`. Passing that map as a single multipart value prevents Spring model binding from populating `MetadataRequest.allRequestParams`, causing `/api/v1/misc/update-metadata` to fail in pipelines.

## Testing

- `git diff --check`

Attempted but could not run locally because the Gradle wrapper could not download Gradle 9.6.0 within its configured 10s timeout:

```text
./gradlew test --tests stirling.software.SPDF.controller.api.pipeline.PipelineProcessorTest
Downloading from https://services.gradle.org/distributions/gradle-9.6.0-bin.zip failed: timeout (10000ms)
```

Fixes #4639

🤖 Generated with [Claude Code](https://claude.com/claude-code)