### PR TITLE
Fix policy running of Redact

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/RedactController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/RedactController.java
@@ -136,11 +136,17 @@ public class RedactController {
                             + "Users can provide text patterns to redact, with options for regex and whole word matching. "
                             + "Input:PDF Output:PDF Type:SISO")
     public ResponseEntity<Resource> redactPdf(@ModelAttribute RedactPdfRequest request) {
-        String[] listOfText = request.getListOfText().split("\n");
+        String rawListOfText = request.getListOfText();
         boolean useRegex = Boolean.TRUE.equals(request.getUseRegex());
         boolean wholeWordSearchBool = Boolean.TRUE.equals(request.getWholeWordSearch());
 
-        if (listOfText.length == 0 || (listOfText.length == 1 && listOfText[0].trim().isEmpty())) {
+        if (rawListOfText == null || rawListOfText.trim().isEmpty()) {
+            throw ExceptionUtils.createIllegalArgumentException(
+                    "error.redaction.no.patterns", "No text patterns provided for redaction");
+        }
+
+        String[] listOfText = rawListOfText.split("\n");
+        if (listOfText.length == 1 && listOfText[0].trim().isEmpty()) {
             throw ExceptionUtils.createIllegalArgumentException(
                     "error.redaction.no.patterns", "No text patterns provided for redaction");
         }

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/security/RedactControllerMoreTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/security/RedactControllerMoreTest.java
@@ -300,6 +300,18 @@ class RedactControllerMoreTest {
         }
 
         @Test
+        @DisplayName("null listOfText throws an illegal-argument error before any load")
+        void nullPatternsThrows() throws Exception {
+            RedactPdfRequest request = new RedactPdfRequest();
+            request.setFileInput(pdfFile(new byte[] {1, 2, 3}));
+            request.setListOfText(null);
+
+            assertThatThrownBy(() -> controller.redactPdf(request))
+                    .isInstanceOf(RuntimeException.class);
+            verify(pdfDocumentFactory, never()).load(any(MultipartFile.class));
+        }
+
+        @Test
         @DisplayName("null file input is reported as a failure")
         void nullFileThrows() {
             RedactPdfRequest request = new RedactPdfRequest();

--- a/frontend/editor/src/core/hooks/tools/shared/toolAutomation.test.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolAutomation.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   deserializeToolStep,
   getExecutableTools,
+  serializeStepFromEndpoint,
   serializeToolStep,
   stepRequiresUpload,
   type WorkingToolStep,
@@ -195,6 +196,41 @@ describe("serialize/deserialize round-trip", () => {
     expect(back.support).toBe("editable");
     expect(back.operation).toBe("/api/v1/security/auto-redact");
     expect(back.params).toMatchObject({ mode: "automatic" });
+  });
+});
+
+describe("serializeStepFromEndpoint", () => {
+  test("maps a wizard step's UI params to the backend contract, filling defaults", () => {
+    // The shape the policy setup wizard holds: an endpoint plus UI-shaped params
+    // (redact's `wordsToRedact`), with several fields left to their defaults.
+    const api = serializeStepFromEndpoint(
+      "/api/v1/security/auto-redact",
+      { mode: "automatic", useRegex: true, wordsToRedact: ["ssn", "card"] },
+      dynamicRegistry,
+    );
+
+    expect(api.operation).toBe("/api/v1/security/auto-redact");
+    // wordsToRedact -> listOfText (the field the backend actually reads), and the
+    // frontend-only `mode` is dropped.
+    expect(api.parameters).toMatchObject({ listOfText: "ssn\ncard" });
+    expect(api.parameters).not.toHaveProperty("wordsToRedact");
+    expect(api.parameters).not.toHaveProperty("mode");
+    // Fields the wizard never set still get their defaults so the body is complete.
+    expect(api.parameters).toHaveProperty("wholeWordSearch");
+    expect(api.parameters).toHaveProperty("customPadding");
+  });
+
+  test("passes an unmapped endpoint's params through unchanged", () => {
+    expect(
+      serializeStepFromEndpoint(
+        "/api/v1/unknown/thing",
+        { keep: true },
+        dynamicRegistry,
+      ),
+    ).toEqual({
+      operation: "/api/v1/unknown/thing",
+      parameters: { keep: true },
+    });
   });
 });
 

--- a/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
@@ -198,6 +198,31 @@ export function serializeToolStep(
 }
 
 /**
+ * Serialize a step held as an endpoint path plus frontend-shaped params - the form the policy setup
+ * wizard keeps, where params match the tool's UI shape (e.g. redact's `wordsToRedact`) rather than
+ * the backend contract - into the backend step contract, mapping params through the tool's
+ * `toApiParams` (merged over its defaults, so fields the wizard never set still get their defaults).
+ * The endpoint maps to a tool by path, so this works for dynamic-endpoint tools whose config
+ * endpoint is a function. Endpoints that map to no known tool pass through unchanged.
+ */
+export function serializeStepFromEndpoint(
+  operation: string,
+  params: ErasedToolParams,
+  registry: Partial<ToolRegistry>,
+): ToolApiStep {
+  const match = findToolByEndpoint({ operation, parameters: params }, registry);
+  const config = match?.[1].operationConfig;
+  if (!config) return { operation, parameters: params };
+  const merged = { ...(config.defaultParameters ?? {}), ...params };
+  return {
+    operation: resolveEndpoint(config, merged) ?? operation,
+    parameters: config.toApiParams
+      ? (config.toApiParams(merged) as Record<string, unknown>)
+      : {},
+  };
+}
+
+/**
  * Find the registry tool for a stored step's endpoint: exact match for static endpoints, else
  * membership in a dynamic tool's declared `endpoints` set (replaying its function can't recover a
  * frontend-only routing field). Replay is only the fallback when no set is declared.

--- a/frontend/editor/src/portal/components/policies/PolicySetupWizard.tsx
+++ b/frontend/editor/src/portal/components/policies/PolicySetupWizard.tsx
@@ -19,7 +19,11 @@ import {
   type PipelineStep,
   type PolicySetupResult,
 } from "@portal/api/policies";
-import type { ToolRegistryEntry } from "@app/data/toolsTaxonomy";
+import type { ToolRegistry, ToolRegistryEntry } from "@app/data/toolsTaxonomy";
+import {
+  deserializeToolStep,
+  serializeStepFromEndpoint,
+} from "@app/hooks/tools/shared/toolAutomation";
 import { fetchSources } from "@portal/api/sources";
 import { useAsync } from "@portal/hooks/useAsync";
 import { PolicyFieldRow } from "@portal/components/policies/PolicyFieldRow";
@@ -121,7 +125,10 @@ const CAPABILITY_META: Record<
   },
 };
 
-function seedTools(entry: CatalogueEntry): ToolState[] {
+function seedTools(
+  entry: CatalogueEntry,
+  registry: Partial<ToolRegistry>,
+): ToolState[] {
   const savedSteps = entry.policy?.steps ?? [];
   const savedByOp = new Map(savedSteps.map((s) => [s.operation, s]));
   // Always use defaultOperations as the canonical list so tools added after a
@@ -135,7 +142,12 @@ function seedTools(entry: CatalogueEntry): ToolState[] {
         : savedSteps.length > 0
           ? false
           : !DISABLED_BY_DEFAULT.has(s.operation),
-      parameters: saved?.parameters ?? s.parameters,
+      // Saved steps are in the backend contract shape; map them back to the UI
+      // shape the config controls edit (e.g. `listOfText` -> `wordsToRedact`).
+      // Presets are already authored in the UI shape, so use them as-is.
+      parameters: saved
+        ? deserializeToolStep(saved, registry).params
+        : s.parameters,
     };
   });
 }
@@ -190,7 +202,9 @@ function PolicySetupWizardBody({
   const isEdit = policy != null;
 
   const [step, setStep] = useState<Step>("workflow");
-  const [tools, setTools] = useState<ToolState[]>(() => seedTools(entry));
+  const [tools, setTools] = useState<ToolState[]>(() =>
+    seedTools(entry, toolRegistry),
+  );
   const [fieldValues, setFieldValues] = useState(() =>
     resolveFieldValues(entry),
   );
@@ -263,10 +277,12 @@ function PolicySetupWizardBody({
     }
     setError(null);
     setSubmitting(true);
-    const steps: PipelineStep[] = enabledTools.map((tl) => ({
-      operation: tl.operation,
-      parameters: tl.parameters,
-    }));
+    // Map each tool's UI-shaped params (e.g. redact's `wordsToRedact`) into the
+    // backend step contract (e.g. `listOfText`) via its `toApiParams`; saving the
+    // UI shape verbatim would drop those fields and the step would run with none.
+    const steps: PipelineStep[] = enabledTools.map((tl) =>
+      serializeStepFromEndpoint(tl.operation, tl.parameters, toolRegistry),
+    );
     try {
       await onSubmit(entry, {
         fieldValues,


### PR DESCRIPTION
# Description of Changes
Policies can currently throw when calling redact:

<img width="1186" height="824" alt="image" src="https://github.com/user-attachments/assets/bdcc09fe-5bf4-4b0a-b119-bcc33c98c7f2" />

Policies really need to be updated to properly make use of the new bidirectional mappings for this, but this will hopefully fix it for now.