### PR TITLE
fix(portal): prefill Stripe Checkout email from the signed-in SaaS account

### DIFF
--- a/frontend/editor/src/portal/billing/stripe.test.ts
+++ b/frontend/editor/src/portal/billing/stripe.test.ts
@@ -5,9 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * already-subscribed-redirect vs neither-secret-nor-url mapping, the mock flag,
  * unconfigured Supabase, and the portal-session path.
  */
-const { getClient, invoke } = vi.hoisted(() => ({
+const { getClient, invoke, getSession } = vi.hoisted(() => ({
   getClient: vi.fn(),
   invoke: vi.fn(),
+  getSession: vi.fn(),
 }));
 
 vi.mock("@portal/auth/saasSupabase", () => ({ ensureSaasSupabase: vi.fn() }));
@@ -26,7 +27,10 @@ const req = { teamId: 1, successUrl: "s", cancelUrl: "c" } as const;
 
 beforeEach(() => {
   invoke.mockReset();
-  getClient.mockReset().mockReturnValue({ functions: { invoke } });
+  getSession.mockReset().mockResolvedValue({ data: { session: null } });
+  getClient
+    .mockReset()
+    .mockReturnValue({ functions: { invoke }, auth: { getSession } });
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -81,6 +85,51 @@ describe("createCheckoutSession", () => {
   it("throws when neither client_secret nor url is returned", async () => {
     invoke.mockResolvedValue({ data: { success: true }, error: null });
     await expect(createCheckoutSession(req)).rejects.toThrow(/neither/);
+  });
+
+  it("prefills billing_owner_email from the signed-in SaaS session", async () => {
+    getSession.mockResolvedValue({
+      data: { session: { user: { email: "leader@acme.com" } } },
+    });
+    invoke.mockResolvedValue({
+      data: { success: true, client_secret: "cs_123" },
+      error: null,
+    });
+    await createCheckoutSession(req);
+    expect(invoke).toHaveBeenCalledWith(
+      "create-checkout-session",
+      expect.objectContaining({
+        body: expect.objectContaining({
+          billing_owner_email: "leader@acme.com",
+        }),
+      }),
+    );
+  });
+
+  it("omits billing_owner_email when no session email is available", async () => {
+    invoke.mockResolvedValue({
+      data: { success: true, client_secret: "cs_123" },
+      error: null,
+    });
+    await createCheckoutSession(req);
+    const body = invoke.mock.calls[0][1].body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("billing_owner_email");
+  });
+
+  it("an explicit billingOwnerEmail overrides the session", async () => {
+    getSession.mockResolvedValue({
+      data: { session: { user: { email: "session@acme.com" } } },
+    });
+    invoke.mockResolvedValue({
+      data: { success: true, client_secret: "cs_123" },
+      error: null,
+    });
+    await createCheckoutSession({
+      ...req,
+      billingOwnerEmail: "explicit@acme.com",
+    });
+    const body = invoke.mock.calls[0][1].body as Record<string, unknown>;
+    expect(body.billing_owner_email).toBe("explicit@acme.com");
   });
 
   it("throws unconfigured when there is no Supabase client", async () => {

--- a/frontend/editor/src/portal/billing/stripe.ts
+++ b/frontend/editor/src/portal/billing/stripe.ts
@@ -63,6 +63,28 @@ interface PortalResponse {
   error?: string;
 }
 
+/**
+ * The signed-in SaaS billing account's email, read from the SaaS Supabase
+ * session (the same identity whose JWT the edge function runs under, and which
+ * owns the Stripe customer). Used to prefill + lock Stripe Checkout's email
+ * field so it can't be left blank for the browser to autofill with the wrong
+ * account — the cause of Stripe-customer↔user mismatches. Best-effort: returns
+ * undefined if the session isn't readable, leaving the field un-prefilled.
+ */
+async function currentBillingEmail(): Promise<string | undefined> {
+  try {
+    ensureSaasSupabase();
+    const supabase = getSupabaseClient();
+    // getSession reads the persisted session (no network round-trip), so the
+    // prefill stays reliable even on a flaky connection.
+    const email = (await supabase?.auth.getSession())?.data.session?.user
+      ?.email;
+    return email ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function invoke<T>(
   name: string,
   body: Record<string, unknown>,
@@ -111,6 +133,13 @@ export interface CheckoutSession {
 export async function createCheckoutSession(
   req: CheckoutSessionRequest,
 ): Promise<CheckoutSession> {
+  // Prefill the checkout email from the signed-in SaaS account unless the caller
+  // supplied one explicitly. Without this the field renders blank and the browser
+  // autofills it (often with the wrong account), creating a Stripe customer that
+  // doesn't match the logged-in user. The edge function should still treat its JWT
+  // as authoritative — this is a client-side prefill, not a trust boundary.
+  const billingOwnerEmail =
+    req.billingOwnerEmail ?? (await currentBillingEmail());
   const res = await invoke<CheckoutResponse>("create-checkout-session", {
     team_id: req.teamId,
     currency: req.currency ?? "usd",
@@ -121,9 +150,7 @@ export async function createCheckoutSession(
     // redirect on completion. A redirect would reload the page, skip that finalize step, and
     // make Stripe ignore onComplete entirely (console warns "redirect_on_completion: always").
     redirect_on_completion: "never",
-    ...(req.billingOwnerEmail
-      ? { billing_owner_email: req.billingOwnerEmail }
-      : {}),
+    ...(billingOwnerEmail ? { billing_owner_email: billingOwnerEmail } : {}),
   });
   if (!res.success) {
     throw new StripeFunctionError(


### PR DESCRIPTION
## What this does

Fixes Stripe Checkout on the SaaS Processor plan creating customers under the wrong email.

- The Processor checkout minted the Stripe session with **no email**, so Stripe showed an empty email field — which the browser autofills, often with the Chrome/Google profile rather than the linked account. Result: Stripe customers that don't match the logged-in user.
- `createCheckoutSession` now **defaults `billing_owner_email` to the signed-in SaaS Supabase session's email** (`auth.getSession()`, local — no network round-trip) unless a caller passes one explicitly. The checkout modal already forwards it and **Stripe locks the field when prefilled**, so it can't be autofilled with the wrong address.
- Single choke point, so `FreePlanView` (and any future caller) get the prefill automatically.

The portal login is Spring but SaaS billing runs on a separate Supabase session — and that Supabase account owns the Stripe customer — so the email is sourced from the Supabase session, not the portal admin profile.

### Follow-up (not in this PR — SaaS edge function repo)
This is a client-side **prefill**, not a trust boundary. To fully prevent duplicate/mismatched customers, the `create-checkout-session` edge function should treat its JWT as authoritative: reuse the team's existing Stripe `customer` (or set `customer_email` from the token) and stamp `metadata` linking customer ↔ user/team. Flagging for the SaaS side.

### Tests
`stripe.test.ts`: prefill from session, omit when no session email, explicit override wins. 11 pass; typecheck / ESLint / Prettier clean.
