### PR TITLE
Fix policies set in the portal not applying in the editor

### DIFF
--- a/frontend/editor/src/proprietary/components/policies/PoliciesSidebar.tsx
+++ b/frontend/editor/src/proprietary/components/policies/PoliciesSidebar.tsx
@@ -12,7 +12,7 @@
  *     collapsed; clicking an icon selects the policy and expands the rail.
  */
 
-import { useState, useEffect, useMemo, type ReactNode } from "react";
+import { useState, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import LocalIcon from "@app/components/shared/LocalIcon";
@@ -282,7 +282,8 @@ export function PolicyDetailTakeover() {
   // The configured policy's backing folder + automation (its real, editable
   // pipeline). `reloadKey` bumps after the edit modal saves so the detail
   // reflects the new steps. Falls back to the preset's rules when unconfigured.
-  const folderId = selectedId ? pol.policies[selectedId]?.folderId : undefined;
+  const selectedState = selectedId ? pol.policies[selectedId] : undefined;
+  const folderId = selectedState?.folderId;
   const [steps, setSteps] = useState<AutomationOperation[]>([]);
   const [backingFolder, setBackingFolder] = useState<WatchedFolder | null>(
     null,
@@ -313,6 +314,31 @@ export function PolicyDetailTakeover() {
       cancelled = true;
     };
   }, [folderId, reloadKey]);
+
+  // A policy authored in the portal arrives with a backend record but no local
+  // backing folder, so the effect above can't load its steps and the detail
+  // view would show an empty pipeline. Hydrate a backing folder from the backend
+  // record — its automation blob, or the stored steps for a portal-authored
+  // policy (ensurePolicyFolder is a no-op once a valid folder exists); it sets
+  // folderId, which re-runs the effect above to populate the view. The ref
+  // guards against a second hydration while the first is still in flight (before
+  // folderId propagates through state).
+  const { ensurePolicyFolder } = pol;
+  const hydratingRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedId || !selectedState?.configured || selectedState.folderId)
+      return;
+    if (hydratingRef.current === selectedId) return;
+    hydratingRef.current = selectedId;
+    void ensurePolicyFolder(selectedId).finally(() => {
+      if (hydratingRef.current === selectedId) hydratingRef.current = null;
+    });
+  }, [
+    selectedId,
+    selectedState?.configured,
+    selectedState?.folderId,
+    ensurePolicyFolder,
+  ]);
 
   // Activity/stats come from the real backend runs the auto-run controller fires
   // on every upload (policyRunStore), filtered to this policy's category. The

--- a/frontend/editor/src/proprietary/hooks/usePolicies.test.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicies.test.ts
@@ -36,7 +36,18 @@ vi.mock("@app/services/policyApi", () => ({
   getPolicyRun: vi.fn(),
 }));
 
+// Minimal tool registry so the hook's endpoint→operation mapping can resolve
+// the compress tool when rebuilding a folder from stored steps.
+vi.mock("@app/contexts/ToolRegistryContext", () => ({
+  useToolRegistry: () => ({
+    allTools: {
+      compress: { operationConfig: { endpoint: "/api/v1/misc/compress-pdf" } },
+    },
+  }),
+}));
+
 import { usePolicies } from "@app/hooks/usePolicies";
+import { getPolicyAutomation } from "@app/services/policyFolders";
 
 // A minimal wizard result (workflow already saved + mapped by the builder).
 const wizardResult = {
@@ -152,5 +163,41 @@ describe("usePolicies", () => {
       await result.current.ensurePolicyFolder("ingestion");
     });
     expect(result.current.policies.ingestion.folderId).toBeTruthy();
+  });
+
+  it("ensurePolicyFolder rebuilds the pipeline from stored steps when a policy has no automation blob (portal-authored)", async () => {
+    // A policy authored in the portal: stored on the backend with steps
+    // (endpoint + params) but no `automation` blob the editor normally uses.
+    api.store.set("be-portal", {
+      id: "be-portal",
+      name: "Ingestion Policy",
+      enabled: true,
+      trigger: null,
+      steps: [
+        {
+          operation: "/api/v1/misc/compress-pdf",
+          parameters: { optimizeLevel: "5" },
+        },
+      ],
+      output: { type: "inline", options: { categoryId: "ingestion" } },
+    } as never);
+
+    const { result } = renderHook(() => usePolicies());
+    // Mount reconcile links the backend policy to the ingestion category.
+    await waitFor(() =>
+      expect(result.current.policies.ingestion.backendId).toBe("be-portal"),
+    );
+
+    let folderId: string | undefined;
+    await act(async () => {
+      folderId = await result.current.ensurePolicyFolder("ingestion");
+    });
+
+    // The rebuilt folder carries the portal's actual settings, mapped back from
+    // the endpoint to the editor's operation id — not the preset defaults.
+    const automation = await getPolicyAutomation(folderId!);
+    expect(automation?.operations).toEqual([
+      { operation: "compress", parameters: { optimizeLevel: "5" } },
+    ]);
   });
 });

--- a/frontend/editor/src/proprietary/hooks/usePolicies.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicies.ts
@@ -9,6 +9,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
 import { useSaaSTeam } from "@app/contexts/SaaSTeamContext";
+import { useToolRegistry } from "@app/contexts/ToolRegistryContext";
 import {
   loadPolicies,
   onPoliciesChange,
@@ -33,6 +34,7 @@ import {
   setPolicyEnabled,
   removePolicy,
 } from "@app/services/policyBackend";
+import { stepsToOperations } from "@app/services/policyPipeline";
 import type { PolicyToStore } from "@app/services/policyPipeline";
 import type {
   PoliciesByCategory,
@@ -67,6 +69,7 @@ export function usePolicies() {
   const [policies, setPolicies] = useState<PoliciesByCategory>(loadPolicies);
   const { config } = useAppConfig();
   const { isTeamLeader } = useSaaSTeam();
+  const { allTools } = useToolRegistry();
 
   useEffect(() => onPoliciesChange(() => setPolicies(loadPolicies())), []);
 
@@ -273,30 +276,39 @@ export function usePolicies() {
    * stored automation is used if present so the configured pipeline survives;
    * otherwise it falls back to the preset.
    */
-  const ensurePolicyFolder = useCallback(async (id: string) => {
-    const state = loadPolicies()[id];
-    const existing = state?.folderId;
-    // A healthy backing folder resolves to an automation; if it does, keep it.
-    if (existing && (await getPolicyAutomation(existing))) return existing;
-    const catalog = loadPolicyCatalog();
-    const category = catalog.categories.find((c) => c.id === id);
-    const config = catalog.configs[id];
-    if (!category || !config) return undefined;
-    // Stale/missing folder → recreate. Prefer the backend's stored automation
-    // (preserves the user's configured steps); else seed from the preset.
-    let operations = config.defaultOperations;
-    if (state?.backendId) {
-      const decoded = await fetchPoliciesByCategory()
-        .then((m) => m.get(id))
-        .catch(() => undefined);
-      if (decoded?.automation?.operations?.length) {
-        operations = decoded.automation.operations;
+  const ensurePolicyFolder = useCallback(
+    async (id: string) => {
+      const state = loadPolicies()[id];
+      const existing = state?.folderId;
+      // A healthy backing folder resolves to an automation; if it does, keep it.
+      if (existing && (await getPolicyAutomation(existing))) return existing;
+      const catalog = loadPolicyCatalog();
+      const category = catalog.categories.find((c) => c.id === id);
+      const config = catalog.configs[id];
+      if (!category || !config) return undefined;
+      // Stale/missing folder → recreate, preserving the configured pipeline.
+      // Prefer the backend's automation blob (the editor's own lossless
+      // round-trip); else rebuild from the stored steps — the case for a policy
+      // authored in the portal, which persists steps but not the blob; else fall
+      // back to the preset.
+      let operations = config.defaultOperations;
+      if (state?.backendId) {
+        const decoded = await fetchPoliciesByCategory()
+          .then((m) => m.get(id))
+          .catch(() => undefined);
+        if (decoded?.automation?.operations?.length) {
+          operations = decoded.automation.operations;
+        } else if (decoded?.steps?.length) {
+          const fromSteps = stepsToOperations(decoded.steps, allTools);
+          if (fromSteps.length) operations = fromSteps;
+        }
       }
-    }
-    const folder = await createPolicyFolder(category, operations);
-    updatePolicy(id, { folderId: folder.id });
-    return folder.id;
-  }, []);
+      const folder = await createPolicyFolder(category, operations);
+      updatePolicy(id, { folderId: folder.id });
+      return folder.id;
+    },
+    [allTools],
+  );
 
   // Only a team leader (SaaS) or a global admin (self-hosted) may configure;
   // everyone else gets the read-only surface. Login disabled (single-user)

--- a/frontend/editor/src/proprietary/services/policyPipeline.ts
+++ b/frontend/editor/src/proprietary/services/policyPipeline.ts
@@ -11,7 +11,10 @@
  * using that registry.
  */
 
-import type { AutomationConfig } from "@app/types/automation";
+import type {
+  AutomationConfig,
+  AutomationOperation,
+} from "@app/types/automation";
 import type { ToolRegistry } from "@app/data/toolsTaxonomy";
 import type { PolicyFolderSettings } from "@app/types/policies";
 
@@ -184,6 +187,37 @@ export function buildPipelineDefinition(
   };
 }
 
+/**
+ * Reconstruct frontend automation operations from stored backend steps — the
+ * inverse of {@link buildPipelineDefinition}'s endpoint mapping. Used to hydrate
+ * a policy authored elsewhere (e.g. the portal) that carries `steps` but no
+ * `automation` blob: each step's endpoint path is mapped back to its tool
+ * registry operation id, keeping the step's parameters. Steps whose endpoint no
+ * longer resolves to a registry tool are dropped (can't be represented as an
+ * editable operation).
+ *
+ * Only endpoints declared as plain strings are matched; a tool whose endpoint is
+ * parameter-dependent (a function) can't be reversed here and is skipped.
+ */
+export function stepsToOperations(
+  steps: BackendPipelineStep[],
+  toolRegistry: Partial<ToolRegistry>,
+): AutomationOperation[] {
+  const operationByEndpoint = new Map<string, string>();
+  for (const [operation, entry] of Object.entries(toolRegistry)) {
+    const endpoint = entry?.operationConfig?.endpoint;
+    if (typeof endpoint === "string")
+      operationByEndpoint.set(endpoint, operation);
+  }
+  const operations: AutomationOperation[] = [];
+  for (const step of steps) {
+    const operation = operationByEndpoint.get(step.operation);
+    if (!operation) continue;
+    operations.push({ operation, parameters: step.parameters ?? {} });
+  }
+  return operations;
+}
+
 /** A frontend policy ready to persist on the backend (the full settings set). */
 export interface PolicyToStore {
   /** Existing backend id (blank/omitted → create). */
@@ -217,6 +251,12 @@ export interface DecodedPolicy {
   enabled: boolean;
   /** Null if the stored policy carried no automation blob. */
   automation: AutomationConfig | null;
+  /**
+   * The engine-runnable steps (endpoint paths + params). Always present. The
+   * fallback source for the editable pipeline when `automation` is null — e.g.
+   * a policy authored in the portal, which stores steps but not the blob.
+   */
+  steps: BackendPipelineStep[];
   sources: string[];
   scopeTypes: string[];
   reviewerEmail: string;
@@ -290,6 +330,7 @@ export function fromBackendPolicy(policy: BackendPolicy): DecodedPolicy {
     name: policy.name,
     enabled: policy.enabled,
     automation: (output.automation as AutomationConfig | undefined) ?? null,
+    steps: Array.isArray(policy.steps) ? policy.steps : [],
     sources: Array.isArray(meta.sources) ? (meta.sources as string[]) : [],
     scopeTypes: Array.isArray(meta.scopeTypes)
       ? (meta.scopeTypes as string[])


### PR DESCRIPTION
The hydration from backend wasn't working properly on the editor so changes made to policy settings in the portal did not apply in the editor