### PR TITLE
ci: reduce Depot GHA cost with draft gating and right-sized runners

### DIFF
--- a/.github/config/.files.yaml
+++ b/.github/config/.files.yaml
@@ -1,12 +1,24 @@
+# Editing the top-level PR router (build.yml) or the path-filter config it
+# reads changes how every job is dispatched, so a change to either must run
+# the full matrix - the only way to test a CI-routing change end to end.
+# Pulled into every area filter below (directly, or transitively via *build).
+ci: &ci
+  - .github/workflows/build.yml
+  - .github/config/.files.yaml
+
 build: &build
+  - *ci
   - build.gradle
   - app/(common|core|proprietary|saas)/build.gradle
   - Taskfile.yml
   - .taskfiles/backend.yml
+  - .github/workflows/backend-build.yml
+  - .github/workflows/check-licence.yml
 
 openapi: &openapi
   - *build
   - app/(common|core|proprietary|saas)/src/main/java/**
+  - .github/workflows/check-openapi.yml
 
 docker-base: &docker-base
   - docker/base/Dockerfile
@@ -45,10 +57,16 @@ project: &project
   - .taskfiles/docker.yml
   - scripts/db-migration/**
   - .github/workflows/db-migration-test.yml
+  - .github/workflows/docker-compose-tests.yml
+  - .github/workflows/test-build-docker.yml
 
 frontend: &frontend
+  - *ci
   - frontend/**
   - .github/workflows/testdriver.yml
+  - .github/workflows/frontend-validation.yml
+  - .github/workflows/e2e-stubbed.yml
+  - .github/workflows/e2e-live.yml
   - testing/**
   - docker/**
   - scripts/translations/*.py
@@ -67,6 +85,7 @@ frontend: &frontend
 # Files that affect the Tauri desktop bundle. Gate the multi-OS Tauri build
 # job on changes to any of these.
 tauri: &tauri
+  - *ci
   - frontend/editor/src-tauri/**
   - frontend/editor/src/desktop/**
   - frontend/editor/tsconfig.desktop.vite.json
@@ -81,6 +100,7 @@ tauri: &tauri
 # the engine validation job on changes to engine sources or to the Java
 # tool surfaces it generates models from.
 engine: &engine
+  - *ci
   - engine/**
   - app/(common|core|proprietary|saas)/src/main/java/**
   - .github/workflows/ai-engine.yml
@@ -115,6 +135,7 @@ licenses-backend: &licenses-backend
 # Files that can affect premium / enterprise behaviour. Gate the enterprise
 # Playwright job on changes to any of these on PRs.
 proprietary: &proprietary
+  - *ci
   - app/proprietary/**
   - frontend/editor/src/proprietary/**
   - frontend/editor/src/core/tests/enterprise/**

--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -11,6 +11,17 @@ name: Backend build, format check, and coverage
 #                  never any runtime/integration testing)
 on:
   workflow_call:
+    inputs:
+      depot_cores:
+        description: "Depot runner vCPU count (used in runs-on). Override for benchmarking."
+        required: false
+        type: string
+        default: "8"
+      full_backend_matrix:
+        description: "Run the full core/proprietary/saas flavor matrix. Callers pass false on draft PRs to build only the cheapest `core` flavor."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -24,14 +35,16 @@ jobs:
 
   build:
     needs: pick
-    runs-on: ${{ needs.pick.outputs.is_fork == 'true' && 'ubuntu-latest' || 'depot-ubuntu-24.04-8' }}
+    runs-on: ${{ needs.pick.outputs.is_fork == 'true' && 'ubuntu-latest' || format('depot-ubuntu-24.04-{0}', inputs.depot_cores || '8') }}
     env:
       DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
         jdk-version: [25]
-        flavor: [core, proprietary, saas]
+        # Draft PRs (full_backend_matrix=false) build only `core` for fast,
+        # cheap feedback; ready PRs / merge queue build all three flavors.
+        flavor: ${{ inputs.full_backend_matrix && fromJSON('["core","proprietary","saas"]') || fromJSON('["core"]') }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,14 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/tauri-build.yml
     secrets: inherit
+    with:
+      # PR smoke build: Linux only (fastest to compile), unsigned, deb only.
+      # Skips rpm + the slow/flaky AppImage pass and all signing/notarization.
+      # The full signed multi-OS matrix runs on release (multiOSReleases.yml).
+      platform: linux
+      sign: false
+      linux_bundles: deb
+      build_appimage: false
 
   ai-engine:
     if: needs.files-changed.outputs.engine == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ name: Build and Test Workflow
 
 on:
   pull_request:
+    # `ready_for_review` is required so flipping a draft to ready re-runs the
+    # heavy suite the draft gates below skip. Keep the other default types.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: ["main"]
   merge_group:
     branches: ["main"]
@@ -68,13 +71,19 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/backend-build.yml
     secrets: inherit
+    with:
+      # Draft PRs build+test only the cheapest `core` flavor for fast
+      # feedback (1x runner instead of 3x). Ready PRs and the merge queue
+      # run the full core/proprietary/saas matrix.
+      full_backend_matrix: ${{ github.event.pull_request.draft != true }}
 
   db-migration-test:
     # Boots the current bootJar against H2 fixtures captured from past
     # releases (v2.0.0 / v2.5.0 / v2.10.0) and verifies admin login still
     # works after Hibernate's ddl-auto=update migrates the schema. Gated on
-    # the `project` filter so doc-only PRs skip this ~5-minute job.
-    if: needs.files-changed.outputs.project == 'true'
+    # the `project` filter so doc-only PRs skip this ~5-minute job, and
+    # skipped on draft PRs (re-runs on ready_for_review).
+    if: github.event.pull_request.draft != true && needs.files-changed.outputs.project == 'true'
     needs: [files-changed]
     permissions:
       contents: read
@@ -99,7 +108,7 @@ jobs:
     secrets: inherit
 
   playwright-e2e:
-    if: needs.files-changed.outputs.frontend == 'true'
+    if: github.event.pull_request.draft != true && needs.files-changed.outputs.frontend == 'true'
     needs: [files-changed]
     permissions:
       contents: read
@@ -107,7 +116,7 @@ jobs:
     secrets: inherit
 
   playwright-e2e-live:
-    if: needs.files-changed.outputs.frontend == 'true'
+    if: github.event.pull_request.draft != true && needs.files-changed.outputs.frontend == 'true'
     needs: [files-changed]
     permissions:
       contents: read
@@ -115,7 +124,7 @@ jobs:
     secrets: inherit
 
   playwright-e2e-enterprise:
-    if: needs.files-changed.outputs.proprietary == 'true'
+    if: github.event.pull_request.draft != true && needs.files-changed.outputs.proprietary == 'true'
     needs: [files-changed]
     permissions:
       contents: read
@@ -131,7 +140,7 @@ jobs:
     secrets: inherit
 
   docker-compose-tests:
-    if: needs.files-changed.outputs.project == 'true'
+    if: github.event.pull_request.draft != true && needs.files-changed.outputs.project == 'true'
     needs: [files-changed]
     permissions:
       actions: write
@@ -143,7 +152,7 @@ jobs:
       docker-base-changed: ${{ needs.files-changed.outputs.docker-base }}
 
   test-build-docker-images:
-    if: github.event_name == 'pull_request' && needs.files-changed.outputs.project == 'true'
+    if: github.event.pull_request.draft != true && github.event_name == 'pull_request' && needs.files-changed.outputs.project == 'true'
     needs: [files-changed, build, check-generateOpenApiDocs, check-licence]
     permissions:
       contents: read
@@ -155,7 +164,7 @@ jobs:
       docker-base-changed: ${{ needs.files-changed.outputs.docker-base }}
 
   tauri-build:
-    if: needs.files-changed.outputs.tauri == 'true'
+    if: github.event.pull_request.draft != true && needs.files-changed.outputs.tauri == 'true'
     needs: [files-changed]
     permissions:
       contents: read

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -21,6 +21,16 @@ on:
         required: false
         type: boolean
         default: true
+      linux_bundles:
+        description: "Linux bundle targets for the deb/rpm step (e.g. 'deb,rpm' or just 'deb'). PR smoke builds pass 'deb' to skip the slower rpm packaging."
+        required: false
+        type: string
+        default: "deb,rpm"
+      build_appimage:
+        description: "Build the Linux AppImage in its own pass. PR smoke builds pass false - AppImage (linuxdeploy) is slow and chronically flaky (#6127), and is not needed to validate the desktop bundle compiles."
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       platform:
@@ -389,7 +399,7 @@ jobs:
           # Linux: build deb+rpm only here. AppImage runs in its own
           # continue-on-error step below so its persistent linuxdeploy
           # failure (#6127 onwards) does not tank deb/rpm uploads.
-          args: ${{ matrix.platform == 'ubuntu-22.04' && '--bundles deb,rpm' || matrix.args }}
+          args: ${{ matrix.platform == 'ubuntu-22.04' && format('--bundles {0}', inputs.linux_bundles) || matrix.args }}
 
       - name: Build Tauri app (unsigned)
         if: ${{ !inputs.sign }}
@@ -409,12 +419,12 @@ jobs:
           # Linux: build deb+rpm only here. AppImage runs in its own
           # continue-on-error step below so its persistent linuxdeploy
           # failure (#6127 onwards) does not tank deb/rpm uploads.
-          args: ${{ matrix.platform == 'ubuntu-22.04' && '--bundles deb,rpm' || matrix.args }}
+          args: ${{ matrix.platform == 'ubuntu-22.04' && format('--bundles {0}', inputs.linux_bundles) || matrix.args }}
 
       # AppImage is decoupled so its linuxdeploy run gets a fresh process
       # (rpm scratch state torn down) and its failure can't tank deb/rpm.
       - name: Build Tauri app (Linux AppImage)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' && inputs.build_appimage
         continue-on-error: true
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -13,10 +13,15 @@ on:
         type: string
         default: "false"
       depot_cores:
-        description: "Depot runner vCPU count (used in runs-on). Override for benchmarking."
+        description: "Depot runner vCPU count for the main image-build matrix (runs a local Gradle build). Override for benchmarking."
         required: false
         type: string
         default: "8"
+      unoserver_depot_cores:
+        description: "Depot runner vCPU count for the unoserver image job (remote build only, no local Gradle). Override for benchmarking."
+        required: false
+        type: string
+        default: "2"
 
 permissions:
   contents: read
@@ -214,7 +219,11 @@ jobs:
 
   test-build-unoserver-image:
     needs: pick
-    runs-on: ${{ needs.pick.outputs.is_fork == 'true' && 'ubuntu-latest' || format('depot-ubuntu-24.04-{0}', inputs.depot_cores || '8') }}
+    # This job does no local Gradle build - the image is built on Depot's
+    # remote BuildKit and only `docker run`'d for a smoke test - so the
+    # orchestration runner sits near-idle. A 2-core runner is plenty and
+    # ~4x cheaper. (Fork PRs fall back to local buildx on ubuntu-latest.)
+    runs-on: ${{ needs.pick.outputs.is_fork == 'true' && 'ubuntu-latest' || format('depot-ubuntu-24.04-{0}', inputs.unoserver_depot_cores || '2') }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: "false"
       depot_cores:
-        description: "Depot runner vCPU count for the main image-build matrix (runs a local Gradle build). Override for benchmarking."
+        description: "Depot runner vCPU count for the image-build matrix's local docker-build path (base-image change only). The common Depot remote-build path uses a fixed small runner. Override for benchmarking."
         required: false
         type: string
         default: "8"
@@ -30,23 +30,18 @@ jobs:
   pick:
     uses: ./.github/workflows/_runner-pick.yml
 
-  # TODO: extract a pre-matrix `prepare` job that runs once and produces
-  # shared artifacts for the three matrix entries below to consume:
-  #   1. `task backend:build` — currently runs 3× in parallel with
-  #      identical env (DISABLE_ADDITIONAL_FEATURES=true,
-  #      STIRLING_PDF_DESKTOP_UI=false). Build once, upload the JAR as an
-  #      artifact, matrix entries download.
-  #   2. The base-image `docker build` (gated on docker-base-changed) —
-  #      currently runs 3× in parallel against the same Dockerfile and
-  #      context. Build once, `docker save` to an artifact, matrix entries
-  #      `docker load` before the embedded build.
-  # Saves ~2 full backend builds + 2 base-image builds per PR that touches
-  # docker. May also be reusable from backend-build.yml's jdk-25 +
-  # spring-security=true matrix entry if `task backend:build` and
-  # `task backend:build:ci` produce equivalent JARs (verify before wiring).
+  # Each matrix entry builds its image from source *inside* Docker
+  # (`gradle clean build -PbuildWithFrontend=true`), so this job does not run
+  # a runner-side `task backend:build` — that only duplicated backend-build's
+  # core-flavor tests and fed nothing into the image. Remaining dedup: when
+  # docker-base-changed, the base image is rebuilt once per matrix entry (3×)
+  # rather than once shared.
   test-build-docker-images:
     needs: pick
-    runs-on: ${{ needs.pick.outputs.is_fork == 'true' && 'ubuntu-latest' || format('depot-ubuntu-24.04-{0}', inputs.depot_cores || '8') }}
+    # Only the local docker-build paths (base-image change, fork fallback)
+    # compile on the runner and need cores; the common Depot path builds the
+    # image remotely, so a small 2-core orchestration runner is enough there.
+    runs-on: ${{ needs.pick.outputs.is_fork == 'true' && 'ubuntu-latest' || format('depot-ubuntu-24.04-{0}', inputs.docker-base-changed == 'true' && inputs.depot_cores || '2') }}
     permissions:
       contents: read
       id-token: write
@@ -92,38 +87,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost
           docker system prune -af || true
           echo "Disk space after cleanup:" && df -h
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: "25"
-          distribution: "temurin"
-
-      - name: Cache Gradle dependency artifacts
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.gradle/caches/modules-2/files-2.1
-            ~/.gradle/caches/modules-2/metadata-2.*
-          key: gradle-deps-${{ runner.os }}-jdk-25-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties', '**/*.gradle', '**/*.gradle.kts', 'settings.gradle', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          gradle-version: 9.6.0
-          cache-disabled: true
-
-      - name: Install Task
-        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
-      - name: Build application
-        run: task backend:build
-        env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_PUBLIC_URL: ${{ secrets.MAVEN_PUBLIC_URL }}
-          DISABLE_ADDITIONAL_FEATURES: true
-          STIRLING_PDF_DESKTOP_UI: false
 
       - name: Set up Depot CLI
         if: env.USE_DEPOT == 'true'
@@ -204,18 +167,6 @@ jobs:
             BASE_IMAGE=${{ steps.build-params.outputs.base_image }}
           provenance: true
           sbom: true
-
-      - name: Upload Reports
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: reports-docker-${{ matrix.artifact-suffix }}
-          path: |
-            build/reports/tests/
-            build/test-results/
-            build/reports/problems/
-          retention-days: 3
-          if-no-files-found: warn
 
   test-build-unoserver-image:
     needs: pick


### PR DESCRIPTION
## Why


## Changes

**1. Draft-PR gating (biggest lever for iterative work).**
The expensive suite skips while a PR is a draft and runs in full when marked ready:
- skipped on draft: `db-migration-test`, `playwright-e2e`, `playwright-e2e-live`, `playwright-e2e-enterprise`, `docker-compose-tests`, `test-build-docker-images`, `tauri-build`
- kept on draft (fast feedback): backend build (core flavor only), `frontend-validation`, `pre-commit`, `dependency-review`, licence/openapi/model checks
- added `ready_for_review` to the `pull_request` trigger types so flipping draft→ready re-runs everything before merge
- `all-checks-passed` treats draft-skipped jobs as `skipped` (= pass); you can't merge a draft anyway

**2. Core-only backend matrix on draft.**
`backend-build` runs 3× (core/proprietary/saas) on every push. On draft PRs it now builds only the cheapest `core` flavor (1× instead of 3×); ready PRs / merge queue run the full matrix. Added a `depot_cores` input so the runner size is tunable like the other reusable workflows.

**3. Right-sized the unoserver docker-build runner (8→2 core).**
`test-build-unoserver-image` does no local Gradle build - built on Depot's remote BuildKit and only `docker run` smoke-tested - so its 8-core runner sat near-idle. Dropped to 2 (tunable via `unoserver_depot_cores`).

**4. Tauri PR build → Linux, deb-only, unsigned, no AppImage.**
The PR path built the full 3-OS matrix (Win + macOS-universal + Linux) *signed + notarized*, with Linux doing a second `tauri-action` pass just for AppImage (`linuxdeploy`, slow + chronically flaky per #6127). A Linux PR build measured ~52m vs ~15m for the compile alone. PRs now build Linux only (fastest to compile), unsigned, `deb` only. Full signed multi-OS matrix still runs on release (`multiOSReleases.yml`); nightly still warms the Rust cache with full defaults.

**5. Dropped the redundant runner-side backend build from `test-build-docker-images`.**
The three embedded Dockerfiles build the JAR + frontend *inside* Docker (`gradle clean build -PbuildWithFrontend=true`, Depot-cached), so the runner's `task backend:build` fed nothing into the image - it only re-ran core-flavor tests `backend-build` already covers. Removed the JDK/Gradle/Task/build/report steps; those three runners drop 8→2 core (8 only when the docker base image changed and a local build is needed).

**6. CI-routing changes now run the full matrix (self-testing).**
Editing `build.yml` previously only matched the `project` filter, so a change to how e2e / enterprise / tauri / engine jobs are dispatched didn't actually run those jobs. Added a `ci` anchor (`build.yml` + `.github/config/.files.yaml`) that every area filter now includes, so editing the router or the filter config runs every job. Also added the orphaned reusable workflows (`e2e-*`, `frontend-validation`, `docker-compose-tests`, `test-build-docker`, `check-*`) to their area filters so editing a reusable self-tests. Composes with draft gating: iterate cheaply in draft, get the full validation once on ready.

 Linux PR path ~52m before change #4.

## Considered but not included (data-driven)
- Sharing one frontend `dist` across the e2e jobs and enabling a shared Gradle build cache: real but smaller wins (backend build is only ~2m) that touch e2e/gradle internals and are better validated in a separate frontend-touching PR.