### PR TITLE
fix(temp-files): prevent cleanup of active registered directories

### DIFF
--- a/app/common/src/main/java/stirling/software/common/service/TempFileCleanupService.java
+++ b/app/common/src/main/java/stirling/software/common/service/TempFileCleanupService.java
@@ -144,8 +144,10 @@ public class TempFileCleanupService {
         int directoriesDeletedCount = 0;
         for (Path directory : registry.getTempDirectories()) {
             try {
-                if (Files.exists(directory)) {
+                if (Files.exists(directory)
+                        && shouldDeleteRegisteredDirectory(directory, maxAgeMillis)) {
                     GeneralUtils.deleteDirectory(directory);
+                    registry.unregisterDirectory(directory);
                     directoriesDeletedCount++;
                     log.debug("Cleaned up temporary directory: {}", directory);
                 }
@@ -273,6 +275,21 @@ public class TempFileCleanupService {
         }
 
         return totalDeletedCount.get();
+    }
+
+    private boolean shouldDeleteRegisteredDirectory(Path directory, long maxAgeMillis) {
+        if (maxAgeMillis <= 0) {
+            return true;
+        }
+
+        try {
+            long currentTime = System.currentTimeMillis();
+            long lastModified = Files.getLastModifiedTime(directory).toMillis();
+            return (currentTime - lastModified) > maxAgeMillis;
+        } catch (IOException e) {
+            log.debug("Could not check directory age, skipping cleanup: {}", directory, e);
+            return false;
+        }
     }
 
     /** Get the system temp directory path based on configuration or system property. */

--- a/app/common/src/main/java/stirling/software/common/util/TempFileManager.java
+++ b/app/common/src/main/java/stirling/software/common/util/TempFileManager.java
@@ -155,6 +155,7 @@ public class TempFileManager {
         if (directory != null && Files.isDirectory(directory)) {
             try {
                 GeneralUtils.deleteDirectory(directory);
+                registry.unregisterDirectory(directory);
                 log.debug("Deleted temp directory: {}", directory.toString());
             } catch (IOException e) {
                 log.warn("Failed to delete temp directory: {}", directory.toString(), e);

--- a/app/common/src/main/java/stirling/software/common/util/TempFileRegistry.java
+++ b/app/common/src/main/java/stirling/software/common/util/TempFileRegistry.java
@@ -86,6 +86,18 @@ public class TempFileRegistry {
     }
 
     /**
+     * Unregister a temporary directory from the registry.
+     *
+     * @param directory The directory to unregister
+     */
+    public void unregisterDirectory(Path directory) {
+        if (directory != null) {
+            tempDirectories.remove(directory);
+            log.debug("Unregistered temp directory: {}", directory.toString());
+        }
+    }
+
+    /**
      * Register a third-party temporary file that requires special handling.
      *
      * @param file The third-party temp file

--- a/app/common/src/test/java/stirling/software/common/service/TempFileCleanupServiceMoreTest.java
+++ b/app/common/src/test/java/stirling/software/common/service/TempFileCleanupServiceMoreTest.java
@@ -176,11 +176,13 @@ class TempFileCleanupServiceMoreTest {
     class ScheduledCleanup {
 
         @Test
-        @DisplayName("deletes registered temp directories and reports counts")
+        @DisplayName("deletes stale registered temp directories and reports counts")
         void deletesRegisteredDirectories() throws IOException {
             when(tempFileManager.cleanupOldTempFiles(anyLong())).thenReturn(2);
             Path regDir = Files.createDirectories(tempDir.resolve("registeredDir"));
             Files.createFile(regDir.resolve("inside.txt"));
+            Files.setLastModifiedTime(
+                    regDir, FileTime.fromMillis(System.currentTimeMillis() - 2L * 60 * 60 * 1000));
             Set<Path> dirs = new HashSet<>();
             dirs.add(regDir);
             when(registry.getTempDirectories()).thenReturn(dirs);
@@ -191,6 +193,22 @@ class TempFileCleanupServiceMoreTest {
             // The registered directory was removed by GeneralUtils.deleteDirectory.
             assertThat(Files.exists(regDir)).isFalse();
             verify(tempFileManager).cleanupOldTempFiles(anyLong());
+        }
+
+        @Test
+        @DisplayName("keeps a fresh registered temp directory")
+        void keepsFreshRegisteredDirectory() throws IOException {
+            when(tempFileManager.cleanupOldTempFiles(anyLong())).thenReturn(0);
+            Path regDir = Files.createDirectories(tempDir.resolve("freshRegisteredDir"));
+            Files.createFile(regDir.resolve("inside.txt"));
+            Set<Path> dirs = new HashSet<>();
+            dirs.add(regDir);
+            when(registry.getTempDirectories()).thenReturn(dirs);
+            lenient().when(registry.contains(any(File.class))).thenReturn(false);
+
+            withIsolatedUserHome(cleanupService::scheduledCleanup);
+
+            assertThat(Files.exists(regDir)).isTrue();
         }
 
         @Test


### PR DESCRIPTION
# Description of Changes

This change prevents the scheduled temporary-file cleanup from deleting registered directories that are still being used by long-running operations such as OCR processing.

## What was changed

- Added an age check for registered temporary directories before scheduled cleanup deletes them.
- Registered directories are now deleted only when their last-modified timestamp exceeds the configured maximum temporary-file age.
- Preserved the existing behavior of deleting registered directories immediately when the configured maximum age is zero or negative.
- Added `unregisterDirectory` to `TempFileRegistry`.
- Removed directories from the registry after they are successfully deleted by:
  - `TempFileCleanupService`
  - `TempFileManager`
- Added test coverage confirming that:
  - Stale registered directories are deleted.
  - Fresh registered directories are retained.
  - Scheduled cleanup continues to report deletion counts correctly.

## Why the change was made

Long-running OCR operations can keep a registered temporary directory active for longer than the scheduled cleanup interval. The previous cleanup implementation deleted every registered directory without checking its age.

For large documents, this could cause the cleanup task to remove files while OCR was still processing them. On Windows, this resulted in file-lock errors and subsequently missing intermediate page images, causing OCR processing to fail.

The age check ensures that actively used temporary directories are not removed prematurely while still allowing stale directories to be cleaned up.

Unregistering successfully deleted directories also prevents obsolete registry entries from accumulating.


If the directory age cannot be determined, cleanup is skipped to avoid deleting potentially active data.

Closes #6925

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
