### PR TITLE
refactor(frontend): replace custom UI SVGs with Material icons

### DIFF
--- a/frontend/editor/src/cloud/components/shared/TeamInvitationBanner.tsx
+++ b/frontend/editor/src/cloud/components/shared/TeamInvitationBanner.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Group, Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CheckIcon from "@mui/icons-material/Check";
 import { InfoBanner } from "@app/components/shared/InfoBanner";
 import { useSaaSTeam } from "@app/contexts/SaaSTeamContext";
 
@@ -82,11 +82,8 @@ export function TeamInvitationBanner() {
         onClick={handleAccept}
         loading={processing}
         leftSection={
-          <LocalIcon
-            icon="check"
-            width="0.9rem"
-            height="0.9rem"
-            style={{ color: "var(--mantine-color-dark-9)" }}
+          <CheckIcon
+            sx={{ color: "var(--mantine-color-dark-9)", fontSize: "0.9rem" }}
           />
         }
       >

--- a/frontend/editor/src/cloud/components/shared/config/configSections/TeamSection.tsx
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/TeamSection.tsx
@@ -13,9 +13,14 @@ import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
 import { useSaaSTeam } from "@app/contexts/SaaSTeamContext";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
 import apiClient from "@app/services/apiClient";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import EditIcon from "@mui/icons-material/Edit";
+import LogoutIcon from "@mui/icons-material/Logout";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
 
 const TeamSection: React.FC = () => {
   const { t } = useTranslation();
@@ -238,7 +243,7 @@ const TeamSection: React.FC = () => {
                   disabled={!newTeamName.trim()}
                   aria-label={t("team.renameSubmit", "Save team name")}
                 >
-                  <LocalIcon icon="check" width="1rem" height="1rem" />
+                  <CheckIcon width="1rem" height="1rem" />
                 </ActionIcon>
                 <ActionIcon
                   variant="tertiary"
@@ -246,7 +251,7 @@ const TeamSection: React.FC = () => {
                   disabled={renamingTeam}
                   aria-label={t("team.renameCancel", "Cancel rename")}
                 >
-                  <LocalIcon icon="close" width="1rem" height="1rem" />
+                  <CloseIcon width="1rem" height="1rem" />
                 </ActionIcon>
               </Group>
             ) : (
@@ -261,7 +266,7 @@ const TeamSection: React.FC = () => {
                     onClick={handleStartRename}
                     aria-label={t("team.editName", "Edit team name")}
                   >
-                    <LocalIcon icon="edit" width="1rem" height="1rem" />
+                    <EditIcon width="1rem" height="1rem" />
                   </ActionIcon>
                 )}
                 {isTeamLeader && (
@@ -288,9 +293,7 @@ const TeamSection: React.FC = () => {
               variant="secondary"
               size="sm"
               onClick={handleLeaveTeam}
-              leftSection={
-                <LocalIcon icon="logout" width="1rem" height="1rem" />
-              }
+              leftSection={<LogoutIcon width="1rem" height="1rem" />}
             >
               {t("team.leaveButton", "Leave Team")}
             </Button>
@@ -455,19 +458,14 @@ const TeamSection: React.FC = () => {
                                   "Member actions",
                                 )}
                               >
-                                <LocalIcon
-                                  icon="more-vert"
-                                  width="1rem"
-                                  height="1rem"
-                                />
+                                <MoreVertIcon width="1rem" height="1rem" />
                               </ActionIcon>
                             </Menu.Target>
                             <Menu.Dropdown>
                               <Menu.Item
                                 color="red"
                                 leftSection={
-                                  <LocalIcon
-                                    icon="person-remove"
+                                  <PersonRemoveIcon
                                     width="1rem"
                                     height="1rem"
                                   />
@@ -522,11 +520,7 @@ const TeamSection: React.FC = () => {
                               "Cancel invitation",
                             )}
                           >
-                            <LocalIcon
-                              icon="close"
-                              width="1rem"
-                              height="1rem"
-                            />
+                            <CloseIcon width="1rem" height="1rem" />
                           </ActionIcon>
                         </Table.Td>
                       )}

--- a/frontend/editor/src/core/components/annotation/shared/DrawingControls.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/DrawingControls.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Group, Tooltip } from "@mantine/core";
 import { useTranslation } from "react-i18next";
-import { LocalIcon } from "@app/components/shared/LocalIcon";
+import RedoIcon from "@mui/icons-material/Redo";
+import UndoIcon from "@mui/icons-material/Undo";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 
@@ -45,12 +46,7 @@ export const DrawingControls: React.FC<DrawingControlsProps> = ({
             onClick={onUndo}
             disabled={undoDisabled}
           >
-            <LocalIcon
-              icon="undo"
-              width={20}
-              height={20}
-              style={{ color: "currentColor" }}
-            />
+            <UndoIcon sx={{ color: "currentColor", fontSize: 20 }} />
           </ActionIcon>
         </Tooltip>
       )}
@@ -63,12 +59,7 @@ export const DrawingControls: React.FC<DrawingControlsProps> = ({
             onClick={onRedo}
             disabled={redoDisabled}
           >
-            <LocalIcon
-              icon="redo"
-              width={20}
-              height={20}
-              style={{ color: "currentColor" }}
-            />
+            <RedoIcon sx={{ color: "currentColor", fontSize: 20 }} />
           </ActionIcon>
         </Tooltip>
       )}

--- a/frontend/editor/src/core/components/fileEditor/AddFileCard.tsx
+++ b/frontend/editor/src/core/components/fileEditor/AddFileCard.tsx
@@ -9,6 +9,7 @@ import styles from "@app/components/fileEditor/FileEditor.module.css";
 import { useFileActionTerminology } from "@app/hooks/useFileActionTerminology";
 import { useFileActionIcons } from "@app/hooks/useFileActionIcons";
 import { openFilesFromDisk } from "@app/services/openFilesFromDisk";
+import AddIcon from "@mui/icons-material/Add";
 
 interface AddFileCardProps {
   onFileSelect: (files: File[]) => void;
@@ -125,8 +126,7 @@ const AddFileCard = ({
                 onClick={handleOpenFilesModal}
                 onMouseEnter={() => setIsUploadHover(false)}
               >
-                <LocalIcon
-                  icon="add"
+                <AddIcon
                   width="1.5rem"
                   height="1.5rem"
                   className="text-[var(--accent-interactive)]"

--- a/frontend/editor/src/core/components/onboarding/OnboardingSlideShell.tsx
+++ b/frontend/editor/src/core/components/onboarding/OnboardingSlideShell.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { Button, type ButtonAccent } from "@app/ui/Button";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CloseIcon from "@mui/icons-material/CloseRounded";
 import { Z_INDEX_OVER_FULLSCREEN_SURFACE } from "@app/styles/zIndex";
 import stirlingMark from "@app/assets/brand/modern-logo/logo512.png";
 import styles from "@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css";
@@ -149,11 +149,7 @@ export default function OnboardingSlideShell({
                 size="md"
                 aria-label={t("common.close", "Close")}
               >
-                <LocalIcon
-                  icon="close-rounded"
-                  width="1.1rem"
-                  height="1.1rem"
-                />
+                <CloseIcon sx={{ fontSize: "1.1rem" }} />
               </ActionIcon>
             )}
           </div>

--- a/frontend/editor/src/core/components/onboarding/slides/FirstLoginSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/FirstLoginSlide.tsx
@@ -3,7 +3,8 @@ import { Stack, PasswordInput, Alert, Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
 import { SlideConfig } from "@app/types/types";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ErrorIcon from "@mui/icons-material/ErrorRounded";
+import InfoIcon from "@mui/icons-material/InfoRounded";
 import { UNIFIED_CIRCLE_CONFIG } from "@app/components/onboarding/slides/unifiedBackgroundConfig";
 import { accountService } from "@app/services/accountService";
 import { alert as showToast } from "@app/components/toast";
@@ -121,11 +122,8 @@ function FirstLoginForm({
         <form onSubmit={handleSubmit}>
           <Stack gap="md">
             <div className={styles.securityAlertRow}>
-              <LocalIcon
-                icon="info-rounded"
-                width={20}
-                height={20}
-                style={{ color: "#3B82F6", flexShrink: 0 }}
+              <InfoIcon
+                sx={{ color: "#3B82F6", flexShrink: 0, fontSize: 20 }}
               />
               <span>
                 {t(
@@ -143,7 +141,7 @@ function FirstLoginForm({
             {error && (
               <Alert
                 icon={
-                  <LocalIcon icon="error-rounded" width="1rem" height="1rem" />
+                  <ErrorIcon sx={{ fontSize: "1rem" }} />
                 }
                 color="red"
                 variant="light"

--- a/frontend/editor/src/core/components/onboarding/slides/FirstLoginSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/FirstLoginSlide.tsx
@@ -140,9 +140,7 @@ function FirstLoginForm({
 
             {error && (
               <Alert
-                icon={
-                  <ErrorIcon sx={{ fontSize: "1rem" }} />
-                }
+                icon={<ErrorIcon sx={{ fontSize: "1rem" }} />}
                 color="red"
                 variant="light"
               >

--- a/frontend/editor/src/core/components/onboarding/slides/MFASetupSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/MFASetupSlide.tsx
@@ -22,7 +22,7 @@ import { UNIFIED_CIRCLE_CONFIG } from "@app/components/onboarding/slides/unified
 import { accountService } from "@app/services/accountService";
 import { useAccountLogout } from "@app/extensions/accountLogout";
 import { useAuth } from "@app/auth/UseSession";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ErrorIcon from "@mui/icons-material/Error";
 import { BASE_PATH, withBasePath } from "@app/constants/app";
 import styles from "@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css";
 import { MfaSetupResponse } from "@app/responses/Mfa/MfaResponse";
@@ -198,7 +198,7 @@ function MFASetupContent({ onMfaSetupComplete }: MFASetupSlideProps) {
 
           {mfaError && (
             <Alert
-              icon={<LocalIcon icon="error" width={16} height={16} />}
+              icon={<ErrorIcon sx={{ fontSize: 16 }} />}
               color="red"
               variant="light"
             >

--- a/frontend/editor/src/core/components/onboarding/slides/SecurityCheckSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/SecurityCheckSlide.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Select } from "@mantine/core";
 import { SlideConfig } from "@app/types/types";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ErrorIcon from "@mui/icons-material/Error";
 import { UNIFIED_CIRCLE_CONFIG } from "@app/components/onboarding/slides/unifiedBackgroundConfig";
 import i18n from "@app/i18n";
 import styles from "@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css";
@@ -22,11 +22,8 @@ export default function SecurityCheckSlide({
       <div className={styles.securitySlideContent}>
         <div className={styles.securityCard}>
           <div className={styles.securityAlertRow}>
-            <LocalIcon
-              icon="error"
-              width={20}
-              height={20}
-              style={{ color: "#F04438", flexShrink: 0 }}
+            <ErrorIcon
+              sx={{ color: "#F04438", flexShrink: 0, fontSize: 20 }}
             />
             <span>
               {i18n.t(

--- a/frontend/editor/src/core/components/onboarding/slides/SecurityCheckSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/SecurityCheckSlide.tsx
@@ -22,9 +22,7 @@ export default function SecurityCheckSlide({
       <div className={styles.securitySlideContent}>
         <div className={styles.securityCard}>
           <div className={styles.securityAlertRow}>
-            <ErrorIcon
-              sx={{ color: "#F04438", flexShrink: 0, fontSize: 20 }}
-            />
+            <ErrorIcon sx={{ color: "#F04438", flexShrink: 0, fontSize: 20 }} />
             <span>
               {i18n.t(
                 "onboarding.securityCheck.message",

--- a/frontend/editor/src/core/components/pageEditor/DragDropGrid.tsx
+++ b/frontend/editor/src/core/components/pageEditor/DragDropGrid.tsx
@@ -14,7 +14,7 @@ import {
   Z_INDEX_DROP_INDICATOR,
   Z_INDEX_DRAG_BADGE,
 } from "@app/styles/zIndex";
-import { LocalIcon } from "@app/components/shared/LocalIcon";
+import DescriptionIcon from "@mui/icons-material/Description";
 import {
   DndContext,
   DragEndEvent,
@@ -1010,7 +1010,7 @@ const DragDropGrid = <T extends DragDropItem>({
                   color: "var(--mantine-color-dimmed)",
                 }}
               >
-                <LocalIcon icon="description" width="3rem" height="3rem" />
+                <DescriptionIcon sx={{ fontSize: "3rem" }} />
               </div>
             )}
           </div>

--- a/frontend/editor/src/core/components/pageEditor/PageSelectByNumberButton.tsx
+++ b/frontend/editor/src/core/components/pageEditor/PageSelectByNumberButton.tsx
@@ -1,6 +1,6 @@
 import { Popover } from "@mantine/core";
 import { ActionIcon } from "@app/ui/ActionIcon";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import PinEndIcon from "@mui/icons-material/PinEnd";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import BulkSelectionPanel from "@app/components/pageEditor/BulkSelectionPanel";
 
@@ -42,7 +42,7 @@ export default function PageSelectByNumberButton({
                 disabled={disabled || totalPages === 0}
                 aria-label={label}
               >
-                <LocalIcon icon="pin-end" width="1.5rem" height="1.5rem" />
+                <PinEndIcon sx={{ fontSize: "1.5rem" }} />
               </ActionIcon>
             </div>
           </Popover.Target>

--- a/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.tsx
+++ b/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.tsx
@@ -1,7 +1,7 @@
 import { TextInput, Text, Flex, Switch } from "@mantine/core";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import GppMaybeOutlinedIcon from "@mui/icons-material/GppMaybeOutlined";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import { usePageSelectionTips } from "@app/components/tooltips/usePageSelectionTips";
 import classes from "@app/components/pageEditor/bulkSelectionPanel/BulkSelectionPanel.module.css";
@@ -40,11 +40,8 @@ const PageSelectionInput = ({
           tips={pageSelectionTips.tips}
         >
           <Flex onClick={(e) => e.stopPropagation()} align="center" gap="xs">
-            <LocalIcon
-              icon="gpp-maybe-outline-rounded"
-              width="1rem"
-              height="1rem"
-              style={{ color: "var(--text-instruction)" }}
+            <GppMaybeOutlinedIcon
+              sx={{ color: "var(--text-instruction)", fontSize: "1rem" }}
             />
             <Text>
               {t("bulkSelection.pageSelection.title", "Page Selection")}

--- a/frontend/editor/src/core/components/pageEditor/pageEditorWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/pageEditor/pageEditorWorkbenchBarButtons.tsx
@@ -4,8 +4,12 @@ import {
   useWorkbenchBarButtons,
   WorkbenchBarButtonWithAction,
 } from "@app/hooks/useWorkbenchBarButtons";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import PageSelectByNumberButton from "@app/components/pageEditor/PageSelectByNumberButton";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import DownloadIcon from "@mui/icons-material/Download";
+import SaveIcon from "@mui/icons-material/Save";
+import SelectAllIcon from "@mui/icons-material/SelectAll";
+import CropSquareIcon from "@mui/icons-material/CropSquare";
 
 interface PageEditorWorkbenchBarButtonsParams {
   totalPages: number;
@@ -64,7 +68,7 @@ export function usePageEditorWorkbenchBarButtons(
     return [
       {
         id: "page-select-all",
-        icon: <LocalIcon icon="select-all" width="1.5rem" height="1.5rem" />,
+        icon: <SelectAllIcon width="1.5rem" height="1.5rem" />,
         tooltip: selectAllLabel,
         ariaLabel: selectAllLabel,
         section: "top" as const,
@@ -75,13 +79,7 @@ export function usePageEditorWorkbenchBarButtons(
       },
       {
         id: "page-deselect-all",
-        icon: (
-          <LocalIcon
-            icon="crop-square-outline"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <CropSquareIcon width="1.5rem" height="1.5rem" />,
         tooltip: deselectAllLabel,
         ariaLabel: deselectAllLabel,
         section: "top" as const,
@@ -113,13 +111,7 @@ export function usePageEditorWorkbenchBarButtons(
       },
       {
         id: "page-delete-selected",
-        icon: (
-          <LocalIcon
-            icon="delete-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <DeleteOutlineRoundedIcon width="1.5rem" height="1.5rem" />,
         tooltip: deleteSelectedLabel,
         ariaLabel: deleteSelectedLabel,
         section: "top" as const,
@@ -130,7 +122,7 @@ export function usePageEditorWorkbenchBarButtons(
       },
       {
         id: "page-export-selected",
-        icon: <LocalIcon icon="download" width="1.5rem" height="1.5rem" />,
+        icon: <DownloadIcon width="1.5rem" height="1.5rem" />,
         tooltip: exportSelectedLabel,
         ariaLabel: exportSelectedLabel,
         section: "top" as const,
@@ -141,7 +133,7 @@ export function usePageEditorWorkbenchBarButtons(
       },
       {
         id: "page-save-changes",
-        icon: <LocalIcon icon="save" width="1.5rem" height="1.5rem" />,
+        icon: <SaveIcon width="1.5rem" height="1.5rem" />,
         tooltip: saveChangesLabel,
         ariaLabel: saveChangesLabel,
         section: "top" as const,

--- a/frontend/editor/src/core/components/pageEditor/pageEditorWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/pageEditor/pageEditorWorkbenchBarButtons.tsx
@@ -9,7 +9,7 @@ import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
 import DownloadIcon from "@mui/icons-material/Download";
 import SaveIcon from "@mui/icons-material/Save";
 import SelectAllIcon from "@mui/icons-material/SelectAll";
-import CropSquareIcon from "@mui/icons-material/CropSquare";
+import LocalIcon from "@app/components/shared/LocalIcon";
 
 interface PageEditorWorkbenchBarButtonsParams {
   totalPages: number;
@@ -79,7 +79,13 @@ export function usePageEditorWorkbenchBarButtons(
       },
       {
         id: "page-deselect-all",
-        icon: <CropSquareIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="crop-square-outline"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         tooltip: deselectAllLabel,
         ariaLabel: deselectAllLabel,
         section: "top" as const,

--- a/frontend/editor/src/core/components/shared/AppConfigModal.tsx
+++ b/frontend/editor/src/core/components/shared/AppConfigModal.tsx
@@ -9,6 +9,8 @@ import { Badge, Modal, Text, Tooltip, Group } from "@mantine/core";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import CloseIcon from "@mui/icons-material/Close";
+import WarningIcon from "@mui/icons-material/Warning";
 import LocalIcon from "@app/components/shared/LocalIcon";
 import { useConfigNavSections } from "@app/components/shared/config/configNavSections";
 import {
@@ -353,12 +355,10 @@ const AppConfigModalInner: React.FC<AppConfigModalProps> = ({
                               </Badge>
                             )}
                             {showPlanWarning && (
-                              <LocalIcon
-                                icon="warning-rounded"
-                                width={14}
-                                height={14}
-                                style={{
+                              <WarningIcon
+                                sx={{
                                   color: "var(--mantine-color-orange-7)",
+                                  fontSize: 14,
                                 }}
                               />
                             )}
@@ -416,7 +416,7 @@ const AppConfigModalInner: React.FC<AppConfigModalProps> = ({
                   aria-label={t("settings.close", "Close")}
                   data-autofocus
                 >
-                  <LocalIcon icon="close-rounded" width={18} height={18} />
+                  <CloseIcon sx={{ fontSize: 18 }} />
                 </ActionIcon>
               </Group>
             </div>

--- a/frontend/editor/src/core/components/shared/AppSwitch.tsx
+++ b/frontend/editor/src/core/components/shared/AppSwitch.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import { Button, Dropdown } from "@app/ui";
+import { AppIcon, Button, Dropdown } from "@app/ui";
 import markLight from "@app/assets/brand/modern-logo/StirlingPDFLogoNoTextLight.svg";
 import markDark from "@app/assets/brand/modern-logo/StirlingPDFLogoNoTextDark.svg";
 import "@app/components/shared/AppSwitch.css";
@@ -45,7 +45,7 @@ export function AppSwitch({
           className="app-switch-btn"
           aria-label={t("portal.shell.sidebar.switchApp", "Switch app")}
         >
-          <KeyboardArrowDownIcon sx={{ fontSize: 14 }} />
+          <AppIcon mui={KeyboardArrowDownIcon} size={14} />
         </Button>
       </Dropdown.Trigger>
       <Dropdown.Menu width="11rem">

--- a/frontend/editor/src/core/components/shared/AppSwitch.tsx
+++ b/frontend/editor/src/core/components/shared/AppSwitch.tsx
@@ -1,28 +1,11 @@
 import { useTranslation } from "react-i18next";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import { Button, Dropdown } from "@app/ui";
 import markLight from "@app/assets/brand/modern-logo/StirlingPDFLogoNoTextLight.svg";
 import markDark from "@app/assets/brand/modern-logo/StirlingPDFLogoNoTextDark.svg";
 import "@app/components/shared/AppSwitch.css";
 
 export type AppSwitchTarget = "editor" | "processor";
-
-function ChevronDownIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={14}
-      height={14}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.75}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <polyline points="6 9 12 15 18 9" />
-    </svg>
-  );
-}
 
 interface AppSwitchProps {
   /** The app this switcher is rendered in (shown as active in the menu). */
@@ -62,7 +45,7 @@ export function AppSwitch({
           className="app-switch-btn"
           aria-label={t("portal.shell.sidebar.switchApp", "Switch app")}
         >
-          <ChevronDownIcon />
+          <KeyboardArrowDownIcon sx={{ fontSize: 14 }} />
         </Button>
       </Dropdown.Trigger>
       <Dropdown.Menu width="11rem">

--- a/frontend/editor/src/core/components/shared/EditableSecretField.tsx
+++ b/frontend/editor/src/core/components/shared/EditableSecretField.tsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { PasswordInput, Group, Tooltip, TextInput } from "@mantine/core";
 import { useTranslation } from "react-i18next";
+import EditIcon from "@mui/icons-material/Edit";
 import { ActionIcon } from "@app/ui/ActionIcon";
-import LocalIcon from "@app/components/shared/LocalIcon";
 
 interface EditableSecretFieldProps {
   label?: string;
@@ -99,7 +99,7 @@ export default function EditableSecretField({
                 "Edit secret value",
               )}
             >
-              <LocalIcon icon="edit" width="1rem" height="1rem" />
+              <EditIcon sx={{ fontSize: "1rem" }} />
             </ActionIcon>
           </Tooltip>
         </Group>

--- a/frontend/editor/src/core/components/shared/FileSidebarFileItem.tsx
+++ b/frontend/editor/src/core/components/shared/FileSidebarFileItem.tsx
@@ -107,7 +107,9 @@ function CheckIcon({
   className?: string;
   style?: React.CSSProperties;
 }) {
-  return <MuiCheckIcon className={className} style={style} sx={{ fontSize: 14 }} />;
+  return (
+    <MuiCheckIcon className={className} style={style} sx={{ fontSize: 14 }} />
+  );
 }
 
 function getSidebarFileIcon(ext: string): React.ReactElement {

--- a/frontend/editor/src/core/components/shared/FileSidebarFileItem.tsx
+++ b/frontend/editor/src/core/components/shared/FileSidebarFileItem.tsx
@@ -11,6 +11,7 @@ import CloudUploadOutlinedIcon from "@mui/icons-material/CloudUploadOutlined";
 import CloudDoneIcon from "@mui/icons-material/CloudDone";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutlined";
 import HistoryIcon from "@mui/icons-material/History";
+import MuiCheckIcon from "@mui/icons-material/Check";
 import type { FileId } from "@app/types/file";
 import { FileDocIcon } from "@app/components/shared/FileDocIcon";
 import {
@@ -106,22 +107,7 @@ function CheckIcon({
   className?: string;
   style?: React.CSSProperties;
 }) {
-  return (
-    <svg
-      className={className}
-      style={style}
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  );
+  return <MuiCheckIcon className={className} style={style} sx={{ fontSize: 14 }} />;
 }
 
 function getSidebarFileIcon(ext: string): React.ReactElement {

--- a/frontend/editor/src/core/components/shared/FirstLoginModal.tsx
+++ b/frontend/editor/src/core/components/shared/FirstLoginModal.tsx
@@ -144,9 +144,7 @@ export default function FirstLoginModal({
 
           {error && (
             <Alert
-              icon={
-                <ErrorIcon sx={{ fontSize: "1rem" }} />
-              }
+              icon={<ErrorIcon sx={{ fontSize: "1rem" }} />}
               title={t("firstLogin.error", "Error")}
               color="red"
             >

--- a/frontend/editor/src/core/components/shared/FirstLoginModal.tsx
+++ b/frontend/editor/src/core/components/shared/FirstLoginModal.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { Modal, Stack, Text, PasswordInput, Alert } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ErrorIcon from "@mui/icons-material/ErrorRounded";
+import InfoIcon from "@mui/icons-material/InfoRounded";
 import { accountService } from "@app/services/accountService";
 import { alert } from "@app/components/toast";
 import { Z_INDEX_OVER_FULLSCREEN_SURFACE } from "@app/styles/zIndex";
@@ -124,7 +125,7 @@ export default function FirstLoginModal({
       <form onSubmit={handleSubmit}>
         <Stack gap="md">
           <Alert
-            icon={<LocalIcon icon="info-rounded" width="1rem" height="1rem" />}
+            icon={<InfoIcon sx={{ fontSize: "1rem" }} />}
             title={t("firstLogin.welcomeTitle", "Welcome!")}
             color="blue"
           >
@@ -144,7 +145,7 @@ export default function FirstLoginModal({
           {error && (
             <Alert
               icon={
-                <LocalIcon icon="error-rounded" width="1rem" height="1rem" />
+                <ErrorIcon sx={{ fontSize: "1rem" }} />
               }
               title={t("firstLogin.error", "Error")}
               color="red"

--- a/frontend/editor/src/core/components/shared/InfoBanner.tsx
+++ b/frontend/editor/src/core/components/shared/InfoBanner.tsx
@@ -4,6 +4,7 @@ import { Button, type ButtonVariant, type ButtonAccent } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
 import LocalIcon from "@app/components/shared/LocalIcon";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 type InfoBannerTone = "info" | "warning";
 
@@ -230,8 +231,7 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
               aria-label={t("infoBanner.dismiss", "Dismiss")}
               style={closeIconColor ? { color: closeIconColor } : undefined}
             >
-              <LocalIcon
-                icon="close-rounded"
+              <CloseRoundedIcon
                 width={compact ? "0.85rem" : "1rem"}
                 height={compact ? "0.85rem" : "1rem"}
               />

--- a/frontend/editor/src/core/components/shared/LandingActions.tsx
+++ b/frontend/editor/src/core/components/shared/LandingActions.tsx
@@ -8,6 +8,8 @@ import { useFileActionTerminology } from "@app/hooks/useFileActionTerminology";
 import { useFileActionIcons } from "@app/hooks/useFileActionIcons";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
 import { useIsMobile } from "@app/hooks/useIsMobile";
+import AddIcon from "@mui/icons-material/Add";
+import QrCodeRoundedIcon from "@mui/icons-material/QrCodeRounded";
 
 type LandingActionsProps = {
   fileInputRef: React.RefObject<HTMLInputElement | null>;
@@ -53,8 +55,7 @@ export function LandingActions({
           variant="secondary"
           className="landing-btn-secondary"
           leftSection={
-            <LocalIcon
-              icon="add"
+            <AddIcon
               width="1rem"
               height="1rem"
               className="text-[var(--accent-interactive)]"
@@ -80,11 +81,7 @@ export function LandingActions({
                 onMobileUploadClick();
               }}
             >
-              <LocalIcon
-                icon="qr-code-rounded"
-                width="1.25rem"
-                height="1.25rem"
-              />
+              <QrCodeRoundedIcon width="1.25rem" height="1.25rem" />
             </ActionIcon>
           </Tooltip>
         )}

--- a/frontend/editor/src/core/components/shared/LanguageSelector.tsx
+++ b/frontend/editor/src/core/components/shared/LanguageSelector.tsx
@@ -264,9 +264,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
               accent="neutral"
               size="sm"
               data-testid="language-selector-button"
-              leftSection={
-                <LanguageIcon sx={{ fontSize: "1.5rem" }} />
-              }
+              leftSection={<LanguageIcon sx={{ fontSize: "1.5rem" }} />}
             >
               <span className={styles.languageText}>{currentLanguage}</span>
             </Button>

--- a/frontend/editor/src/core/components/shared/LanguageSelector.tsx
+++ b/frontend/editor/src/core/components/shared/LanguageSelector.tsx
@@ -4,8 +4,8 @@ import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import { useTranslation } from "react-i18next";
+import LanguageIcon from "@mui/icons-material/Language";
 import { supportedLanguages, setUserLanguage } from "@app/i18n";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import styles from "@app/components/shared/LanguageSelector.module.css";
 import { Z_INDEX_CONFIG_MODAL } from "@app/styles/zIndex";
 
@@ -256,7 +256,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
               title={!opened && tooltip ? tooltip : undefined}
               aria-label={tooltip ?? currentLanguage}
             >
-              <LocalIcon icon="language" width="1.5rem" height="1.5rem" />
+              <LanguageIcon sx={{ fontSize: "1.5rem" }} />
             </ActionIcon>
           ) : (
             <Button
@@ -265,7 +265,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
               size="sm"
               data-testid="language-selector-button"
               leftSection={
-                <LocalIcon icon="language" width="1.5rem" height="1.5rem" />
+                <LanguageIcon sx={{ fontSize: "1.5rem" }} />
               }
             >
               <span className={styles.languageText}>{currentLanguage}</span>

--- a/frontend/editor/src/core/components/shared/LocalIcon.tsx
+++ b/frontend/editor/src/core/components/shared/LocalIcon.tsx
@@ -24,6 +24,9 @@ interface LocalIconProps {
   height?: string | number;
   style?: React.CSSProperties;
   className?: string;
+  "aria-hidden"?: boolean;
+  "aria-label"?: string;
+  role?: string;
 }
 
 /**

--- a/frontend/editor/src/core/components/shared/PageEditorFileDropdown.tsx
+++ b/frontend/editor/src/core/components/shared/PageEditorFileDropdown.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Menu, Loader, Group, Text, Checkbox } from "@mantine/core";
-import { LocalIcon } from "@app/components/shared/LocalIcon";
+import DashboardCustomizeIcon from "@mui/icons-material/DashboardCustomizeRounded";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import AddIcon from "@mui/icons-material/Add";
@@ -182,11 +182,7 @@ export const PageEditorFileDropdown: React.FC<PageEditorFileDropdownProps> = ({
           {switchingTo === "pageEditor" ? (
             <Loader size="xs" />
           ) : (
-            <LocalIcon
-              icon="dashboard-customize-rounded"
-              width="1.4rem"
-              height="1.4rem"
-            />
+            <DashboardCustomizeIcon sx={{ fontSize: "1.4rem" }} />
           )}
           <span className="ph-no-capture">
             {selectedCount}/{totalCount} files selected

--- a/frontend/editor/src/core/components/shared/TextInput.tsx
+++ b/frontend/editor/src/core/components/shared/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
+import CloseIcon from "@mui/icons-material/Close";
 import { ActionIcon } from "@app/ui/ActionIcon";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import styles from "@app/components/shared/textInput/TextInput.module.css";
 
 /**
@@ -117,7 +117,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             onClick={handleClear}
             aria-label={t("textInput.clear", "Clear input")}
           >
-            <LocalIcon icon="close-rounded" width="1.25rem" height="1.25rem" />
+            <CloseIcon sx={{ fontSize: "1.25rem" }} />
           </ActionIcon>
         )}
       </div>

--- a/frontend/editor/src/core/components/shared/Tooltip.tsx
+++ b/frontend/editor/src/core/components/shared/Tooltip.tsx
@@ -7,8 +7,8 @@ import React, {
 } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import CloseIcon from "@mui/icons-material/Close";
 import { ActionIcon } from "@app/ui/ActionIcon";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { addEventListenerWithCleanup } from "@app/utils/genericUtils";
 import { useTooltipPosition } from "@app/hooks/useTooltipPosition";
 import { TooltipTip } from "@app/types/tips";
@@ -408,7 +408,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
           title={t("tooltip.close", "Close tooltip")}
           aria-label={t("tooltip.close", "Close tooltip")}
         >
-          <LocalIcon icon="close-rounded" width="1.25rem" height="1.25rem" />
+          <CloseIcon sx={{ fontSize: "1.25rem" }} />
         </ActionIcon>
       )}
       {arrow && !sidebarTooltip && (

--- a/frontend/editor/src/core/components/shared/UpdateModal.tsx
+++ b/frontend/editor/src/core/components/shared/UpdateModal.tsx
@@ -16,7 +16,7 @@ import {
 } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CloseIcon from "@mui/icons-material/Close";
 import { useTranslation } from "react-i18next";
 import {
   updateService,
@@ -278,7 +278,7 @@ const UpdateModal: React.FC<UpdateModalProps> = ({
               variant="tertiary"
               aria-label={t("update.closeModal", "Close update modal")}
             >
-              <LocalIcon icon="close-rounded" width={20} height={20} />
+              <CloseIcon sx={{ fontSize: 20 }} />
             </ActionIcon>
           )}
         </Group>

--- a/frontend/editor/src/core/components/shared/WorkbenchBar.tsx
+++ b/frontend/editor/src/core/components/shared/WorkbenchBar.tsx
@@ -54,6 +54,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import PrintIcon from "@mui/icons-material/Print";
 import ShieldOutlinedIcon from "@mui/icons-material/ShieldOutlined";
 import "@app/components/shared/WorkbenchBar.css";
+import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
 
 const SECTION_ORDER: WorkbenchBarSection[] = ["top", "middle", "bottom"];
 
@@ -415,13 +416,7 @@ export default function WorkbenchBar({
           {
             value: "pageEditor" as WorkbenchType,
             label: t("workbenchBar.multiTool", "Multi-Tool"),
-            icon: (
-              <LocalIcon
-                icon="dashboard-customize-outline-rounded"
-                width="1rem"
-                height="1rem"
-              />
-            ),
+            icon: <DashboardCustomizeOutlinedIcon width="1rem" height="1rem" />,
           },
         ]
       : []),

--- a/frontend/editor/src/core/components/shared/WorkbenchBar.tsx
+++ b/frontend/editor/src/core/components/shared/WorkbenchBar.tsx
@@ -54,7 +54,6 @@ import CloseIcon from "@mui/icons-material/Close";
 import PrintIcon from "@mui/icons-material/Print";
 import ShieldOutlinedIcon from "@mui/icons-material/ShieldOutlined";
 import "@app/components/shared/WorkbenchBar.css";
-import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
 
 const SECTION_ORDER: WorkbenchBarSection[] = ["top", "middle", "bottom"];
 
@@ -416,7 +415,13 @@ export default function WorkbenchBar({
           {
             value: "pageEditor" as WorkbenchType,
             label: t("workbenchBar.multiTool", "Multi-Tool"),
-            icon: <DashboardCustomizeOutlinedIcon width="1rem" height="1rem" />,
+            icon: (
+              <LocalIcon
+                icon="dashboard-customize-outline-rounded"
+                width="1rem"
+                height="1rem"
+              />
+            ),
           },
         ]
       : []),

--- a/frontend/editor/src/core/components/shared/config/LoginRequiredBanner.tsx
+++ b/frontend/editor/src/core/components/shared/config/LoginRequiredBanner.tsx
@@ -1,6 +1,6 @@
 import { Alert, Text } from "@mantine/core";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import LockIcon from "@mui/icons-material/Lock";
 
 interface LoginRequiredBannerProps {
   show: boolean;
@@ -19,7 +19,7 @@ export default function LoginRequiredBanner({
 
   return (
     <Alert
-      icon={<LocalIcon icon="lock" width={20} height={20} />}
+      icon={<LockIcon sx={{ fontSize: 20 }} />}
       title={t("admin.settings.loginDisabled.title", "Login Mode Required")}
       color="blue"
       variant="light"

--- a/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
+++ b/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback } from "react";
 import { Select, Text } from "@mantine/core";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import SearchIcon from "@mui/icons-material/Search";
 import { NavKey, VALID_NAV_KEYS } from "@app/components/shared/config/types";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
 import type {
@@ -210,7 +210,7 @@ export const SettingsSearchBar: React.FC<SettingsSearchBarProps> = ({
       onSearchChange={setSearchValue}
       onChange={handleSearchNavigation}
       placeholder={t("settings.search.placeholder", "Search settings pages...")}
-      leftSection={<LocalIcon icon="search-rounded" width={16} height={16} />}
+      leftSection={<SearchIcon sx={{ fontSize: 16 }} />}
       aria-label={t("navbar.search", "Search")}
       nothingFoundMessage={t("search.noResults", "No results found")}
       searchable

--- a/frontend/editor/src/core/components/shared/config/configSections/GeneralSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/GeneralSection.tsx
@@ -27,7 +27,6 @@ import type {
   ViewerZoomSetting,
 } from "@app/services/preferencesService";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { updateService, UpdateSummary } from "@app/services/updateService";
 import UpdateModal from "@app/components/shared/UpdateModal";
 import type {
@@ -37,6 +36,10 @@ import type {
   DesktopInstallCanInstall,
 } from "@app/components/shared/UpdateModal";
 import { useFrontendVersionInfo } from "@app/hooks/useFrontendVersionInfo";
+import AdminPanelSettingsRoundedIcon from "@mui/icons-material/AdminPanelSettingsRounded";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
+import SystemUpdateAltRoundedIcon from "@mui/icons-material/SystemUpdateAltRounded";
 
 const DEFAULT_AUTO_UNZIP_FILE_LIMIT = 4;
 const BANNER_DISMISSED_KEY = "stirlingpdf_features_banner_dismissed";
@@ -201,12 +204,11 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
             onClick={handleDismissBanner}
             aria-label={t("settings.general.enableFeatures.dismiss", "Dismiss")}
           >
-            <LocalIcon icon="close-rounded" width="1rem" height="1rem" />
+            <CloseRoundedIcon width="1rem" height="1rem" />
           </ActionIcon>
           <Stack gap="sm">
             <Group gap="xs">
-              <LocalIcon
-                icon="admin-panel-settings-rounded"
+              <AdminPanelSettingsRoundedIcon
                 width="1.2rem"
                 height="1.2rem"
                 style={{ color: "var(--mantine-color-blue-6)" }}
@@ -350,11 +352,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                   loading={checkingUpdate}
                   disabled={!currentVersion}
                   leftSection={
-                    <LocalIcon
-                      icon="refresh-rounded"
-                      width="1rem"
-                      height="1rem"
-                    />
+                    <RefreshRoundedIcon width="1rem" height="1rem" />
                   }
                 >
                   {t(
@@ -372,11 +370,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                     }
                     onClick={() => setUpdateModalOpened(true)}
                     leftSection={
-                      <LocalIcon
-                        icon="system-update-alt-rounded"
-                        width="1rem"
-                        height="1rem"
-                      />
+                      <SystemUpdateAltRoundedIcon width="1rem" height="1rem" />
                     }
                   >
                     {t("settings.general.updates.viewDetails", "View Details")}

--- a/frontend/editor/src/core/components/shared/config/configSections/HelpSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/HelpSection.tsx
@@ -41,9 +41,7 @@ const HelpSection: React.FC<HelpSectionProps> = ({
             <Button
               variant="secondary"
               size="sm"
-              leftSection={
-                <BuildOutlinedIcon sx={{ fontSize: "1rem" }} />
-              }
+              leftSection={<BuildOutlinedIcon sx={{ fontSize: "1rem" }} />}
               onClick={() => startTour("tools")}
             >
               {t("settings.help.toolsTour.start", "Start")}
@@ -66,9 +64,7 @@ const HelpSection: React.FC<HelpSectionProps> = ({
               <Button
                 variant="secondary"
                 size="sm"
-                leftSection={
-                  <PersonIcon sx={{ fontSize: "1rem" }} />
-                }
+                leftSection={<PersonIcon sx={{ fontSize: "1rem" }} />}
                 onClick={() => startTour("admin")}
               >
                 {t("settings.help.adminTour.start", "Start")}

--- a/frontend/editor/src/core/components/shared/config/configSections/HelpSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/HelpSection.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { Group, Paper, Stack, Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
-import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
 import PersonIcon from "@mui/icons-material/PersonRounded";
 import { requestStartTour } from "@app/constants/events";
+import LocalIcon from "@app/components/shared/LocalIcon";
 
 interface HelpSectionProps {
   isAdmin: boolean;
@@ -41,7 +41,13 @@ const HelpSection: React.FC<HelpSectionProps> = ({
             <Button
               variant="secondary"
               size="sm"
-              leftSection={<BuildOutlinedIcon sx={{ fontSize: "1rem" }} />}
+              leftSection={
+                <LocalIcon
+                  icon="build-outline-rounded"
+                  width="1rem"
+                  height="1rem"
+                />
+              }
               onClick={() => startTour("tools")}
             >
               {t("settings.help.toolsTour.start", "Start")}

--- a/frontend/editor/src/core/components/shared/config/configSections/HelpSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/HelpSection.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Group, Paper, Stack, Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
+import PersonIcon from "@mui/icons-material/PersonRounded";
 import { requestStartTour } from "@app/constants/events";
 
 interface HelpSectionProps {
@@ -41,11 +42,7 @@ const HelpSection: React.FC<HelpSectionProps> = ({
               variant="secondary"
               size="sm"
               leftSection={
-                <LocalIcon
-                  icon="build-outline-rounded"
-                  width="1rem"
-                  height="1rem"
-                />
+                <BuildOutlinedIcon sx={{ fontSize: "1rem" }} />
               }
               onClick={() => startTour("tools")}
             >
@@ -70,7 +67,7 @@ const HelpSection: React.FC<HelpSectionProps> = ({
                 variant="secondary"
                 size="sm"
                 leftSection={
-                  <LocalIcon icon="person-rounded" width="1rem" height="1rem" />
+                  <PersonIcon sx={{ fontSize: "1rem" }} />
                 }
                 onClick={() => startTour("admin")}
               >

--- a/frontend/editor/src/core/components/shared/config/configSections/LegalSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/LegalSection.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Anchor, Group, Paper, Stack, Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
 import { useFooterInfo } from "@app/hooks/useFooterInfo";
 import { useCookieConsent } from "@app/hooks/useCookieConsent";
@@ -88,7 +88,7 @@ const LegalSection: React.FC = () => {
     >
       <Group gap={6} wrap="nowrap">
         {link.label}
-        <LocalIcon icon="open-in-new-rounded" width="0.9rem" height="0.9rem" />
+        <OpenInNewIcon sx={{ fontSize: "0.9rem" }} />
       </Group>
     </Anchor>
   );

--- a/frontend/editor/src/core/components/shared/config/configSections/ProviderCard.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/ProviderCard.tsx
@@ -20,6 +20,8 @@ import {
   Provider,
   ProviderField,
 } from "@app/components/shared/config/configSections/providerDefinitions";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
 
 interface ProviderCardProps {
   provider: Provider;
@@ -234,13 +236,9 @@ export default function ProviderCard({
               }
               rightSection={
                 expanded ? (
-                  <LocalIcon icon="close-rounded" width="1rem" height="1rem" />
+                  <CloseRoundedIcon width="1rem" height="1rem" />
                 ) : isConfigured ? (
-                  <LocalIcon
-                    icon="expand-more-rounded"
-                    width="1rem"
-                    height="1rem"
-                  />
+                  <ExpandMoreRoundedIcon width="1rem" height="1rem" />
                 ) : undefined
               }
             >

--- a/frontend/editor/src/core/components/toast/ToastRenderer.tsx
+++ b/frontend/editor/src/core/components/toast/ToastRenderer.tsx
@@ -6,6 +6,7 @@ import { LocalIcon } from "@app/components/shared/LocalIcon";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { Button } from "@app/ui/Button";
 import "@app/components/toast/ToastRenderer.css";
+import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
 
 const locationToClass: Record<ToastLocation, string> = {
   "top-left": "toast-container--top-left",
@@ -115,7 +116,7 @@ export default function ToastRenderer() {
                         }}
                         className={`toast-button toast-expand-button ${t.isExpanded ? "toast-expand-button--expanded" : ""}`}
                       >
-                        <LocalIcon icon="expand-more-rounded" />
+                        <ExpandMoreRoundedIcon />
                       </ActionIcon>
                     )}
                     <ActionIcon

--- a/frontend/editor/src/core/components/tools/addAttachments/AddAttachmentsSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addAttachments/AddAttachmentsSettings.tsx
@@ -5,8 +5,10 @@
  */
 import { Stack, Text, Group, ScrollArea, Checkbox } from "@mantine/core";
 import { useTranslation } from "react-i18next";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { AddAttachmentsParameters } from "@app/hooks/tools/addAttachments/useAddAttachmentsParameters";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import { Button as DSButton } from "@app/ui/Button";
 interface AddAttachmentsSettingsProps {
@@ -51,7 +53,7 @@ const AddAttachmentsSettings = ({
           as="label"
           htmlFor="attachments-input"
           disabled={disabled}
-          leftSection={<LocalIcon icon="add" width="14" height="14" />}
+          leftSection={<AddIcon sx={{ fontSize: 14 }} />}
         >
           {parameters.attachments?.length > 0
             ? t("AddAttachmentsRequest.addMoreFiles", "Add more files...")
@@ -112,7 +114,7 @@ const AddAttachmentsSettings = ({
                   </Group>
                   <DSButton
                     leftSection={
-                      <LocalIcon icon="close-rounded" width="14" height="14" />
+                      <CloseIcon sx={{ fontSize: 14 }} />
                     }
                     aria-label={t(
                       "AddAttachmentsRequest.removeFile",
@@ -167,11 +169,12 @@ const AddAttachmentsSettings = ({
                 sidebarTooltip={true}
                 pinOnClick={true}
               >
-                <LocalIcon
-                  icon="info-outline-rounded"
-                  width="1.25rem"
-                  height="1.25rem"
-                  style={{ color: "var(--icon-files-color)", cursor: "help" }}
+                <InfoOutlinedIcon
+                  sx={{
+                    color: "var(--icon-files-color)",
+                    cursor: "help",
+                    fontSize: "1.25rem",
+                  }}
                 />
               </Tooltip>
             </Group>

--- a/frontend/editor/src/core/components/tools/addAttachments/AddAttachmentsSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addAttachments/AddAttachmentsSettings.tsx
@@ -113,9 +113,7 @@ const AddAttachmentsSettings = ({
                     </Text>
                   </Group>
                   <DSButton
-                    leftSection={
-                      <CloseIcon sx={{ fontSize: 14 }} />
-                    }
+                    leftSection={<CloseIcon sx={{ fontSize: 14 }} />}
                     aria-label={t(
                       "AddAttachmentsRequest.removeFile",
                       "Remove file",

--- a/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.tsx
@@ -9,12 +9,14 @@ import {
   NumberInput,
 } from "@mantine/core";
 import { AddStampParameters } from "@app/components/tools/addStamp/useAddStampParameters";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import styles from "@app/components/tools/addStamp/StampPreview.module.css";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { Z_INDEX_AUTOMATE_DROPDOWN } from "@app/styles/zIndex";
+import OpacityIcon from "@mui/icons-material/Opacity";
+import RotateRightRoundedIcon from "@mui/icons-material/RotateRightRounded";
+import ZoomInMapRoundedIcon from "@mui/icons-material/ZoomInMapRounded";
 
 interface StampPositionFormattingSettingsProps {
   parameters: AddStampParameters;
@@ -90,11 +92,7 @@ const StampPositionFormattingSettings = ({
             className="flex-1"
             onClick={() => onParameterChange("_activePill", "rotation")}
           >
-            <LocalIcon
-              icon="rotate-right-rounded"
-              width="1.1rem"
-              height="1.1rem"
-            />
+            <RotateRightRoundedIcon width="1.1rem" height="1.1rem" />
           </ActionIcon>
         </Tooltip>
         <Tooltip
@@ -109,7 +107,7 @@ const StampPositionFormattingSettings = ({
             className="flex-1"
             onClick={() => onParameterChange("_activePill", "opacity")}
           >
-            <LocalIcon icon="opacity" width="1.1rem" height="1.1rem" />
+            <OpacityIcon width="1.1rem" height="1.1rem" />
           </ActionIcon>
         </Tooltip>
         <Tooltip
@@ -132,11 +130,7 @@ const StampPositionFormattingSettings = ({
             className="flex-1"
             onClick={() => onParameterChange("_activePill", "fontSize")}
           >
-            <LocalIcon
-              icon="zoom-in-map-rounded"
-              width="1.1rem"
-              height="1.1rem"
-            />
+            <ZoomInMapRoundedIcon width="1.1rem" height="1.1rem" />
           </ActionIcon>
         </Tooltip>
       </div>

--- a/frontend/editor/src/core/components/tools/compare/hooks/useCompareWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/tools/compare/hooks/useCompareWorkbenchBarButtons.tsx
@@ -6,6 +6,9 @@ import { alert } from "@app/components/toast";
 import type { ToastLocation } from "@app/components/toast/types";
 import type { WorkbenchBarButtonWithAction } from "@app/hooks/useWorkbenchBarButtons";
 import { useIsMobile } from "@app/hooks/useIsMobile";
+import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 
 type Pane = "base" | "comparison";
 
@@ -82,7 +85,7 @@ export const useCompareWorkbenchBarButtons = ({
       },
       {
         id: "compare-zoom-out",
-        icon: <LocalIcon icon="zoom-out" width="1.5rem" height="1.5rem" />,
+        icon: <ZoomOutIcon width="1.5rem" height="1.5rem" />,
         tooltip: t("compare.actions.zoomOut", "Zoom out"),
         ariaLabel: t("compare.actions.zoomOut", "Zoom out"),
         section: "top",
@@ -102,7 +105,7 @@ export const useCompareWorkbenchBarButtons = ({
       },
       {
         id: "compare-zoom-in",
-        icon: <LocalIcon icon="zoom-in" width="1.5rem" height="1.5rem" />,
+        icon: <ZoomInIcon width="1.5rem" height="1.5rem" />,
         tooltip: t("compare.actions.zoomIn", "Zoom in"),
         ariaLabel: t("compare.actions.zoomIn", "Zoom in"),
         section: "top",
@@ -122,9 +125,7 @@ export const useCompareWorkbenchBarButtons = ({
       },
       {
         id: "compare-reset-view",
-        icon: (
-          <LocalIcon icon="refresh-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <RefreshRoundedIcon width="1.5rem" height="1.5rem" />,
         tooltip: t("compare.actions.resetView", "Reset zoom and pan"),
         ariaLabel: t("compare.actions.resetView", "Reset zoom and pan"),
         section: "top",

--- a/frontend/editor/src/core/components/tools/editTableOfContents/BookmarkEditor.tsx
+++ b/frontend/editor/src/core/components/tools/editTableOfContents/BookmarkEditor.tsx
@@ -18,6 +18,10 @@ import {
   BookmarkNode,
   createBookmarkNode,
 } from "@app/utils/editTableOfContents";
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import BookmarkAddRoundedIcon from "@mui/icons-material/BookmarkAddRounded";
+import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
+import SubdirectoryArrowRightRoundedIcon from "@mui/icons-material/SubdirectoryArrowRightRounded";
 
 interface BookmarkEditorProps {
   bookmarks: BookmarkNode[];
@@ -283,7 +287,7 @@ export default function BookmarkEditor({
                     "Add child bookmark",
                   )}
                 >
-                  <LocalIcon icon="subdirectory-arrow-right-rounded" />
+                  <SubdirectoryArrowRightRoundedIcon />
                 </ActionIcon>
               </Tooltip>
               <Tooltip
@@ -304,7 +308,7 @@ export default function BookmarkEditor({
                     "Add sibling bookmark",
                   )}
                 >
-                  <LocalIcon icon="add-rounded" />
+                  <AddRoundedIcon />
                 </ActionIcon>
               </Tooltip>
               <Tooltip
@@ -326,7 +330,7 @@ export default function BookmarkEditor({
                     "Remove bookmark",
                   )}
                 >
-                  <LocalIcon icon="delete-rounded" />
+                  <DeleteRoundedIcon />
                 </ActionIcon>
               </Tooltip>
             </Group>
@@ -410,7 +414,7 @@ export default function BookmarkEditor({
         </div>
         <Button
           variant="secondary"
-          leftSection={<LocalIcon icon="bookmark-add-rounded" />}
+          leftSection={<BookmarkAddRoundedIcon />}
           onMouseDown={(e) => {
             e.preventDefault();
             handleAddTopLevel();
@@ -427,10 +431,7 @@ export default function BookmarkEditor({
       {bookmarks.length === 0 ? (
         <Paper withBorder radius="md" ta="center" py="xl">
           <Stack gap="xs" align="center" px="lg">
-            <LocalIcon
-              icon="bookmark-add-rounded"
-              style={{ fontSize: "2.25rem" }}
-            />
+            <BookmarkAddRoundedIcon style={{ fontSize: "2.25rem" }} />
             <Text fw={600}>
               {t("editTableOfContents.editor.empty.title", "No bookmarks yet")}
             </Text>
@@ -442,7 +443,7 @@ export default function BookmarkEditor({
             </Text>
             <Button
               variant="tertiary"
-              leftSection={<LocalIcon icon="add-rounded" />}
+              leftSection={<AddRoundedIcon />}
               onMouseDown={(e) => {
                 e.preventDefault();
                 handleAddTopLevel();

--- a/frontend/editor/src/core/components/tools/editTableOfContents/EditTableOfContentsSettings.tsx
+++ b/frontend/editor/src/core/components/tools/editTableOfContents/EditTableOfContentsSettings.tsx
@@ -3,8 +3,14 @@ import { useTranslation } from "react-i18next";
 import { Alert, Divider, Stack, Switch, Text, Tooltip } from "@mantine/core";
 import { Button as DSButton } from "@app/ui/Button";
 import { FilePicker } from "@app/ui/FilePicker";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { BookmarkNode } from "@app/utils/editTableOfContents";
+import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
+import ContentPasteRoundedIcon from "@mui/icons-material/ContentPasteRounded";
+import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
+import ErrorOutlineRoundedIcon from "@mui/icons-material/ErrorOutlineRounded";
+import FolderRoundedIcon from "@mui/icons-material/FolderRounded";
+import PictureAsPdfRoundedIcon from "@mui/icons-material/PictureAsPdfRounded";
+import UploadRoundedIcon from "@mui/icons-material/UploadRounded";
 
 interface EditTableOfContentsSettingsProps {
   bookmarks: BookmarkNode[];
@@ -82,7 +88,7 @@ export default function EditTableOfContentsSettings({
       <Stack gap="sm">
         <DSButton
           variant="secondary"
-          leftSection={<LocalIcon icon="folder-rounded" />}
+          leftSection={<FolderRoundedIcon />}
           onClick={onSelectFiles}
           fullWidth
         >
@@ -103,7 +109,7 @@ export default function EditTableOfContentsSettings({
         >
           <DSButton
             variant="secondary"
-            leftSection={<LocalIcon icon="picture-as-pdf-rounded" />}
+            leftSection={<PictureAsPdfRoundedIcon />}
             onClick={onLoadFromPdf}
             loading={isLoading}
             disabled={disabled || !selectedFileName}
@@ -117,7 +123,7 @@ export default function EditTableOfContentsSettings({
           accept="application/json"
           disabled={disabled}
           variant="secondary"
-          leftSection={<LocalIcon icon="upload-rounded" />}
+          leftSection={<UploadRoundedIcon />}
           fullWidth
         >
           {t("editTableOfContents.actions.importJson", "Import JSON")}
@@ -135,7 +141,7 @@ export default function EditTableOfContentsSettings({
         >
           <DSButton
             variant="secondary"
-            leftSection={<LocalIcon icon="content-paste-rounded" />}
+            leftSection={<ContentPasteRoundedIcon />}
             onClick={onImportClipboard}
             disabled={disabled || !canReadClipboard}
             fullWidth
@@ -149,11 +155,7 @@ export default function EditTableOfContentsSettings({
       </Stack>
 
       {loadError && (
-        <Alert
-          color="red"
-          radius="md"
-          icon={<LocalIcon icon="error-outline-rounded" />}
-        >
+        <Alert color="red" radius="md" icon={<ErrorOutlineRoundedIcon />}>
           {loadError}
         </Alert>
       )}
@@ -169,7 +171,7 @@ export default function EditTableOfContentsSettings({
       <Stack gap="sm">
         <DSButton
           variant="secondary"
-          leftSection={<LocalIcon icon="download-rounded" />}
+          leftSection={<DownloadRoundedIcon />}
           onClick={onExportJson}
           disabled={disabled || bookmarks.length === 0}
           fullWidth
@@ -189,7 +191,7 @@ export default function EditTableOfContentsSettings({
         >
           <DSButton
             variant="secondary"
-            leftSection={<LocalIcon icon="content-copy-rounded" />}
+            leftSection={<ContentCopyRoundedIcon />}
             onClick={onExportClipboard}
             disabled={disabled || bookmarks.length === 0 || !canWriteClipboard}
             fullWidth

--- a/frontend/editor/src/core/components/tools/editTableOfContents/EditTableOfContentsWorkbenchView.tsx
+++ b/frontend/editor/src/core/components/tools/editTableOfContents/EditTableOfContentsWorkbenchView.tsx
@@ -2,13 +2,15 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Box, Card, Divider, Group, Stack, Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { BookmarkNode } from "@app/utils/editTableOfContents";
 import ErrorNotification from "@app/components/tools/shared/ErrorNotification";
 import ResultsPreview from "@app/components/tools/shared/ResultsPreview";
 import BookmarkEditor from "@app/components/tools/editTableOfContents/BookmarkEditor";
 import { useFileActionTerminology } from "@app/hooks/useFileActionTerminology";
 import { downloadFromUrl } from "@app/services/downloadService";
+import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
+import MenuBookRoundedIcon from "@mui/icons-material/MenuBookRounded";
+import RotateLeftIcon from "@mui/icons-material/RotateLeft";
 
 export interface EditTableOfContentsWorkbenchViewData {
   bookmarks: BookmarkNode[];
@@ -150,7 +152,7 @@ const EditTableOfContentsWorkbenchView = ({
             <Divider />
             <Group justify="flex-end">
               <Button
-                leftSection={<LocalIcon icon="menu-book-rounded" />}
+                leftSection={<MenuBookRoundedIcon />}
                 onClick={onExecute}
                 disabled={isExecuteDisabled}
                 loading={isExecuting}
@@ -201,7 +203,7 @@ const EditTableOfContentsWorkbenchView = ({
               <Group justify="flex-end" gap="sm">
                 {downloadUrl && (
                   <Button
-                    leftSection={<LocalIcon icon="download-rounded" />}
+                    leftSection={<DownloadRoundedIcon />}
                     onClick={() =>
                       downloadFromUrl(
                         downloadUrl,
@@ -214,7 +216,7 @@ const EditTableOfContentsWorkbenchView = ({
                 )}
                 <Button
                   variant="secondary"
-                  leftSection={<LocalIcon icon="rotate-left" />}
+                  leftSection={<RotateLeftIcon />}
                   onClick={onUndo}
                   disabled={isExecuting}
                 >

--- a/frontend/editor/src/core/components/tools/overlayPdfs/OverlayPdfsSettings.tsx
+++ b/frontend/editor/src/core/components/tools/overlayPdfs/OverlayPdfsSettings.tsx
@@ -14,7 +14,8 @@ import {
   type OverlayPdfsParameters,
   type OverlayMode,
 } from "@app/hooks/tools/overlayPdfs/useOverlayPdfsParameters";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/CloseRounded";
 import { useFilesModalContext } from "@app/contexts/FilesModalContext";
 import styles from "@app/components/tools/overlayPdfs/OverlayPdfsSettings.module.css";
 import { Z_INDEX_AUTOMATE_DROPDOWN } from "@app/styles/zIndex";
@@ -187,7 +188,7 @@ export default function OverlayPdfsSettings({
           size="sm"
           onClick={handleOpenOverlayFilesModal}
           disabled={disabled}
-          leftSection={<LocalIcon icon="add" width="14" height="14" />}
+          leftSection={<AddIcon sx={{ fontSize: 14 }} />}
           fullWidth
         >
           {parameters.overlayFiles?.length > 0
@@ -231,11 +232,7 @@ export default function OverlayPdfsSettings({
                         disabled={disabled}
                         aria-label={t("remove", "Remove")}
                       >
-                        <LocalIcon
-                          icon="close-rounded"
-                          width="14"
-                          height="14"
-                        />
+                        <CloseIcon sx={{ fontSize: 14 }} />
                       </ActionIcon>
                     </Group>
                   ))}

--- a/frontend/editor/src/core/components/tools/pdfTextEditor/FontStatusPanel.tsx
+++ b/frontend/editor/src/core/components/tools/pdfTextEditor/FontStatusPanel.tsx
@@ -30,7 +30,7 @@ import {
   getFontStatusColor,
   getFontStatusDescription,
 } from "@app/tools/pdfTextEditor/fontAnalysis";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ChevronRightIcon from "@mui/icons-material/ChevronRightRounded";
 import { Tooltip as CustomTooltip } from "@app/components/shared/Tooltip";
 
 interface FontStatusPanelProps {
@@ -261,22 +261,12 @@ const FontStatusPanel: React.FC<FontStatusPanelProps> = ({
           </Flex>
 
           {isCollapsed ? (
-            <LocalIcon
-              icon="chevron-right-rounded"
-              width="1.2rem"
-              height="1.2rem"
-              style={{
-                color: "var(--mantine-color-dimmed)",
-              }}
+            <ChevronRightIcon
+              sx={{ color: "var(--mantine-color-dimmed)", fontSize: "1.2rem" }}
             />
           ) : (
-            <LocalIcon
-              icon="expand-more-rounded"
-              width="1.2rem"
-              height="1.2rem"
-              style={{
-                color: "var(--mantine-color-dimmed)",
-              }}
+            <ExpandMoreIcon
+              sx={{ color: "var(--mantine-color-dimmed)", fontSize: "1.2rem" }}
             />
           )}
         </Flex>

--- a/frontend/editor/src/core/components/tools/pdfTextEditor/PdfTextEditorSidebar.tsx
+++ b/frontend/editor/src/core/components/tools/pdfTextEditor/PdfTextEditorSidebar.tsx
@@ -29,7 +29,6 @@ import FontStatusPanel from "@app/components/tools/pdfTextEditor/FontStatusPanel
 import ToolStep from "@app/components/tools/shared/ToolStep";
 import { usePdfTextEditorTips } from "@app/components/tooltips/usePdfTextEditorTips";
 import { Tooltip } from "@app/components/shared/Tooltip";
-import LocalIcon from "@app/components/shared/LocalIcon";
 
 type GroupingMode = "auto" | "paragraph" | "singleLine";
 
@@ -153,11 +152,7 @@ const PdfTextEditorSidebar = ({ data }: PdfTextEditorSidebarProps) => {
                     size="sm"
                     aria-label={t("pdfTextEditor.title", "PDF Text Editor")}
                   >
-                    <LocalIcon
-                      icon="info-outline-rounded"
-                      width="1.25rem"
-                      height="1.25rem"
-                    />
+                    <InfoOutlinedIcon sx={{ fontSize: "1.25rem" }} />
                   </ActionIcon>
                 </Tooltip>
               </Flex>

--- a/frontend/editor/src/core/components/tools/shared/ToolStep.tsx
+++ b/frontend/editor/src/core/components/tools/shared/ToolStep.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useMemo } from "react";
 import { Text, Stack, Flex, Divider } from "@mantine/core";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import { TooltipTip } from "@app/types/tips";
 import {
@@ -11,6 +10,9 @@ import {
   createReviewToolStep,
   ReviewToolStepProps,
 } from "@app/components/tools/shared/ReviewToolStep";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
+import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
+import InfoOutlineRoundedIcon from "@mui/icons-material/InfoOutlineRounded";
 
 interface ToolStepContextType {
   visibleStepCount: number;
@@ -60,8 +62,7 @@ const renderTooltipTitle = (
           <Text fw={400} size="sm">
             {title}
           </Text>
-          <LocalIcon
-            icon="info-outline-rounded"
+          <InfoOutlineRoundedIcon
             width="1.25rem"
             height="1.25rem"
             style={{ color: "var(--icon-files-color)" }}
@@ -134,8 +135,7 @@ const ToolStep = ({
           </Flex>
 
           {isCollapsed ? (
-            <LocalIcon
-              icon="chevron-right-rounded"
+            <ChevronRightRoundedIcon
               width="1.2rem"
               height="1.2rem"
               style={{
@@ -144,8 +144,7 @@ const ToolStep = ({
               }}
             />
           ) : (
-            <LocalIcon
-              icon="expand-more-rounded"
+            <ExpandMoreRoundedIcon
               width="1.2rem"
               height="1.2rem"
               style={{

--- a/frontend/editor/src/core/components/tools/shared/ToolWorkflowTitle.tsx
+++ b/frontend/editor/src/core/components/tools/shared/ToolWorkflowTitle.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Flex, Text, Divider } from "@mantine/core";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Tooltip } from "@app/components/shared/Tooltip";
 
 export interface ToolWorkflowTitleProps {
@@ -27,11 +27,8 @@ export function ToolWorkflowTitle({
         {title}
       </Text>
       {tooltip && (
-        <LocalIcon
-          icon="info-outline-rounded"
-          width="1.25rem"
-          height="1.25rem"
-          style={{ color: "var(--icon-files-color)" }}
+        <InfoOutlinedIcon
+          sx={{ color: "var(--icon-files-color)", fontSize: "1.25rem" }}
         />
       )}
     </Flex>

--- a/frontend/editor/src/core/components/tools/sign/SavedSignaturesSection.tsx
+++ b/frontend/editor/src/core/components/tools/sign/SavedSignaturesSection.tsx
@@ -11,13 +11,18 @@ import {
   TextInput,
   Tooltip,
 } from "@mantine/core";
-import { LocalIcon } from "@app/components/shared/LocalIcon";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import {
   SavedSignature,
   SavedSignatureType,
 } from "@app/hooks/tools/sign/useSavedSignatures";
 import type { StorageType } from "@app/services/signatureStorageService";
+import CheckCircleOutlineRoundedIcon from "@mui/icons-material/CheckCircleOutlineRounded";
+import ChevronLeftRoundedIcon from "@mui/icons-material/ChevronLeftRounded";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import GroupsRoundedIcon from "@mui/icons-material/GroupsRounded";
+import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 
 interface SavedSignaturesSectionProps {
   signatures: SavedSignature[];
@@ -276,7 +281,7 @@ export const SavedSignaturesSection = ({
           {groupedSignatures.personal.length > 0 && activePersonalSignature && (
             <Stack gap="xs">
               <Group gap="xs">
-                <LocalIcon icon="person-rounded" width={18} height={18} />
+                <PersonRoundedIcon width={18} height={18} />
                 <Text fw={600} size="sm">
                   {translate("saved.personalHeading", "Personal Signatures")}
                 </Text>
@@ -308,11 +313,7 @@ export const SavedSignaturesSection = ({
                     }
                     disabled={disabled || activePersonalIndex === 0}
                   >
-                    <LocalIcon
-                      icon="chevron-left-rounded"
-                      width={18}
-                      height={18}
-                    />
+                    <ChevronLeftRoundedIcon width={18} height={18} />
                   </ActionIcon>
                   <ActionIcon
                     variant="secondary"
@@ -331,11 +332,7 @@ export const SavedSignaturesSection = ({
                         groupedSignatures.personal.length - 1
                     }
                   >
-                    <LocalIcon
-                      icon="chevron-right-rounded"
-                      width={18}
-                      height={18}
-                    />
+                    <ChevronRightRoundedIcon width={18} height={18} />
                   </ActionIcon>
                 </Group>
               </Group>
@@ -356,11 +353,7 @@ export const SavedSignaturesSection = ({
                         onClick={() => onUseSignature(activePersonalSignature)}
                         disabled={disabled}
                       >
-                        <LocalIcon
-                          icon="check-circle-outline-rounded"
-                          width={18}
-                          height={18}
-                        />
+                        <CheckCircleOutlineRoundedIcon width={18} height={18} />
                       </ActionIcon>
                       <Tooltip label={translate("saved.delete", "Remove")}>
                         <ActionIcon
@@ -372,11 +365,7 @@ export const SavedSignaturesSection = ({
                           }
                           disabled={disabled}
                         >
-                          <LocalIcon
-                            icon="delete-outline-rounded"
-                            width={18}
-                            height={18}
-                          />
+                          <DeleteOutlineRoundedIcon width={18} height={18} />
                         </ActionIcon>
                       </Tooltip>
                     </Group>
@@ -406,7 +395,7 @@ export const SavedSignaturesSection = ({
           {groupedSignatures.shared.length > 0 && activeSharedSignature && (
             <Stack gap="xs">
               <Group gap="xs">
-                <LocalIcon icon="groups-rounded" width={18} height={18} />
+                <GroupsRoundedIcon width={18} height={18} />
                 <Text fw={600} size="sm">
                   {translate("saved.sharedHeading", "Shared Signatures")}
                 </Text>
@@ -438,11 +427,7 @@ export const SavedSignaturesSection = ({
                     }
                     disabled={disabled || activeSharedIndex === 0}
                   >
-                    <LocalIcon
-                      icon="chevron-left-rounded"
-                      width={18}
-                      height={18}
-                    />
+                    <ChevronLeftRoundedIcon width={18} height={18} />
                   </ActionIcon>
                   <ActionIcon
                     variant="secondary"
@@ -457,11 +442,7 @@ export const SavedSignaturesSection = ({
                       activeSharedIndex >= groupedSignatures.shared.length - 1
                     }
                   >
-                    <LocalIcon
-                      icon="chevron-right-rounded"
-                      width={18}
-                      height={18}
-                    />
+                    <ChevronRightRoundedIcon width={18} height={18} />
                   </ActionIcon>
                 </Group>
               </Group>
@@ -482,11 +463,7 @@ export const SavedSignaturesSection = ({
                         onClick={() => onUseSignature(activeSharedSignature)}
                         disabled={disabled}
                       >
-                        <LocalIcon
-                          icon="check-circle-outline-rounded"
-                          width={18}
-                          height={18}
-                        />
+                        <CheckCircleOutlineRoundedIcon width={18} height={18} />
                       </ActionIcon>
                       {isAdmin && (
                         <Tooltip label={translate("saved.delete", "Remove")}>
@@ -499,11 +476,7 @@ export const SavedSignaturesSection = ({
                             }
                             disabled={disabled}
                           >
-                            <LocalIcon
-                              icon="delete-outline-rounded"
-                              width={18}
-                              height={18}
-                            />
+                            <DeleteOutlineRoundedIcon width={18} height={18} />
                           </ActionIcon>
                         </Tooltip>
                       )}
@@ -571,11 +544,7 @@ export const SavedSignaturesSection = ({
                       }
                       disabled={disabled || activeLocalStorageIndex === 0}
                     >
-                      <LocalIcon
-                        icon="chevron-left-rounded"
-                        width={18}
-                        height={18}
-                      />
+                      <ChevronLeftRoundedIcon width={18} height={18} />
                     </ActionIcon>
                     <ActionIcon
                       variant="secondary"
@@ -594,11 +563,7 @@ export const SavedSignaturesSection = ({
                           groupedSignatures.localStorage.length - 1
                       }
                     >
-                      <LocalIcon
-                        icon="chevron-right-rounded"
-                        width={18}
-                        height={18}
-                      />
+                      <ChevronRightRoundedIcon width={18} height={18} />
                     </ActionIcon>
                   </Group>
                 </Group>
@@ -621,8 +586,7 @@ export const SavedSignaturesSection = ({
                           }
                           disabled={disabled}
                         >
-                          <LocalIcon
-                            icon="check-circle-outline-rounded"
+                          <CheckCircleOutlineRoundedIcon
                             width={18}
                             height={18}
                           />
@@ -637,11 +601,7 @@ export const SavedSignaturesSection = ({
                             }
                             disabled={disabled}
                           >
-                            <LocalIcon
-                              icon="delete-outline-rounded"
-                              width={18}
-                              height={18}
-                            />
+                            <DeleteOutlineRoundedIcon width={18} height={18} />
                           </ActionIcon>
                         </Tooltip>
                       </Group>

--- a/frontend/editor/src/core/components/tools/sign/SignSettings.tsx
+++ b/frontend/editor/src/core/components/tools/sign/SignSettings.tsx
@@ -35,6 +35,8 @@ import {
 } from "@app/hooks/tools/sign/useSavedSignatures";
 import { SavedSignaturesSection } from "@app/components/tools/sign/SavedSignaturesSection";
 import { buildSignaturePreview } from "@app/utils/signaturePreview";
+import PauseCircleRoundedIcon from "@mui/icons-material/PauseCircleRounded";
+import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
 
 type SignatureDrafts = {
   canvas?: string;
@@ -1126,9 +1128,7 @@ const SignSettings = ({
             aria-label={translate("mode.pause", "Pause placement")}
             onClick={handlePausePlacement}
             disabled={disabled || !onDeactivateSignature}
-            leftSection={
-              <LocalIcon icon="pause-circle-rounded" width={20} height={20} />
-            }
+            leftSection={<PauseCircleRoundedIcon width={20} height={20} />}
           >
             {translate("mode.pause", "Pause placement")}
           </Button>
@@ -1142,9 +1142,7 @@ const SignSettings = ({
             disabled={
               disabled || !isCurrentTypeReady || !onActivateSignaturePlacement
             }
-            leftSection={
-              <LocalIcon icon="play-arrow-rounded" width={20} height={20} />
-            }
+            leftSection={<PlayArrowRoundedIcon width={20} height={20} />}
           >
             {translate("mode.resume", "Resume placement")}
           </Button>

--- a/frontend/editor/src/core/components/tools/split/SplitSettings.tsx
+++ b/frontend/editor/src/core/components/tools/split/SplitSettings.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   Select,
 } from "@mantine/core";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import DownloadIcon from "@mui/icons-material/DownloadRounded";
 import { useTranslation } from "react-i18next";
 import { SPLIT_METHODS } from "@app/constants/splitConstants";
 import { SplitParameters } from "@app/hooks/tools/split/useSplitParameters";
@@ -211,7 +211,7 @@ const SplitSettings = ({
         size="sm"
         style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
       >
-        <LocalIcon icon="download-rounded" width="2rem" height="2rem" />
+        <DownloadIcon sx={{ fontSize: "2rem" }} />
         {t(
           "autoSplitPDF.dividerDownload2",
           "Download 'Auto Splitter Divider (with instructions).pdf'",

--- a/frontend/editor/src/core/components/tools/toolPicker/ToolSearch.tsx
+++ b/frontend/editor/src/core/components/tools/toolPicker/ToolSearch.tsx
@@ -100,9 +100,7 @@ const ToolSearch = ({
       }
       icon={
         iconOverride ??
-        (hideIcon ? undefined : (
-          <SearchIcon sx={{ fontSize: "1.25rem" }} />
-        ))
+        (hideIcon ? undefined : <SearchIcon sx={{ fontSize: "1.25rem" }} />)
       }
       iconClickable={!!iconOverride}
       autoComplete="off"

--- a/frontend/editor/src/core/components/tools/toolPicker/ToolSearch.tsx
+++ b/frontend/editor/src/core/components/tools/toolPicker/ToolSearch.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { Stack, Text } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import SearchIcon from "@mui/icons-material/Search";
 import { ToolRegistryEntry } from "@app/data/toolsTaxonomy";
 import { TextInput } from "@app/components/shared/TextInput";
 import "@app/components/tools/toolPicker/ToolPicker.css";
@@ -101,7 +101,7 @@ const ToolSearch = ({
       icon={
         iconOverride ??
         (hideIcon ? undefined : (
-          <LocalIcon icon="search-rounded" width="1.25rem" height="1.25rem" />
+          <SearchIcon sx={{ fontSize: "1.25rem" }} />
         ))
       }
       iconClickable={!!iconOverride}

--- a/frontend/editor/src/core/components/viewer/AnnotationMenuButtons.tsx
+++ b/frontend/editor/src/core/components/viewer/AnnotationMenuButtons.tsx
@@ -6,7 +6,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import CommentIcon from "@mui/icons-material/ChatBubbleOutlineRounded";
 import AddCommentIcon from "@mui/icons-material/AddCommentOutlined";
 import OpenInNewIcon from "@mui/icons-material/OpenInNewRounded";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import LinkIcon from "@mui/icons-material/Link";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import type { FirstLinkTarget } from "@app/components/viewer/useAnnotationMenuHandlers";
@@ -142,7 +142,7 @@ export function LinkButton({
             size="md"
             onClick={() => setOpen((o) => !o)}
           >
-            <LocalIcon icon="link" width="1.25rem" height="1.25rem" />
+            <LinkIcon sx={{ fontSize: "1.25rem" }} />
           </ActionIcon>
         </Tooltip>
       </Popover.Target>

--- a/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { Box, ScrollArea, Text, Loader, Stack, TextInput } from "@mantine/core";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useViewer } from "@app/contexts/ViewerContext";
@@ -11,6 +10,10 @@ import DownloadIcon from "@mui/icons-material/DownloadRounded";
 import { useTranslation } from "react-i18next";
 import "@app/components/viewer/SidebarBase.css";
 import "@app/components/viewer/AttachmentSidebar.css";
+import AddIcon from "@mui/icons-material/Add";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import SearchIcon from "@mui/icons-material/Search";
 
 interface AttachmentSidebarProps {
   visible: boolean;
@@ -392,7 +395,7 @@ export const AttachmentSidebar = ({
             )}
             title={t("viewer.attachments.close", "Close attachments")}
           >
-            <LocalIcon icon="close-rounded" width="1.1rem" height="1.1rem" />
+            <CloseRoundedIcon width="1.1rem" height="1.1rem" />
           </ActionIcon>
         </Box>
       </div>
@@ -409,9 +412,7 @@ export const AttachmentSidebar = ({
             "Search attachments",
           )}
           onChange={(event) => setSearchTerm(event.currentTarget.value)}
-          leftSection={
-            <LocalIcon icon="search" width="1.1rem" height="1.1rem" />
-          }
+          leftSection={<SearchIcon width="1.1rem" height="1.1rem" />}
           size="xs"
         />
       </Box>
@@ -453,7 +454,7 @@ export const AttachmentSidebar = ({
                 aria-label={t("viewer.attachments.retry", "Retry")}
                 onClick={requestReload}
               >
-                <LocalIcon icon="refresh" />
+                <RefreshIcon />
               </ActionIcon>
             </Stack>
           )}
@@ -475,8 +476,7 @@ export const AttachmentSidebar = ({
 
           {showEmptyState && (
             <Stack align="center" gap="sm" py="lg">
-              <LocalIcon
-                icon="attachment-rounded"
+              <AttachmentIcon
                 width="2rem"
                 height="2rem"
                 style={{ color: "var(--mantine-color-dimmed)" }}
@@ -491,9 +491,7 @@ export const AttachmentSidebar = ({
                 variant="secondary"
                 size="sm"
                 onClick={handleAddAttachment}
-                leftSection={
-                  <LocalIcon icon="add" width="1rem" height="1rem" />
-                }
+                leftSection={<AddIcon width="1rem" height="1rem" />}
               >
                 {t("viewer.attachments.addAttachment", "Add attachment")}
               </Button>
@@ -508,9 +506,7 @@ export const AttachmentSidebar = ({
                 fullWidth
                 justify="start"
                 onClick={handleAddAttachment}
-                leftSection={
-                  <LocalIcon icon="add" width="0.9rem" height="0.9rem" />
-                }
+                leftSection={<AddIcon width="0.9rem" height="0.9rem" />}
                 style={{ marginBottom: "var(--space-xs)" }}
               >
                 {t("viewer.attachments.addAttachment", "Add attachment")}

--- a/frontend/editor/src/core/components/viewer/BookmarkSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/BookmarkSidebar.tsx
@@ -23,6 +23,12 @@ import { useTranslation } from "react-i18next";
 import BookmarksIcon from "@mui/icons-material/BookmarksRounded";
 import "@app/components/viewer/SidebarBase.css";
 import "@app/components/viewer/BookmarkSidebar.css";
+import AddIcon from "@mui/icons-material/Add";
+import BookmarkAddRoundedIcon from "@mui/icons-material/BookmarkAddRounded";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import SearchIcon from "@mui/icons-material/Search";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 
 interface BookmarkSidebarProps {
   visible: boolean;
@@ -705,11 +711,7 @@ export const BookmarkSidebar = ({
                     "Expand all bookmarks",
                   )}
                 >
-                  <LocalIcon
-                    icon="unfold-more"
-                    width="1.1rem"
-                    height="1.1rem"
-                  />
+                  <UnfoldMoreIcon width="1.1rem" height="1.1rem" />
                 </ActionIcon>
               ) : (
                 <ActionIcon
@@ -725,11 +727,7 @@ export const BookmarkSidebar = ({
                     "Collapse all bookmarks",
                   )}
                 >
-                  <LocalIcon
-                    icon="unfold-less"
-                    width="1.1rem"
-                    height="1.1rem"
-                  />
+                  <UnfoldLessIcon width="1.1rem" height="1.1rem" />
                 </ActionIcon>
               )}
             </>
@@ -748,7 +746,7 @@ export const BookmarkSidebar = ({
               "Close bookmarks sidebar",
             )}
           >
-            <LocalIcon icon="close-rounded" width="1.1rem" height="1.1rem" />
+            <CloseRoundedIcon width="1.1rem" height="1.1rem" />
           </ActionIcon>
         </Box>
       </div>
@@ -765,9 +763,7 @@ export const BookmarkSidebar = ({
             "Search bookmarks",
           )}
           onChange={(event) => setSearchTerm(event.currentTarget.value)}
-          leftSection={
-            <LocalIcon icon="search" width="1.1rem" height="1.1rem" />
-          }
+          leftSection={<SearchIcon width="1.1rem" height="1.1rem" />}
           size="xs"
         />
       </Box>
@@ -817,8 +813,7 @@ export const BookmarkSidebar = ({
           )}
           {showEmptyState && !isAddingBookmark && (
             <Stack align="center" gap="sm" py="lg">
-              <LocalIcon
-                icon="bookmark-add-rounded"
+              <BookmarkAddRoundedIcon
                 width="2rem"
                 height="2rem"
                 style={{ color: "var(--mantine-color-dimmed)" }}
@@ -830,9 +825,7 @@ export const BookmarkSidebar = ({
                 variant="tertiary"
                 size="sm"
                 onClick={handleOpenAddBookmark}
-                leftSection={
-                  <LocalIcon icon="add" width="1rem" height="1rem" />
-                }
+                leftSection={<AddIcon width="1rem" height="1rem" />}
               >
                 Add bookmark
               </Button>
@@ -916,9 +909,7 @@ export const BookmarkSidebar = ({
                   fullWidth
                   justify="start"
                   onClick={handleOpenAddBookmark}
-                  leftSection={
-                    <LocalIcon icon="add" width="0.9rem" height="0.9rem" />
-                  }
+                  leftSection={<AddIcon width="0.9rem" height="0.9rem" />}
                   style={{ marginBottom: "var(--space-xs)" }}
                 >
                   Add bookmark
@@ -959,8 +950,7 @@ export const BookmarkSidebar = ({
             style={{ width: "100%" }}
           >
             <Group gap="xs" justify="center" wrap="nowrap">
-              <LocalIcon
-                icon="bookmark-add-rounded"
+              <BookmarkAddRoundedIcon
                 width="0.95rem"
                 height="0.95rem"
                 style={{ color: "var(--mantine-color-blue-5)" }}

--- a/frontend/editor/src/core/components/viewer/CommentsSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/CommentsSidebar.tsx
@@ -36,6 +36,10 @@ import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
 import { useAnnotation as useAnnotationContext } from "@app/contexts/AnnotationContext";
 import LocalIcon from "@app/components/shared/LocalIcon";
 import { compareEntriesByVisualOrder } from "@app/components/viewer/commentsSidebarOrder";
+import AddIcon from "@mui/icons-material/Add";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import CommentIcon from "@mui/icons-material/Comment";
+import TouchAppRoundedIcon from "@mui/icons-material/TouchAppRounded";
 
 const SIDEBAR_WIDTH = "18rem";
 
@@ -696,8 +700,7 @@ export function CommentsSidebar({
           gap: "0.5rem",
         }}
       >
-        <LocalIcon
-          icon="comment"
+        <CommentIcon
           width="1.25rem"
           height="1.25rem"
           style={{ color: "var(--mantine-color-dimmed)", flexShrink: 0 }}
@@ -715,7 +718,7 @@ export function CommentsSidebar({
                 aria-label={t("viewer.comments.addComment", "Add comment")}
                 onClick={handleAddComment}
               >
-                <LocalIcon icon="add" width="1.25rem" height="1.25rem" />
+                <AddIcon width="1.25rem" height="1.25rem" />
               </ActionIcon>
             </Tooltip>
             <Menu position="bottom-end" withArrow>
@@ -760,7 +763,7 @@ export function CommentsSidebar({
             )}
             title={t("viewer.comments.close", "Close comments")}
           >
-            <LocalIcon icon="close-rounded" width="1.1rem" height="1.1rem" />
+            <CloseRoundedIcon width="1.1rem" height="1.1rem" />
           </ActionIcon>
         )}
       </div>
@@ -768,8 +771,7 @@ export function CommentsSidebar({
         <Stack p="sm" gap="md">
           {totalCount === 0 ? (
             <Stack align="center" gap="sm" py="lg">
-              <LocalIcon
-                icon="comment"
+              <CommentIcon
                 width="2rem"
                 height="2rem"
                 style={{ color: "var(--mantine-color-dimmed)" }}
@@ -787,11 +789,7 @@ export function CommentsSidebar({
                   size="sm"
                   onClick={handleCancelPlacingComment}
                   leftSection={
-                    <LocalIcon
-                      icon="touch-app-rounded"
-                      width="1rem"
-                      height="1rem"
-                    />
+                    <TouchAppRoundedIcon width="1rem" height="1rem" />
                   }
                 >
                   {t(
@@ -804,9 +802,7 @@ export function CommentsSidebar({
                   variant="tertiary"
                   size="sm"
                   onClick={handleAddComment}
-                  leftSection={
-                    <LocalIcon icon="add" width="1rem" height="1rem" />
-                  }
+                  leftSection={<AddIcon width="1rem" height="1rem" />}
                 >
                   {t("viewer.comments.addComment", "Add comment")}
                 </Button>
@@ -823,11 +819,7 @@ export function CommentsSidebar({
                   justify="start"
                   onClick={handleCancelPlacingComment}
                   leftSection={
-                    <LocalIcon
-                      icon="touch-app-rounded"
-                      width="0.9rem"
-                      height="0.9rem"
-                    />
+                    <TouchAppRoundedIcon width="0.9rem" height="0.9rem" />
                   }
                   style={{ paddingInline: 6 }}
                 >
@@ -843,9 +835,7 @@ export function CommentsSidebar({
                   fullWidth
                   justify="start"
                   onClick={handleAddComment}
-                  leftSection={
-                    <LocalIcon icon="add" width="0.9rem" height="0.9rem" />
-                  }
+                  leftSection={<AddIcon width="0.9rem" height="0.9rem" />}
                   style={{ paddingInline: 6 }}
                 >
                   {t("viewer.comments.addComment", "Add comment")}

--- a/frontend/editor/src/core/components/viewer/LayerSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/LayerSidebar.tsx
@@ -9,6 +9,8 @@ import {
   Tooltip,
 } from "@mantine/core";
 import LayersIcon from "@mui/icons-material/Layers";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
@@ -258,23 +260,9 @@ export function LayerSidebar({
               }}
             >
               {isExpanded ? (
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 12 12"
-                  fill="currentColor"
-                >
-                  <path d="M2 4l4 4 4-4z" />
-                </svg>
+                <ArrowDropDownIcon sx={{ fontSize: 12 }} />
               ) : (
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 12 12"
-                  fill="currentColor"
-                >
-                  <path d="M4 2l4 4-4 4z" />
-                </svg>
+                <ArrowRightIcon sx={{ fontSize: 12 }} />
               )}
             </span>
           ) : (

--- a/frontend/editor/src/core/components/viewer/LayerSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/LayerSidebar.tsx
@@ -14,7 +14,7 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CloseIcon from "@mui/icons-material/CloseRounded";
 import { useTranslation } from "react-i18next";
 import { useViewer } from "@app/contexts/ViewerContext";
 import "@app/components/viewer/SidebarBase.css";
@@ -362,7 +362,7 @@ export function LayerSidebar({
             aria-label={t("viewer.layers.closeSidebar", "Close layers sidebar")}
             title={t("viewer.layers.closeSidebar", "Close layers sidebar")}
           >
-            <LocalIcon icon="close-rounded" width="1.1rem" height="1.1rem" />
+            <CloseIcon sx={{ fontSize: "1.1rem" }} />
           </ActionIcon>
         </div>
       </div>

--- a/frontend/editor/src/core/components/viewer/SearchInterface.tsx
+++ b/frontend/editor/src/core/components/viewer/SearchInterface.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Box, TextInput, Text, Group } from "@mantine/core";
 import { useTranslation } from "react-i18next";
-import { LocalIcon } from "@app/components/shared/LocalIcon";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { ViewerContext } from "@app/contexts/ViewerContext";
+import CloseIcon from "@mui/icons-material/Close";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 
 interface SearchInterfaceProps {
   visible: boolean;
@@ -206,7 +208,7 @@ export function SearchInterface({ visible, onClose }: SearchInterfaceProps) {
           onClick={handleCloseClick}
           aria-label={t("viewer.search.close", "Close search")}
         >
-          <LocalIcon icon="close" width="1rem" height="1rem" />
+          <CloseIcon width="1rem" height="1rem" />
         </ActionIcon>
       </Group>
 
@@ -230,7 +232,7 @@ export function SearchInterface({ visible, onClose }: SearchInterfaceProps) {
                 onClick={handleClearSearch}
                 aria-label={t("viewer.search.clear", "Clear search")}
               >
-                <LocalIcon icon="close" width="0.875rem" height="0.875rem" />
+                <CloseIcon width="0.875rem" height="0.875rem" />
               </ActionIcon>
             )
           }
@@ -282,7 +284,7 @@ export function SearchInterface({ visible, onClose }: SearchInterfaceProps) {
             disabled={!resultInfo || resultInfo.currentIndex <= 1}
             aria-label={t("viewer.search.previous", "Previous result")}
           >
-            <LocalIcon icon="keyboard-arrow-up" width="1rem" height="1rem" />
+            <KeyboardArrowUpIcon width="1rem" height="1rem" />
           </ActionIcon>
           <ActionIcon
             variant="tertiary"
@@ -293,7 +295,7 @@ export function SearchInterface({ visible, onClose }: SearchInterfaceProps) {
             }
             aria-label={t("viewer.search.next", "Next result")}
           >
-            <LocalIcon icon="keyboard-arrow-down" width="1rem" height="1rem" />
+            <KeyboardArrowDownIcon width="1rem" height="1rem" />
           </ActionIcon>
         </Group>
       </Group>

--- a/frontend/editor/src/core/components/viewer/ThumbnailSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/ThumbnailSidebar.tsx
@@ -4,7 +4,7 @@ import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
 import { useViewer } from "@app/contexts/ViewerContext";
 import { PrivateContent } from "@app/components/shared/PrivateContent";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CloseIcon from "@mui/icons-material/CloseRounded";
 import ViewListIcon from "@mui/icons-material/ViewList";
 import "@app/components/viewer/SidebarBase.css";
 
@@ -198,7 +198,7 @@ export function ThumbnailSidebar({
                 "Close thumbnails sidebar",
               )}
             >
-              <LocalIcon icon="close-rounded" width="1.1rem" height="1.1rem" />
+              <CloseIcon sx={{ fontSize: "1.1rem" }} />
             </ActionIcon>
           </div>
           {/* Thumbnails Container */}

--- a/frontend/editor/src/core/components/viewer/ViewerAnnotationControls.tsx
+++ b/frontend/editor/src/core/components/viewer/ViewerAnnotationControls.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import { AppIcon } from "@app/ui/AppIcon";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import { ViewerContext } from "@app/contexts/ViewerContext";
@@ -196,11 +196,7 @@ export default function ViewerAnnotationControls({
               : t("workbenchBar.redact", "Redact")
           }
         >
-          <LocalIcon
-            icon="scan-delete-rounded"
-            width="1.25rem"
-            height="1.25rem"
-          />
+          <AppIcon symbol="scan-delete-rounded" size="1.25rem" />
         </ActionIcon>
       </Tooltip>
 
@@ -231,14 +227,13 @@ export default function ViewerAnnotationControls({
             "Toggle Annotations Visibility",
           )}
         >
-          <LocalIcon
-            icon={
+          <AppIcon
+            symbol={
               viewerContext?.isAnnotationsVisible
                 ? "visibility"
                 : "preview-off-rounded"
             }
-            width="1.25rem"
-            height="1.25rem"
+            size="1.25rem"
           />
         </ActionIcon>
       </Tooltip>

--- a/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
@@ -8,7 +8,6 @@ import {
   useWorkbenchBarButtons,
   WorkbenchBarButtonWithAction,
 } from "@app/hooks/useWorkbenchBarButtons";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { Tooltip } from "@app/components/shared/Tooltip";
 import { SearchInterface } from "@app/components/viewer/SearchInterface";
 import ViewerAnnotationControls from "@app/components/viewer/ViewerAnnotationControls";
@@ -27,6 +26,15 @@ import LayersIcon from "@mui/icons-material/Layers";
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import StopIcon from "@mui/icons-material/Stop";
 import { useViewerReadAloud } from "@app/components/viewer/useViewerReadAloud";
+import AttachmentRoundedIcon from "@mui/icons-material/AttachmentRounded";
+import BookmarkAddRoundedIcon from "@mui/icons-material/BookmarkAddRounded";
+import CommentIcon from "@mui/icons-material/Comment";
+import EditIcon from "@mui/icons-material/Edit";
+import PanToolRoundedIcon from "@mui/icons-material/PanToolRounded";
+import RotateLeftIcon from "@mui/icons-material/RotateLeft";
+import RotateRightIcon from "@mui/icons-material/RotateRight";
+import SearchIcon from "@mui/icons-material/Search";
+import ViewListIcon from "@mui/icons-material/ViewList";
 
 export function useViewerWorkbenchBarButtons(
   isRulerActive?: boolean,
@@ -176,7 +184,7 @@ export function useViewerWorkbenchBarButtons(
                     aria-label={searchLabel}
                     onClick={viewer.searchInterfaceActions.toggle}
                   >
-                    <LocalIcon icon="search" width="1rem" height="1rem" />
+                    <SearchIcon width="1rem" height="1rem" />
                   </ActionIcon>
                 </div>
               </Popover.Target>
@@ -194,7 +202,7 @@ export function useViewerWorkbenchBarButtons(
       },
       {
         id: "viewer-pan-mode",
-        icon: <LocalIcon icon="pan-tool-rounded" width="1rem" height="1rem" />,
+        icon: <PanToolRoundedIcon width="1rem" height="1rem" />,
         tooltip:
           !isPanning && pendingCount > 0 && redactionActiveType !== null
             ? applyRedactionsLabel
@@ -236,7 +244,7 @@ export function useViewerWorkbenchBarButtons(
       },
       {
         id: "viewer-rotate-left",
-        icon: <LocalIcon icon="rotate-left" width="1rem" height="1rem" />,
+        icon: <RotateLeftIcon width="1rem" height="1rem" />,
         tooltip: rotateLeftLabel,
         ariaLabel: rotateLeftLabel,
         section: "top" as const,
@@ -247,7 +255,7 @@ export function useViewerWorkbenchBarButtons(
       },
       {
         id: "viewer-rotate-right",
-        icon: <LocalIcon icon="rotate-right" width="1rem" height="1rem" />,
+        icon: <RotateRightIcon width="1rem" height="1rem" />,
         tooltip: rotateRightLabel,
         ariaLabel: rotateRightLabel,
         section: "top" as const,
@@ -258,7 +266,7 @@ export function useViewerWorkbenchBarButtons(
       },
       {
         id: "viewer-toggle-sidebar",
-        icon: <LocalIcon icon="view-list" width="1rem" height="1rem" />,
+        icon: <ViewListIcon width="1rem" height="1rem" />,
         tooltip: sidebarLabel,
         ariaLabel: sidebarLabel,
         section: "top" as const,
@@ -270,13 +278,7 @@ export function useViewerWorkbenchBarButtons(
       },
       {
         id: "viewer-toggle-bookmarks",
-        icon: (
-          <LocalIcon
-            icon="bookmark-add-rounded"
-            width="1.25rem"
-            height="1.25rem"
-          />
-        ),
+        icon: <BookmarkAddRoundedIcon width="1.25rem" height="1.25rem" />,
         tooltip: bookmarkLabel,
         ariaLabel: bookmarkLabel,
         section: "top" as const,
@@ -288,13 +290,7 @@ export function useViewerWorkbenchBarButtons(
       },
       {
         id: "viewer-toggle-attachments",
-        icon: (
-          <LocalIcon
-            icon="attachment-rounded"
-            width="1.25rem"
-            height="1.25rem"
-          />
-        ),
+        icon: <AttachmentRoundedIcon width="1.25rem" height="1.25rem" />,
         tooltip: attachmentLabel,
         ariaLabel: attachmentLabel,
         section: "top" as const,
@@ -322,7 +318,7 @@ export function useViewerWorkbenchBarButtons(
         : []),
       {
         id: "viewer-toggle-comments",
-        icon: <LocalIcon icon="comment" width="1rem" height="1rem" />,
+        icon: <CommentIcon width="1rem" height="1rem" />,
         tooltip: commentsLabel,
         ariaLabel: commentsLabel,
         section: "top" as const,
@@ -474,7 +470,7 @@ export function useViewerWorkbenchBarButtons(
               aria-pressed={isAnnotationsActive}
               aria-label={annotationsLabel}
             >
-              <LocalIcon icon="edit" width="1rem" height="1rem" />
+              <EditIcon width="1rem" height="1rem" />
             </ActionIcon>
           </Tooltip>
         ),

--- a/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
+++ b/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
@@ -61,6 +61,53 @@ import { extractPagesOperationConfig } from "@app/hooks/tools/extractPages/useEx
 import { ENDPOINTS as SPLIT_ENDPOINT_NAMES } from "@app/constants/splitConstants";
 import { ToolId } from "@app/types/toolId";
 import { CONVERT_SUPPORTED_FORMATS } from "@app/constants/convertSupportedFornats";
+import AttachmentRoundedIcon from "@mui/icons-material/AttachmentRounded";
+import CompareRoundedIcon from "@mui/icons-material/CompareRounded";
+import ContentCutRoundedIcon from "@mui/icons-material/ContentCutRounded";
+import CropFreeRoundedIcon from "@mui/icons-material/CropFreeRounded";
+import CropRoundedIcon from "@mui/icons-material/CropRounded";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import FormatColorFillRoundedIcon from "@mui/icons-material/FormatColorFillRounded";
+import JavascriptRoundedIcon from "@mui/icons-material/JavascriptRounded";
+import MoveDownRoundedIcon from "@mui/icons-material/MoveDownRounded";
+import OpenInNewRoundedIcon from "@mui/icons-material/OpenInNewRounded";
+import PasswordRoundedIcon from "@mui/icons-material/PasswordRounded";
+import RotateRightRoundedIcon from "@mui/icons-material/RotateRightRounded";
+import SyncAltRoundedIcon from "@mui/icons-material/SyncAltRounded";
+import TextFieldsRoundedIcon from "@mui/icons-material/TextFieldsRounded";
+import TocRoundedIcon from "@mui/icons-material/TocRounded";
+import UploadRoundedIcon from "@mui/icons-material/UploadRounded";
+import ZoomInMapRoundedIcon from "@mui/icons-material/ZoomInMapRounded";
+import ApprovalOutlinedIcon from "@mui/icons-material/ApprovalOutlined";
+import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
+import AssignmentOutlinedIcon from "@mui/icons-material/AssignmentOutlined";
+import AutoModeOutlinedIcon from "@mui/icons-material/AutoModeOutlined";
+import BrandingWatermarkOutlinedIcon from "@mui/icons-material/BrandingWatermarkOutlined";
+import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
+import CleaningServicesOutlinedIcon from "@mui/icons-material/CleaningServicesOutlined";
+import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
+import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
+import DrawRoundedIcon from "@mui/icons-material/DrawRounded";
+import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import EditSquareIcon from "@mui/icons-material/EditSquare";
+import FactCheckOutlinedIcon from "@mui/icons-material/FactCheckOutlined";
+import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import LayersClearOutlinedIcon from "@mui/icons-material/LayersClearOutlined";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import LibraryAddOutlinedIcon from "@mui/icons-material/LibraryAddOutlined";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import LooksOneOutlinedIcon from "@mui/icons-material/LooksOneOutlined";
+import MarkChatUnreadRoundedIcon from "@mui/icons-material/MarkChatUnreadRounded";
+import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
+import NumbersRoundedIcon from "@mui/icons-material/NumbersRounded";
+import PaletteOutlinedIcon from "@mui/icons-material/PaletteOutlined";
+import PhotoLibraryOutlinedIcon from "@mui/icons-material/PhotoLibraryOutlined";
+import RemoveModeratorOutlinedIcon from "@mui/icons-material/RemoveModeratorOutlined";
+import ScannerOutlinedIcon from "@mui/icons-material/ScannerOutlined";
+import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
+import VerifiedOutlinedIcon from "@mui/icons-material/VerifiedOutlined";
+import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
+import WorkspacePremiumOutlinedIcon from "@mui/icons-material/WorkspacePremiumOutlined";
 
 export interface TranslatedToolCatalog {
   allTools: ToolRegistry;
@@ -85,13 +132,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       ...prototypeTools,
       // Recommended Tools in order
       pdfTextEditor: {
-        icon: (
-          <LocalIcon
-            icon="edit-square-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <EditSquareIcon width="1.5rem" height="1.5rem" />,
         name: t("home.pdfTextEditor.title", "PDF Text Editor"),
         component: lazy(() => import("@app/tools/pdfTextEditor/PdfTextEditor")),
         description: t(
@@ -108,13 +149,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         versionStatus: "alpha",
       },
       multiTool: {
-        icon: (
-          <LocalIcon
-            icon="dashboard-customize-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <DashboardCustomizeOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.multiTool.title", "Multi-Tool"),
         component: null,
         workbench: "pageEditor",
@@ -131,13 +166,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       merge: {
-        icon: (
-          <LocalIcon
-            icon="library-add-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <LibraryAddOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.merge.title", "Merge"),
         component: lazy(() => import("@app/tools/Merge")),
         description: t(
@@ -156,13 +185,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       },
       // Signing
       certSign: {
-        icon: (
-          <LocalIcon
-            icon="workspace-premium-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <WorkspacePremiumOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.certSign.title", "Certificate Sign"),
         component: lazy(() => import("@app/tools/CertSign")),
         description: t(
@@ -181,13 +204,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       timestampPdf: {
-        icon: (
-          <LocalIcon
-            icon="schedule-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ScheduleOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.timestampPdf.title", "Timestamp PDF"),
         component: lazy(() => import("@app/tools/TimestampPdf")),
         description: t(
@@ -203,9 +220,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "timestampPdf"),
       },
       sign: {
-        icon: (
-          <LocalIcon icon="signature-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <DrawRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.sign.title", "Sign"),
         component: lazy(() => import("@app/tools/Sign")),
         description: t(
@@ -237,13 +252,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "sharedSign"),
       },
       addText: {
-        icon: (
-          <LocalIcon
-            icon="text-fields-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <TextFieldsRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.addText.title", "Add Text"),
         component: lazy(() => import("@app/tools/AddText")),
         description: t(
@@ -259,13 +268,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         supportsAutomate: false,
       },
       addImage: {
-        icon: (
-          <LocalIcon
-            icon="image-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ImageOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.addImage.title", "Add Image"),
         component: lazy(() => import("@app/tools/AddImage")),
         description: t("home.addImage.desc", "Add images anywhere in your PDF"),
@@ -278,13 +281,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         supportsAutomate: false,
       },
       annotate: {
-        icon: (
-          <LocalIcon
-            icon="edit-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <EditOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.annotate.title", "Annotate"),
         component: lazy(() => import("@app/tools/Annotate")),
         description: t(
@@ -304,9 +301,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Document Security
 
       addPassword: {
-        icon: (
-          <LocalIcon icon="password-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <PasswordRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.addPassword.title", "Add Password"),
         component: lazy(() => import("@app/tools/AddPassword")),
         description: t(
@@ -324,13 +319,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "addPassword"),
       },
       watermark: {
-        icon: (
-          <LocalIcon
-            icon="branding-watermark-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <BrandingWatermarkOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.watermark.title", "Add Watermark"),
         component: lazy(() => import("@app/tools/AddWatermark")),
         maxFiles: -1,
@@ -349,13 +338,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "watermark"),
       },
       addStamp: {
-        icon: (
-          <LocalIcon
-            icon="approval-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ApprovalOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.addStamp.title", "Add Stamp to PDF"),
         component: lazy(() => import("@app/tools/AddStamp")),
         description: t(
@@ -374,13 +357,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       sanitize: {
-        icon: (
-          <LocalIcon
-            icon="cleaning-services-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <CleaningServicesOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.sanitize.title", "Sanitize"),
         component: lazy(() => import("@app/tools/Sanitize")),
         maxFiles: -1,
@@ -398,13 +375,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "sanitize"),
       },
       flatten: {
-        icon: (
-          <LocalIcon
-            icon="layers-clear-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <LayersClearOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.flatten.title", "Flatten"),
         component: lazy(() => import("@app/tools/Flatten")),
         description: t(
@@ -444,13 +415,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       formFill: {
-        icon: (
-          <LocalIcon
-            icon="text-fields-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <TextFieldsRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.formFill.title", "Fill Form"),
         component: lazy(() => import("@app/tools/formFill/FormFill")),
         description: t(
@@ -466,7 +431,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: ["form", "fill", "fillable", "input", "field", "acroform"],
       },
       changePermissions: {
-        icon: <LocalIcon icon="lock-outline" width="1.5rem" height="1.5rem" />,
+        icon: <LockOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.changePermissions.title", "Change Permissions"),
         component: lazy(() => import("@app/tools/ChangePermissions")),
         description: t(
@@ -485,13 +450,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "changePermissions"),
       },
       getPdfInfo: {
-        icon: (
-          <LocalIcon
-            icon="fact-check-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <FactCheckOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.getPdfInfo.title", "Get ALL Info on PDF"),
         component: lazy(() => import("@app/tools/GetPdfInfo")),
         description: t(
@@ -507,13 +466,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         maxFiles: 1,
       },
       validateSignature: {
-        icon: (
-          <LocalIcon
-            icon="verified-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <VerifiedOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.validateSignature.title", "Validate PDF Signature"),
         component: lazy(() => import("@app/tools/ValidateSignature")),
         description: t(
@@ -531,13 +484,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Document Review
 
       read: {
-        icon: (
-          <LocalIcon
-            icon="article-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ArticleOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.read.title", "Read"),
         component: null,
         workbench: "viewer",
@@ -553,13 +500,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       changeMetadata: {
-        icon: (
-          <LocalIcon
-            icon="assignment-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <AssignmentOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.changeMetadata.title", "Change Metadata"),
         component: lazy(() => import("@app/tools/ChangeMetadata")),
         description: t(
@@ -578,7 +519,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "changeMetadata"),
       },
       editTableOfContents: {
-        icon: <LocalIcon icon="toc-rounded" width="1.5rem" height="1.5rem" />,
+        icon: <TocRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.editTableOfContents.title", "Edit Table of Contents"),
         component: lazy(() => import("@app/tools/EditTableOfContents")),
         description: t(
@@ -597,7 +538,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Page Formatting
 
       crop: {
-        icon: <LocalIcon icon="crop-rounded" width="1.5rem" height="1.5rem" />,
+        icon: <CropRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.crop.title", "Crop PDF"),
         component: lazy(() => import("@app/tools/Crop")),
         description: t(
@@ -614,13 +555,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       rotate: {
-        icon: (
-          <LocalIcon
-            icon="rotate-right-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <RotateRightRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.rotate.title", "Rotate"),
         component: lazy(() => import("@app/tools/Rotate")),
         description: t("home.rotate.desc", "Easily rotate your PDFs."),
@@ -635,13 +570,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "rotate"),
       },
       split: {
-        icon: (
-          <LocalIcon
-            icon="content-cut-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ContentCutRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.split.title", "Split"),
         component: lazy(() => import("@app/tools/Split")),
         description: t("home.split.desc", "Split PDFs into multiple documents"),
@@ -655,9 +584,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "split"),
       },
       reorganizePages: {
-        icon: (
-          <LocalIcon icon="move-down-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <MoveDownRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.reorganizePages.title", "Reorganize Pages"),
         component: lazy(() => import("@app/tools/ReorganizePages")),
         description: t(
@@ -672,9 +599,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       scalePages: {
-        icon: (
-          <LocalIcon icon="crop-free-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <CropFreeRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.scalePages.title", "Adjust page size/scale"),
         component: lazy(() => import("@app/tools/AdjustPageScale")),
         description: t(
@@ -693,7 +618,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "scalePages"),
       },
       addPageNumbers: {
-        icon: <LocalIcon icon="123-rounded" width="1.5rem" height="1.5rem" />,
+        icon: <NumbersRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.addPageNumbers.title", "Add Page Numbers"),
         component: lazy(() => import("@app/tools/AddPageNumbers")),
         description: t(
@@ -712,13 +637,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "addPageNumbers"),
       },
       pageLayout: {
-        icon: (
-          <LocalIcon
-            icon="dashboard-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <DashboardOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.pageLayout.title", "Multi-Page Layout"),
         component: lazy(() => import("@app/tools/PageLayout")),
         description: t(
@@ -735,13 +654,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "pageLayout"),
       },
       bookletImposition: {
-        icon: (
-          <LocalIcon
-            icon="menu-book-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <MenuBookOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.bookletImposition.title", "Booklet Imposition"),
         component: lazy(() => import("@app/tools/BookletImposition")),
         operationConfig: asRegistryConfig(bookletImpositionOperationConfig),
@@ -758,13 +671,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         endpoints: ["booklet-imposition"],
       },
       pdfToSinglePage: {
-        icon: (
-          <LocalIcon
-            icon="looks-one-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <LooksOneOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.pdfToSinglePage.title", "PDF to Single Large Page"),
         component: lazy(() => import("@app/tools/SingleLargePage")),
 
@@ -781,9 +688,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       addAttachments: {
-        icon: (
-          <LocalIcon icon="attachment-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <AttachmentRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.addAttachments.title", "Add Attachments"),
         component: lazy(() => import("@app/tools/AddAttachments")),
         description: t(
@@ -805,9 +710,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Extraction
 
       extractPages: {
-        icon: (
-          <LocalIcon icon="upload-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <UploadRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.extractPages.title", "Extract Pages"),
         component: lazy(() => import("@app/tools/ExtractPages")),
         description: t(
@@ -825,13 +728,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         endpoints: ["rearrange-pages"],
       },
       extractImages: {
-        icon: (
-          <LocalIcon
-            icon="photo-library-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <PhotoLibraryOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.extractImages.title", "Extract Images"),
         component: lazy(() => import("@app/tools/ExtractImages")),
         description: t(
@@ -853,13 +750,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Removal
 
       removePages: {
-        icon: (
-          <LocalIcon
-            icon="delete-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <DeleteOutlineRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.removePages.title", "Remove Pages"),
         component: lazy(() => import("@app/tools/RemovePages")),
         description: t(
@@ -902,13 +793,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       removeAnnotations: {
-        icon: (
-          <LocalIcon
-            icon="thread-unread-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <MarkChatUnreadRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.removeAnnotations.title", "Remove Annotations"),
         component: lazy(() => import("@app/tools/RemoveAnnotations")),
         description: t(
@@ -971,13 +856,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "removePassword"),
       },
       removeCertSign: {
-        icon: (
-          <LocalIcon
-            icon="remove-moderator-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <RemoveModeratorOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.removeCertSign.title", "Remove Certificate Sign"),
         component: lazy(() => import("@app/tools/RemoveCertificateSign")),
         description: t(
@@ -996,9 +875,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Automation
 
       automate: {
-        icon: (
-          <LocalIcon icon="automation-outline" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <AutoModeOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.automate.title", "Automate"),
         component: lazy(() => import("@app/tools/Automate")),
         description: t(
@@ -1034,9 +911,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Advanced Formatting
 
       adjustContrast: {
-        icon: (
-          <LocalIcon icon="palette-outline" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <PaletteOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.adjustContrast.title", "Adjust Colors/Contrast"),
         component: lazy(() => import("@app/tools/AdjustContrast")),
         description: t(
@@ -1055,13 +930,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "adjustContrast"),
       },
       repair: {
-        icon: (
-          <LocalIcon
-            icon="build-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <BuildOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.repair.title", "Repair"),
         component: lazy(() => import("@app/tools/Repair")),
         description: t(
@@ -1077,13 +946,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       scannerImageSplit: {
-        icon: (
-          <LocalIcon
-            icon="scanner-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ScannerOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t(
           "home.scannerImageSplit.title",
           "Detect & Split Scanned Photos",
@@ -1105,13 +968,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "scannerImageSplit"),
       },
       overlayPdfs: {
-        icon: (
-          <LocalIcon
-            icon="layers-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <LayersOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.overlay-pdfs.title", "Overlay PDFs"),
         component: lazy(() => import("@app/tools/OverlayPdfs")),
         description: t(
@@ -1128,13 +985,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       replaceColor: {
-        icon: (
-          <LocalIcon
-            icon="format-color-fill-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <FormatColorFillRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.replaceColor.title", "Replace & Invert Color"),
         component: lazy(() => import("@app/tools/ReplaceColor")),
         description: t(
@@ -1153,13 +1004,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "replaceColor"),
       },
       scannerEffect: {
-        icon: (
-          <LocalIcon
-            icon="scanner-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ScannerOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.scannerEffect.title", "Scanner Effect"),
         component: null,
         description: t(
@@ -1176,9 +1021,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Developer Tools
 
       showJS: {
-        icon: (
-          <LocalIcon icon="javascript-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <JavascriptRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.showJS.title", "Show JavaScript"),
         component: lazy(() => import("@app/tools/ShowJS")),
         description: t(
@@ -1195,8 +1038,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       },
       devApi: {
         icon: (
-          <LocalIcon
-            icon="open-in-new-rounded"
+          <OpenInNewRoundedIcon
             width="1.5rem"
             height="1.5rem"
             style={{ color: "#2F7BF6" }}
@@ -1215,8 +1057,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       },
       devFolderScanning: {
         icon: (
-          <LocalIcon
-            icon="open-in-new-rounded"
+          <OpenInNewRoundedIcon
             width="1.5rem"
             height="1.5rem"
             style={{ color: "#2F7BF6" }}
@@ -1238,8 +1079,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       },
       devSsoGuide: {
         icon: (
-          <LocalIcon
-            icon="open-in-new-rounded"
+          <OpenInNewRoundedIcon
             width="1.5rem"
             height="1.5rem"
             style={{ color: "#2F7BF6" }}
@@ -1258,8 +1098,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       },
       devAirgapped: {
         icon: (
-          <LocalIcon
-            icon="open-in-new-rounded"
+          <OpenInNewRoundedIcon
             width="1.5rem"
             height="1.5rem"
             style={{ color: "#2F7BF6" }}
@@ -1282,9 +1121,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
 
       // Recommended Tools
       compare: {
-        icon: (
-          <LocalIcon icon="compare-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <CompareRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.compare.title", "Compare"),
         component: lazy(() => import("@app/tools/Compare")),
         description: t(
@@ -1301,13 +1138,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         supportsAutomate: false,
       },
       compress: {
-        icon: (
-          <LocalIcon
-            icon="zoom-in-map-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <ZoomInMapRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.compress.title", "Compress"),
         component: lazy(() => import("@app/tools/Compress")),
         description: t(
@@ -1325,9 +1156,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "compress"),
       },
       convert: {
-        icon: (
-          <LocalIcon icon="sync-alt-rounded" width="1.5rem" height="1.5rem" />
-        ),
+        icon: <SyncAltRoundedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.convert.title", "Convert"),
         component: lazy(() => import("@app/tools/Convert")),
         description: t(
@@ -1389,13 +1218,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "ocr"),
       },
       redact: {
-        icon: (
-          <LocalIcon
-            icon="visibility-off-outline-rounded"
-            width="1.5rem"
-            height="1.5rem"
-          />
-        ),
+        icon: <VisibilityOffOutlinedIcon width="1.5rem" height="1.5rem" />,
         name: t("home.redact.title", "Redact"),
         component: lazy(() => import("@app/tools/Redact")),
         description: t(

--- a/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
+++ b/frontend/editor/src/core/data/useTranslatedToolRegistry.tsx
@@ -78,36 +78,6 @@ import TextFieldsRoundedIcon from "@mui/icons-material/TextFieldsRounded";
 import TocRoundedIcon from "@mui/icons-material/TocRounded";
 import UploadRoundedIcon from "@mui/icons-material/UploadRounded";
 import ZoomInMapRoundedIcon from "@mui/icons-material/ZoomInMapRounded";
-import ApprovalOutlinedIcon from "@mui/icons-material/ApprovalOutlined";
-import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
-import AssignmentOutlinedIcon from "@mui/icons-material/AssignmentOutlined";
-import AutoModeOutlinedIcon from "@mui/icons-material/AutoModeOutlined";
-import BrandingWatermarkOutlinedIcon from "@mui/icons-material/BrandingWatermarkOutlined";
-import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
-import CleaningServicesOutlinedIcon from "@mui/icons-material/CleaningServicesOutlined";
-import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
-import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
-import DrawRoundedIcon from "@mui/icons-material/DrawRounded";
-import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
-import EditSquareIcon from "@mui/icons-material/EditSquare";
-import FactCheckOutlinedIcon from "@mui/icons-material/FactCheckOutlined";
-import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
-import LayersClearOutlinedIcon from "@mui/icons-material/LayersClearOutlined";
-import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
-import LibraryAddOutlinedIcon from "@mui/icons-material/LibraryAddOutlined";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import LooksOneOutlinedIcon from "@mui/icons-material/LooksOneOutlined";
-import MarkChatUnreadRoundedIcon from "@mui/icons-material/MarkChatUnreadRounded";
-import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
-import NumbersRoundedIcon from "@mui/icons-material/NumbersRounded";
-import PaletteOutlinedIcon from "@mui/icons-material/PaletteOutlined";
-import PhotoLibraryOutlinedIcon from "@mui/icons-material/PhotoLibraryOutlined";
-import RemoveModeratorOutlinedIcon from "@mui/icons-material/RemoveModeratorOutlined";
-import ScannerOutlinedIcon from "@mui/icons-material/ScannerOutlined";
-import ScheduleOutlinedIcon from "@mui/icons-material/ScheduleOutlined";
-import VerifiedOutlinedIcon from "@mui/icons-material/VerifiedOutlined";
-import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
-import WorkspacePremiumOutlinedIcon from "@mui/icons-material/WorkspacePremiumOutlined";
 
 export interface TranslatedToolCatalog {
   allTools: ToolRegistry;
@@ -132,7 +102,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       ...prototypeTools,
       // Recommended Tools in order
       pdfTextEditor: {
-        icon: <EditSquareIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="edit-square-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.pdfTextEditor.title", "PDF Text Editor"),
         component: lazy(() => import("@app/tools/pdfTextEditor/PdfTextEditor")),
         description: t(
@@ -149,7 +125,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         versionStatus: "alpha",
       },
       multiTool: {
-        icon: <DashboardCustomizeOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="dashboard-customize-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.multiTool.title", "Multi-Tool"),
         component: null,
         workbench: "pageEditor",
@@ -166,7 +148,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       merge: {
-        icon: <LibraryAddOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="library-add-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.merge.title", "Merge"),
         component: lazy(() => import("@app/tools/Merge")),
         description: t(
@@ -185,7 +173,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       },
       // Signing
       certSign: {
-        icon: <WorkspacePremiumOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="workspace-premium-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.certSign.title", "Certificate Sign"),
         component: lazy(() => import("@app/tools/CertSign")),
         description: t(
@@ -204,7 +198,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       timestampPdf: {
-        icon: <ScheduleOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="schedule-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.timestampPdf.title", "Timestamp PDF"),
         component: lazy(() => import("@app/tools/TimestampPdf")),
         description: t(
@@ -220,7 +220,9 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "timestampPdf"),
       },
       sign: {
-        icon: <DrawRoundedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon icon="signature-rounded" width="1.5rem" height="1.5rem" />
+        ),
         name: t("home.sign.title", "Sign"),
         component: lazy(() => import("@app/tools/Sign")),
         description: t(
@@ -268,7 +270,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         supportsAutomate: false,
       },
       addImage: {
-        icon: <ImageOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="image-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.addImage.title", "Add Image"),
         component: lazy(() => import("@app/tools/AddImage")),
         description: t("home.addImage.desc", "Add images anywhere in your PDF"),
@@ -281,7 +289,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         supportsAutomate: false,
       },
       annotate: {
-        icon: <EditOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="edit-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.annotate.title", "Annotate"),
         component: lazy(() => import("@app/tools/Annotate")),
         description: t(
@@ -319,7 +333,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "addPassword"),
       },
       watermark: {
-        icon: <BrandingWatermarkOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="branding-watermark-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.watermark.title", "Add Watermark"),
         component: lazy(() => import("@app/tools/AddWatermark")),
         maxFiles: -1,
@@ -338,7 +358,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "watermark"),
       },
       addStamp: {
-        icon: <ApprovalOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="approval-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.addStamp.title", "Add Stamp to PDF"),
         component: lazy(() => import("@app/tools/AddStamp")),
         description: t(
@@ -357,7 +383,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       sanitize: {
-        icon: <CleaningServicesOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="cleaning-services-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.sanitize.title", "Sanitize"),
         component: lazy(() => import("@app/tools/Sanitize")),
         maxFiles: -1,
@@ -375,7 +407,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "sanitize"),
       },
       flatten: {
-        icon: <LayersClearOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="layers-clear-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.flatten.title", "Flatten"),
         component: lazy(() => import("@app/tools/Flatten")),
         description: t(
@@ -431,7 +469,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: ["form", "fill", "fillable", "input", "field", "acroform"],
       },
       changePermissions: {
-        icon: <LockOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: <LocalIcon icon="lock-outline" width="1.5rem" height="1.5rem" />,
         name: t("home.changePermissions.title", "Change Permissions"),
         component: lazy(() => import("@app/tools/ChangePermissions")),
         description: t(
@@ -450,7 +488,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "changePermissions"),
       },
       getPdfInfo: {
-        icon: <FactCheckOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="fact-check-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.getPdfInfo.title", "Get ALL Info on PDF"),
         component: lazy(() => import("@app/tools/GetPdfInfo")),
         description: t(
@@ -466,7 +510,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         maxFiles: 1,
       },
       validateSignature: {
-        icon: <VerifiedOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="verified-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.validateSignature.title", "Validate PDF Signature"),
         component: lazy(() => import("@app/tools/ValidateSignature")),
         description: t(
@@ -484,7 +534,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Document Review
 
       read: {
-        icon: <ArticleOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="article-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.read.title", "Read"),
         component: null,
         workbench: "viewer",
@@ -500,7 +556,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       changeMetadata: {
-        icon: <AssignmentOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="assignment-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.changeMetadata.title", "Change Metadata"),
         component: lazy(() => import("@app/tools/ChangeMetadata")),
         description: t(
@@ -618,7 +680,7 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "scalePages"),
       },
       addPageNumbers: {
-        icon: <NumbersRoundedIcon width="1.5rem" height="1.5rem" />,
+        icon: <LocalIcon icon="123-rounded" width="1.5rem" height="1.5rem" />,
         name: t("home.addPageNumbers.title", "Add Page Numbers"),
         component: lazy(() => import("@app/tools/AddPageNumbers")),
         description: t(
@@ -637,7 +699,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "addPageNumbers"),
       },
       pageLayout: {
-        icon: <DashboardOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="dashboard-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.pageLayout.title", "Multi-Page Layout"),
         component: lazy(() => import("@app/tools/PageLayout")),
         description: t(
@@ -654,7 +722,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "pageLayout"),
       },
       bookletImposition: {
-        icon: <MenuBookOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="menu-book-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.bookletImposition.title", "Booklet Imposition"),
         component: lazy(() => import("@app/tools/BookletImposition")),
         operationConfig: asRegistryConfig(bookletImpositionOperationConfig),
@@ -671,7 +745,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         endpoints: ["booklet-imposition"],
       },
       pdfToSinglePage: {
-        icon: <LooksOneOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="looks-one-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.pdfToSinglePage.title", "PDF to Single Large Page"),
         component: lazy(() => import("@app/tools/SingleLargePage")),
 
@@ -728,7 +808,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         endpoints: ["rearrange-pages"],
       },
       extractImages: {
-        icon: <PhotoLibraryOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="photo-library-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.extractImages.title", "Extract Images"),
         component: lazy(() => import("@app/tools/ExtractImages")),
         description: t(
@@ -793,7 +879,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         ),
       },
       removeAnnotations: {
-        icon: <MarkChatUnreadRoundedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="thread-unread-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.removeAnnotations.title", "Remove Annotations"),
         component: lazy(() => import("@app/tools/RemoveAnnotations")),
         description: t(
@@ -856,7 +948,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "removePassword"),
       },
       removeCertSign: {
-        icon: <RemoveModeratorOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="remove-moderator-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.removeCertSign.title", "Remove Certificate Sign"),
         component: lazy(() => import("@app/tools/RemoveCertificateSign")),
         description: t(
@@ -875,7 +973,9 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Automation
 
       automate: {
-        icon: <AutoModeOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon icon="automation-outline" width="1.5rem" height="1.5rem" />
+        ),
         name: t("home.automate.title", "Automate"),
         component: lazy(() => import("@app/tools/Automate")),
         description: t(
@@ -911,7 +1011,9 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
       // Advanced Formatting
 
       adjustContrast: {
-        icon: <PaletteOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon icon="palette-outline" width="1.5rem" height="1.5rem" />
+        ),
         name: t("home.adjustContrast.title", "Adjust Colors/Contrast"),
         component: lazy(() => import("@app/tools/AdjustContrast")),
         description: t(
@@ -930,7 +1032,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "adjustContrast"),
       },
       repair: {
-        icon: <BuildOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="build-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.repair.title", "Repair"),
         component: lazy(() => import("@app/tools/Repair")),
         description: t(
@@ -946,7 +1054,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         automationSettings: null,
       },
       scannerImageSplit: {
-        icon: <ScannerOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="scanner-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t(
           "home.scannerImageSplit.title",
           "Detect & Split Scanned Photos",
@@ -968,7 +1082,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "scannerImageSplit"),
       },
       overlayPdfs: {
-        icon: <LayersOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="layers-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.overlay-pdfs.title", "Overlay PDFs"),
         component: lazy(() => import("@app/tools/OverlayPdfs")),
         description: t(
@@ -1004,7 +1124,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "replaceColor"),
       },
       scannerEffect: {
-        icon: <ScannerOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="scanner-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.scannerEffect.title", "Scanner Effect"),
         component: null,
         description: t(
@@ -1218,7 +1344,13 @@ export function useTranslatedToolCatalog(): TranslatedToolCatalog {
         synonyms: getSynonyms(t, "ocr"),
       },
       redact: {
-        icon: <VisibilityOffOutlinedIcon width="1.5rem" height="1.5rem" />,
+        icon: (
+          <LocalIcon
+            icon="visibility-off-outline-rounded"
+            width="1.5rem"
+            height="1.5rem"
+          />
+        ),
         name: t("home.redact.title", "Redact"),
         component: lazy(() => import("@app/tools/Redact")),
         description: t(

--- a/frontend/editor/src/core/pages/HomePage.tsx
+++ b/frontend/editor/src/core/pages/HomePage.tsx
@@ -41,7 +41,7 @@ import { Button } from "@app/ui/Button";
 import "@app/pages/HomePage.css";
 import FolderRoundedIcon from "@mui/icons-material/FolderRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
-import AutoModeOutlinedIcon from "@mui/icons-material/AutoModeOutlined";
+import LocalIcon from "@app/components/shared/LocalIcon";
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "stirling.fileSidebarCollapsed";
 
@@ -448,7 +448,11 @@ export default function HomePage() {
                     }
                   }}
                 >
-                  <AutoModeOutlinedIcon width="1.5rem" height="1.5rem" />
+                  <LocalIcon
+                    icon="automation-outline"
+                    width="1.5rem"
+                    height="1.5rem"
+                  />
                   <span className="mobile-bottom-button-label">
                     {t("quickAccess.automate", "Automate")}
                   </span>

--- a/frontend/editor/src/core/pages/HomePage.tsx
+++ b/frontend/editor/src/core/pages/HomePage.tsx
@@ -25,7 +25,6 @@ import RightSidebar from "@app/components/tools/RightSidebar";
 import Workbench from "@app/components/layout/Workbench";
 import FileSidebar from "@app/components/shared/FileSidebar";
 import FileManager from "@app/components/FileManager";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import AppConfigModal from "@app/components/shared/AppConfigModalLazy";
 import { getStartupNavigationAction } from "@app/utils/homePageNavigation";
 import { HomePageExtensions } from "@app/components/home/HomePageExtensions";
@@ -40,6 +39,9 @@ import type { FileSidebarProps } from "@app/components/shared/FileSidebar";
 
 import { Button } from "@app/ui/Button";
 import "@app/pages/HomePage.css";
+import FolderRoundedIcon from "@mui/icons-material/FolderRounded";
+import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
+import AutoModeOutlinedIcon from "@mui/icons-material/AutoModeOutlined";
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "stirling.fileSidebarCollapsed";
 
@@ -446,11 +448,7 @@ export default function HomePage() {
                     }
                   }}
                 >
-                  <LocalIcon
-                    icon="automation-outline"
-                    width="1.5rem"
-                    height="1.5rem"
-                  />
+                  <AutoModeOutlinedIcon width="1.5rem" height="1.5rem" />
                   <span className="mobile-bottom-button-label">
                     {t("quickAccess.automate", "Automate")}
                   </span>
@@ -462,11 +460,7 @@ export default function HomePage() {
                 aria-label={t("home.mobile.openFiles", "Open files")}
                 onClick={() => navigate("/files")}
               >
-                <LocalIcon
-                  icon="folder-rounded"
-                  width="1.5rem"
-                  height="1.5rem"
-                />
+                <FolderRoundedIcon width="1.5rem" height="1.5rem" />
                 <span className="mobile-bottom-button-label">
                   {t("quickAccess.files", "Files")}
                 </span>
@@ -477,11 +471,7 @@ export default function HomePage() {
                 aria-label={t("quickAccess.config", "Config")}
                 onClick={() => setConfigModalOpen(true)}
               >
-                <LocalIcon
-                  icon="settings-rounded"
-                  width="1.5rem"
-                  height="1.5rem"
-                />
+                <SettingsRoundedIcon width="1.5rem" height="1.5rem" />
                 <span className="mobile-bottom-button-label">
                   {t("quickAccess.config", "Config")}
                 </span>

--- a/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
+++ b/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
@@ -32,6 +32,12 @@ import type {
 import type { ViewerContextType } from "@app/contexts/ViewerContext";
 import type { SignParameters } from "@app/hooks/tools/sign/useSignParameters";
 import type { BuildToolOptionsExtras } from "@app/tools/annotate/useAnnotationStyleState";
+import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
+import FormatAlignCenterIcon from "@mui/icons-material/FormatAlignCenter";
+import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
+import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import TouchAppRoundedIcon from "@mui/icons-material/TouchAppRounded";
 
 interface StyleState {
   inkColor: string;
@@ -646,11 +652,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                       size="md"
                       aria-label={t("annotation.alignLeft", "Align left")}
                     >
-                      <LocalIcon
-                        icon="format-align-left"
-                        width={18}
-                        height={18}
-                      />
+                      <FormatAlignLeftIcon width={18} height={18} />
                     </ActionIcon>
                     <ActionIcon
                       variant={
@@ -660,11 +662,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                       size="md"
                       aria-label={t("annotation.alignCenter", "Align center")}
                     >
-                      <LocalIcon
-                        icon="format-align-center"
-                        width={18}
-                        height={18}
-                      />
+                      <FormatAlignCenterIcon width={18} height={18} />
                     </ActionIcon>
                     <ActionIcon
                       variant={
@@ -674,11 +672,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                       size="md"
                       aria-label={t("annotation.alignRight", "Align right")}
                     >
-                      <LocalIcon
-                        icon="format-align-right"
-                        width={18}
-                        height={18}
-                      />
+                      <FormatAlignRightIcon width={18} height={18} />
                     </ActionIcon>
                   </Group>
                 </Box>
@@ -1194,9 +1188,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
             onClick={() => {
               activateAnnotationTool("select");
             }}
-            leftSection={
-              <LocalIcon icon="touch-app-rounded" width={20} height={20} />
-            }
+            leftSection={<TouchAppRoundedIcon width={20} height={20} />}
           >
             {t("annotation.selectAndMove", "Select and Edit")}
           </Button>
@@ -1218,7 +1210,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     disabled={isApplyingChanges}
                     aria-label={t("annotation.moreActions", "More actions")}
                   >
-                    <LocalIcon icon="more-horiz" width={20} height={20} />
+                    <MoreHorizIcon width={20} height={20} />
                   </ActionIcon>
                 </Tooltip>
               </Menu.Target>
@@ -1226,9 +1218,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                 <Menu.Item
                   color="red"
                   disabled={isClearingDocumentAnnotations || isApplyingChanges}
-                  leftSection={
-                    <LocalIcon icon="delete-rounded" width={18} height={18} />
-                  }
+                  leftSection={<DeleteRoundedIcon width={18} height={18} />}
                   onClick={() => setIsClearDocumentModalOpen(true)}
                 >
                   {t(
@@ -1327,9 +1317,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
               accent="danger"
               loading={isClearingDocumentAnnotations}
               disabled={isApplyingChanges}
-              leftSection={
-                <LocalIcon icon="delete-rounded" width={18} height={18} />
-              }
+              leftSection={<DeleteRoundedIcon width={18} height={18} />}
               onClick={() => void handleConfirmClearDocumentAnnotations()}
             >
               {t("annotation.clearDocumentAnnotationsConfirm", "Clear all")}

--- a/frontend/editor/src/core/ui/AppIcon.tsx
+++ b/frontend/editor/src/core/ui/AppIcon.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties } from "react";
+import type { SvgIconComponent } from "@mui/icons-material";
+import LocalIcon from "@app/components/shared/LocalIcon";
+
+interface AppIconCommonProps {
+  size?: string | number;
+  color?: CSSProperties["color"];
+  className?: string;
+  style?: CSSProperties;
+  label?: string;
+}
+
+type AppIconSource =
+  | { mui: SvgIconComponent; symbol?: never }
+  | { mui?: never; symbol: string };
+
+export type AppIconProps = AppIconCommonProps & AppIconSource;
+
+/**
+ * Renders static Material Icons and local Material Symbols through one API.
+ * Prefer `mui` for exact MUI catalog matches and `symbol` for dynamic or
+ * Material-Symbol-only glyphs.
+ */
+export function AppIcon({
+  mui: MuiIcon,
+  symbol,
+  size = 18,
+  color,
+  className,
+  style,
+  label,
+}: AppIconProps) {
+  const iconStyle = { ...style, color, fontSize: size };
+  const accessibilityProps = label
+    ? ({ "aria-label": label, role: "img" } as const)
+    : ({ "aria-hidden": true } as const);
+
+  if (MuiIcon) {
+    return (
+      <MuiIcon
+        className={className}
+        style={iconStyle}
+        titleAccess={label}
+        {...accessibilityProps}
+      />
+    );
+  }
+
+  return (
+    <LocalIcon
+      icon={symbol}
+      width={size}
+      height={size}
+      className={className}
+      style={iconStyle}
+      {...accessibilityProps}
+    />
+  );
+}

--- a/frontend/editor/src/core/ui/ChatFABButton.tsx
+++ b/frontend/editor/src/core/ui/ChatFABButton.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes } from "react";
+import CheckIcon from "@mui/icons-material/Check";
 import "@app/ui/ChatFABButton.css";
 
 export interface ChatFABButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -44,21 +45,7 @@ export function ChatFABButton({
       )}
       {showTick && (
         <span className="chat-fab-btn__tick" aria-hidden="true">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width={10}
-            height={10}
-            viewBox="0 0 10 10"
-            fill="none"
-          >
-            <path
-              d="M2 5l2 2 4-4"
-              stroke="#fff"
-              strokeWidth={1.6}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <CheckIcon sx={{ color: "#fff", fontSize: 10 }} />
         </span>
       )}
     </button>

--- a/frontend/editor/src/core/ui/Checkbox.tsx
+++ b/frontend/editor/src/core/ui/Checkbox.tsx
@@ -45,10 +45,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           {...rest}
         />
         <span className="sui-check__box" aria-hidden>
-          <CheckIcon
-            className="sui-check__tick"
-            sx={{ fontSize: 10 }}
-          />
+          <CheckIcon className="sui-check__tick" sx={{ fontSize: 10 }} />
           <span className="sui-check__dash" />
         </span>
         {leadingIcon && (

--- a/frontend/editor/src/core/ui/Checkbox.tsx
+++ b/frontend/editor/src/core/ui/Checkbox.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+import CheckIcon from "@mui/icons-material/Check";
 import "@app/ui/Checkbox.css";
 
 export interface CheckboxProps extends Omit<
@@ -44,19 +45,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           {...rest}
         />
         <span className="sui-check__box" aria-hidden>
-          <svg
-            viewBox="0 0 16 16"
-            width="10"
-            height="10"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2.5}
-            strokeLinecap="round"
-            strokeLinejoin="round"
+          <CheckIcon
             className="sui-check__tick"
-          >
-            <polyline points="3 8.5 7 12 13 4" />
-          </svg>
+            sx={{ fontSize: 10 }}
+          />
           <span className="sui-check__dash" />
         </span>
         {leadingIcon && (

--- a/frontend/editor/src/core/ui/Collapsible.tsx
+++ b/frontend/editor/src/core/ui/Collapsible.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import "@app/ui/Collapsible.css";
 
 export interface CollapsibleProps {
@@ -40,21 +41,11 @@ export function Collapsible({
         <span className="sui-collapsible__head-main">{header}</span>
         <span className="sui-collapsible__head-end">
           {aside}
-          <svg
+          <KeyboardArrowDownIcon
             className="sui-collapsible__chevron"
             data-open={open}
-            viewBox="0 0 24 24"
-            width={16}
-            height={16}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden
-          >
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
+            sx={{ fontSize: 16 }}
+          />
         </span>
       </button>
       <div className="sui-collapsible__body" data-open={open}>

--- a/frontend/editor/src/core/ui/Drawer.tsx
+++ b/frontend/editor/src/core/ui/Drawer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { FocusTrap } from "@mantine/core";
+import CloseIcon from "@mui/icons-material/Close";
 import { Button } from "@app/ui/Button";
 import "@app/ui/Drawer.css";
 
@@ -107,22 +108,7 @@ export function Drawer({
                 className="sui-drawer__close"
                 onClick={onClose}
                 aria-label="Close"
-                leftSection={
-                  <svg
-                    viewBox="0 0 24 24"
-                    width="16"
-                    height="16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.75}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
-                  </svg>
-                }
+                leftSection={<CloseIcon sx={{ fontSize: 16 }} />}
               />
             </header>
           )}

--- a/frontend/editor/src/core/ui/Modal.tsx
+++ b/frontend/editor/src/core/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { FocusTrap } from "@mantine/core";
+import CloseIcon from "@mui/icons-material/Close";
 import { Button } from "@app/ui/Button";
 import "@app/ui/Modal.css";
 
@@ -100,22 +101,7 @@ export function Modal({
                 className="sui-modal__close"
                 onClick={onClose}
                 aria-label="Close"
-                leftSection={
-                  <svg
-                    viewBox="0 0 24 24"
-                    width="16"
-                    height="16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.75}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
-                  </svg>
-                }
+                leftSection={<CloseIcon sx={{ fontSize: 16 }} />}
               />
             </header>
           )}

--- a/frontend/editor/src/core/ui/SectionHeader.tsx
+++ b/frontend/editor/src/core/ui/SectionHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import "@app/ui/SectionHeader.css";
 
 export interface SectionHeaderProps {
@@ -32,21 +33,11 @@ export function SectionHeader({
       <span className="sui-sectionhdr__title">{title}</span>
       {count != null && <span className="sui-sectionhdr__count">{count}</span>}
       {collapsible && (
-        <svg
+        <KeyboardArrowDownIcon
           className="sui-sectionhdr__chevron"
           data-collapsed={!expanded}
-          viewBox="0 0 24 24"
-          width={14}
-          height={14}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden
-        >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
+          sx={{ fontSize: 14 }}
+        />
       )}
     </>
   );

--- a/frontend/editor/src/core/ui/SettingsShell.tsx
+++ b/frontend/editor/src/core/ui/SettingsShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import CloseIcon from "@mui/icons-material/Close";
 import { Button } from "@app/ui/Button";
 import "@app/ui/SettingsShell.css";
 
@@ -99,22 +100,7 @@ export function SettingsShell({
                 className="sui-settings-shell__close"
                 onClick={onClose}
                 aria-label="Close"
-                leftSection={
-                  <svg
-                    viewBox="0 0 24 24"
-                    width="16"
-                    height="16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.75}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
-                  </svg>
-                }
+                leftSection={<CloseIcon sx={{ fontSize: 16 }} />}
               />
             )}
           </div>

--- a/frontend/editor/src/core/ui/index.ts
+++ b/frontend/editor/src/core/ui/index.ts
@@ -1,5 +1,6 @@
 export * from "@app/ui/Button";
 export * from "@app/ui/ActionIcon";
+export * from "@app/ui/AppIcon";
 export * from "@app/ui/FilePicker";
 export * from "@app/ui/SegmentedControl";
 export * from "@app/ui/StatusBadge";

--- a/frontend/editor/src/desktop/components/DesktopOnboardingModal.tsx
+++ b/frontend/editor/src/desktop/components/DesktopOnboardingModal.tsx
@@ -4,7 +4,6 @@ import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
 import CloseIcon from "@mui/icons-material/Close";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import AnimatedSlideBackground from "@app/components/onboarding/slides/AnimatedSlideBackground";
 import OnboardingStepper from "@app/components/onboarding/OnboardingStepper";
 import { SetupWizard } from "@app/components/SetupWizard";
@@ -12,6 +11,8 @@ import WelcomeSlide from "@app/components/onboarding/slides/WelcomeSlide";
 import { Z_INDEX_OVER_FULLSCREEN_SURFACE } from "@app/styles/zIndex";
 import styles from "@app/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css";
 import { connectionModeService } from "@app/services/connectionModeService";
+import LoginIcon from "@mui/icons-material/Login";
+import RocketLaunchIcon from "@mui/icons-material/RocketLaunch";
 
 const ONBOARDING_KEY = "stirling-desktop-onboarding-seen";
 
@@ -125,19 +126,13 @@ export function DesktopOnboardingModal() {
           <div className={styles.heroLogo} key={`logo-${step}`}>
             <div className={styles.heroLogoCircle}>
               {step === 0 ? (
-                <LocalIcon
-                  icon="rocket-launch"
+                <RocketLaunchIcon
                   width={64}
                   height={64}
                   className={styles.heroIcon}
                 />
               ) : (
-                <LocalIcon
-                  icon="login"
-                  width={64}
-                  height={64}
-                  className={styles.heroIcon}
-                />
+                <LoginIcon width={64} height={64} className={styles.heroIcon} />
               )}
             </div>
           </div>

--- a/frontend/editor/src/desktop/components/SetupWizard/ServerSelection.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/ServerSelection.tsx
@@ -7,7 +7,7 @@ import {
   SSOProviderConfig,
 } from "@app/services/connectionModeService";
 import { connectionModeService } from "@app/services/connectionModeService";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 
 interface ServerSelectionProps {
   onSelect: (config: ServerConfig) => void;
@@ -270,13 +270,7 @@ export const ServerSelection: React.FC<ServerSelectionProps> = ({
           <Alert
             variant="light"
             color="orange"
-            icon={
-              <LocalIcon
-                icon="warning-rounded"
-                width="1.25rem"
-                height="1.25rem"
-              />
-            }
+            icon={<WarningRoundedIcon width="1.25rem" height="1.25rem" />}
             title={t(
               "setup.server.error.securityDisabled.title",
               "Login Not Enabled",

--- a/frontend/editor/src/desktop/components/shared/SelfHostedOfflineBanner.tsx
+++ b/frontend/editor/src/desktop/components/shared/SelfHostedOfflineBanner.tsx
@@ -3,7 +3,6 @@ import { Paper, Group, Text, Popover, List, ScrollArea } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
 import { useConversionCloudStatus } from "@app/hooks/useConversionCloudStatus";
 import {
@@ -22,6 +21,8 @@ import {
 } from "@app/constants/convertConstants";
 import { ENDPOINTS as SPLIT_ENDPOINTS } from "@app/constants/splitConstants";
 import type { ToolId } from "@app/types/toolId";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 
 const BANNER_BG = "var(--mantine-color-gray-1)";
 const BANNER_BORDER = "var(--mantine-color-gray-3)";
@@ -217,8 +218,7 @@ export function SelfHostedOfflineBanner() {
           wrap="nowrap"
           style={{ minWidth: 0, flex: 1 }}
         >
-          <LocalIcon
-            icon="warning-rounded"
+          <WarningRoundedIcon
             width="1rem"
             height="1rem"
             style={{ color: BANNER_ICON, flexShrink: 0 }}
@@ -293,7 +293,7 @@ export function SelfHostedOfflineBanner() {
           aria-label={t("close", "Close")}
           style={{ color: BANNER_TEXT }}
         >
-          <LocalIcon icon="close-rounded" width="0.8rem" height="0.8rem" />
+          <CloseRoundedIcon width="0.8rem" height="0.8rem" />
         </ActionIcon>
       </Group>
     </Paper>

--- a/frontend/editor/src/portal/components/icons.tsx
+++ b/frontend/editor/src/portal/components/icons.tsx
@@ -1,304 +1,144 @@
-import type { ReactNode } from "react";
+import AccountTreeOutlined from "@mui/icons-material/AccountTreeOutlined";
+import AutoAwesomeOutlined from "@mui/icons-material/AutoAwesomeOutlined";
+import BarChartOutlined from "@mui/icons-material/BarChartOutlined";
+import Close from "@mui/icons-material/Close";
+import CodeOutlined from "@mui/icons-material/CodeOutlined";
+import DarkModeOutlined from "@mui/icons-material/DarkModeOutlined";
+import DescriptionOutlined from "@mui/icons-material/DescriptionOutlined";
+import DnsOutlined from "@mui/icons-material/DnsOutlined";
+import DownloadOutlined from "@mui/icons-material/DownloadOutlined";
+import ElectricalServicesOutlined from "@mui/icons-material/ElectricalServicesOutlined";
+import GridViewOutlined from "@mui/icons-material/GridViewOutlined";
+import GroupsOutlined from "@mui/icons-material/GroupsOutlined";
+import HomeOutlined from "@mui/icons-material/HomeOutlined";
+import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
+import LightModeOutlined from "@mui/icons-material/LightModeOutlined";
+import Link from "@mui/icons-material/Link";
+import LockOutlined from "@mui/icons-material/LockOutlined";
+import MenuBookOutlined from "@mui/icons-material/MenuBookOutlined";
+import NotificationsOutlined from "@mui/icons-material/NotificationsOutlined";
+import OpenInNew from "@mui/icons-material/OpenInNew";
+import PersonAddAltOutlined from "@mui/icons-material/PersonAddAltOutlined";
+import RequestQuoteOutlined from "@mui/icons-material/RequestQuoteOutlined";
+import Search from "@mui/icons-material/Search";
+import SendOutlined from "@mui/icons-material/SendOutlined";
+import SettingsOutlined from "@mui/icons-material/SettingsOutlined";
+import ShieldOutlined from "@mui/icons-material/ShieldOutlined";
+import SmartToyOutlined from "@mui/icons-material/SmartToyOutlined";
 
 interface IconProps {
   size?: number;
   className?: string;
 }
 
-function Svg({
-  size = 18,
-  className,
-  children,
-}: IconProps & { children: ReactNode }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.75}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      {children}
-    </svg>
-  );
+function muiIconProps({ size = 18, className }: IconProps) {
+  return { className, sx: { fontSize: size } };
 }
 
 export function HomeIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-      <polyline points="9 22 9 12 15 12 15 22" />
-    </Svg>
-  );
+  return <HomeOutlined {...muiIconProps(props)} />;
 }
 
 export function EditorIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-      <polyline points="14 2 14 8 20 8" />
-      <path d="m10 13-2 2 2 2" />
-      <path d="m14 17 2-2-2-2" />
-    </Svg>
-  );
+  return <CodeOutlined {...muiIconProps(props)} />;
 }
 
 export function SourcesIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M9 2v6" />
-      <path d="M15 2v6" />
-      <path d="M6 8h12v3a6 6 0 0 1-12 0z" />
-      <path d="M12 14v8" />
-    </Svg>
-  );
+  return <ElectricalServicesOutlined {...muiIconProps(props)} />;
 }
 
 export function PipelinesIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <rect x="3" y="3" width="6" height="6" rx="1" />
-      <rect x="15" y="3" width="6" height="6" rx="1" />
-      <rect x="9" y="15" width="6" height="6" rx="1" />
-      <path d="M6 9v3a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9" />
-      <path d="M12 14v1" />
-    </Svg>
-  );
+  return <AccountTreeOutlined {...muiIconProps(props)} />;
 }
 
 export function DocumentsIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-      <polyline points="14 2 14 8 20 8" />
-      <line x1="8" y1="13" x2="16" y2="13" />
-      <line x1="8" y1="17" x2="16" y2="17" />
-      <line x1="8" y1="9" x2="10" y2="9" />
-    </Svg>
-  );
+  return <DescriptionOutlined {...muiIconProps(props)} />;
 }
 
 export function InfrastructureIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <rect x="3" y="4" width="18" height="6" rx="1" />
-      <rect x="3" y="14" width="18" height="6" rx="1" />
-      <line x1="7" y1="7" x2="7.01" y2="7" />
-      <line x1="7" y1="17" x2="7.01" y2="17" />
-    </Svg>
-  );
+  return <DnsOutlined {...muiIconProps(props)} />;
 }
 
 export function UsageIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <line x1="6" y1="20" x2="6" y2="10" />
-      <line x1="12" y1="20" x2="12" y2="4" />
-      <line x1="18" y1="20" x2="18" y2="14" />
-      <line x1="3" y1="20" x2="21" y2="20" />
-    </Svg>
-  );
+  return <BarChartOutlined {...muiIconProps(props)} />;
 }
 
 export function DocsIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M2 4.5A2.5 2.5 0 0 1 4.5 2H20v17H4.5A2.5 2.5 0 0 0 2 21.5z" />
-      <path d="M2 19.5A2.5 2.5 0 0 1 4.5 17H20" />
-    </Svg>
-  );
+  return <MenuBookOutlined {...muiIconProps(props)} />;
 }
 
 export function SettingsIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <circle cx="12" cy="12" r="3" />
-      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-    </Svg>
-  );
+  return <SettingsOutlined {...muiIconProps(props)} />;
 }
 
 export function SearchIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <circle cx="11" cy="11" r="7" />
-      <line x1="21" y1="21" x2="16.65" y2="16.65" />
-    </Svg>
-  );
+  return <Search {...muiIconProps(props)} />;
 }
 
 export function SunIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <circle cx="12" cy="12" r="4" />
-      <line x1="12" y1="2" x2="12" y2="4" />
-      <line x1="12" y1="20" x2="12" y2="22" />
-      <line x1="4.93" y1="4.93" x2="6.34" y2="6.34" />
-      <line x1="17.66" y1="17.66" x2="19.07" y2="19.07" />
-      <line x1="2" y1="12" x2="4" y2="12" />
-      <line x1="20" y1="12" x2="22" y2="12" />
-      <line x1="4.93" y1="19.07" x2="6.34" y2="17.66" />
-      <line x1="17.66" y1="6.34" x2="19.07" y2="4.93" />
-    </Svg>
-  );
+  return <LightModeOutlined {...muiIconProps(props)} />;
 }
 
 export function MoonIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-    </Svg>
-  );
+  return <DarkModeOutlined {...muiIconProps(props)} />;
 }
 
 export function BellIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
-    </Svg>
-  );
+  return <NotificationsOutlined {...muiIconProps(props)} />;
 }
 
 export function ChevronDownIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <polyline points="6 9 12 15 18 9" />
-    </Svg>
-  );
+  return <KeyboardArrowDown {...muiIconProps(props)} />;
 }
 
 export function SparklesIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z" />
-      <path d="M19 4v3" />
-      <path d="M17.5 5.5h3" />
-    </Svg>
-  );
+  return <AutoAwesomeOutlined {...muiIconProps(props)} />;
 }
 
 export function CloseIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <line x1="18" y1="6" x2="6" y2="18" />
-      <line x1="6" y1="6" x2="18" y2="18" />
-    </Svg>
-  );
+  return <Close {...muiIconProps(props)} />;
 }
 
 export function SendIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <line x1="22" y1="2" x2="11" y2="13" />
-      <polygon points="22 2 15 22 11 13 2 9 22 2" />
-    </Svg>
-  );
+  return <SendOutlined {...muiIconProps(props)} />;
 }
 
 export function UsersIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-      <circle cx="9" cy="7" r="4" />
-      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-    </Svg>
-  );
+  return <GroupsOutlined {...muiIconProps(props)} />;
 }
 
 export function PoliciesIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-      <path d="m9 12 2 2 4-4" />
-    </Svg>
-  );
+  return <ShieldOutlined {...muiIconProps(props)} />;
 }
 
 export function ComponentsIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <rect x="3" y="3" width="7" height="7" rx="1" />
-      <rect x="14" y="3" width="7" height="7" rx="1" />
-      <rect x="3" y="14" width="7" height="7" rx="1" />
-      <rect x="14" y="14" width="7" height="7" rx="1" />
-    </Svg>
-  );
+  return <GridViewOutlined {...muiIconProps(props)} />;
 }
 
 export function AgentBuilderIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <rect x="3" y="11" width="18" height="10" rx="2" />
-      <circle cx="12" cy="5" r="2" />
-      <path d="M12 7v4" />
-      <line x1="8" y1="16" x2="8" y2="16" />
-      <line x1="16" y1="16" x2="16" y2="16" />
-    </Svg>
-  );
+  return <SmartToyOutlined {...muiIconProps(props)} />;
 }
 
 export function ProcurementIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-      <polyline points="14 2 14 8 20 8" />
-      <path d="m9 15 2 2 4-4" />
-    </Svg>
-  );
+  return <RequestQuoteOutlined {...muiIconProps(props)} />;
 }
 
 export function DownloadIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-      <polyline points="7 10 12 15 17 10" />
-      <line x1="12" y1="15" x2="12" y2="3" />
-    </Svg>
-  );
+  return <DownloadOutlined {...muiIconProps(props)} />;
 }
 
 export function LinkIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-      <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-    </Svg>
-  );
+  return <Link {...muiIconProps(props)} />;
 }
 
 export function LockIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <rect x="3" y="11" width="18" height="11" rx="2" />
-      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-    </Svg>
-  );
+  return <LockOutlined {...muiIconProps(props)} />;
 }
 
 export function UserPlusIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-      <circle cx="9" cy="7" r="4" />
-      <line x1="19" y1="8" x2="19" y2="14" />
-      <line x1="22" y1="11" x2="16" y2="11" />
-    </Svg>
-  );
+  return <PersonAddAltOutlined {...muiIconProps(props)} />;
 }
 
 export function ExternalLinkIcon(props: IconProps) {
-  return (
-    <Svg {...props}>
-      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-      <polyline points="15 3 21 3 21 9" />
-      <line x1="10" y1="14" x2="21" y2="3" />
-    </Svg>
-  );
+  return <OpenInNew {...muiIconProps(props)} />;
 }

--- a/frontend/editor/src/proprietary/components/shared/ChangeUserPasswordModal.tsx
+++ b/frontend/editor/src/proprietary/components/shared/ChangeUserPasswordModal.tsx
@@ -12,7 +12,9 @@ import {
 } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import LockIcon from "@mui/icons-material/Lock";
 import { alert } from "@app/components/toast";
 import {
   ChangeUserPasswordRequest,
@@ -237,15 +239,15 @@ export default function ChangeUserPasswordModal({
             zIndex: 1,
           }}
         >
-          <LocalIcon icon="close-rounded" />
+          <CloseIcon />
         </ActionIcon>
         <Stack gap="lg" pt="md">
           <Stack gap="md" align="center">
-            <LocalIcon
-              icon="lock"
-              width="3rem"
-              height="3rem"
-              style={{ color: "var(--mantine-color-gray-6)" }}
+            <LockIcon
+              sx={{
+                color: "var(--mantine-color-gray-6)",
+                fontSize: "3rem",
+              }}
             />
             <Text size="xl" fw={600} ta="center">
               {t("workspace.people.changePassword.title", "Change password")}
@@ -350,11 +352,7 @@ export default function ChangeUserPasswordModal({
                       onClick={handleCopyPassword}
                       disabled={processing}
                     >
-                      <LocalIcon
-                        icon="content-copy"
-                        width="0.9rem"
-                        height="0.9rem"
-                      />
+                      <ContentCopyIcon sx={{ fontSize: "0.9rem" }} />
                     </ActionIcon>
                   </Tooltip>
                 </Group>

--- a/frontend/editor/src/proprietary/components/shared/InviteMembersModal.tsx
+++ b/frontend/editor/src/proprietary/components/shared/InviteMembersModal.tsx
@@ -17,6 +17,9 @@ import {
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { SegmentedControl } from "@app/ui/SegmentedControl";
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import LocalIcon from "@app/components/shared/LocalIcon";
 import { alert } from "@app/components/toast";
 import { userManagementService } from "@app/services/userManagementService";
@@ -374,16 +377,13 @@ export default function InviteMembersModal({
             zIndex: 1,
           }}
         >
-          <LocalIcon icon="close-rounded" />
+          <CloseIcon />
         </ActionIcon>
         <Stack gap="lg" pt="md">
           {/* Header with Icon */}
           <Stack gap="md" align="center">
-            <LocalIcon
-              icon="person-add"
-              width="3rem"
-              height="3rem"
-              style={{ color: "var(--mantine-color-gray-6)" }}
+            <PersonAddIcon
+              sx={{ color: "var(--mantine-color-gray-6)", fontSize: "3rem" }}
             />
             <Text size="xl" fw={600} ta="center">
               {t("workspace.people.inviteMembers.label", "Invite Members")}
@@ -628,11 +628,7 @@ export default function InviteMembersModal({
                           }
                         }}
                       >
-                        <LocalIcon
-                          icon="content-copy"
-                          width="1rem"
-                          height="1rem"
-                        />
+                        <ContentCopyIcon sx={{ fontSize: "1rem" }} />
                       </Button>
                     </Group>
                   </Stack>

--- a/frontend/editor/src/proprietary/components/shared/config/EnterpriseRequiredBanner.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/EnterpriseRequiredBanner.tsx
@@ -1,6 +1,6 @@
 import { Alert, Text } from "@mantine/core";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import WorkspacePremiumIcon from "@mui/icons-material/WorkspacePremiumRounded";
 
 interface EnterpriseRequiredBannerProps {
   show: boolean;
@@ -21,7 +21,7 @@ export default function EnterpriseRequiredBanner({
   return (
     <Alert
       icon={
-        <LocalIcon icon="workspace-premium-rounded" width={20} height={20} />
+        <WorkspacePremiumIcon sx={{ fontSize: 20 }} />
       }
       title={t(
         "admin.settings.enterpriseRequired.title",

--- a/frontend/editor/src/proprietary/components/shared/config/EnterpriseRequiredBanner.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/EnterpriseRequiredBanner.tsx
@@ -20,9 +20,7 @@ export default function EnterpriseRequiredBanner({
 
   return (
     <Alert
-      icon={
-        <WorkspacePremiumIcon sx={{ fontSize: 20 }} />
-      }
+      icon={<WorkspacePremiumIcon sx={{ fontSize: 20 }} />}
       title={t(
         "admin.settings.enterpriseRequired.title",
         "Enterprise License Required",

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AccountSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AccountSection.tsx
@@ -12,7 +12,14 @@ import {
 } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import CloseIcon from "@mui/icons-material/Close";
+import EditIcon from "@mui/icons-material/Edit";
+import ErrorIcon from "@mui/icons-material/Error";
+import InfoIcon from "@mui/icons-material/Info";
+import KeyIcon from "@mui/icons-material/Key";
+import LogoutIcon from "@mui/icons-material/Logout";
+import SaveIcon from "@mui/icons-material/Save";
 import { alert as showToast } from "@app/components/toast";
 import { useAuth } from "@app/auth/UseSession";
 import { accountService } from "@app/services/accountService";
@@ -368,7 +375,7 @@ const AccountSection: React.FC = () => {
           <Stack gap="xs">
             {isSsoUser && (
               <Alert
-                icon={<LocalIcon icon="info" width="1rem" height="1rem" />}
+                icon={<InfoIcon sx={{ fontSize: "1rem" }} />}
                 color="blue"
                 variant="light"
               >
@@ -382,7 +389,7 @@ const AccountSection: React.FC = () => {
             <Group gap="sm" wrap="wrap">
               {!isSsoUser && (
                 <Button
-                  leftSection={<LocalIcon icon="key-rounded" />}
+                  leftSection={<KeyIcon />}
                   onClick={() => setPasswordModalOpen(true)}
                 >
                   {t("settings.security.password.update", "Update password")}
@@ -392,7 +399,7 @@ const AccountSection: React.FC = () => {
               {!isSsoUser && (
                 <Button
                   variant="secondary"
-                  leftSection={<LocalIcon icon="edit-rounded" />}
+                  leftSection={<EditIcon />}
                   onClick={() => setUsernameModalOpen(true)}
                 >
                   {t("account.changeUsername", "Change username")}
@@ -402,7 +409,7 @@ const AccountSection: React.FC = () => {
               <Button
                 variant="secondary"
                 accent="danger"
-                leftSection={<LocalIcon icon="logout-rounded" />}
+                leftSection={<LogoutIcon />}
                 onClick={handleLogout}
               >
                 {t("settings.general.logout", "Log out")}
@@ -425,7 +432,7 @@ const AccountSection: React.FC = () => {
           </Text>
           {isSsoUser ? (
             <Alert
-              icon={<LocalIcon icon="info" width="1rem" height="1rem" />}
+              icon={<InfoIcon sx={{ fontSize: "1rem" }} />}
               color="blue"
               variant="light"
             >
@@ -439,7 +446,7 @@ const AccountSection: React.FC = () => {
               {!mfaEnabled ? (
                 <Button
                   leftSection={
-                    <LocalIcon icon="check-circle-outline-rounded" />
+                    <CheckCircleOutlinedIcon />
                   }
                   onClick={handleStartMfaSetup}
                   loading={mfaLoading}
@@ -454,7 +461,7 @@ const AccountSection: React.FC = () => {
                 <Button
                   variant="secondary"
                   accent="danger"
-                  leftSection={<LocalIcon icon="close-rounded" />}
+                  leftSection={<CloseIcon />}
                   onClick={() => {
                     setMfaError("");
                     setMfaDisableCode("");
@@ -492,7 +499,7 @@ const AccountSection: React.FC = () => {
             {passwordError && (
               <Alert
                 icon={
-                  <LocalIcon icon="error-rounded" width="1rem" height="1rem" />
+                  <ErrorIcon sx={{ fontSize: "1rem" }} />
                 }
                 color="red"
                 variant="light"
@@ -554,7 +561,7 @@ const AccountSection: React.FC = () => {
               <Button
                 type="submit"
                 loading={passwordSubmitting}
-                leftSection={<LocalIcon icon="save-rounded" />}
+                leftSection={<SaveIcon />}
               >
                 {t("settings.security.password.update", "Update password")}
               </Button>
@@ -615,7 +622,7 @@ const AccountSection: React.FC = () => {
             {mfaError && (
               <Alert
                 icon={
-                  <LocalIcon icon="error-rounded" width="1rem" height="1rem" />
+                  <ErrorIcon sx={{ fontSize: "1rem" }} />
                 }
                 color="red"
                 variant="light"
@@ -673,7 +680,7 @@ const AccountSection: React.FC = () => {
             {mfaError && (
               <Alert
                 icon={
-                  <LocalIcon icon="error-rounded" width="1rem" height="1rem" />
+                  <ErrorIcon sx={{ fontSize: "1rem" }} />
                 }
                 color="red"
                 variant="light"
@@ -729,7 +736,7 @@ const AccountSection: React.FC = () => {
             {usernameError && (
               <Alert
                 icon={
-                  <LocalIcon icon="error-rounded" width="1rem" height="1rem" />
+                  <ErrorIcon sx={{ fontSize: "1rem" }} />
                 }
                 color="red"
                 variant="light"
@@ -768,7 +775,7 @@ const AccountSection: React.FC = () => {
               <Button
                 type="submit"
                 loading={usernameSubmitting}
-                leftSection={<LocalIcon icon="save-rounded" />}
+                leftSection={<SaveIcon />}
               >
                 {t("common.save", "Save")}
               </Button>

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AccountSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AccountSection.tsx
@@ -445,9 +445,7 @@ const AccountSection: React.FC = () => {
             <Group gap="sm" wrap="wrap">
               {!mfaEnabled ? (
                 <Button
-                  leftSection={
-                    <CheckCircleOutlinedIcon />
-                  }
+                  leftSection={<CheckCircleOutlinedIcon />}
                   onClick={handleStartMfaSetup}
                   loading={mfaLoading}
                   disabled={changeButtonDisabled}
@@ -498,9 +496,7 @@ const AccountSection: React.FC = () => {
 
             {passwordError && (
               <Alert
-                icon={
-                  <ErrorIcon sx={{ fontSize: "1rem" }} />
-                }
+                icon={<ErrorIcon sx={{ fontSize: "1rem" }} />}
                 color="red"
                 variant="light"
               >
@@ -621,9 +617,7 @@ const AccountSection: React.FC = () => {
             )}
             {mfaError && (
               <Alert
-                icon={
-                  <ErrorIcon sx={{ fontSize: "1rem" }} />
-                }
+                icon={<ErrorIcon sx={{ fontSize: "1rem" }} />}
                 color="red"
                 variant="light"
               >
@@ -679,9 +673,7 @@ const AccountSection: React.FC = () => {
             </Text>
             {mfaError && (
               <Alert
-                icon={
-                  <ErrorIcon sx={{ fontSize: "1rem" }} />
-                }
+                icon={<ErrorIcon sx={{ fontSize: "1rem" }} />}
                 color="red"
                 variant="light"
               >
@@ -735,9 +727,7 @@ const AccountSection: React.FC = () => {
 
             {usernameError && (
               <Alert
-                icon={
-                  <ErrorIcon sx={{ fontSize: "1rem" }} />
-                }
+                icon={<ErrorIcon sx={{ fontSize: "1rem" }} />}
                 color="red"
                 variant="light"
               >

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminAuditSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminAuditSection.tsx
@@ -32,7 +32,8 @@ import { useLoginRequired } from "@app/hooks/useLoginRequired";
 import LoginRequiredBanner from "@app/components/shared/config/LoginRequiredBanner";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
 import EnterpriseRequiredBanner from "@app/components/shared/config/EnterpriseRequiredBanner";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import InfoIcon from "@mui/icons-material/Info";
 
 const AdminAuditSection: React.FC = () => {
   const { t } = useTranslation();
@@ -161,7 +162,7 @@ const AdminAuditSection: React.FC = () => {
       {/* Info banner about audit settings */}
       {isEnabled && (
         <Alert
-          icon={<LocalIcon icon="info" width="1.2rem" height="1.2rem" />}
+          icon={<InfoIcon width="1.2rem" height="1.2rem" />}
           title={t("audit.configureAudit", "Configure Audit Logging")}
           color="blue"
           variant="light"
@@ -177,13 +178,7 @@ const AdminAuditSection: React.FC = () => {
               variant="secondary"
               size="sm"
               onClick={() => navigate("/settings/adminSecurity#auditLogging")}
-              rightSection={
-                <LocalIcon
-                  icon="arrow-forward"
-                  width="0.9rem"
-                  height="0.9rem"
-                />
-              }
+              rightSection={<ArrowForwardIcon width="0.9rem" height="0.9rem" />}
             >
               {t("audit.goToSettings", "Go to Audit Settings")}
             </Button>

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminConnectionsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminConnectionsSection.tsx
@@ -15,7 +15,6 @@ import {
   Collapse,
 } from "@mantine/core";
 import { alert } from "@app/components/toast";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import RestartConfirmationModal from "@app/components/shared/config/RestartConfirmationModal";
 import { useRestartServer } from "@app/components/shared/config/useRestartServer";
 import { useAdminSettings } from "@app/hooks/useAdminSettings";
@@ -31,6 +30,7 @@ import {
 import apiClient from "@app/services/apiClient";
 import { useLoginRequired } from "@app/hooks/useLoginRequired";
 import LoginRequiredBanner from "@app/components/shared/config/LoginRequiredBanner";
+import QrCodeRoundedIcon from "@mui/icons-material/QrCodeRounded";
 
 interface FeedbackFlags {
   noValidDocument?: boolean;
@@ -640,11 +640,7 @@ export default function AdminConnectionsSection() {
         <Paper withBorder p="md" radius="md">
           <Stack gap="md">
             <Group gap="xs" align="center">
-              <LocalIcon
-                icon="qr-code-rounded"
-                width="1.25rem"
-                height="1.25rem"
-              />
+              <QrCodeRoundedIcon width="1.25rem" height="1.25rem" />
               <Text fw={600} size="sm">
                 {t(
                   "admin.settings.connections.mobileScanner.label",

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminDatabaseSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminDatabaseSection.tsx
@@ -34,11 +34,18 @@ import { useLoginRequired } from "@app/hooks/useLoginRequired";
 import LoginRequiredBanner from "@app/components/shared/config/LoginRequiredBanner";
 import EditableSecretField from "@app/components/shared/EditableSecretField";
 import apiClient from "@app/services/apiClient";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import databaseManagementService, {
   DatabaseBackupFile,
 } from "@app/services/databaseManagementService";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
+import BackupIcon from "@mui/icons-material/Backup";
+import DeleteIcon from "@mui/icons-material/Delete";
+import DownloadIcon from "@mui/icons-material/Download";
+import InfoIcon from "@mui/icons-material/Info";
+import PlayCircleIcon from "@mui/icons-material/PlayCircle";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import UploadIcon from "@mui/icons-material/Upload";
+import WarningIcon from "@mui/icons-material/Warning";
 
 interface DatabaseSettingsData {
   enableCustomDatabase?: boolean;
@@ -771,7 +778,7 @@ export default function AdminDatabaseSection() {
 
           {!isEmbeddedH2 && (
             <Alert
-              icon={<LocalIcon icon="info" width="1.2rem" height="1.2rem" />}
+              icon={<InfoIcon width="1.2rem" height="1.2rem" />}
               color="yellow"
               radius="md"
             >
@@ -794,7 +801,7 @@ export default function AdminDatabaseSection() {
               <Stack gap="md">
                 <Group justify="space-between" align="center">
                   <Group gap="xs">
-                    <LocalIcon icon="backup" width="1.4rem" height="1.4rem" />
+                    <BackupIcon width="1.4rem" height="1.4rem" />
                     <Text fw={600}>
                       {t(
                         "admin.settings.database.manageBackups",
@@ -805,18 +812,14 @@ export default function AdminDatabaseSection() {
                   <Group gap="xs">
                     <Button
                       variant="secondary"
-                      leftSection={
-                        <LocalIcon icon="refresh" width="1rem" height="1rem" />
-                      }
+                      leftSection={<RefreshIcon width="1rem" height="1rem" />}
                       onClick={loadBackupData}
                       disabled={!loginEnabled || !isEmbeddedH2}
                     >
                       {t("admin.settings.database.refresh", "Refresh")}
                     </Button>
                     <Button
-                      leftSection={
-                        <LocalIcon icon="upload" width="1rem" height="1rem" />
-                      }
+                      leftSection={<UploadIcon width="1rem" height="1rem" />}
                       onClick={handleCreateBackup}
                       loading={creatingBackup}
                       disabled={!loginEnabled || !isEmbeddedH2}
@@ -854,11 +857,7 @@ export default function AdminDatabaseSection() {
                       loading={importingUpload}
                       disabled={!loginEnabled || !isEmbeddedH2}
                       leftSection={
-                        <LocalIcon
-                          icon="play-circle"
-                          width="1rem"
-                          height="1rem"
-                        />
+                        <PlayCircleIcon width="1rem" height="1rem" />
                       }
                     >
                       {t(
@@ -940,11 +939,7 @@ export default function AdminDatabaseSection() {
                                   {downloadingFile === backup.fileName ? (
                                     <Loader size="xs" />
                                   ) : (
-                                    <LocalIcon
-                                      icon="download"
-                                      width="1rem"
-                                      height="1rem"
-                                    />
+                                    <DownloadIcon width="1rem" height="1rem" />
                                   )}
                                 </ActionIcon>
                               </Tooltip>
@@ -969,11 +964,7 @@ export default function AdminDatabaseSection() {
                                   {importingBackupFile === backup.fileName ? (
                                     <Loader size="xs" />
                                   ) : (
-                                    <LocalIcon
-                                      icon="backup"
-                                      width="1rem"
-                                      height="1rem"
-                                    />
+                                    <BackupIcon width="1rem" height="1rem" />
                                   )}
                                 </ActionIcon>
                               </Tooltip>
@@ -999,11 +990,7 @@ export default function AdminDatabaseSection() {
                                   {deletingFile === backup.fileName ? (
                                     <Loader size="xs" />
                                   ) : (
-                                    <LocalIcon
-                                      icon="delete"
-                                      width="1rem"
-                                      height="1rem"
-                                    />
+                                    <DeleteIcon width="1rem" height="1rem" />
                                   )}
                                 </ActionIcon>
                               </Tooltip>
@@ -1041,7 +1028,7 @@ export default function AdminDatabaseSection() {
             <Alert
               color="red"
               variant="light"
-              icon={<LocalIcon icon="warning" width="1.2rem" height="1.2rem" />}
+              icon={<WarningIcon width="1.2rem" height="1.2rem" />}
             >
               <Text fw={600}>
                 {t(
@@ -1110,7 +1097,7 @@ export default function AdminDatabaseSection() {
             <Alert
               color="red"
               variant="light"
-              icon={<LocalIcon icon="warning" width="1.2rem" height="1.2rem" />}
+              icon={<WarningIcon width="1.2rem" height="1.2rem" />}
             >
               <Text fw={600}>
                 {t(

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminMcpSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminMcpSection.tsx
@@ -15,7 +15,6 @@ import {
   List,
 } from "@mantine/core";
 import { alert } from "@app/components/toast";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import RestartConfirmationModal from "@app/components/shared/config/RestartConfirmationModal";
 import { useRestartServer } from "@app/components/shared/config/useRestartServer";
 import { useAdminSettings } from "@app/hooks/useAdminSettings";
@@ -25,6 +24,7 @@ import { SettingsStickyFooter } from "@app/components/shared/config/SettingsStic
 import apiClient from "@app/services/apiClient";
 import { useLoginRequired } from "@app/hooks/useLoginRequired";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 
 interface McpAuthData {
   mode?: string;
@@ -473,7 +473,7 @@ export default function AdminMcpSection() {
           variant="light"
           color="blue"
           title={t("admin.settings.mcp.guide.title", "Connect an MCP client")}
-          icon={<LocalIcon icon="info-rounded" width="1rem" height="1rem" />}
+          icon={<InfoRoundedIcon width="1rem" height="1rem" />}
         >
           <Stack gap={6}>
             <List size="xs" type="ordered" spacing={4}>

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPremiumSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPremiumSection.tsx
@@ -12,7 +12,6 @@ import {
   List,
 } from "@mantine/core";
 import { alert } from "@app/components/toast";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import RestartConfirmationModal from "@app/components/shared/config/RestartConfirmationModal";
 import { useRestartServer } from "@app/components/shared/config/useRestartServer";
 import { useAdminSettings } from "@app/hooks/useAdminSettings";
@@ -21,6 +20,7 @@ import PendingBadge from "@app/components/shared/config/PendingBadge";
 import { SettingsStickyFooter } from "@app/components/shared/config/SettingsStickyFooter";
 import { useLoginRequired } from "@app/hooks/useLoginRequired";
 import LoginRequiredBanner from "@app/components/shared/config/LoginRequiredBanner";
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 
 interface PremiumSettingsData {
   key?: string;
@@ -116,7 +116,7 @@ export default function AdminPremiumSection() {
             "admin.settings.premium.movedFeatures.title",
             "Premium Features Distributed",
           )}
-          icon={<LocalIcon icon="info-rounded" width="1rem" height="1rem" />}
+          icon={<InfoRoundedIcon width="1rem" height="1rem" />}
         >
           <Text size="sm">
             {t(

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminSecuritySection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminSecuritySection.tsx
@@ -16,7 +16,8 @@ import {
   Textarea,
 } from "@mantine/core";
 import { alert } from "@app/components/toast";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import InfoIcon from "@mui/icons-material/Info";
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 import RestartConfirmationModal from "@app/components/shared/config/RestartConfirmationModal";
 import { useRestartServer } from "@app/components/shared/config/useRestartServer";
 import { useAdminSettings } from "@app/hooks/useAdminSettings";
@@ -497,7 +498,7 @@ export default function AdminSecuritySection() {
             "admin.settings.security.ssoNotice.title",
             "Looking for SSO/SAML settings?",
           )}
-          icon={<LocalIcon icon="info-rounded" width="1rem" height="1rem" />}
+          icon={<InfoRoundedIcon sx={{ fontSize: "1rem" }} />}
         >
           <Text size="sm">
             {t(
@@ -861,7 +862,7 @@ export default function AdminSecuritySection() {
 
             <Alert
               color="yellow"
-              icon={<LocalIcon icon="info" />}
+              icon={<InfoIcon />}
               title={t(
                 "admin.settings.security.audit.advancedOptions.title",
                 "Advanced Options",

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminUsageSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminUsageSection.tsx
@@ -9,11 +9,13 @@ import usageAnalyticsService, {
 } from "@app/services/usageAnalyticsService";
 import UsageAnalyticsChart from "@app/components/shared/config/configSections/usage/UsageAnalyticsChart";
 import UsageAnalyticsTable from "@app/components/shared/config/configSections/usage/UsageAnalyticsTable";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { useLoginRequired } from "@app/hooks/useLoginRequired";
 import LoginRequiredBanner from "@app/components/shared/config/LoginRequiredBanner";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
 import EnterpriseRequiredBanner from "@app/components/shared/config/EnterpriseRequiredBanner";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import InfoIcon from "@mui/icons-material/Info";
+import RefreshIcon from "@mui/icons-material/Refresh";
 
 const AdminUsageSection: React.FC = () => {
   const { t } = useTranslation();
@@ -279,7 +281,7 @@ const AdminUsageSection: React.FC = () => {
       {/* Info banner about usage analytics and audit relationship */}
       {loginEnabled && hasEnterpriseLicense && (
         <Alert
-          icon={<LocalIcon icon="info" width="1.2rem" height="1.2rem" />}
+          icon={<InfoIcon width="1.2rem" height="1.2rem" />}
           title={t("usage.aboutUsageAnalytics", "About Usage Analytics")}
           color="cyan"
           variant="light"
@@ -297,11 +299,7 @@ const AdminUsageSection: React.FC = () => {
                 size="sm"
                 onClick={() => navigate("/settings/adminSecurity")}
                 rightSection={
-                  <LocalIcon
-                    icon="arrow-forward"
-                    width="0.9rem"
-                    height="0.9rem"
-                  />
+                  <ArrowForwardIcon width="0.9rem" height="0.9rem" />
                 }
               >
                 {t("usage.configureSettings", "Configure Analytics Settings")}
@@ -311,11 +309,7 @@ const AdminUsageSection: React.FC = () => {
                 size="sm"
                 onClick={() => navigate("/settings/adminSecurity#auditLogging")}
                 rightSection={
-                  <LocalIcon
-                    icon="arrow-forward"
-                    width="0.9rem"
-                    height="0.9rem"
-                  />
+                  <ArrowForwardIcon width="0.9rem" height="0.9rem" />
                 }
               >
                 {t("usage.viewAuditLogs", "View Audit Logs")}
@@ -355,9 +349,7 @@ const AdminUsageSection: React.FC = () => {
               />
               <Button
                 variant="secondary"
-                leftSection={
-                  <LocalIcon icon="refresh" width="1rem" height="1rem" />
-                }
+                leftSection={<RefreshIcon width="1rem" height="1rem" />}
                 onClick={handleRefresh}
                 loading={loading}
                 disabled={showDemoData}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/ApiKeys.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/ApiKeys.tsx
@@ -7,7 +7,8 @@ import RefreshModal from "./apiKeys/RefreshModal";
 // eslint-disable-next-line no-restricted-imports
 import useApiKey from "./apiKeys/hooks/useApiKey";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
+import OpenInNewRoundedIcon from "@mui/icons-material/OpenInNewRounded";
 
 export default function ApiKeys() {
   const [copied, setCopied] = useState<string | null>(null);
@@ -77,8 +78,7 @@ export default function ApiKeys() {
         }}
       >
         <Group gap="xs" wrap="nowrap" align="flex-start">
-          <LocalIcon
-            icon="info-rounded"
+          <InfoRoundedIcon
             width={18}
             height={18}
             style={{ marginTop: 2, flexShrink: 0, opacity: 0.7 }}
@@ -106,11 +106,7 @@ export default function ApiKeys() {
                   }}
                 >
                   {t("config.apiKeys.docsLink", "API Documentation")}
-                  <LocalIcon
-                    icon="open-in-new-rounded"
-                    width={14}
-                    height={14}
-                  />
+                  <OpenInNewRoundedIcon width={14} height={14} />
                 </Anchor>
               </Text>
               <Text size="sm">
@@ -125,11 +121,7 @@ export default function ApiKeys() {
                   }}
                 >
                   {t("config.apiKeys.schemaLink", "API Schema Reference")}
-                  <LocalIcon
-                    icon="open-in-new-rounded"
-                    width={14}
-                    height={14}
-                  />
+                  <OpenInNewRoundedIcon width={14} height={14} />
                 </Anchor>
               </Text>
             </Stack>

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/PeopleSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/PeopleSection.tsx
@@ -36,6 +36,18 @@ import UpdateSeatsButton from "@app/components/shared/UpdateSeatsButton";
 import { useLicense } from "@app/contexts/LicenseContext";
 import ChangeUserPasswordModal from "@app/components/shared/ChangeUserPasswordModal";
 import { useAuth } from "@app/auth/UseSession";
+import CloseIcon from "@mui/icons-material/Close";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import InfoIcon from "@mui/icons-material/Info";
+import KeyIcon from "@mui/icons-material/Key";
+import LockIcon from "@mui/icons-material/Lock";
+import LockOpenIcon from "@mui/icons-material/LockOpen";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import PersonOffIcon from "@mui/icons-material/PersonOff";
+import SearchIcon from "@mui/icons-material/Search";
+import HowToRegOutlinedIcon from "@mui/icons-material/HowToRegOutlined";
 
 export default function PeopleSection() {
   const { t } = useTranslation();
@@ -559,7 +571,7 @@ export default function PeopleSection() {
       <Group justify="space-between">
         <TextInput
           placeholder={t("workspace.people.searchMembers")}
-          leftSection={<LocalIcon icon="search" width="1rem" height="1rem" />}
+          leftSection={<SearchIcon width="1rem" height="1rem" />}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.currentTarget.value)}
           style={{ maxWidth: 300 }}
@@ -573,9 +585,7 @@ export default function PeopleSection() {
           withArrow
         >
           <Button
-            leftSection={
-              <LocalIcon icon="person-add" width="1rem" height="1rem" />
-            }
+            leftSection={<PersonAddIcon width="1rem" height="1rem" />}
             onClick={handleAddMembersClick}
             disabled={
               !loginEnabled ||
@@ -787,7 +797,7 @@ export default function PeopleSection() {
                         size="sm"
                         aria-label={t("workspace.people.userInfo", "User info")}
                       >
-                        <LocalIcon icon="info" width="1rem" height="1rem" />
+                        <InfoIcon width="1rem" height="1rem" />
                       </ActionIcon>
                     </Tooltip>
 
@@ -803,11 +813,7 @@ export default function PeopleSection() {
                               "Member actions",
                             )}
                           >
-                            <LocalIcon
-                              icon="more-vert"
-                              width="1rem"
-                              height="1rem"
-                            />
+                            <MoreVertIcon width="1rem" height="1rem" />
                           </ActionIcon>
                         </Menu.Target>
                         <Menu.Dropdown
@@ -816,11 +822,7 @@ export default function PeopleSection() {
                           {!isCurrentUser(user) && (
                             <Menu.Item
                               leftSection={
-                                <LocalIcon
-                                  icon="edit"
-                                  width="1rem"
-                                  height="1rem"
-                                />
+                                <EditIcon width="1rem" height="1rem" />
                               }
                               onClick={() => openEditModal(user)}
                               disabled={!loginEnabled}
@@ -834,11 +836,7 @@ export default function PeopleSection() {
                           {!isCurrentUser(user) && (
                             <Menu.Item
                               leftSection={
-                                <LocalIcon
-                                  icon="lock"
-                                  width="1rem"
-                                  height="1rem"
-                                />
+                                <LockIcon width="1rem" height="1rem" />
                               }
                               onClick={() => openChangePasswordModal(user)}
                               disabled={!loginEnabled}
@@ -853,14 +851,9 @@ export default function PeopleSection() {
                             <Menu.Item
                               leftSection={
                                 user.enabled ? (
-                                  <LocalIcon
-                                    icon="person-off"
-                                    width="1rem"
-                                    height="1rem"
-                                  />
+                                  <PersonOffIcon width="1rem" height="1rem" />
                                 ) : (
-                                  <LocalIcon
-                                    icon="person-check"
+                                  <HowToRegOutlinedIcon
                                     width="1rem"
                                     height="1rem"
                                   />
@@ -877,11 +870,7 @@ export default function PeopleSection() {
                           {!isCurrentUser(user) && isLockedUser(user) && (
                             <Menu.Item
                               leftSection={
-                                <LocalIcon
-                                  icon="lock-open"
-                                  width="1rem"
-                                  height="1rem"
-                                />
+                                <LockOpenIcon width="1rem" height="1rem" />
                               }
                               onClick={() => handleUnlockUser(user)}
                               disabled={!loginEnabled}
@@ -898,11 +887,7 @@ export default function PeopleSection() {
                               <Menu.Item
                                 color="red"
                                 leftSection={
-                                  <LocalIcon
-                                    icon="key"
-                                    width="1rem"
-                                    height="1rem"
-                                  />
+                                  <KeyIcon width="1rem" height="1rem" />
                                 }
                                 onClick={async () => {
                                   try {
@@ -953,11 +938,7 @@ export default function PeopleSection() {
                               <Menu.Item
                                 color="red"
                                 leftSection={
-                                  <LocalIcon
-                                    icon="delete"
-                                    width="1rem"
-                                    height="1rem"
-                                  />
+                                  <DeleteIcon width="1rem" height="1rem" />
                                 }
                                 onClick={() => handleDeleteUser(user)}
                                 disabled={!loginEnabled}
@@ -1015,13 +996,12 @@ export default function PeopleSection() {
               zIndex: 1,
             }}
           >
-            <LocalIcon icon="close" width="1.25rem" height="1.25rem" />
+            <CloseIcon width="1.25rem" height="1.25rem" />
           </ActionIcon>
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
             <Stack gap="md" align="center">
-              <LocalIcon
-                icon="edit"
+              <EditIcon
                 width="3rem"
                 height="3rem"
                 style={{ color: "var(--mantine-color-gray-6)" }}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/PeopleSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/PeopleSection.tsx
@@ -47,7 +47,6 @@ import MoreVertIcon from "@mui/icons-material/MoreVert";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import PersonOffIcon from "@mui/icons-material/PersonOff";
 import SearchIcon from "@mui/icons-material/Search";
-import HowToRegOutlinedIcon from "@mui/icons-material/HowToRegOutlined";
 
 export default function PeopleSection() {
   const { t } = useTranslation();
@@ -853,7 +852,8 @@ export default function PeopleSection() {
                                 user.enabled ? (
                                   <PersonOffIcon width="1rem" height="1rem" />
                                 ) : (
-                                  <HowToRegOutlinedIcon
+                                  <LocalIcon
+                                    icon="person-check"
                                     width="1rem"
                                     height="1rem"
                                   />

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/TeamDetailsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/TeamDetailsSection.tsx
@@ -17,7 +17,6 @@ import {
 } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { alert } from "@app/components/toast";
 import { teamService, Team } from "@app/services/teamService";
 import {
@@ -26,6 +25,16 @@ import {
 } from "@app/services/userManagementService";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
 import ChangeUserPasswordModal from "@app/components/shared/ChangeUserPasswordModal";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import DeleteIcon from "@mui/icons-material/Delete";
+import InfoIcon from "@mui/icons-material/Info";
+import LockIcon from "@mui/icons-material/Lock";
+import LockOpenIcon from "@mui/icons-material/LockOpen";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
+import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 
 interface TeamDetailsSectionProps {
   teamId: number;
@@ -369,7 +378,7 @@ export default function TeamDetailsSection({
           onClick={onBack}
           aria-label={t("common.back", "Back")}
         >
-          <LocalIcon icon="arrow-back" width="1.2rem" height="1.2rem" />
+          <ArrowBackIcon width="1.2rem" height="1.2rem" />
         </ActionIcon>
         <div style={{ flex: 1 }}>
           <Text fw={600} size="lg">
@@ -393,9 +402,7 @@ export default function TeamDetailsSection({
           zIndex={Z_INDEX_OVER_CONFIG_MODAL}
         >
           <Button
-            leftSection={
-              <LocalIcon icon="person-add" width="1rem" height="1rem" />
-            }
+            leftSection={<PersonAddIcon width="1rem" height="1rem" />}
             onClick={() => setAddMemberModalOpened(true)}
             disabled={
               team.name === "Internal" ||
@@ -573,7 +580,7 @@ export default function TeamDetailsSection({
                             "User info",
                           )}
                         >
-                          <LocalIcon icon="info" width="1rem" height="1rem" />
+                          <InfoIcon width="1rem" height="1rem" />
                         </ActionIcon>
                       </Tooltip>
 
@@ -587,11 +594,7 @@ export default function TeamDetailsSection({
                               "Member actions",
                             )}
                           >
-                            <LocalIcon
-                              icon="more-vert"
-                              width="1rem"
-                              height="1rem"
-                            />
+                            <MoreVertIcon width="1rem" height="1rem" />
                           </ActionIcon>
                         </Menu.Target>
                         <Menu.Dropdown
@@ -599,11 +602,7 @@ export default function TeamDetailsSection({
                         >
                           <Menu.Item
                             leftSection={
-                              <LocalIcon
-                                icon="swap-horiz"
-                                width="1rem"
-                                height="1rem"
-                              />
+                              <SwapHorizIcon width="1rem" height="1rem" />
                             }
                             onClick={() => openChangeTeamModal(user)}
                             disabled={processing || team.name === "Internal"}
@@ -615,11 +614,7 @@ export default function TeamDetailsSection({
                           </Menu.Item>
                           <Menu.Item
                             leftSection={
-                              <LocalIcon
-                                icon="lock"
-                                width="1rem"
-                                height="1rem"
-                              />
+                              <LockIcon width="1rem" height="1rem" />
                             }
                             onClick={() => openChangePasswordModal(user)}
                             disabled={processing}
@@ -632,11 +627,7 @@ export default function TeamDetailsSection({
                           {isLockedUser(user) && (
                             <Menu.Item
                               leftSection={
-                                <LocalIcon
-                                  icon="lock-open"
-                                  width="1rem"
-                                  height="1rem"
-                                />
+                                <LockOpenIcon width="1rem" height="1rem" />
                               }
                               onClick={() => handleUnlockUser(user)}
                               disabled={processing}
@@ -651,8 +642,7 @@ export default function TeamDetailsSection({
                             team.name !== "Default" && (
                               <Menu.Item
                                 leftSection={
-                                  <LocalIcon
-                                    icon="person-remove"
+                                  <PersonRemoveIcon
                                     width="1rem"
                                     height="1rem"
                                   />
@@ -670,11 +660,7 @@ export default function TeamDetailsSection({
                           <Menu.Item
                             color="red"
                             leftSection={
-                              <LocalIcon
-                                icon="delete"
-                                width="1rem"
-                                height="1rem"
-                              />
+                              <DeleteIcon width="1rem" height="1rem" />
                             }
                             onClick={() => handleDeleteUser(user)}
                             disabled={processing || team.name === "Internal"}
@@ -723,13 +709,12 @@ export default function TeamDetailsSection({
               zIndex: 1,
             }}
           >
-            <LocalIcon icon="close-rounded" />
+            <CloseRoundedIcon />
           </ActionIcon>
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
             <Stack gap="md" align="center">
-              <LocalIcon
-                icon="person-add"
+              <PersonAddIcon
                 width="3rem"
                 height="3rem"
                 style={{ color: "var(--mantine-color-gray-6)" }}
@@ -806,13 +791,12 @@ export default function TeamDetailsSection({
               zIndex: 1,
             }}
           >
-            <LocalIcon icon="close-rounded" />
+            <CloseRoundedIcon />
           </ActionIcon>
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
             <Stack gap="md" align="center">
-              <LocalIcon
-                icon="swap-horiz"
+              <SwapHorizIcon
                 width="3rem"
                 height="3rem"
                 style={{ color: "var(--mantine-color-gray-6)" }}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/TeamsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/TeamsSection.tsx
@@ -16,6 +16,11 @@ import {
 } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import GroupIcon from "@mui/icons-material/Group";
 import LocalIcon from "@app/components/shared/LocalIcon";
 import { alert } from "@app/components/toast";
 import { teamService, Team } from "@app/services/teamService";
@@ -284,7 +289,7 @@ export default function TeamsSection() {
       {/* Header Actions */}
       <Group justify="flex-end">
         <Button
-          leftSection={<LocalIcon icon="add" width="1rem" height="1rem" />}
+          leftSection={<AddIcon sx={{ fontSize: "1rem" }} />}
           onClick={() => setCreateModalOpened(true)}
           disabled={!loginEnabled}
         >
@@ -411,7 +416,7 @@ export default function TeamsSection() {
                       </Menu.Item>
                       <Menu.Item
                         leftSection={
-                          <LocalIcon icon="group" width="1rem" height="1rem" />
+                          <GroupIcon sx={{ fontSize: "1rem" }} />
                         }
                         onClick={() => openAddMemberModal(team)}
                         disabled={!loginEnabled}
@@ -420,7 +425,7 @@ export default function TeamsSection() {
                       </Menu.Item>
                       <Menu.Item
                         leftSection={
-                          <LocalIcon icon="edit" width="1rem" height="1rem" />
+                          <EditIcon sx={{ fontSize: "1rem" }} />
                         }
                         onClick={() => openRenameModal(team)}
                         disabled={!loginEnabled}
@@ -431,7 +436,7 @@ export default function TeamsSection() {
                       <Menu.Item
                         color="red"
                         leftSection={
-                          <LocalIcon icon="delete" width="1rem" height="1rem" />
+                          <DeleteIcon sx={{ fontSize: "1rem" }} />
                         }
                         onClick={() => handleDeleteTeam(team)}
                         disabled={!loginEnabled || team.name === "Internal"}
@@ -470,7 +475,7 @@ export default function TeamsSection() {
               zIndex: 1,
             }}
           >
-            <LocalIcon icon="close" width="1.25rem" height="1.25rem" />
+            <CloseIcon sx={{ fontSize: "1.25rem" }} />
           </ActionIcon>
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
@@ -530,7 +535,7 @@ export default function TeamsSection() {
               zIndex: 1,
             }}
           >
-            <LocalIcon icon="close" width="1.25rem" height="1.25rem" />
+            <CloseIcon sx={{ fontSize: "1.25rem" }} />
           </ActionIcon>
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
@@ -596,7 +601,7 @@ export default function TeamsSection() {
               zIndex: 1,
             }}
           >
-            <LocalIcon icon="close" width="1.25rem" height="1.25rem" />
+            <CloseIcon sx={{ fontSize: "1.25rem" }} />
           </ActionIcon>
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/TeamsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/TeamsSection.tsx
@@ -21,7 +21,6 @@ import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import GroupIcon from "@mui/icons-material/Group";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { alert } from "@app/components/toast";
 import { teamService, Team } from "@app/services/teamService";
 import {
@@ -32,6 +31,10 @@ import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
 import TeamDetailsSection from "@app/components/shared/config/configSections/TeamDetailsSection";
 import { useLoginRequired } from "@app/hooks/useLoginRequired";
 import LoginRequiredBanner from "@app/components/shared/config/LoginRequiredBanner";
+import GroupAddIcon from "@mui/icons-material/GroupAdd";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 
 export default function TeamsSection() {
   const { t } = useTranslation();
@@ -391,11 +394,7 @@ export default function TeamsSection() {
                           "Team actions",
                         )}
                       >
-                        <LocalIcon
-                          icon="more-vert"
-                          width="1rem"
-                          height="1rem"
-                        />
+                        <MoreVertIcon width="1rem" height="1rem" />
                       </ActionIcon>
                     </Menu.Target>
                     <Menu.Dropdown
@@ -403,11 +402,7 @@ export default function TeamsSection() {
                     >
                       <Menu.Item
                         leftSection={
-                          <LocalIcon
-                            icon="visibility"
-                            width="1rem"
-                            height="1rem"
-                          />
+                          <VisibilityIcon width="1rem" height="1rem" />
                         }
                         onClick={() => setViewingTeamId(team.id)}
                         disabled={!loginEnabled}
@@ -415,18 +410,14 @@ export default function TeamsSection() {
                         {t("workspace.teams.viewTeam", "View Team")}
                       </Menu.Item>
                       <Menu.Item
-                        leftSection={
-                          <GroupIcon sx={{ fontSize: "1rem" }} />
-                        }
+                        leftSection={<GroupIcon sx={{ fontSize: "1rem" }} />}
                         onClick={() => openAddMemberModal(team)}
                         disabled={!loginEnabled}
                       >
                         {t("workspace.teams.addMember")}
                       </Menu.Item>
                       <Menu.Item
-                        leftSection={
-                          <EditIcon sx={{ fontSize: "1rem" }} />
-                        }
+                        leftSection={<EditIcon sx={{ fontSize: "1rem" }} />}
                         onClick={() => openRenameModal(team)}
                         disabled={!loginEnabled}
                       >
@@ -435,9 +426,7 @@ export default function TeamsSection() {
                       <Menu.Divider />
                       <Menu.Item
                         color="red"
-                        leftSection={
-                          <DeleteIcon sx={{ fontSize: "1rem" }} />
-                        }
+                        leftSection={<DeleteIcon sx={{ fontSize: "1rem" }} />}
                         onClick={() => handleDeleteTeam(team)}
                         disabled={!loginEnabled || team.name === "Internal"}
                       >
@@ -480,8 +469,7 @@ export default function TeamsSection() {
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
             <Stack gap="md" align="center">
-              <LocalIcon
-                icon="group-add"
+              <GroupAddIcon
                 width="3rem"
                 height="3rem"
                 style={{ color: "var(--mantine-color-gray-6)" }}
@@ -540,8 +528,7 @@ export default function TeamsSection() {
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
             <Stack gap="md" align="center">
-              <LocalIcon
-                icon="edit"
+              <EditIcon
                 width="3rem"
                 height="3rem"
                 style={{ color: "var(--mantine-color-gray-6)" }}
@@ -606,8 +593,7 @@ export default function TeamsSection() {
           <Stack gap="lg" pt="md">
             {/* Header with Icon */}
             <Stack gap="md" align="center">
-              <LocalIcon
-                icon="person-add"
+              <PersonAddIcon
                 width="3rem"
                 height="3rem"
                 style={{ color: "var(--mantine-color-gray-6)" }}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/apiKeys/ApiKeySection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/apiKeys/ApiKeySection.tsx
@@ -61,9 +61,7 @@ export default function ApiKeySection({
             variant="secondary"
             accent="neutral"
             onClick={() => onCopy(publicKey, "public")}
-            leftSection={
-              <ContentCopyIcon sx={{ fontSize: 14 }} />
-            }
+            leftSection={<ContentCopyIcon sx={{ fontSize: 14 }} />}
             style={{
               marginLeft: 12,
             }}
@@ -78,9 +76,7 @@ export default function ApiKeySection({
             variant="secondary"
             accent="neutral"
             onClick={onRefresh}
-            leftSection={
-              <RefreshIcon sx={{ fontSize: 14 }} />
-            }
+            leftSection={<RefreshIcon sx={{ fontSize: 14 }} />}
             style={{
               marginLeft: 8,
             }}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/apiKeys/ApiKeySection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/apiKeys/ApiKeySection.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Box, Group, Paper } from "@mantine/core";
 import { Button } from "@app/ui/Button";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ContentCopyIcon from "@mui/icons-material/ContentCopyRounded";
+import RefreshIcon from "@mui/icons-material/RefreshRounded";
 import FitText from "@app/components/shared/FitText";
 import { useTranslation } from "react-i18next";
 
@@ -61,7 +62,7 @@ export default function ApiKeySection({
             accent="neutral"
             onClick={() => onCopy(publicKey, "public")}
             leftSection={
-              <LocalIcon icon="content-copy-rounded" width={14} height={14} />
+              <ContentCopyIcon sx={{ fontSize: 14 }} />
             }
             style={{
               marginLeft: 12,
@@ -78,7 +79,7 @@ export default function ApiKeySection({
             accent="neutral"
             onClick={onRefresh}
             leftSection={
-              <LocalIcon icon="refresh-rounded" width={14} height={14} />
+              <RefreshIcon sx={{ fontSize: 14 }} />
             }
             style={{
               marginLeft: 8,

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditClearDataSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditClearDataSection.tsx
@@ -12,7 +12,9 @@ import {
 import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
 import auditService from "@app/services/auditService";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import WarningIcon from "@mui/icons-material/Warning";
 
 interface AuditClearDataSectionProps {
   loginEnabled?: boolean;
@@ -72,9 +74,7 @@ const AuditClearDataSection: React.FC<AuditClearDataSectionProps> = ({
       <Stack gap="lg">
         <Alert
           color="green"
-          icon={
-            <LocalIcon icon="check-circle" width="1.2rem" height="1.2rem" />
-          }
+          icon={<CheckCircleIcon width="1.2rem" height="1.2rem" />}
           title={t("audit.clearData.success", "Success")}
           onClose={() => setSuccess(false)}
           closeButtonLabel="Close alert"
@@ -94,7 +94,7 @@ const AuditClearDataSection: React.FC<AuditClearDataSectionProps> = ({
       <Stack gap="lg">
         <Alert
           color="orange"
-          icon={<LocalIcon icon="warning" width="1.2rem" height="1.2rem" />}
+          icon={<WarningIcon width="1.2rem" height="1.2rem" />}
           title={t(
             "audit.clearData.confirmTitle",
             "Please confirm you want to delete",
@@ -165,7 +165,7 @@ const AuditClearDataSection: React.FC<AuditClearDataSectionProps> = ({
             {error && (
               <Alert
                 color="red"
-                icon={<LocalIcon icon="error" width="1.2rem" height="1.2rem" />}
+                icon={<ErrorIcon width="1.2rem" height="1.2rem" />}
               >
                 {error}
               </Alert>
@@ -202,7 +202,7 @@ const AuditClearDataSection: React.FC<AuditClearDataSectionProps> = ({
     <Stack gap="lg">
       <Alert
         color="red"
-        icon={<LocalIcon icon="warning" width="1.2rem" height="1.2rem" />}
+        icon={<WarningIcon width="1.2rem" height="1.2rem" />}
         title={t("audit.clearData.warning1", "This action cannot be undone")}
       >
         <Text size="sm">

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditEventsTable.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditEventsTable.tsx
@@ -22,6 +22,7 @@ import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
 import { useAuditFilters } from "@app/hooks/useAuditFilters";
 import AuditFiltersForm from "@app/components/shared/config/configSections/audit/AuditFiltersForm";
 import LocalIcon from "@app/components/shared/LocalIcon";
+import SearchIcon from "@mui/icons-material/Search";
 
 interface AuditEventsTableProps {
   loginEnabled?: boolean;
@@ -403,8 +404,7 @@ const AuditEventsTable: React.FC<AuditEventsTableProps> = ({
                       <Table.Td colSpan={totalColumns}>
                         <Group justify="center" py="xl">
                           <Stack align="center" gap={0}>
-                            <LocalIcon
-                              icon="search"
+                            <SearchIcon
                               width="2rem"
                               height="2rem"
                               style={{ opacity: 0.4 }}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditExportSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditExportSection.tsx
@@ -4,9 +4,9 @@ import { Button } from "@app/ui/Button";
 import { SegmentedControl } from "@app/ui/SegmentedControl";
 import { useTranslation } from "react-i18next";
 import auditService from "@app/services/auditService";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { useAuditFilters } from "@app/hooks/useAuditFilters";
 import AuditFiltersForm from "@app/components/shared/config/configSections/audit/AuditFiltersForm";
+import DownloadIcon from "@mui/icons-material/Download";
 
 interface AuditExportSectionProps {
   loginEnabled?: boolean;
@@ -244,9 +244,7 @@ const AuditExportSection: React.FC<AuditExportSectionProps> = ({
         {/* Export Button */}
         <Group justify="flex-end">
           <Button
-            leftSection={
-              <LocalIcon icon="download" width="1rem" height="1rem" />
-            }
+            leftSection={<DownloadIcon width="1rem" height="1rem" />}
             onClick={handleExport}
             loading={exporting}
             disabled={!loginEnabled || exporting}

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditStatsCards.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/audit/AuditStatsCards.tsx
@@ -12,6 +12,10 @@ import {
 import { useTranslation } from "react-i18next";
 import auditService, { AuditStats } from "@app/services/auditService";
 import LocalIcon from "@app/components/shared/LocalIcon";
+import AnalyticsIcon from "@mui/icons-material/Analytics";
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
+import GroupIcon from "@mui/icons-material/Group";
+import SpeedIcon from "@mui/icons-material/Speed";
 
 interface AuditStatsCardsProps {
   loginEnabled?: boolean;
@@ -146,7 +150,7 @@ const AuditStatsCards: React.FC<AuditStatsCardsProps> = ({
             <Text size="sm" c="dimmed">
               {t("audit.stats.totalEvents", "Total Events")}
             </Text>
-            <LocalIcon icon="analytics" width="1.2rem" height="1.2rem" />
+            <AnalyticsIcon width="1.2rem" height="1.2rem" />
           </Group>
           <Text size="xl" fw={700}>
             {stats.totalEvents.toLocaleString()}
@@ -179,11 +183,7 @@ const AuditStatsCards: React.FC<AuditStatsCardsProps> = ({
             <Text size="sm" c="dimmed">
               {t("audit.stats.successRate", "Success Rate")}
             </Text>
-            <LocalIcon
-              icon="check-circle-rounded"
-              width="1.2rem"
-              height="1.2rem"
-            />
+            <CheckCircleRoundedIcon width="1.2rem" height="1.2rem" />
           </Group>
           <Text size="xl" fw={700}>
             {stats.successRate.toFixed(1)}%
@@ -221,7 +221,7 @@ const AuditStatsCards: React.FC<AuditStatsCardsProps> = ({
             <Text size="sm" c="dimmed">
               {t("audit.stats.activeUsers", "Active Users")}
             </Text>
-            <LocalIcon icon="group" width="1.2rem" height="1.2rem" />
+            <GroupIcon width="1.2rem" height="1.2rem" />
           </Group>
           <Text size="xl" fw={700}>
             {stats.uniqueUsers}
@@ -253,7 +253,7 @@ const AuditStatsCards: React.FC<AuditStatsCardsProps> = ({
             <Text size="sm" c="dimmed">
               {t("audit.stats.avgLatency", "Avg Latency")}
             </Text>
-            <LocalIcon icon="speed" width="1.2rem" height="1.2rem" />
+            <SpeedIcon width="1.2rem" height="1.2rem" />
           </Group>
           <Text size="xl" fw={700}>
             {stats.avgLatencyMs > 0

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/plan/LicenseKeySection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/plan/LicenseKeySection.tsx
@@ -18,6 +18,10 @@ import { LicenseInfo } from "@app/services/licenseService";
 import licenseService from "@app/services/licenseService";
 import { useLicense } from "@app/contexts/LicenseContext";
 import { useLoginRequired } from "@app/hooks/useLoginRequired";
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
+import UploadFileRoundedIcon from "@mui/icons-material/UploadFileRounded";
+import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 
 interface LicenseKeySectionProps {
   currentLicenseInfo?: LicenseInfo;
@@ -136,7 +140,7 @@ const LicenseKeySection: React.FC<LicenseKeySectionProps> = ({
           <Alert
             variant="light"
             color="blue"
-            icon={<LocalIcon icon="info-rounded" width="1rem" height="1rem" />}
+            icon={<InfoRoundedIcon width="1rem" height="1rem" />}
           >
             <Text size="sm">
               {t(
@@ -151,9 +155,7 @@ const LicenseKeySection: React.FC<LicenseKeySectionProps> = ({
             <Alert
               variant="light"
               color="red"
-              icon={
-                <LocalIcon icon="warning-rounded" width="1rem" height="1rem" />
-              }
+              icon={<WarningRoundedIcon width="1rem" height="1rem" />}
               title={t(
                 "admin.settings.premium.key.overwriteWarning.title",
                 "⚠️ Warning: Existing License Detected",
@@ -187,13 +189,7 @@ const LicenseKeySection: React.FC<LicenseKeySectionProps> = ({
             <Alert
               variant="light"
               color="green"
-              icon={
-                <LocalIcon
-                  icon="check-circle-rounded"
-                  width="1rem"
-                  height="1rem"
-                />
-              }
+              icon={<CheckCircleRoundedIcon width="1rem" height="1rem" />}
             >
               <Stack gap="xs">
                 <Text size="sm" fw={500}>
@@ -299,11 +295,7 @@ const LicenseKeySection: React.FC<LicenseKeySectionProps> = ({
                     disabled={!loginEnabled || savingLicense}
                     variant="secondary"
                     leftSection={
-                      <LocalIcon
-                        icon="upload-file-rounded"
-                        width="1rem"
-                        height="1rem"
-                      />
+                      <UploadFileRoundedIcon width="1rem" height="1rem" />
                     }
                   >
                     {licenseFile

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/plan/StaticCheckoutModal.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/plan/StaticCheckoutModal.tsx
@@ -12,7 +12,6 @@ import {
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
 import { EmailStage } from "@app/components/shared/stripeCheckout/stages/EmailStage";
 import { validateEmail } from "@app/components/shared/stripeCheckout/utils/checkoutUtils";
 import { getClickablePaperStyle } from "@app/components/shared/stripeCheckout/utils/cardStyles";
@@ -25,6 +24,9 @@ import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
 import { useIsMobile } from "@app/hooks/useIsMobile";
 import licenseService from "@app/services/licenseService";
 import { useLicense } from "@app/contexts/LicenseContext";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 
 interface StaticCheckoutModalProps {
   opened: boolean;
@@ -247,9 +249,7 @@ const StaticCheckoutModal: React.FC<StaticCheckoutModalProps> = ({
             <Alert
               variant="light"
               color="blue"
-              icon={
-                <LocalIcon icon="info-rounded" width="1rem" height="1rem" />
-              }
+              icon={<InfoRoundedIcon width="1rem" height="1rem" />}
             >
               <Stack gap="sm">
                 <Text size="sm" fw={600}>
@@ -271,13 +271,7 @@ const StaticCheckoutModal: React.FC<StaticCheckoutModalProps> = ({
               <Alert
                 variant="light"
                 color="green"
-                icon={
-                  <LocalIcon
-                    icon="check-circle-rounded"
-                    width="1rem"
-                    height="1rem"
-                  />
-                }
+                icon={<CheckCircleRoundedIcon width="1rem" height="1rem" />}
                 title={t(
                   "plan.static.licenseActivation.success",
                   "License Activated!",
@@ -367,7 +361,7 @@ const StaticCheckoutModal: React.FC<StaticCheckoutModalProps> = ({
               onClick={handleGoBack}
               aria-label={t("common.back", "Back")}
             >
-              <LocalIcon icon="arrow-back" width={20} height={20} />
+              <ArrowBackIcon width={20} height={20} />
             </ActionIcon>
           )}
           <Text fw={600} size="lg">

--- a/frontend/editor/src/proprietary/components/shared/stripeCheckout/StripeCheckout.tsx
+++ b/frontend/editor/src/proprietary/components/shared/stripeCheckout/StripeCheckout.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { Modal, Text, Group } from "@mantine/core";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
-import LocalIcon from "@app/components/shared/LocalIcon";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import licenseService from "@app/services/licenseService";
 import { useIsMobile } from "@app/hooks/useIsMobile";
 import { Z_INDEX_OVER_CONFIG_MODAL } from "@app/styles/zIndex";
@@ -281,7 +281,7 @@ const StripeCheckout: React.FC<StripeCheckoutProps> = ({
               onClick={navigation.goBack}
               aria-label={t("common.back", "Back")}
             >
-              <LocalIcon icon="arrow-back" width={20} height={20} />
+              <ArrowBackIcon sx={{ fontSize: 20 }} />
             </ActionIcon>
           )}
           <Text fw={600} size="lg">

--- a/frontend/editor/src/prototypes/data/usePrototypeToolRegistry.tsx
+++ b/frontend/editor/src/prototypes/data/usePrototypeToolRegistry.tsx
@@ -10,7 +10,7 @@ import { pdfCommentAgentOperationConfig } from "@app/hooks/tools/pdfCommentAgent
 import { asRegistryConfig } from "@app/hooks/tools/shared/toolOperationTypes";
 import PdfCommentAgent from "@app/tools/PdfCommentAgent";
 import { getSynonyms } from "@app/utils/toolSynonyms";
-import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
+import LocalIcon from "@app/components/shared/LocalIcon";
 
 /**
  * Prototype tool registry extension — real implementation.
@@ -26,7 +26,13 @@ export function usePrototypeToolRegistry(): PrototypeToolRegistry {
     () =>
       ({
         pdfCommentAgent: {
-          icon: <AddCommentOutlinedIcon width="1.5rem" height="1.5rem" />,
+          icon: (
+            <LocalIcon
+              icon="add-comment-outline-rounded"
+              width="1.5rem"
+              height="1.5rem"
+            />
+          ),
           name: t("home.pdfCommentAgent.title", "Add AI comments"),
           component: PdfCommentAgent,
           description: t(

--- a/frontend/editor/src/prototypes/data/usePrototypeToolRegistry.tsx
+++ b/frontend/editor/src/prototypes/data/usePrototypeToolRegistry.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import LocalIcon from "@app/components/shared/LocalIcon";
 import {
   SubcategoryId,
   ToolCategoryId,
@@ -11,6 +10,7 @@ import { pdfCommentAgentOperationConfig } from "@app/hooks/tools/pdfCommentAgent
 import { asRegistryConfig } from "@app/hooks/tools/shared/toolOperationTypes";
 import PdfCommentAgent from "@app/tools/PdfCommentAgent";
 import { getSynonyms } from "@app/utils/toolSynonyms";
+import AddCommentOutlinedIcon from "@mui/icons-material/AddCommentOutlined";
 
 /**
  * Prototype tool registry extension — real implementation.
@@ -26,13 +26,7 @@ export function usePrototypeToolRegistry(): PrototypeToolRegistry {
     () =>
       ({
         pdfCommentAgent: {
-          icon: (
-            <LocalIcon
-              icon="add-comment-outline-rounded"
-              width="1.5rem"
-              height="1.5rem"
-            />
-          ),
+          icon: <AddCommentOutlinedIcon width="1.5rem" height="1.5rem" />,
           name: t("home.pdfCommentAgent.title", "Add AI comments"),
           component: PdfCommentAgent,
           description: t(

--- a/frontend/editor/src/saas/components/shared/AppConfigModal.tsx
+++ b/frontend/editor/src/saas/components/shared/AppConfigModal.tsx
@@ -22,6 +22,7 @@ import {
   Z_INDEX_OVER_FULLSCREEN_SURFACE,
   Z_INDEX_OVER_SETTINGS_MODAL,
 } from "@app/styles/zIndex";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 interface AppConfigModalProps {
   opened: boolean;
@@ -290,7 +291,7 @@ const AppConfigModal: React.FC<AppConfigModalProps> = ({
                   onClick={onClose}
                   aria-label={t("common.close", "Close")}
                 >
-                  <LocalIcon icon="close-rounded" width={18} height={18} />
+                  <CloseRoundedIcon width={18} height={18} />
                 </ActionIcon>
               </div>
               <div className="modal-body">{activeComponent}</div>

--- a/frontend/editor/src/saas/components/shared/config/configSections/McpSection.tsx
+++ b/frontend/editor/src/saas/components/shared/config/configSections/McpSection.tsx
@@ -18,6 +18,9 @@ import { useAppConfig } from "@app/contexts/AppConfigContext";
 import { openAppSettings } from "@app/utils/appSettings";
 import { useAuth } from "@app/auth/UseSession";
 import { isUserAnonymous } from "@app/auth/supabase";
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
+import KeyRoundedIcon from "@mui/icons-material/KeyRounded";
+import SmartToyRoundedIcon from "@mui/icons-material/SmartToyRounded";
 
 /** Strip a single trailing slash so we can safely append paths. */
 function trimTrailingSlash(url: string): string {
@@ -149,7 +152,7 @@ export default function McpSection() {
         <div>
           <Group gap="sm" align="center">
             <ThemeIcon variant="light" size="lg" radius="md">
-              <LocalIcon icon="smart-toy-rounded" width={22} height={22} />
+              <SmartToyRoundedIcon width={22} height={22} />
             </ThemeIcon>
             <Text fw={600} size="lg">
               {t("config.mcp.title", "MCP Server")}
@@ -261,9 +264,7 @@ export default function McpSection() {
             <Alert
               variant="light"
               color="blue"
-              icon={
-                <LocalIcon icon="info-rounded" width="1rem" height="1rem" />
-              }
+              icon={<InfoRoundedIcon width="1rem" height="1rem" />}
             >
               <Group
                 justify="space-between"
@@ -281,9 +282,7 @@ export default function McpSection() {
                   size="sm"
                   variant="secondary"
                   style={{ flexShrink: 0 }}
-                  leftSection={
-                    <LocalIcon icon="key-rounded" width={14} height={14} />
-                  }
+                  leftSection={<KeyRoundedIcon width={14} height={14} />}
                   onClick={() => openAppSettings("api-keys")}
                 >
                   {t("config.mcp.viewApiKeys", "View API keys")}

--- a/frontend/editor/src/saas/components/tools/sign/SignSettings.tsx
+++ b/frontend/editor/src/saas/components/tools/sign/SignSettings.tsx
@@ -35,6 +35,8 @@ import {
 } from "@app/hooks/tools/sign/useSavedSignatures";
 import { SavedSignaturesSection } from "@app/components/tools/sign/SavedSignaturesSection";
 import { buildSignaturePreview } from "@app/utils/signaturePreview";
+import PauseCircleRoundedIcon from "@mui/icons-material/PauseCircleRounded";
+import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
 
 type SignatureDrafts = {
   canvas?: string;
@@ -1158,9 +1160,7 @@ const SignSettings = ({
             aria-label={translate("mode.pause", "Pause placement")}
             onClick={handlePausePlacement}
             disabled={disabled || !onDeactivateSignature}
-            leftSection={
-              <LocalIcon icon="pause-circle-rounded" width={20} height={20} />
-            }
+            leftSection={<PauseCircleRoundedIcon width={20} height={20} />}
           >
             {translate("mode.pause", "Pause placement")}
           </Button>
@@ -1174,9 +1174,7 @@ const SignSettings = ({
             disabled={
               disabled || !isCurrentTypeReady || !onActivateSignaturePlacement
             }
-            leftSection={
-              <LocalIcon icon="play-arrow-rounded" width={20} height={20} />
-            }
+            leftSection={<PlayArrowRoundedIcon width={20} height={20} />}
           >
             {translate("mode.resume", "Resume placement")}
           </Button>


### PR DESCRIPTION
# Description of Changes

Replaced hand-written SVG icons with direct imports from `@mui/icons-material` across the portal and shared frontend UI components.

The changes include:

- Replaced all custom icons in the portal icon module with equivalent Material icons.
- Replaced generic close, chevron, check, and disclosure SVGs in shared UI components.
- Preserved existing icon export names and the `size` and `className` interfaces used by portal consumers.
- Kept brand logos, file illustrations, cloud-provider logos, operating-system logos, and specialized PDF viewer graphics unchanged.
- Used direct icon imports to retain effective tree-shaking.

This change reduces duplicated SVG markup and makes common interface symbols more consistent with the rest of the frontend. Some Material icons differ slightly in shape from the previous custom SVGs, but their meaning and behavior remain unchanged.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
