### PR TITLE
fix(portal): translate policy category labels in PolicySummary

### DIFF
--- a/frontend/editor/src/portal/components/PolicySummary.tsx
+++ b/frontend/editor/src/portal/components/PolicySummary.tsx
@@ -67,8 +67,8 @@ export function PolicySummary() {
             {policyIcon(entry.category.icon)}
           </span>
           <div className="portal-policysum__cat-text">
-            <strong>{entry.category.label}</strong>
-            <span>{entry.category.desc}</span>
+            <strong>{t(entry.category.label)}</strong>
+            <span>{t(entry.category.desc)}</span>
           </div>
         </div>
       ),
@@ -92,7 +92,7 @@ export function PolicySummary() {
       render: ({ entry, state }) => (
         <span className="portal-policysum__rule">
           {state === "active"
-            ? entry.config.summary
+            ? t(entry.config.summary)
             : t("portal.policySummary.noRule")}
         </span>
       ),


### PR DESCRIPTION
## What

The portal's **"What runs on your PDFs"** table (`PolicySummary`) rendered raw i18n keys instead of text:

- `portal.policies.categories.ingestion.label` / `.desc`
- `portal.policies.categories.security.label` / `.desc`
- …and the other three categories (compliance, routing, retention)

## Why it broke

[#6910 "Remove in-app portal mocks"](https://github.com/Stirling-Tools/Stirling-PDF/pull/6910) moved the policy catalogue to real data and converted each category's `label`/`desc` (and each config's `summary`) into **i18n keys** — see the `// values are i18n keys — render with t()` note in `api/policies.ts`. Every consumer was updated to call `t()` (`PolicyCategoryCard`, `PolicyDetailPanel`, `PolicySetupWizard`)… except `PolicySummary`, which was not part of that PR and kept rendering the fields verbatim.

The translation keys themselves already exist in `en-US/translation.toml` (`[portal.policies.categories.*]`) — nothing was missing, they just weren't being looked up.

## Fix

Wrap the values in `t()` in `PolicySummary.tsx` (the `t` from `useTranslation` was already in scope):
- category `label` / `desc` in the Policy column
- `config.summary` in the Active-rule column (same keyed-value treatment, latent until a policy is active)

## Test plan

- [ ] Open the portal Home / policies summary → each row shows the translated category name + description (e.g. "Ingestion" / "Classify documents…") instead of a dotted key.
- [ ] A row with an active policy shows its translated rule summary in the Active rule column.