### PR TITLE
Portal: honour RUN_SUBPATH in editor + login redirects

### DIFF
--- a/frontend/editor/src/core/components/onboarding/Onboarding.tsx
+++ b/frontend/editor/src/core/components/onboarding/Onboarding.tsx
@@ -3,6 +3,7 @@ import { type StepType } from "@reactour/tour";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useLocation } from "react-router-dom";
 import { isAuthRoute } from "@app/constants/routes";
+import { withBasePath } from "@app/constants/app";
 import { dispatchTourState } from "@app/constants/events";
 import { useOnboardingOrchestrator } from "@app/components/onboarding/orchestrator/useOnboardingOrchestrator";
 import { useBypassOnboarding } from "@app/components/onboarding/useBypassOnboarding";
@@ -77,7 +78,7 @@ export default function Onboarding() {
   );
 
   const redirectToLogin = useCallback(() => {
-    window.location.assign("/login");
+    window.location.assign(withBasePath("/login"));
   }, []);
 
   const handlePasswordChanged = useCallback(async () => {

--- a/frontend/editor/src/core/components/onboarding/slides/MFASetupSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/MFASetupSlide.tsx
@@ -23,7 +23,7 @@ import { accountService } from "@app/services/accountService";
 import { useAccountLogout } from "@app/extensions/accountLogout";
 import { useAuth } from "@app/auth/UseSession";
 import LocalIcon from "@app/components/shared/LocalIcon";
-import { BASE_PATH } from "@app/constants/app";
+import { BASE_PATH, withBasePath } from "@app/constants/app";
 import styles from "@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css";
 import { MfaSetupResponse } from "@app/responses/Mfa/MfaResponse";
 
@@ -84,7 +84,7 @@ function MFASetupContent({ onMfaSetupComplete }: MFASetupSlideProps) {
   }, [fetchMfaSetup]);
 
   const redirectToLogin = useCallback(() => {
-    window.location.assign("/login");
+    window.location.assign(withBasePath("/login"));
   }, []);
 
   const onLogout = useCallback(async () => {

--- a/frontend/editor/src/core/components/shared/LoginAgreementModal.tsx
+++ b/frontend/editor/src/core/components/shared/LoginAgreementModal.tsx
@@ -16,6 +16,7 @@ import remarkGfm from "remark-gfm";
 import apiClient from "@app/services/apiClient";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
 import { useAuth } from "@app/auth/UseSession";
+import { withBasePath } from "@app/constants/app";
 import { Z_INDEX_SIGN_IN_MODAL } from "@app/styles/zIndex";
 
 const ACCEPTED_STORAGE_KEY = "loginAgreementAccepted";
@@ -144,7 +145,7 @@ export default function LoginAgreementModal() {
       } catch {
         /* ignore */
       }
-      window.location.assign("/login");
+      window.location.assign(withBasePath("/login"));
     } else {
       // Anonymous / desktop: best-effort close the window; if that is a no-op (web),
       // reload so the agreement re-blocks until accepted.

--- a/frontend/editor/src/portal-saas/auth/PortalAuthBoundary.tsx
+++ b/frontend/editor/src/portal-saas/auth/PortalAuthBoundary.tsx
@@ -2,6 +2,7 @@ import { useEffect, type ReactNode } from "react";
 import { AuthProvider } from "@app/auth";
 import { useAuth } from "@app/auth/context";
 import { Spinner } from "@app/ui";
+import { withBasePath } from "@app/constants/app";
 import { ensureSaasSupabase } from "@portal/auth/saasSupabase";
 import { EDITOR_URL } from "@portal/auth/editorUrl";
 
@@ -34,7 +35,7 @@ function SaasPortalGate({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!blocked) return;
     // Guest (has a session but anonymous) -> editor; no session -> login.
-    window.location.href = session ? EDITOR_URL : "/login";
+    window.location.href = session ? EDITOR_URL : withBasePath("/login");
   }, [blocked, session]);
   if (loading || blocked) {
     return (

--- a/frontend/editor/src/portal-saas/components/billing/PortalBillingGate.tsx
+++ b/frontend/editor/src/portal-saas/components/billing/PortalBillingGate.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from "@app/constants/app";
 import { Usage } from "@portal/views/Usage";
 
 /**
@@ -13,7 +14,7 @@ export function PortalBillingGate() {
   return (
     <Usage
       onReauth={() => {
-        window.location.href = "/login";
+        window.location.href = withBasePath("/login");
       }}
     />
   );

--- a/frontend/editor/src/portal/auth/editorUrl.ts
+++ b/frontend/editor/src/portal/auth/editorUrl.ts
@@ -1,17 +1,29 @@
-/**
- * Where to send users to reach the editor app (app switcher, and the auth gate
- * bouncing non-admins out).
- *
- * Sourced from VITE_EDITOR_URL so it's configurable per deploy rather than
- * hardcoded, falling back to "/" (the editor serves the portal at /processor
- * on the same origin, so the root is the editor). For dev cross-app navigation to
- * a separately-running editor, set VITE_EDITOR_URL in editor/.env.local.
- */
-export const EDITOR_URL = import.meta.env.VITE_EDITOR_URL || "/";
+import { withBasePath } from "@app/constants/app";
+
+const CONFIGURED_EDITOR_URL = import.meta.env.VITE_EDITOR_URL || "";
 
 /**
  * When the editor is at the root of this origin, the portal and editor are
  * route-sets of one SPA — switching apps can be a client-side navigation
- * instead of a full page load.
+ * instead of a full page load. True unless a distinct VITE_EDITOR_URL points at
+ * a separately-running editor (dev cross-app setup).
  */
-export const EDITOR_IS_SAME_APP = EDITOR_URL === "/";
+export const EDITOR_IS_SAME_APP =
+  !CONFIGURED_EDITOR_URL || CONFIGURED_EDITOR_URL === "/";
+
+/**
+ * Where to send users to reach the editor app (app switcher, the auth gate
+ * bouncing non-admins out, the "Open in browser" CTAs on the home hero and the
+ * download-editor modal).
+ *
+ * Sourced from VITE_EDITOR_URL so it's configurable per deploy. When unset (the
+ * editor is this same app at the origin root), it resolves to the deploy's base
+ * path — so a subpath deploy (RUN_SUBPATH=/app → served under /app) lands on
+ * /app/ rather than the origin root. These CTAs use window.location, which
+ * bypasses the router basename, so the base path has to be baked in here. For
+ * dev cross-app navigation to a separately-running editor, set VITE_EDITOR_URL
+ * in editor/.env.local.
+ */
+export const EDITOR_URL = EDITOR_IS_SAME_APP
+  ? withBasePath("/")
+  : CONFIGURED_EDITOR_URL;

--- a/frontend/editor/src/proprietary/components/shared/config/OverviewHeader.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/OverviewHeader.tsx
@@ -2,6 +2,7 @@ import { Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@app/auth/UseSession";
+import { withBasePath } from "@app/constants/app";
 
 export function OverviewHeader() {
   const { t } = useTranslation();
@@ -13,7 +14,7 @@ export function OverviewHeader() {
     } catch (error) {
       console.error("Logout error:", error);
     } finally {
-      window.location.assign("/login");
+      window.location.assign(withBasePath("/login"));
     }
   };
 

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AccountSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AccountSection.tsx
@@ -19,7 +19,7 @@ import { accountService } from "@app/services/accountService";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
 import { QRCodeSVG } from "qrcode.react";
 import { useAccountLogout } from "@app/extensions/accountLogout";
-import { BASE_PATH } from "@app/constants/app";
+import { BASE_PATH, withBasePath } from "@app/constants/app";
 import { MfaSetupResponse } from "@app/responses/Mfa/MfaResponse";
 
 const AccountSection: React.FC = () => {
@@ -80,7 +80,7 @@ const AccountSection: React.FC = () => {
   );
 
   const redirectToLogin = useCallback(() => {
-    window.location.assign("/login");
+    window.location.assign(withBasePath("/login"));
   }, []);
 
   const handleLogout = useCallback(async () => {


### PR DESCRIPTION
## What's wrong

When the app is served under a subpath (`RUN_SUBPATH=/app` → everything lives under `/app`), several buttons/redirects send you to the **origin root** instead of `/app`:

- **Home hero "Open in browser"** (`WelcomeBanner`) → went to `/`
- **Download-editor modal "Open in browser"** (`DownloadEditorModal`) → went to `/`
- **Auth-gate / SaaS session redirects** → went to `/`
- **Logout / session-expiry / onboarding redirects to `/login`** → went to origin `/login`

## Why

These all use **raw `window.location`** (a full browser navigation), which bypasses the React Router `basename`. Two root causes:

1. `EDITOR_URL` fell back to a hardcoded `"/"`.
2. Several paths hardcoded `"/login"`.

Client-side `navigate(...)` calls already respect the basename — those were left alone.

## The fix

- **`editorUrl.ts`** — when the editor is this same app (no `VITE_EDITOR_URL`), `EDITOR_URL` now resolves through `withBasePath("/")`: `/app/` under a subpath, `/` otherwise. One change fixes the home hero, the download modal, and the auth-gate/session redirects.
- Routed the remaining raw `window.location` `"/login"` redirects through `withBasePath("/login")`: onboarding, MFA setup, login-agreement modal, account/overview logout, and the SaaS billing gate.

## Verification

Typecheck (proprietary/saas/portal), eslint, and prettier all pass on the changed files.