### PR TITLE
Portal Agent Builder: SVG upload icon

### DIFF
--- a/frontend/editor/src/portal/components/agent-builder/BootstrapDialog.tsx
+++ b/frontend/editor/src/portal/components/agent-builder/BootstrapDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import FileUploadRounded from "@mui/icons-material/FileUploadRounded";
 import { Button, Modal } from "@app/ui";
 import "@portal/views/AgentBuilder.css";
 
@@ -58,7 +59,7 @@ export function BootstrapDialog({ open, onClose }: BootstrapDialogProps) {
             onChange={(e) => setFileName(e.target.files?.[0]?.name ?? null)}
           />
           <span className="portal-agents__dropzone-icon" aria-hidden>
-            ⇪
+            <FileUploadRounded style={{ fontSize: "1.5rem" }} />
           </span>
           <span className="portal-agents__dropzone-text">
             {fileName ?? t("portal.agentBuilder.bootstrap.dropzoneText")}

--- a/frontend/editor/src/portal/views/AgentBuilder.tsx
+++ b/frontend/editor/src/portal/views/AgentBuilder.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import FileUploadRounded from "@mui/icons-material/FileUploadRounded";
 import { Button, EmptyState, Skeleton } from "@app/ui";
 import { useTier } from "@portal/contexts/TierContext";
 import { useAsync, useSectionFlags } from "@portal/hooks/useAsync";
@@ -41,7 +42,7 @@ export function AgentBuilder() {
         </div>
         <Button
           onClick={() => setBootstrapOpen(true)}
-          leftSection={<span aria-hidden>⇪</span>}
+          leftSection={<FileUploadRounded style={{ fontSize: "1.2rem" }} />}
         >
           {t("portal.agentBuilder.bootstrapFromDocument")}
         </Button>


### PR DESCRIPTION
# Description of Changes

Replaces the upload glyph in the agent bootstrap dialog with a proper SVG icon.

Part of a portal (processor) UI-consistency pass, split into small focused PRs.

## Before / after

<!-- paste before / after screenshots here -->

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
