### PR TITLE
Match external-link tool buttons to normal tool button size

### DIFF
--- a/frontend/editor/src/core/components/tools/toolPicker/ToolButton.tsx
+++ b/frontend/editor/src/core/components/tools/toolPicker/ToolButton.tsx
@@ -265,7 +265,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({
       variant="tertiary"
       accent="neutral"
       size="sm"
-      p="sm"
+      p="none"
       fullWidth
       justify="start"
       className="tool-button"


### PR DESCRIPTION
The external-link "Developer Tools" buttons (API, Automated Folder Scanning, SSO Guide, Air-gapped Setup) used `p="sm"` while normal tool buttons use `p="none"`, making them render larger; this aligns their padding so they match the size of every other tool button.

<img width="308" height="196" alt="Screenshot 2026-07-10 at 5 01 40 PM" src="https://github.com/user-attachments/assets/fb125500-28fb-4b83-85ed-2edc12e66fc0" />
