### PR TITLE
Hide Infrastructure tab in portal SaaS build

### DIFF
--- a/frontend/editor/src/portal-saas/components/navVisibility.test.ts
+++ b/frontend/editor/src/portal-saas/components/navVisibility.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+// Resolves to the SaaS override (src/portal-saas/components) via the @portal cascade.
+import { HIDDEN_NAV_VIEWS } from "@portal/components/navVisibility";
+
+describe("navVisibility (SaaS) — hidden nav entries", () => {
+  it("hides the Infrastructure tab (not built for SaaS yet)", () => {
+    expect(HIDDEN_NAV_VIEWS.has("infrastructure")).toBe(true);
+  });
+});

--- a/frontend/editor/src/portal-saas/components/navVisibility.ts
+++ b/frontend/editor/src/portal-saas/components/navVisibility.ts
@@ -1,0 +1,10 @@
+import type { ViewId } from "@portal/contexts/ViewContext";
+
+/**
+ * SaaS flavor: the Infrastructure tab isn't built for SaaS yet, so hide it from
+ * the sidebar until it is. Drop the entry here (or empty the set) to bring it
+ * back.
+ */
+export const HIDDEN_NAV_VIEWS: ReadonlySet<ViewId> = new Set<ViewId>([
+  "infrastructure",
+]);

--- a/frontend/editor/src/portal/components/Sidebar.tsx
+++ b/frontend/editor/src/portal/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import { useTier } from "@portal/contexts/TierContext";
 import { useTheme } from "@portal/contexts/ThemeContext";
 import { useUI } from "@portal/contexts/UIContext";
 import { LinkAccountFooterItem } from "@portal/components/LinkAccountFooterItem";
+import { HIDDEN_NAV_VIEWS } from "@portal/components/navVisibility";
 import { useAsync } from "@portal/hooks/useAsync";
 import { fetchHomeKpis, type KpiEntry } from "@portal/api/home";
 import { EDITOR_URL, EDITOR_IS_SAME_APP } from "@portal/auth/editorUrl";
@@ -129,16 +130,18 @@ export function Sidebar() {
   // a takeover modal (matching the marketing prototype).
 
   function renderGroup(entries: NavEntry[]) {
-    return entries.map((entry) => (
-      <NavItem
-        key={entry.id}
-        id={entry.id}
-        label={t(`portal.nav.${entry.id}`)}
-        icon={entry.icon}
-        isActive={activeView === entry.id}
-        onClick={(id) => setActiveView(id as ViewId)}
-      />
-    ));
+    return entries
+      .filter((entry) => !HIDDEN_NAV_VIEWS.has(entry.id))
+      .map((entry) => (
+        <NavItem
+          key={entry.id}
+          id={entry.id}
+          label={t(`portal.nav.${entry.id}`)}
+          icon={entry.icon}
+          isActive={activeView === entry.id}
+          onClick={(id) => setActiveView(id as ViewId)}
+        />
+      ));
   }
 
   return (

--- a/frontend/editor/src/portal/components/navVisibility.ts
+++ b/frontend/editor/src/portal/components/navVisibility.ts
@@ -1,0 +1,8 @@
+import type { ViewId } from "@portal/contexts/ViewContext";
+
+/**
+ * Nav entries the sidebar should hide for the current build flavor. Self-hosted
+ * shows the full nav, so this is empty. The SaaS build shadows this file to hide
+ * views that aren't wired up there yet (see portal-saas/components/navVisibility).
+ */
+export const HIDDEN_NAV_VIEWS: ReadonlySet<ViewId> = new Set();


### PR DESCRIPTION
## What

Hides the **Infrastructure** tab from the portal sidebar when the portal runs in the **SaaS** flavor. The Infrastructure view isn't built for SaaS yet, so it's removed from the nav for now — we can bring it back once it's ready.

## How

Adds a small nav-visibility flavor seam, matching the existing `@portal/*` cascade pattern (like `usePlanTier`):

- `portal/components/navVisibility.ts` — core/self-hosted: empty set, full nav shown.
- `portal-saas/components/navVisibility.ts` — SaaS shadow: hides `"infrastructure"`.
- `Sidebar.tsx` filters nav entries against `HIDDEN_NAV_VIEWS` in `renderGroup`.

To restore the tab later, empty the set in `portal-saas/components/navVisibility.ts`.

## Notes

- Self-hosted build is unchanged (resolves the empty core set).
- Only the sidebar entry is hidden; the `/infrastructure` route still exists (no nav path reaches it in SaaS).

## Testing

- New `portal-saas/components/navVisibility.test.ts` asserts the SaaS shadow hides `infrastructure`.
- Full `portal-saas` suite passes (13 tests).
- `tsc` clean for the portal layer; SaaS layer typechecks the new files with no errors.
