### PR TITLE
Guard against stray file drops navigating the app

### DIFF
--- a/frontend/editor/src/core/components/AppLayout.tsx
+++ b/frontend/editor/src/core/components/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { useBanner } from "@app/contexts/BannerContext";
+import { useGlobalFileDropGuard } from "@app/hooks/useGlobalFileDropGuard";
 import NavigationWarningModal from "@app/components/shared/NavigationWarningModal";
 import LoginAgreementModal from "@app/components/shared/LoginAgreementModal";
 
@@ -13,6 +14,10 @@ interface AppLayoutProps {
  */
 export function AppLayout({ children }: AppLayoutProps) {
   const { banner } = useBanner();
+
+  // Stop stray file drops outside a dropzone from navigating the webview to
+  // the file (which blocks the desktop app). See issue #6872.
+  useGlobalFileDropGuard();
 
   return (
     <>

--- a/frontend/editor/src/core/hooks/useGlobalFileDropGuard.test.ts
+++ b/frontend/editor/src/core/hooks/useGlobalFileDropGuard.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  installFileDropGuard,
+  isExternalFileDrag,
+} from "@app/hooks/useGlobalFileDropGuard";
+
+/**
+ * jsdom does not implement a full DragEvent/DataTransfer, so we dispatch a
+ * plain cancelable Event with a stubbed `dataTransfer.types` and read
+ * `defaultPrevented` to observe whether the guard cancelled the default
+ * navigation. This keeps the tests hermetic and framework-free.
+ */
+function dispatchDrag(
+  type: "dragover" | "drop",
+  types: string[] | undefined,
+): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    configurable: true,
+    value: types === undefined ? null : { types },
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("isExternalFileDrag", () => {
+  test("is true when the drag carries files", () => {
+    const event = new Event("drop") as DragEvent;
+    Object.defineProperty(event, "dataTransfer", {
+      value: { types: ["Files"] },
+    });
+    expect(isExternalFileDrag(event)).toBe(true);
+  });
+
+  test("is false for an internal (non-file) drag", () => {
+    const event = new Event("drop") as DragEvent;
+    Object.defineProperty(event, "dataTransfer", {
+      value: { types: ["text/plain"] },
+    });
+    expect(isExternalFileDrag(event)).toBe(false);
+  });
+
+  test("is false when dataTransfer is absent", () => {
+    const event = new Event("drop") as DragEvent;
+    Object.defineProperty(event, "dataTransfer", { value: null });
+    expect(isExternalFileDrag(event)).toBe(false);
+  });
+});
+
+describe("installFileDropGuard", () => {
+  let dispose: (() => void) | undefined;
+
+  afterEach(() => {
+    dispose?.();
+    dispose = undefined;
+  });
+
+  test("prevents default for an external file drop", () => {
+    dispose = installFileDropGuard(window);
+    const event = dispatchDrag("drop", ["Files"]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("prevents default for an external file dragover", () => {
+    dispose = installFileDropGuard(window);
+    const event = dispatchDrag("dragover", ["Files"]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("does not prevent default for an internal drag", () => {
+    dispose = installFileDropGuard(window);
+    const event = dispatchDrag("drop", ["text/plain"]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("removes its listeners when disposed", () => {
+    installFileDropGuard(window)();
+    const event = dispatchDrag("drop", ["Files"]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/frontend/editor/src/core/hooks/useGlobalFileDropGuard.ts
+++ b/frontend/editor/src/core/hooks/useGlobalFileDropGuard.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+/**
+ * True when a drag/drop event carries operating-system files (an external
+ * file drag) rather than internal HTML5 drag-and-drop payloads such as page
+ * or file-tile reordering, which use custom data types instead of "Files".
+ */
+export function isExternalFileDrag(event: DragEvent): boolean {
+  const types = event.dataTransfer?.types;
+  if (!types) {
+    return false;
+  }
+  return Array.from(types).includes("Files");
+}
+
+/**
+ * Attach window-level guards that stop a stray external file drop from
+ * navigating the document to the dropped file.
+ *
+ * Intended dropzones (e.g. the Mantine Dropzone in FileManager) still receive
+ * and process their own drop events - their element-level handlers run first
+ * during bubbling and read `dataTransfer.files` there. This guard only cancels
+ * the leftover browser/webview default action (navigating to the file) for
+ * file drops that no dropzone handled, so it never interferes with dropzone
+ * uploads or with internal, non-file drag-and-drop.
+ *
+ * Returns a disposer that removes the listeners.
+ */
+export function installFileDropGuard(target: Window = window): () => void {
+  const onDragOver = (event: DragEvent): void => {
+    if (isExternalFileDrag(event)) {
+      event.preventDefault();
+    }
+  };
+  const onDrop = (event: DragEvent): void => {
+    if (isExternalFileDrag(event)) {
+      event.preventDefault();
+    }
+  };
+
+  target.addEventListener("dragover", onDragOver);
+  target.addEventListener("drop", onDrop);
+
+  return () => {
+    target.removeEventListener("dragover", onDragOver);
+    target.removeEventListener("drop", onDrop);
+  };
+}
+
+/**
+ * Prevents an accidental file drop outside a dropzone from replacing the app
+ * with a full-screen view of the dropped file, which in the desktop webview
+ * leaves the window unusable. See issue #6872.
+ */
+export function useGlobalFileDropGuard(): void {
+  useEffect(() => installFileDropGuard(window), []);
+}


### PR DESCRIPTION
# Description of Changes

Closes #6872

## What was changed
Added a window-level drag/drop guard so that dropping a file **outside** an
intended dropzone no longer navigates the webview to the dropped file.

- New hook `useGlobalFileDropGuard` (`frontend/editor/src/core/hooks/useGlobalFileDropGuard.ts`):
  - `isExternalFileDrag(event)` — true only when the drag carries OS files
    (`dataTransfer.types` includes `"Files"`).
  - `installFileDropGuard(target)` — attaches `dragover` + `drop` listeners that
    `preventDefault()` external file drags and returns a disposer.
  - `useGlobalFileDropGuard()` — thin React hook wrapping the installer with
    `useEffect` cleanup.
- `AppLayout` calls the hook once. `AppLayout` is the single shared layout
  rendered by every flavour's `App.tsx` (core/proprietary/saas/prototypes, and
  desktop via the `@app` cascade), so one call site covers all builds.
- Unit tests in `useGlobalFileDropGuard.test.ts`.

## Why the change was made
On the desktop build, dropping a PDF onto a sidebar (i.e. anywhere that is not
the Mantine `Dropzone`) let the webview perform its default action and open the
file full-screen, replacing the app UI and leaving the window unclosable
(issue #6872). There was no global guard against stray file drops.

## Notes / scope
- The guard fires **only** for external file drags (`types` includes `"Files"`)
  and runs at the bubble phase, so intended dropzones still read
  `dataTransfer.files` in their own handlers and internal, non-file
  drag-and-drop (page/file reordering) is unaffected.
- Frontend-only change; no backend or API surface touched.

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] I have added unit tests for the new drop-guard hook (`useGlobalFileDropGuard.test.ts`)
- [x] ESLint (`--max-warnings=0`), `tsc --noEmit` (core + proprietary), and Vitest pass locally for the changed files