### PR TITLE
Redesign policies to use typed mappings properly

### DIFF
--- a/frontend/editor/src/core/hooks/tools/shared/toolAutomation.test.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolAutomation.test.ts
@@ -13,7 +13,6 @@ import {
 import {
   deserializeToolStep,
   getExecutableTools,
-  serializeStepFromEndpoint,
   serializeToolStep,
   stepRequiresUpload,
   type WorkingToolStep,
@@ -196,41 +195,6 @@ describe("serialize/deserialize round-trip", () => {
     expect(back.support).toBe("editable");
     expect(back.operation).toBe("/api/v1/security/auto-redact");
     expect(back.params).toMatchObject({ mode: "automatic" });
-  });
-});
-
-describe("serializeStepFromEndpoint", () => {
-  test("maps a wizard step's UI params to the backend contract, filling defaults", () => {
-    // The shape the policy setup wizard holds: an endpoint plus UI-shaped params
-    // (redact's `wordsToRedact`), with several fields left to their defaults.
-    const api = serializeStepFromEndpoint(
-      "/api/v1/security/auto-redact",
-      { mode: "automatic", useRegex: true, wordsToRedact: ["ssn", "card"] },
-      dynamicRegistry,
-    );
-
-    expect(api.operation).toBe("/api/v1/security/auto-redact");
-    // wordsToRedact -> listOfText (the field the backend actually reads), and the
-    // frontend-only `mode` is dropped.
-    expect(api.parameters).toMatchObject({ listOfText: "ssn\ncard" });
-    expect(api.parameters).not.toHaveProperty("wordsToRedact");
-    expect(api.parameters).not.toHaveProperty("mode");
-    // Fields the wizard never set still get their defaults so the body is complete.
-    expect(api.parameters).toHaveProperty("wholeWordSearch");
-    expect(api.parameters).toHaveProperty("customPadding");
-  });
-
-  test("passes an unmapped endpoint's params through unchanged", () => {
-    expect(
-      serializeStepFromEndpoint(
-        "/api/v1/unknown/thing",
-        { keep: true },
-        dynamicRegistry,
-      ),
-    ).toEqual({
-      operation: "/api/v1/unknown/thing",
-      parameters: { keep: true },
-    });
   });
 });
 

--- a/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
@@ -182,12 +182,7 @@ export function newWorkingToolStep(
   };
 }
 
-/**
- * Build a typed {@link ToolOperationDescriptor} from a registry entry's (erased) config, pinned to
- * `operation` — the shared frontend<->backend conversion primitive. Returns null when the endpoint
- * isn't a known tool endpoint or the tool lacks the bidirectional mappers, so callers fall back to
- * one-directional handling.
- */
+/** Descriptor for a registry entry's (erased) config, or null when it can't round-trip. */
 function descriptorFor(
   operation: string,
   config: RegistryToolOperationConfig,
@@ -216,7 +211,6 @@ export function serializeToolStep(
   }
   const merged = { ...(config.defaultParameters ?? {}), ...step.params };
   const operation = resolveEndpoint(config, merged) ?? step.operation;
-  // Convert through the shared descriptor when the tool round-trips; else map one-directionally.
   const descriptor = descriptorFor(operation, config);
   const parameters = descriptor
     ? (descriptor.toApi(merged) as Record<string, unknown>)
@@ -274,7 +268,6 @@ export function deserializeToolStep(
   if (!match) return unmappedStep(step);
   const [toolId, entry] = match;
   const config = entry.operationConfig;
-  // Convert through the shared descriptor when the tool round-trips; else map one-directionally.
   const descriptor = config && descriptorFor(step.operation, config);
   const params: ErasedToolParams = descriptor
     ? descriptor.fromApi(step.parameters)

--- a/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
@@ -26,6 +26,10 @@ import {
   type ErasedToolParams,
   type RegistryToolOperationConfig,
 } from "@app/hooks/tools/shared/toolOperationTypes";
+import {
+  describeToolOperation,
+  type ToolOperationDescriptor,
+} from "@app/hooks/tools/shared/toolOperationDescriptor";
 
 /**
  * How much of a tool's parameters a UI can edit when composing a backend step:
@@ -178,6 +182,27 @@ export function newWorkingToolStep(
   };
 }
 
+/**
+ * Build a typed {@link ToolOperationDescriptor} from a registry entry's (erased) config, pinned to
+ * `operation` — the shared frontend<->backend conversion primitive. Returns null when the endpoint
+ * isn't a known tool endpoint or the tool lacks the bidirectional mappers, so callers fall back to
+ * one-directional handling.
+ */
+function descriptorFor(
+  operation: string,
+  config: RegistryToolOperationConfig,
+): ToolOperationDescriptor<ToolEndpoint, ErasedToolParams> | null {
+  if (
+    !isToolEndpoint(operation) ||
+    !config.toApiParams ||
+    !config.fromApiParams ||
+    config.defaultParameters === undefined
+  ) {
+    return null;
+  }
+  return describeToolOperation(operation, config);
+}
+
 /** Serialize a working step into the backend step contract (endpoint + backend parameters). */
 export function serializeToolStep(
   step: WorkingToolStep,
@@ -191,35 +216,14 @@ export function serializeToolStep(
   }
   const merged = { ...(config.defaultParameters ?? {}), ...step.params };
   const operation = resolveEndpoint(config, merged) ?? step.operation;
-  const parameters = config.toApiParams
-    ? (config.toApiParams(merged) as Record<string, unknown>)
-    : {};
-  return { operation, parameters };
-}
-
-/**
- * Serialize a step held as an endpoint path plus frontend-shaped params - the form the policy setup
- * wizard keeps, where params match the tool's UI shape (e.g. redact's `wordsToRedact`) rather than
- * the backend contract - into the backend step contract, mapping params through the tool's
- * `toApiParams` (merged over its defaults, so fields the wizard never set still get their defaults).
- * The endpoint maps to a tool by path, so this works for dynamic-endpoint tools whose config
- * endpoint is a function. Endpoints that map to no known tool pass through unchanged.
- */
-export function serializeStepFromEndpoint(
-  operation: string,
-  params: ErasedToolParams,
-  registry: Partial<ToolRegistry>,
-): ToolApiStep {
-  const match = findToolByEndpoint({ operation, parameters: params }, registry);
-  const config = match?.[1].operationConfig;
-  if (!config) return { operation, parameters: params };
-  const merged = { ...(config.defaultParameters ?? {}), ...params };
-  return {
-    operation: resolveEndpoint(config, merged) ?? operation,
-    parameters: config.toApiParams
+  // Convert through the shared descriptor when the tool round-trips; else map one-directionally.
+  const descriptor = descriptorFor(operation, config);
+  const parameters = descriptor
+    ? (descriptor.toApi(merged) as Record<string, unknown>)
+    : config.toApiParams
       ? (config.toApiParams(merged) as Record<string, unknown>)
-      : {},
-  };
+      : {};
+  return { operation, parameters };
 }
 
 /**
@@ -270,12 +274,16 @@ export function deserializeToolStep(
   if (!match) return unmappedStep(step);
   const [toolId, entry] = match;
   const config = entry.operationConfig;
-  const params: ErasedToolParams = config?.fromApiParams
-    ? {
-        ...(config.defaultParameters ?? {}),
-        ...config.fromApiParams(step.parameters as never),
-      }
-    : { ...(config?.defaultParameters ?? {}) };
+  // Convert through the shared descriptor when the tool round-trips; else map one-directionally.
+  const descriptor = config && descriptorFor(step.operation, config);
+  const params: ErasedToolParams = descriptor
+    ? descriptor.fromApi(step.parameters)
+    : config?.fromApiParams
+      ? {
+          ...(config.defaultParameters ?? {}),
+          ...config.fromApiParams(step.parameters as never),
+        }
+      : { ...(config?.defaultParameters ?? {}) };
   // Validate against the generated endpoint set instead of casting the matched string.
   const operation =
     resolveEndpoint(config, params) ??

--- a/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolAutomation.ts
@@ -26,10 +26,6 @@ import {
   type ErasedToolParams,
   type RegistryToolOperationConfig,
 } from "@app/hooks/tools/shared/toolOperationTypes";
-import {
-  describeToolOperation,
-  type ToolOperationDescriptor,
-} from "@app/hooks/tools/shared/toolOperationDescriptor";
 
 /**
  * How much of a tool's parameters a UI can edit when composing a backend step:
@@ -182,22 +178,6 @@ export function newWorkingToolStep(
   };
 }
 
-/** Descriptor for a registry entry's (erased) config, or null when it can't round-trip. */
-function descriptorFor(
-  operation: string,
-  config: RegistryToolOperationConfig,
-): ToolOperationDescriptor<ToolEndpoint, ErasedToolParams> | null {
-  if (
-    !isToolEndpoint(operation) ||
-    !config.toApiParams ||
-    !config.fromApiParams ||
-    config.defaultParameters === undefined
-  ) {
-    return null;
-  }
-  return describeToolOperation(operation, config);
-}
-
 /** Serialize a working step into the backend step contract (endpoint + backend parameters). */
 export function serializeToolStep(
   step: WorkingToolStep,
@@ -211,12 +191,9 @@ export function serializeToolStep(
   }
   const merged = { ...(config.defaultParameters ?? {}), ...step.params };
   const operation = resolveEndpoint(config, merged) ?? step.operation;
-  const descriptor = descriptorFor(operation, config);
-  const parameters = descriptor
-    ? (descriptor.toApi(merged) as Record<string, unknown>)
-    : config.toApiParams
-      ? (config.toApiParams(merged) as Record<string, unknown>)
-      : {};
+  const parameters = config.toApiParams
+    ? (config.toApiParams(merged) as Record<string, unknown>)
+    : {};
   return { operation, parameters };
 }
 
@@ -268,15 +245,12 @@ export function deserializeToolStep(
   if (!match) return unmappedStep(step);
   const [toolId, entry] = match;
   const config = entry.operationConfig;
-  const descriptor = config && descriptorFor(step.operation, config);
-  const params: ErasedToolParams = descriptor
-    ? descriptor.fromApi(step.parameters)
-    : config?.fromApiParams
-      ? {
-          ...(config.defaultParameters ?? {}),
-          ...config.fromApiParams(step.parameters as never),
-        }
-      : { ...(config?.defaultParameters ?? {}) };
+  const params: ErasedToolParams = config?.fromApiParams
+    ? {
+        ...(config.defaultParameters ?? {}),
+        ...config.fromApiParams(step.parameters as never),
+      }
+    : { ...(config?.defaultParameters ?? {}) };
   // Validate against the generated endpoint set instead of casting the matched string.
   const operation =
     resolveEndpoint(config, params) ??

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.test.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.test.ts
@@ -5,10 +5,9 @@ interface Params {
   a: number;
 }
 
+// A minimal bidirectional mapping that type-checks against the flatten endpoint's model.
 const CONFIG = {
   defaultParameters: { a: 1 } satisfies Params,
-  // A minimal bidirectional mapping for the flatten endpoint (arbitrary choice; the mappers here
-  // just have to be present and type-check against that endpoint's model).
   toApiParams: (p: Params) => ({ renderDpi: p.a }),
   fromApiParams: (api: { renderDpi?: number }) => ({ a: api.renderDpi ?? 0 }),
 };
@@ -22,7 +21,6 @@ describe("describeToolOperation", () => {
 
   test("fromApi merges the mapped values over the defaults", () => {
     const d = describeToolOperation("/api/v1/misc/flatten", CONFIG);
-    // renderDpi maps to `a`; any field the mapper omits keeps its default.
     expect(d.fromApi({ renderDpi: 72 })).toEqual({ a: 72 });
   });
 

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.test.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.test.ts
@@ -5,8 +5,9 @@ interface Params {
   a: number;
 }
 
-// A minimal bidirectional mapping that type-checks against the flatten endpoint's model.
+// A minimal config that type-checks against the flatten endpoint's model.
 const CONFIG = {
+  endpoint: "/api/v1/misc/flatten" as const,
   defaultParameters: { a: 1 } satisfies Params,
   toApiParams: (p: Params) => ({ renderDpi: p.a }),
   fromApiParams: (api: { renderDpi?: number }) => ({ a: api.renderDpi ?? 0 }),
@@ -27,6 +28,7 @@ describe("describeToolOperation", () => {
   test("throws when the config lacks a mapper", () => {
     expect(() =>
       describeToolOperation("/api/v1/misc/flatten", {
+        endpoint: "/api/v1/misc/flatten" as const,
         defaultParameters: { a: 1 },
         toApiParams: (p: Params) => ({ renderDpi: p.a }),
       }),

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.test.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { describeToolOperation } from "@app/hooks/tools/shared/toolOperationDescriptor";
+
+interface Params {
+  a: number;
+}
+
+const CONFIG = {
+  defaultParameters: { a: 1 } satisfies Params,
+  // A minimal bidirectional mapping for the flatten endpoint (arbitrary choice; the mappers here
+  // just have to be present and type-check against that endpoint's model).
+  toApiParams: (p: Params) => ({ renderDpi: p.a }),
+  fromApiParams: (api: { renderDpi?: number }) => ({ a: api.renderDpi ?? 0 }),
+};
+
+describe("describeToolOperation", () => {
+  test("wraps the config's mappers and endpoint into a descriptor", () => {
+    const d = describeToolOperation("/api/v1/misc/flatten", CONFIG);
+    expect(d.endpoint).toBe("/api/v1/misc/flatten");
+    expect(d.toApi({ a: 200 })).toEqual({ renderDpi: 200 });
+  });
+
+  test("fromApi merges the mapped values over the defaults", () => {
+    const d = describeToolOperation("/api/v1/misc/flatten", CONFIG);
+    // renderDpi maps to `a`; any field the mapper omits keeps its default.
+    expect(d.fromApi({ renderDpi: 72 })).toEqual({ a: 72 });
+  });
+
+  test("throws when the config lacks a mapper", () => {
+    expect(() =>
+      describeToolOperation("/api/v1/misc/flatten", {
+        defaultParameters: { a: 1 },
+        toApiParams: (p: Params) => ({ renderDpi: p.a }),
+      }),
+    ).toThrow(/mappers/);
+  });
+});

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.ts
@@ -1,0 +1,65 @@
+/**
+ * A tool operation described as a typed, self-contained unit: its endpoint plus the two mappers
+ * that convert between the tool's frontend parameter shape and the backend request model for that
+ * endpoint. This is the single seam through which callers convert safely between the two parameter
+ * models without ever touching `Record<string, unknown>` themselves.
+ *
+ * It is a thin, typed wrapper over the bidirectional mappers already declared on every tool's
+ * `operationConfig` (`toApiParams` / `fromApiParams`), keeping the frontend<->backend mapping
+ * single-sourced in the tools while binding it to the generated per-endpoint request model
+ * ({@link ToolApiParams}).
+ */
+
+import type { ToolApiParams, ToolEndpoint } from "@app/types/toolApiTypes";
+
+/** A tool operation with a known endpoint and type-safe conversion in both directions. */
+export interface ToolOperationDescriptor<E extends ToolEndpoint, TParams> {
+  /** The endpoint this operation calls — always known, as a literal. */
+  readonly endpoint: E;
+  /** Complete default frontend parameters for the operation. */
+  readonly defaultParameters: TParams;
+  /** Frontend params -> the backend request model for {@link endpoint}. */
+  toApi(params: TParams): ToolApiParams[E];
+  /** Backend request model -> complete frontend params (defaults merged under the mapped values). */
+  fromApi(api: ToolApiParams[E]): TParams;
+}
+
+/**
+ * The subset of a tool's `operationConfig` this descriptor needs: the bidirectional mappers bound
+ * to endpoint {@link E}, plus defaults. Structural (not the full config type) so `E` is inferred
+ * from the `endpoint` argument and mismatched endpoint/config pairings are a compile error — a
+ * config whose mappers target a different endpoint won't satisfy `ToolApiParams[E]`.
+ */
+export interface BidirectionalToolConfig<TParams, E extends ToolEndpoint> {
+  defaultParameters?: TParams;
+  toApiParams?(params: TParams): ToolApiParams[E];
+  fromApiParams?(api: ToolApiParams[E]): Partial<TParams>;
+}
+
+/**
+ * Build a {@link ToolOperationDescriptor} from a tool's operation config, pinned to `endpoint`.
+ * The endpoint is passed explicitly (not read from `config.endpoint`) because dynamic-endpoint
+ * tools declare `endpoint` as a function; passing the literal also binds `E` so the config's
+ * mappers are checked against that endpoint's request model.
+ *
+ * Throws if the config lacks defaults or either mapper — a policy/pipeline tool must be able to
+ * round-trip its parameters, so a missing mapper is a wiring error, not a runtime-recoverable state.
+ */
+export function describeToolOperation<E extends ToolEndpoint, TParams>(
+  endpoint: E,
+  config: BidirectionalToolConfig<TParams, E>,
+): ToolOperationDescriptor<E, TParams> {
+  const { toApiParams, fromApiParams, defaultParameters } = config;
+  if (!toApiParams || !fromApiParams || defaultParameters === undefined) {
+    throw new Error(
+      `describeToolOperation: "${endpoint}" needs defaultParameters and both ` +
+        `toApiParams/fromApiParams mappers`,
+    );
+  }
+  return {
+    endpoint,
+    defaultParameters,
+    toApi: (params) => toApiParams(params),
+    fromApi: (api) => ({ ...defaultParameters, ...fromApiParams(api) }),
+  };
+}

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.ts
@@ -13,20 +13,30 @@ export interface ToolOperationDescriptor<E extends ToolEndpoint, TParams> {
   fromApi(api: ToolApiParams[E]): TParams;
 }
 
-/** Structural subset of a tool's config; separate so `E` is inferred from the endpoint argument. */
-export interface BidirectionalToolConfig<TParams, E extends ToolEndpoint> {
+/**
+ * Structural subset of a tool's config. `CE` is the config's declared endpoint type, inferred from
+ * the `endpoint` field: the literal for static tools, or the whole `ToolEndpoint` union for
+ * dynamic-endpoint tools (whose endpoint is a function typed against the union).
+ */
+export interface BidirectionalToolConfig<TParams, CE extends ToolEndpoint> {
+  endpoint: CE | null | ((params: TParams) => CE | null);
   defaultParameters?: TParams;
-  toApiParams?(params: TParams): ToolApiParams[E];
-  fromApiParams?(api: ToolApiParams[E]): Partial<TParams>;
+  toApiParams?(params: TParams): ToolApiParams[CE];
+  fromApiParams?(api: ToolApiParams[CE]): Partial<TParams>;
 }
 
 /**
  * Pin a config to `endpoint` (passed explicitly, since dynamic-endpoint tools declare `endpoint` as
- * a function). Throws when the mappers or defaults are missing.
+ * a function). `E extends CE` rejects pairing a static tool's config with the wrong endpoint, while
+ * allowing a dynamic tool whose `CE` is the full union. Throws when mappers or defaults are missing.
  */
-export function describeToolOperation<E extends ToolEndpoint, TParams>(
+export function describeToolOperation<
+  E extends CE,
+  CE extends ToolEndpoint,
+  TParams,
+>(
   endpoint: E,
-  config: BidirectionalToolConfig<TParams, E>,
+  config: BidirectionalToolConfig<TParams, CE>,
 ): ToolOperationDescriptor<E, TParams> {
   const { toApiParams, fromApiParams, defaultParameters } = config;
   if (!toApiParams || !fromApiParams || defaultParameters === undefined) {
@@ -37,7 +47,13 @@ export function describeToolOperation<E extends ToolEndpoint, TParams>(
   return {
     endpoint,
     defaultParameters,
-    toApi: (params) => toApiParams(params),
-    fromApi: (api) => ({ ...defaultParameters, ...fromApiParams(api) }),
+    // A dynamic tool's mapper is typed against the union; narrow to this endpoint (sound - the
+    // runtime mapper produces this endpoint's model).
+    toApi: (params) => toApiParams(params) as ToolApiParams[E],
+    fromApi: (api) =>
+      ({
+        ...defaultParameters,
+        ...fromApiParams(api as ToolApiParams[CE]),
+      }) as TParams,
   };
 }

--- a/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.ts
+++ b/frontend/editor/src/core/hooks/tools/shared/toolOperationDescriptor.ts
@@ -1,35 +1,19 @@
 /**
- * A tool operation described as a typed, self-contained unit: its endpoint plus the two mappers
- * that convert between the tool's frontend parameter shape and the backend request model for that
- * endpoint. This is the single seam through which callers convert safely between the two parameter
- * models without ever touching `Record<string, unknown>` themselves.
- *
- * It is a thin, typed wrapper over the bidirectional mappers already declared on every tool's
- * `operationConfig` (`toApiParams` / `fromApiParams`), keeping the frontend<->backend mapping
- * single-sourced in the tools while binding it to the generated per-endpoint request model
- * ({@link ToolApiParams}).
+ * Typed wrapper over a tool's `toApiParams`/`fromApiParams` mappers, binding one endpoint to safe
+ * frontend<->backend parameter conversion.
  */
 
 import type { ToolApiParams, ToolEndpoint } from "@app/types/toolApiTypes";
 
-/** A tool operation with a known endpoint and type-safe conversion in both directions. */
 export interface ToolOperationDescriptor<E extends ToolEndpoint, TParams> {
-  /** The endpoint this operation calls — always known, as a literal. */
   readonly endpoint: E;
-  /** Complete default frontend parameters for the operation. */
   readonly defaultParameters: TParams;
-  /** Frontend params -> the backend request model for {@link endpoint}. */
   toApi(params: TParams): ToolApiParams[E];
-  /** Backend request model -> complete frontend params (defaults merged under the mapped values). */
+  /** Backend model -> full frontend params (defaults merged under the mapped values). */
   fromApi(api: ToolApiParams[E]): TParams;
 }
 
-/**
- * The subset of a tool's `operationConfig` this descriptor needs: the bidirectional mappers bound
- * to endpoint {@link E}, plus defaults. Structural (not the full config type) so `E` is inferred
- * from the `endpoint` argument and mismatched endpoint/config pairings are a compile error — a
- * config whose mappers target a different endpoint won't satisfy `ToolApiParams[E]`.
- */
+/** Structural subset of a tool's config; separate so `E` is inferred from the endpoint argument. */
 export interface BidirectionalToolConfig<TParams, E extends ToolEndpoint> {
   defaultParameters?: TParams;
   toApiParams?(params: TParams): ToolApiParams[E];
@@ -37,13 +21,8 @@ export interface BidirectionalToolConfig<TParams, E extends ToolEndpoint> {
 }
 
 /**
- * Build a {@link ToolOperationDescriptor} from a tool's operation config, pinned to `endpoint`.
- * The endpoint is passed explicitly (not read from `config.endpoint`) because dynamic-endpoint
- * tools declare `endpoint` as a function; passing the literal also binds `E` so the config's
- * mappers are checked against that endpoint's request model.
- *
- * Throws if the config lacks defaults or either mapper — a policy/pipeline tool must be able to
- * round-trip its parameters, so a missing mapper is a wiring error, not a runtime-recoverable state.
+ * Pin a config to `endpoint` (passed explicitly, since dynamic-endpoint tools declare `endpoint` as
+ * a function). Throws when the mappers or defaults are missing.
  */
 export function describeToolOperation<E extends ToolEndpoint, TParams>(
   endpoint: E,
@@ -52,8 +31,7 @@ export function describeToolOperation<E extends ToolEndpoint, TParams>(
   const { toApiParams, fromApiParams, defaultParameters } = config;
   if (!toApiParams || !fromApiParams || defaultParameters === undefined) {
     throw new Error(
-      `describeToolOperation: "${endpoint}" needs defaultParameters and both ` +
-        `toApiParams/fromApiParams mappers`,
+      `describeToolOperation: "${endpoint}" is missing mappers or defaults`,
     );
   }
   return {

--- a/frontend/editor/src/portal/api/policies.ts
+++ b/frontend/editor/src/portal/api/policies.ts
@@ -12,6 +12,8 @@
 import { apiClient } from "@portal/api/http";
 import { fromWirePolicy, toWirePolicy } from "@app/policies/codec";
 import { runsToActivity, runsToStats } from "@app/policies/runs";
+import { policyStep, type PolicyToolStep } from "@app/policies/operations";
+import type { ToolEndpoint } from "@app/types/toolApiTypes";
 import type {
   PolicyDecodedState,
   PolicyRunView,
@@ -65,7 +67,7 @@ export interface PolicyConfigDef {
   rules: string[];
   scopeLabel: string;
   fields: PolicyField[];
-  defaultOperations: WirePipelineStep[];
+  defaultOperations: PolicyToolStep[];
 }
 
 export interface PolicyState {
@@ -127,20 +129,15 @@ export interface CatalogueEntry {
 }
 
 /* ──────────────────────────────────────────────────────────────────────── */
-/*  Tool → endpoint registry                                                  */
+/*  Endpoint display labels                                                   */
 /* ──────────────────────────────────────────────────────────────────────── */
 
-export const TOOL_ENDPOINTS: Record<string, string> = {
-  redact: "/api/v1/security/auto-redact",
-  sanitize: "/api/v1/security/sanitize-pdf",
-  watermark: "/api/v1/security/add-watermark",
-  ocr: "/api/v1/misc/ocr-pdf",
-  flatten: "/api/v1/misc/flatten",
-  compress: "/api/v1/misc/compress-pdf",
-};
-
-/** Values are i18n keys — render with t(). */
-export const ENDPOINT_LABELS: Record<string, string> = {
+/**
+ * i18n keys for the endpoints policies call, keyed by the generated {@link ToolEndpoint} so a
+ * renamed/removed endpoint is a compile error here. Used to label stored steps (whose `operation`
+ * is the endpoint path) in the read-only detail view.
+ */
+export const ENDPOINT_LABELS: Partial<Record<ToolEndpoint, string>> = {
   "/api/v1/security/auto-redact": "portal.policies.endpoints.autoRedact",
   "/api/v1/security/sanitize-pdf": "portal.policies.endpoints.sanitizePdf",
   "/api/v1/security/add-watermark": "portal.policies.endpoints.addWatermark",
@@ -153,7 +150,8 @@ export function humanizeEndpoint(
   path: string,
   t: (key: string) => string,
 ): string {
-  if (ENDPOINT_LABELS[path]) return t(ENDPOINT_LABELS[path]);
+  const label = ENDPOINT_LABELS[path as ToolEndpoint];
+  if (label) return t(label);
   const last = path.split("/").filter(Boolean).pop() ?? path;
   return last
     .replace(/-/g, " ")
@@ -229,10 +227,7 @@ export const POLICY_CONFIG: Record<string, PolicyConfigDef> = {
       "portal.policies.config.ingestion.rules.3",
     ],
     scopeLabel: "portal.policies.config.scopeAll",
-    defaultOperations: [
-      { operation: TOOL_ENDPOINTS.ocr, parameters: {} },
-      { operation: TOOL_ENDPOINTS.flatten, parameters: {} },
-    ],
+    defaultOperations: [policyStep("ocr"), policyStep("flatten")],
     fields: [
       {
         label: "portal.policies.config.ingestion.fields.minConfidence",
@@ -259,32 +254,17 @@ export const POLICY_CONFIG: Record<string, PolicyConfigDef> = {
     ],
     scopeLabel: "portal.policies.config.scopeAll",
     defaultOperations: [
-      {
-        operation: TOOL_ENDPOINTS.redact,
-        parameters: {
-          mode: "automatic",
-          useRegex: true,
-          convertPDFToImage: true,
-          wordsToRedact: DEFAULT_PII_PATTERNS,
-        },
-      },
-      {
-        operation: TOOL_ENDPOINTS.sanitize,
-        parameters: {
-          removeJavaScript: true,
-          removeEmbeddedFiles: false,
-          removeMetadata: false,
-          removeLinks: false,
-          removeFonts: false,
-        },
-      },
-      {
-        operation: TOOL_ENDPOINTS.watermark,
-        // convertPDFToImage bakes the watermark in so it can't be stripped
-        parameters: {
-          convertPDFToImage: true,
-        },
-      },
+      // Redact ships with the high-risk PII regexes so it works out of the box; flatten-to-image
+      // so redacted text is truly removed, not just hidden behind a box.
+      policyStep("redact", {
+        useRegex: true,
+        convertPDFToImage: true,
+        wordsToRedact: DEFAULT_PII_PATTERNS,
+      }),
+      // Sanitize is fixed to JavaScript removal only (embedded files default on, so turn it off).
+      policyStep("sanitize", { removeEmbeddedFiles: false }),
+      // convertPDFToImage bakes the watermark in so it can't be stripped.
+      policyStep("watermark", { convertPDFToImage: true }),
     ],
     fields: [],
   },
@@ -296,10 +276,7 @@ export const POLICY_CONFIG: Record<string, PolicyConfigDef> = {
       "portal.policies.config.compliance.rules.2",
     ],
     scopeLabel: "portal.policies.config.scopeAll",
-    defaultOperations: [
-      { operation: TOOL_ENDPOINTS.sanitize, parameters: {} },
-      { operation: TOOL_ENDPOINTS.flatten, parameters: {} },
-    ],
+    defaultOperations: [policyStep("sanitize"), policyStep("flatten")],
     fields: [
       {
         label: "portal.policies.config.compliance.fields.frameworks",
@@ -342,7 +319,7 @@ export const POLICY_CONFIG: Record<string, PolicyConfigDef> = {
       "portal.policies.config.routing.rules.2",
     ],
     scopeLabel: "portal.policies.config.scopeAll",
-    defaultOperations: [{ operation: TOOL_ENDPOINTS.compress, parameters: {} }],
+    defaultOperations: [policyStep("compress")],
     fields: [
       {
         label: "portal.policies.config.routing.fields.destination",
@@ -373,7 +350,7 @@ export const POLICY_CONFIG: Record<string, PolicyConfigDef> = {
       "portal.policies.config.retention.rules.2",
     ],
     scopeLabel: "portal.policies.config.scopeAll",
-    defaultOperations: [{ operation: TOOL_ENDPOINTS.compress, parameters: {} }],
+    defaultOperations: [policyStep("compress")],
     fields: [
       {
         label: "portal.policies.config.retention.fields.keepFor",

--- a/frontend/editor/src/portal/api/policies.ts
+++ b/frontend/editor/src/portal/api/policies.ts
@@ -257,7 +257,7 @@ export const POLICY_CONFIG: Record<string, PolicyConfigDef> = {
         convertPDFToImage: true,
         wordsToRedact: DEFAULT_PII_PATTERNS,
       }),
-      // JavaScript removal only (embedded-files defaults on).
+      // JavaScript removal only; the tool enables removeEmbeddedFiles by default, so turn it off.
       policyStep("sanitize", { removeEmbeddedFiles: false }),
       // Bake in via image so it can't be stripped.
       policyStep("watermark", { convertPDFToImage: true }),

--- a/frontend/editor/src/portal/api/policies.ts
+++ b/frontend/editor/src/portal/api/policies.ts
@@ -132,11 +132,7 @@ export interface CatalogueEntry {
 /*  Endpoint display labels                                                   */
 /* ──────────────────────────────────────────────────────────────────────── */
 
-/**
- * i18n keys for the endpoints policies call, keyed by the generated {@link ToolEndpoint} so a
- * renamed/removed endpoint is a compile error here. Used to label stored steps (whose `operation`
- * is the endpoint path) in the read-only detail view.
- */
+/** i18n keys keyed by {@link ToolEndpoint}; labels stored steps in the detail view. */
 export const ENDPOINT_LABELS: Partial<Record<ToolEndpoint, string>> = {
   "/api/v1/security/auto-redact": "portal.policies.endpoints.autoRedact",
   "/api/v1/security/sanitize-pdf": "portal.policies.endpoints.sanitizePdf",
@@ -254,16 +250,15 @@ export const POLICY_CONFIG: Record<string, PolicyConfigDef> = {
     ],
     scopeLabel: "portal.policies.config.scopeAll",
     defaultOperations: [
-      // Redact ships with the high-risk PII regexes so it works out of the box; flatten-to-image
-      // so redacted text is truly removed, not just hidden behind a box.
+      // Flatten to image so redactions can't be lifted off.
       policyStep("redact", {
         useRegex: true,
         convertPDFToImage: true,
         wordsToRedact: DEFAULT_PII_PATTERNS,
       }),
-      // Sanitize is fixed to JavaScript removal only (embedded files default on, so turn it off).
+      // JavaScript removal only (embedded-files defaults on).
       policyStep("sanitize", { removeEmbeddedFiles: false }),
-      // convertPDFToImage bakes the watermark in so it can't be stripped.
+      // Bake in via image so it can't be stripped.
       policyStep("watermark", { convertPDFToImage: true }),
     ],
     fields: [],

--- a/frontend/editor/src/portal/components/policies/PolicySetupWizard.test.tsx
+++ b/frontend/editor/src/portal/components/policies/PolicySetupWizard.test.tsx
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fireEvent,
+  render as baseRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import { PolicySetupWizard } from "@portal/components/policies/PolicySetupWizard";
+import {
+  POLICY_CATEGORIES,
+  POLICY_CONFIG,
+  type CatalogueEntry,
+  type DecoratedPolicy,
+  type PolicySetupResult,
+  type PipelineStep,
+} from "@portal/api/policies";
+
+const render = (ui: Parameters<typeof baseRender>[0]) =>
+  baseRender(ui, { wrapper: MantineProvider });
+
+// Deterministic i18n: return the fallback when given, else the key. initReactI18next is stubbed
+// because the import graph pulls core/i18n.ts, which registers it as a plugin.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    // Second arg is a string fallback in some call sites and an interpolation object in others;
+    // only treat a string as the fallback.
+    t: (key: string, fallback?: unknown) =>
+      typeof fallback === "string" ? fallback : key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+  initReactI18next: { type: "3rdParty", init: vi.fn() },
+}));
+
+const fetchSources = vi.fn();
+vi.mock("@portal/api/sources", () => ({
+  fetchSources: () => fetchSources(),
+}));
+
+const CONTINUE = "portal.policies.wizard.actions.continue";
+const SAVE_CHANGES = "portal.policies.wizard.actions.saveChanges";
+const ENABLE = "portal.policies.wizard.actions.enablePolicy";
+
+const security = POLICY_CATEGORIES.find((c) => c.id === "security")!;
+const securityConfig = POLICY_CONFIG.security;
+
+function editEntry(steps: PipelineStep[]): CatalogueEntry {
+  const policy: DecoratedPolicy = {
+    category: security,
+    config: securityConfig,
+    state: {
+      configured: true,
+      status: "active",
+      sources: ["editor"],
+      scopeTypes: [],
+      reviewerEmail: "",
+      fieldValues: {},
+      runOn: "upload",
+      outputMode: "new_version",
+      outputName: "",
+      outputNamePosition: "suffix",
+      maxRetries: 0,
+      retryDelayMinutes: 0,
+      backendId: "pol-1",
+      isDefault: true,
+    },
+    steps,
+    stats: { enforced: 0, dataProcessed: "-", activeFor: "-" },
+    activity: [],
+  };
+  return { category: security, config: securityConfig, policy };
+}
+
+/** Advance the wizard from the workflow tab to the settings tab and submit. */
+async function submitWizard(saveLabel: string) {
+  fireEvent.click(await screen.findByRole("button", { name: CONTINUE }));
+  fireEvent.click(await screen.findByRole("button", { name: saveLabel }));
+}
+
+describe("PolicySetupWizard", () => {
+  beforeEach(() => {
+    fetchSources.mockResolvedValue({ sources: [] });
+  });
+
+  it("round-trips a saved step's backend params on edit", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const entry = editEntry([
+      {
+        operation: "/api/v1/security/auto-redact",
+        parameters: { listOfText: "foo\nbar", useRegex: true },
+      },
+    ]);
+
+    render(
+      <PolicySetupWizard entry={entry} onClose={vi.fn()} onSubmit={onSubmit} />,
+    );
+    await submitWizard(SAVE_CHANGES);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const result = onSubmit.mock.calls[0][1] as PolicySetupResult;
+    // Only the saved tool is enabled on edit, and its patterns survive the wire -> UI -> wire trip.
+    expect(result.steps).toEqual([
+      expect.objectContaining({
+        operation: "/api/v1/security/auto-redact",
+        parameters: expect.objectContaining({ listOfText: "foo\nbar" }),
+      }),
+    ]);
+  });
+
+  it("seeds the preset chain for a new policy (redact + sanitize on, watermark off)", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const entry: CatalogueEntry = {
+      category: security,
+      config: securityConfig,
+      policy: null,
+    };
+
+    render(
+      <PolicySetupWizard entry={entry} onClose={vi.fn()} onSubmit={onSubmit} />,
+    );
+    await submitWizard(ENABLE);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const result = onSubmit.mock.calls[0][1] as PolicySetupResult;
+    const endpoints = result.steps.map((s) => s.operation);
+    expect(endpoints).toEqual([
+      "/api/v1/security/auto-redact",
+      "/api/v1/security/sanitize-pdf",
+    ]);
+    // Redact carries the preset PII patterns as the backend's listOfText.
+    const redact = result.steps[0].parameters as { listOfText?: string };
+    expect(redact.listOfText).toBeTruthy();
+  });
+});

--- a/frontend/editor/src/portal/components/policies/PolicySetupWizard.tsx
+++ b/frontend/editor/src/portal/components/policies/PolicySetupWizard.tsx
@@ -13,23 +13,24 @@ import {
 } from "@app/ui";
 import { SettingsRow } from "@app/ui/SettingsRow";
 import {
-  TOOL_ENDPOINTS,
   humanizeEndpoint,
   type CatalogueEntry,
   type PipelineStep,
   type PolicySetupResult,
 } from "@portal/api/policies";
-import type { ToolRegistry, ToolRegistryEntry } from "@app/data/toolsTaxonomy";
 import {
-  deserializeToolStep,
-  serializeStepFromEndpoint,
-} from "@app/hooks/tools/shared/toolAutomation";
+  policyEndpoint,
+  policyStepFromWire,
+  policyStepToWire,
+  type PolicyParams,
+  type PolicyToolId,
+  type PolicyToolStep,
+} from "@app/policies/operations";
 import { fetchSources } from "@portal/api/sources";
 import { useAsync } from "@portal/hooks/useAsync";
 import { PolicyFieldRow } from "@portal/components/policies/PolicyFieldRow";
 import { policyIcon } from "@portal/components/policies/policyIcons";
 import { sourceTypeMeta } from "@portal/components/sources/sourceTypes";
-import { useToolRegistry } from "@app/contexts/ToolRegistryContext";
 import { PolicyRedactConfig } from "@app/components/policies/PolicyRedactConfig";
 import { PolicyWatermarkConfig } from "@app/components/policies/PolicyWatermarkConfig";
 import "@portal/views/Policies.css";
@@ -47,12 +48,11 @@ interface PolicySetupWizardProps {
 
 type Step = "workflow" | "settings";
 
-/** A configurable tool in the workflow step: whether it runs + its params. */
-interface ToolState {
-  operation: string;
-  enabled: boolean;
-  parameters: Record<string, unknown>;
-}
+/**
+ * A configurable tool in the workflow step: a typed policy step (tool id + its typed params) plus
+ * whether it runs. Discriminated on `toolId`, so `params` is always the right shape for the tool.
+ */
+type ToolState = PolicyToolStep & { enabled: boolean };
 
 /** Resolve each field's effective value: saved override, else definition default. */
 function resolveFieldValues(
@@ -69,9 +69,9 @@ function resolveFieldValues(
  * round-trips); otherwise the category preset's default chain. Each preset step
  * starts enabled — the user toggles tools off in the workflow.
  */
-// Temporary: tracks which tools start disabled until the tool registry lands in
-// the portal and can drive this via registry metadata or a defaultEnabled flag.
-const DISABLED_BY_DEFAULT = new Set(["/api/v1/security/add-watermark"]);
+// Temporary: tracks which tools start disabled until the catalogue can drive this via
+// a defaultEnabled flag.
+const DISABLED_BY_DEFAULT = new Set<PolicyToolId>(["watermark"]);
 
 /**
  * Policy-facing framing for each capability a policy can include. Labels and
@@ -81,43 +81,43 @@ const DISABLED_BY_DEFAULT = new Set(["/api/v1/security/add-watermark"]);
  * the humanised endpoint name with no description.
  */
 const CAPABILITY_META: Record<
-  string,
+  PolicyToolId,
   { labelKey: string; labelEn: string; descKey: string; descEn: string }
 > = {
-  [TOOL_ENDPOINTS.redact]: {
+  redact: {
     labelKey: "portal.policies.wizard.capability.redact.label",
     labelEn: "Redact sensitive information",
     descKey: "portal.policies.wizard.capability.redact.desc",
     descEn:
       "Finds and blacks out sensitive details — like Social Security and card numbers — so they can't be read.",
   },
-  [TOOL_ENDPOINTS.sanitize]: {
+  sanitize: {
     labelKey: "portal.policies.wizard.capability.sanitize.label",
     labelEn: "Strip active content",
     descKey: "portal.policies.wizard.capability.sanitize.desc",
     descEn:
       "Removes hidden JavaScript so nothing can run automatically when the document is opened.",
   },
-  [TOOL_ENDPOINTS.watermark]: {
+  watermark: {
     labelKey: "portal.policies.wizard.capability.watermark.label",
     labelEn: "Apply a watermark",
     descKey: "portal.policies.wizard.capability.watermark.desc",
     descEn: "Stamps a visible mark (e.g. “Confidential”) across every page.",
   },
-  [TOOL_ENDPOINTS.ocr]: {
+  ocr: {
     labelKey: "portal.policies.wizard.capability.ocr.label",
     labelEn: "Make text searchable",
     descKey: "portal.policies.wizard.capability.ocr.desc",
     descEn: "Runs OCR so scanned pages become selectable, searchable text.",
   },
-  [TOOL_ENDPOINTS.flatten]: {
+  flatten: {
     labelKey: "portal.policies.wizard.capability.flatten.label",
     labelEn: "Flatten the document",
     descKey: "portal.policies.wizard.capability.flatten.desc",
     descEn:
       "Merges form fields and annotations into the page so they can't be edited.",
   },
-  [TOOL_ENDPOINTS.compress]: {
+  compress: {
     labelKey: "portal.policies.wizard.capability.compress.label",
     labelEn: "Reduce file size",
     descKey: "portal.policies.wizard.capability.compress.desc",
@@ -125,29 +125,26 @@ const CAPABILITY_META: Record<
   },
 };
 
-function seedTools(
-  entry: CatalogueEntry,
-  registry: Partial<ToolRegistry>,
-): ToolState[] {
+function seedTools(entry: CatalogueEntry): ToolState[] {
   const savedSteps = entry.policy?.steps ?? [];
-  const savedByOp = new Map(savedSteps.map((s) => [s.operation, s]));
+  // Saved steps are backend wire steps; decode each to a typed policy step, keyed by tool id.
+  const savedByTool = new Map<PolicyToolId, PolicyToolStep>();
+  for (const wire of savedSteps) {
+    const step = policyStepFromWire(wire);
+    if (step) savedByTool.set(step.toolId, step);
+  }
   // Always use defaultOperations as the canonical list so tools added after a
-  // policy was first saved still appear when editing.
-  return entry.config.defaultOperations.map((s) => {
-    const saved = savedByOp.get(s.operation);
+  // policy was first saved still appear when editing. A saved step's params win
+  // (so editing round-trips); otherwise the preset's typed defaults.
+  return entry.config.defaultOperations.map((preset) => {
+    const saved = savedByTool.get(preset.toolId);
     return {
-      operation: s.operation,
+      ...(saved ?? preset),
       enabled: saved
         ? true
         : savedSteps.length > 0
           ? false
-          : !DISABLED_BY_DEFAULT.has(s.operation),
-      // Saved steps are in the backend contract shape; map them back to the UI
-      // shape the config controls edit (e.g. `listOfText` -> `wordsToRedact`).
-      // Presets are already authored in the UI shape, so use them as-is.
-      parameters: saved
-        ? deserializeToolStep(saved, registry).params
-        : s.parameters,
+          : !DISABLED_BY_DEFAULT.has(preset.toolId),
     };
   });
 }
@@ -185,26 +182,12 @@ function PolicySetupWizardBody({
   onSubmit: (entry: CatalogueEntry, result: PolicySetupResult) => Promise<void>;
 }) {
   const { t } = useTranslation();
-  const { allTools: toolRegistry } = useToolRegistry();
-
-  // Portal tool operations are endpoint paths (/api/v1/…), not short registry IDs.
-  // Build a reverse map so we can look up icons and display names by endpoint.
-  const registryByEndpoint = useMemo(() => {
-    const map = new Map<string, ToolRegistryEntry>();
-    for (const entry of Object.values(toolRegistry)) {
-      const ep = (entry as ToolRegistryEntry).operationConfig?.endpoint;
-      if (typeof ep === "string") map.set(ep, entry as ToolRegistryEntry);
-    }
-    return map;
-  }, [toolRegistry]);
 
   const { category, config, policy } = entry;
   const isEdit = policy != null;
 
   const [step, setStep] = useState<Step>("workflow");
-  const [tools, setTools] = useState<ToolState[]>(() =>
-    seedTools(entry, toolRegistry),
-  );
+  const [tools, setTools] = useState<ToolState[]>(() => seedTools(entry));
   const [fieldValues, setFieldValues] = useState(() =>
     resolveFieldValues(entry),
   );
@@ -256,9 +239,20 @@ function PolicySetupWizardBody({
 
   const enabledTools = useMemo(() => tools.filter((tl) => tl.enabled), [tools]);
 
-  function patchTool(operation: string, patch: Partial<ToolState>) {
+  function setToolEnabled(toolId: PolicyToolId, enabled: boolean) {
     setTools((prev) =>
-      prev.map((tl) => (tl.operation === operation ? { ...tl, ...patch } : tl)),
+      prev.map((tl) => (tl.toolId === toolId ? { ...tl, enabled } : tl)),
+    );
+  }
+
+  function setToolParams<Id extends PolicyToolId>(
+    toolId: Id,
+    params: PolicyParams<Id>,
+  ) {
+    setTools((prev) =>
+      prev.map((tl) =>
+        tl.toolId === toolId ? ({ ...tl, params } as ToolState) : tl,
+      ),
     );
   }
 
@@ -277,11 +271,10 @@ function PolicySetupWizardBody({
     }
     setError(null);
     setSubmitting(true);
-    // Map each tool's UI-shaped params (e.g. redact's `wordsToRedact`) into the
-    // backend step contract (e.g. `listOfText`) via its `toApiParams`; saving the
-    // UI shape verbatim would drop those fields and the step would run with none.
+    // Map each typed policy step to its backend wire step (frontend params ->
+    // the endpoint's request model) via the tool's descriptor.
     const steps: PipelineStep[] = enabledTools.map((tl) =>
-      serializeStepFromEndpoint(tl.operation, tl.parameters, toolRegistry),
+      policyStepToWire(tl),
     );
     try {
       await onSubmit(entry, {
@@ -386,20 +379,16 @@ function PolicySetupWizardBody({
           <Card padding="none">
             <div className="portal-policies__capabilities">
               {tools.map((tl) => {
-                const meta = CAPABILITY_META[tl.operation];
+                const meta = CAPABILITY_META[tl.toolId];
                 const label = meta
                   ? t(meta.labelKey, meta.labelEn)
-                  : (registryByEndpoint.get(tl.operation)?.name ??
-                    humanizeEndpoint(tl.operation, t));
+                  : humanizeEndpoint(policyEndpoint(tl.toolId), t);
                 const description = meta
                   ? t(meta.descKey, meta.descEn)
                   : undefined;
-                const hasConfig =
-                  tl.operation === TOOL_ENDPOINTS.redact ||
-                  tl.operation === TOOL_ENDPOINTS.watermark;
                 return (
                   <div
-                    key={tl.operation}
+                    key={tl.toolId}
                     className="portal-policies__capability"
                     data-on={tl.enabled || undefined}
                   >
@@ -411,27 +400,27 @@ function PolicySetupWizardBody({
                           size="sm"
                           checked={tl.enabled}
                           onChange={(checked) =>
-                            patchTool(tl.operation, { enabled: checked })
+                            setToolEnabled(tl.toolId, checked)
                           }
                           label=""
                         />
                       }
                     />
-                    {tl.enabled && hasConfig && (
+                    {tl.enabled && (
                       <div className="portal-policies__capability-config">
-                        {tl.operation === TOOL_ENDPOINTS.redact && (
+                        {tl.toolId === "redact" && (
                           <PolicyRedactConfig
-                            parameters={tl.parameters}
-                            onChange={(parameters) =>
-                              patchTool(tl.operation, { parameters })
+                            parameters={tl.params}
+                            onChange={(params) =>
+                              setToolParams("redact", params)
                             }
                           />
                         )}
-                        {tl.operation === TOOL_ENDPOINTS.watermark && (
+                        {tl.toolId === "watermark" && (
                           <PolicyWatermarkConfig
-                            parameters={tl.parameters}
-                            onChange={(parameters) =>
-                              patchTool(tl.operation, { parameters })
+                            parameters={tl.params}
+                            onChange={(params) =>
+                              setToolParams("watermark", params)
                             }
                           />
                         )}

--- a/frontend/editor/src/portal/components/policies/PolicySetupWizard.tsx
+++ b/frontend/editor/src/portal/components/policies/PolicySetupWizard.tsx
@@ -48,10 +48,7 @@ interface PolicySetupWizardProps {
 
 type Step = "workflow" | "settings";
 
-/**
- * A configurable tool in the workflow step: a typed policy step (tool id + its typed params) plus
- * whether it runs. Discriminated on `toolId`, so `params` is always the right shape for the tool.
- */
+/** A policy step plus whether it runs. */
 type ToolState = PolicyToolStep & { enabled: boolean };
 
 /** Resolve each field's effective value: saved override, else definition default. */
@@ -69,8 +66,7 @@ function resolveFieldValues(
  * round-trips); otherwise the category preset's default chain. Each preset step
  * starts enabled — the user toggles tools off in the workflow.
  */
-// Temporary: tracks which tools start disabled until the catalogue can drive this via
-// a defaultEnabled flag.
+// Temporary until the catalogue carries a defaultEnabled flag.
 const DISABLED_BY_DEFAULT = new Set<PolicyToolId>(["watermark"]);
 
 /**
@@ -127,15 +123,13 @@ const CAPABILITY_META: Record<
 
 function seedTools(entry: CatalogueEntry): ToolState[] {
   const savedSteps = entry.policy?.steps ?? [];
-  // Saved steps are backend wire steps; decode each to a typed policy step, keyed by tool id.
   const savedByTool = new Map<PolicyToolId, PolicyToolStep>();
   for (const wire of savedSteps) {
     const step = policyStepFromWire(wire);
     if (step) savedByTool.set(step.toolId, step);
   }
-  // Always use defaultOperations as the canonical list so tools added after a
-  // policy was first saved still appear when editing. A saved step's params win
-  // (so editing round-trips); otherwise the preset's typed defaults.
+  // defaultOperations is the canonical list (so tools added later still show on edit); a saved
+  // step's params win over the preset.
   return entry.config.defaultOperations.map((preset) => {
     const saved = savedByTool.get(preset.toolId);
     return {
@@ -271,8 +265,6 @@ function PolicySetupWizardBody({
     }
     setError(null);
     setSubmitting(true);
-    // Map each typed policy step to its backend wire step (frontend params ->
-    // the endpoint's request model) via the tool's descriptor.
     const steps: PipelineStep[] = enabledTools.map((tl) =>
       policyStepToWire(tl),
     );

--- a/frontend/editor/src/portal/mocks/policies.ts
+++ b/frontend/editor/src/portal/mocks/policies.ts
@@ -4,12 +4,33 @@
  * only builds seed data for the MSW handlers and tests.
  */
 
-import type { PolicyRunView, WirePolicy } from "@app/policies/types";
-import { POLICY_CONFIG } from "@portal/api/policies";
+import type {
+  PolicyRunView,
+  WirePipelineStep,
+  WirePolicy,
+} from "@app/policies/types";
 
 /* ──────────────────────────────────────────────────────────────────────── */
 /*  Seed data — real backend wire format                                      */
 /* ──────────────────────────────────────────────────────────────────────── */
+
+// Backend-shaped steps for the seeded Security policy (redact PII + strip JavaScript), mirroring
+// what the security preset persists. Written as literal wire steps so this fixtures module stays
+// independent of the live typed catalogue (@portal/api/policies) and its tool-operation graph.
+const SECURITY_STEPS: WirePipelineStep[] = [
+  {
+    operation: "/api/v1/security/auto-redact",
+    parameters: {
+      listOfText: "",
+      useRegex: true,
+      convertPDFToImage: true,
+    },
+  },
+  {
+    operation: "/api/v1/security/sanitize-pdf",
+    parameters: { removeJavaScript: true },
+  },
+];
 
 export function seedPolicies(): WirePolicy[] {
   return [
@@ -19,7 +40,7 @@ export function seedPolicies(): WirePolicy[] {
       owner: "security@acme.com",
       enabled: true,
       trigger: null,
-      steps: POLICY_CONFIG.security.defaultOperations,
+      steps: SECURITY_STEPS,
       output: {
         type: "inline",
         options: {

--- a/frontend/editor/src/portal/mocks/policies.ts
+++ b/frontend/editor/src/portal/mocks/policies.ts
@@ -14,9 +14,8 @@ import type {
 /*  Seed data — real backend wire format                                      */
 /* ──────────────────────────────────────────────────────────────────────── */
 
-// Backend-shaped steps for the seeded Security policy (redact PII + strip JavaScript), mirroring
-// what the security preset persists. Written as literal wire steps so this fixtures module stays
-// independent of the live typed catalogue (@portal/api/policies) and its tool-operation graph.
+// Literal wire steps (not derived from the catalogue) so this fixtures module stays independent of
+// @portal/api/policies and its heavy tool-operation import graph.
 const SECURITY_STEPS: WirePipelineStep[] = [
   {
     operation: "/api/v1/security/auto-redact",

--- a/frontend/editor/src/proprietary/components/policies/PolicyPiiField.tsx
+++ b/frontend/editor/src/proprietary/components/policies/PolicyPiiField.tsx
@@ -1,6 +1,7 @@
 import { MultiSelect } from "@app/ui/MultiSelect";
 import { useTranslation } from "react-i18next";
 import { PII_PRESETS } from "@app/data/policyDefinitions";
+import type { RedactParameters } from "@app/hooks/tools/redact/useRedactParameters";
 
 /** The set of preset regexes — used to separate preset words from custom ones. */
 export const PRESET_PATTERNS = new Set(PII_PRESETS.map((p) => p.pattern));
@@ -8,8 +9,8 @@ const PATTERN_BY_VALUE = new Map(PII_PRESETS.map((p) => [p.value, p.pattern]));
 const VALUE_BY_PATTERN = new Map(PII_PRESETS.map((p) => [p.pattern, p.value]));
 
 interface PolicyPiiFieldProps {
-  parameters: Record<string, unknown>;
-  onChange: (parameters: Record<string, unknown>) => void;
+  parameters: RedactParameters;
+  onChange: (parameters: RedactParameters) => void;
   disabled?: boolean;
 }
 
@@ -26,9 +27,7 @@ export function PolicyPiiField({
   disabled,
 }: PolicyPiiFieldProps) {
   const { t } = useTranslation();
-  const words = Array.isArray(parameters.wordsToRedact)
-    ? (parameters.wordsToRedact as string[])
-    : [];
+  const words = parameters.wordsToRedact;
   const selected = words
     .map((w) => VALUE_BY_PATTERN.get(w))
     .filter((v): v is string => Boolean(v));

--- a/frontend/editor/src/proprietary/components/policies/PolicyRedactConfig.tsx
+++ b/frontend/editor/src/proprietary/components/policies/PolicyRedactConfig.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import { PolicyPiiField } from "@app/components/policies/PolicyPiiField";
+import type { RedactParameters } from "@app/hooks/tools/redact/useRedactParameters";
 
 interface PolicyRedactConfigProps {
-  parameters: Record<string, unknown>;
-  onChange: (parameters: Record<string, unknown>) => void;
+  parameters: RedactParameters;
+  onChange: (parameters: RedactParameters) => void;
   disabled?: boolean;
 }
 

--- a/frontend/editor/src/proprietary/components/policies/PolicyWatermarkConfig.tsx
+++ b/frontend/editor/src/proprietary/components/policies/PolicyWatermarkConfig.tsx
@@ -3,8 +3,8 @@ import AddWatermarkSingleStepSettings from "@app/components/tools/addWatermark/A
 import type { AddWatermarkParameters } from "@app/hooks/tools/addWatermark/useAddWatermarkParameters";
 
 interface PolicyWatermarkConfigProps {
-  parameters: Record<string, unknown>;
-  onChange: (parameters: Record<string, unknown>) => void;
+  parameters: AddWatermarkParameters;
+  onChange: (parameters: AddWatermarkParameters) => void;
   disabled?: boolean;
 }
 
@@ -20,7 +20,7 @@ export function PolicyWatermarkConfig({
   disabled,
 }: PolicyWatermarkConfigProps) {
   useEffect(() => {
-    const patch: Record<string, unknown> = {};
+    const patch: Partial<AddWatermarkParameters> = {};
     if (parameters.convertPDFToImage !== true) patch.convertPDFToImage = true;
     // Policies only support text watermarks.
     if (parameters.watermarkType !== "text") patch.watermarkType = "text";
@@ -29,7 +29,7 @@ export function PolicyWatermarkConfig({
 
   return (
     <AddWatermarkSingleStepSettings
-      parameters={parameters as unknown as AddWatermarkParameters}
+      parameters={parameters}
       onParameterChange={(key, value) =>
         onChange({ ...parameters, [key]: value })
       }

--- a/frontend/editor/src/proprietary/policies/operations.test.ts
+++ b/frontend/editor/src/proprietary/policies/operations.test.ts
@@ -54,10 +54,10 @@ describe("policyStep", () => {
       wordsToRedact: ["ssn", "card"],
     });
     expect(step.toolId).toBe("redact");
-    // Overrides applied…
+    // Overrides applied...
     expect(step.params.useRegex).toBe(true);
     expect(step.params.wordsToRedact).toEqual(["ssn", "card"]);
-    // …and untouched fields fall back to the tool's defaults.
+    // ...and untouched fields fall back to the tool's defaults.
     expect(step.params.mode).toBe("automatic");
     expect(step.params.redactColor).toBe("#000000");
   });

--- a/frontend/editor/src/proprietary/policies/operations.test.ts
+++ b/frontend/editor/src/proprietary/policies/operations.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+import {
+  POLICY_OPERATIONS,
+  policyEndpoint,
+  policyStep,
+  policyStepFromWire,
+  policyStepToWire,
+  policyToolIdForEndpoint,
+  type PolicyToolId,
+} from "@app/policies/operations";
+
+const ALL_TOOL_IDS = Object.keys(POLICY_OPERATIONS) as PolicyToolId[];
+
+describe("POLICY_OPERATIONS", () => {
+  test("every category operation is a typed descriptor with a known endpoint", () => {
+    // The catalogue uses these six across all categories; each must be wired.
+    expect(ALL_TOOL_IDS.sort()).toEqual([
+      "compress",
+      "flatten",
+      "ocr",
+      "redact",
+      "sanitize",
+      "watermark",
+    ]);
+    for (const id of ALL_TOOL_IDS) {
+      expect(POLICY_OPERATIONS[id].endpoint).toBe(policyEndpoint(id));
+      expect(typeof POLICY_OPERATIONS[id].toApi).toBe("function");
+      expect(typeof POLICY_OPERATIONS[id].fromApi).toBe("function");
+    }
+  });
+
+  test("policyEndpoint returns the pinned endpoint literal", () => {
+    expect(policyEndpoint("redact")).toBe("/api/v1/security/auto-redact");
+    expect(policyEndpoint("sanitize")).toBe("/api/v1/security/sanitize-pdf");
+    expect(policyEndpoint("watermark")).toBe("/api/v1/security/add-watermark");
+    expect(policyEndpoint("ocr")).toBe("/api/v1/misc/ocr-pdf");
+    expect(policyEndpoint("flatten")).toBe("/api/v1/misc/flatten");
+    expect(policyEndpoint("compress")).toBe("/api/v1/misc/compress-pdf");
+  });
+
+  test("policyToolIdForEndpoint maps endpoints back, and rejects non-policy ones", () => {
+    for (const id of ALL_TOOL_IDS) {
+      expect(policyToolIdForEndpoint(policyEndpoint(id))).toBe(id);
+    }
+    expect(policyToolIdForEndpoint("/api/v1/misc/repair")).toBeNull();
+    expect(policyToolIdForEndpoint("not-an-endpoint")).toBeNull();
+  });
+});
+
+describe("policyStep", () => {
+  test("merges partial params over the tool's defaults", () => {
+    const step = policyStep("redact", {
+      useRegex: true,
+      wordsToRedact: ["ssn", "card"],
+    });
+    expect(step.toolId).toBe("redact");
+    // Overrides applied…
+    expect(step.params.useRegex).toBe(true);
+    expect(step.params.wordsToRedact).toEqual(["ssn", "card"]);
+    // …and untouched fields fall back to the tool's defaults.
+    expect(step.params.mode).toBe("automatic");
+    expect(step.params.redactColor).toBe("#000000");
+  });
+});
+
+describe("wire conversion", () => {
+  test("redact maps frontend params to the backend request model (wordsToRedact -> listOfText)", () => {
+    const wire = policyStepToWire(
+      policyStep("redact", {
+        useRegex: true,
+        convertPDFToImage: true,
+        wordsToRedact: ["ssn", "card"],
+      }),
+    );
+    expect(wire.operation).toBe("/api/v1/security/auto-redact");
+    // The backend field the endpoint actually reads, and no frontend-only `mode`/`wordsToRedact`.
+    expect(wire.parameters).toMatchObject({
+      listOfText: "ssn\ncard",
+      useRegex: true,
+      convertPDFToImage: true,
+    });
+    expect(wire.parameters).not.toHaveProperty("wordsToRedact");
+    expect(wire.parameters).not.toHaveProperty("mode");
+  });
+
+  test("every policy operation round-trips through wire and back", () => {
+    for (const id of ALL_TOOL_IDS) {
+      const step = policyStep(id);
+      const back = policyStepFromWire(policyStepToWire(step));
+      expect(back?.toolId).toBe(id);
+    }
+  });
+
+  test("redact round-trip preserves the configured patterns", () => {
+    const step = policyStep("redact", {
+      useRegex: true,
+      wordsToRedact: ["ssn", "card"],
+    });
+    const back = policyStepFromWire(policyStepToWire(step));
+    expect(back?.toolId).toBe("redact");
+    if (back?.toolId === "redact") {
+      expect(back.params.wordsToRedact).toEqual(["ssn", "card"]);
+      expect(back.params.useRegex).toBe(true);
+    }
+  });
+
+  test("a non-policy endpoint decodes to null", () => {
+    expect(
+      policyStepFromWire({ operation: "/api/v1/misc/repair", parameters: {} }),
+    ).toBeNull();
+  });
+});

--- a/frontend/editor/src/proprietary/policies/operations.ts
+++ b/frontend/editor/src/proprietary/policies/operations.ts
@@ -1,0 +1,162 @@
+/**
+ * The fixed set of tool operations the Policies feature can run, each as a typed
+ * {@link ToolOperationDescriptor}. This is the type-safe source of truth the Policies catalogue,
+ * setup wizard, and wire conversion all build on: every operation here has a known endpoint, a
+ * typed frontend parameter model, and safe conversion to/from its backend request model.
+ *
+ * Covers every operation the Policies frontend uses today (across all categories):
+ * redact + sanitize + watermark (security), ocr + flatten (ingestion/compliance),
+ * compress (routing/retention). Adding a category operation means adding it here — the catalogue
+ * cannot reference an operation that isn't typed.
+ */
+
+import { describeToolOperation } from "@app/hooks/tools/shared/toolOperationDescriptor";
+import { redactOperationConfig } from "@app/hooks/tools/redact/useRedactOperation";
+import { sanitizeOperationConfig } from "@app/hooks/tools/sanitize/useSanitizeOperation";
+import { addWatermarkOperationConfig } from "@app/hooks/tools/addWatermark/useAddWatermarkOperation";
+import { ocrOperationConfig } from "@app/hooks/tools/ocr/useOCROperation";
+import { flattenOperationConfig } from "@app/hooks/tools/flatten/useFlattenOperation";
+import { compressOperationConfig } from "@app/hooks/tools/compress/useCompressOperation";
+import type { ToolOperationDescriptor } from "@app/hooks/tools/shared/toolOperationDescriptor";
+import type { ToolApiParams, ToolEndpoint } from "@app/types/toolApiTypes";
+import type { WirePipelineStep } from "@app/policies/types";
+
+/**
+ * Typed descriptor per policy tool. The key is the policy-facing tool id; the endpoint literal is
+ * pinned here (redact resolves its endpoint dynamically, so it must be given explicitly).
+ */
+export const POLICY_OPERATIONS = {
+  redact: describeToolOperation(
+    "/api/v1/security/auto-redact",
+    redactOperationConfig,
+  ),
+  sanitize: describeToolOperation(
+    "/api/v1/security/sanitize-pdf",
+    sanitizeOperationConfig,
+  ),
+  watermark: describeToolOperation(
+    "/api/v1/security/add-watermark",
+    addWatermarkOperationConfig,
+  ),
+  ocr: describeToolOperation("/api/v1/misc/ocr-pdf", ocrOperationConfig),
+  flatten: describeToolOperation(
+    "/api/v1/misc/flatten",
+    flattenOperationConfig,
+  ),
+  compress: describeToolOperation(
+    "/api/v1/misc/compress-pdf",
+    compressOperationConfig,
+  ),
+} as const;
+
+/** A policy tool id — the key of a typed operation in {@link POLICY_OPERATIONS}. */
+export type PolicyToolId = keyof typeof POLICY_OPERATIONS;
+
+/** The frontend parameter model for a given policy tool. */
+export type PolicyParams<Id extends PolicyToolId> =
+  (typeof POLICY_OPERATIONS)[Id] extends ToolOperationDescriptor<
+    ToolEndpoint,
+    infer P
+  >
+    ? P
+    : never;
+
+/**
+ * A configured policy step: a tool id paired with that tool's typed parameters. A discriminated
+ * union over {@link PolicyToolId} so `params` is always the right shape for `toolId`.
+ */
+export type PolicyToolStep = {
+  [Id in PolicyToolId]: { toolId: Id; params: PolicyParams<Id> };
+}[PolicyToolId];
+
+/** A policy step narrowed to a single tool id. */
+export type PolicyToolStepOf<Id extends PolicyToolId> = Extract<
+  PolicyToolStep,
+  { toolId: Id }
+>;
+
+const POLICY_TOOL_IDS = Object.keys(POLICY_OPERATIONS) as PolicyToolId[];
+
+const TOOL_ID_BY_ENDPOINT = new Map<string, PolicyToolId>(
+  POLICY_TOOL_IDS.map((id) => [POLICY_OPERATIONS[id].endpoint, id]),
+);
+
+/** The endpoint a policy tool calls (a generated {@link ToolEndpoint} literal). */
+export function policyEndpoint(toolId: PolicyToolId): ToolEndpoint {
+  return POLICY_OPERATIONS[toolId].endpoint;
+}
+
+/** Map a stored step's endpoint path back to its policy tool id, or null if it isn't a policy tool. */
+export function policyToolIdForEndpoint(endpoint: string): PolicyToolId | null {
+  return TOOL_ID_BY_ENDPOINT.get(endpoint) ?? null;
+}
+
+/**
+ * Build a policy step for `toolId`, merging the given partial params over the tool's defaults so
+ * the result is always complete. Params are checked against the tool's frontend model, so a typo
+ * or wrong-typed field is a compile error (not a value silently dropped at the backend).
+ */
+export function policyStep<Id extends PolicyToolId>(
+  toolId: Id,
+  params: Partial<PolicyParams<Id>> = {},
+): PolicyToolStepOf<Id> {
+  const defaults = POLICY_OPERATIONS[toolId].defaultParameters as object;
+  return {
+    toolId,
+    params: { ...defaults, ...(params as object) },
+  } as PolicyToolStepOf<Id>;
+}
+
+/**
+ * Serialize a typed policy step to the backend wire step, mapping frontend params to the endpoint's
+ * request model via the tool's `toApi`. This is the single frontend->backend boundary for policies.
+ */
+export function policyStepToWire(step: PolicyToolStep): WirePipelineStep {
+  return serializeStep(step);
+}
+
+// Generic over the tool id to keep params correlated at the call sites. TypeScript can't correlate
+// the indexed descriptor with the indexed params through a single generic, so `op` is widened to a
+// same-params descriptor here — a contained cast at the (untyped) wire boundary.
+function serializeStep<Id extends PolicyToolId>(step: {
+  toolId: Id;
+  params: PolicyParams<Id>;
+}): WirePipelineStep {
+  const op = POLICY_OPERATIONS[step.toolId] as ToolOperationDescriptor<
+    ToolEndpoint,
+    PolicyParams<Id>
+  >;
+  return {
+    operation: op.endpoint,
+    parameters: op.toApi(step.params) as Record<string, unknown>,
+  };
+}
+
+/**
+ * Rehydrate a stored wire step into a typed policy step via the tool's `fromApi`, or null if the
+ * endpoint isn't a policy tool. This is the single backend->frontend boundary for policies; the one
+ * cast lives here because wire parameters are untyped JSON from the backend.
+ */
+export function policyStepFromWire(
+  wire: WirePipelineStep,
+): PolicyToolStep | null {
+  const toolId = policyToolIdForEndpoint(wire.operation);
+  if (!toolId) return null;
+  return deserializeStep(toolId, wire.parameters);
+}
+
+function deserializeStep<Id extends PolicyToolId>(
+  toolId: Id,
+  parameters: Record<string, unknown>,
+): PolicyToolStepOf<Id> {
+  const op = POLICY_OPERATIONS[toolId] as ToolOperationDescriptor<
+    ToolEndpoint,
+    PolicyParams<Id>
+  >;
+  // Wire parameters are untyped JSON from the backend; this cast is the single point where they
+  // enter the typed model, after which `fromApi` maps them to the tool's frontend params.
+  const params = op.fromApi(
+    parameters as unknown as ToolApiParams[ToolEndpoint],
+  );
+  return { toolId, params } as unknown as PolicyToolStepOf<Id>;
+}

--- a/frontend/editor/src/proprietary/policies/operations.ts
+++ b/frontend/editor/src/proprietary/policies/operations.ts
@@ -1,13 +1,7 @@
 /**
- * The fixed set of tool operations the Policies feature can run, each as a typed
- * {@link ToolOperationDescriptor}. This is the type-safe source of truth the Policies catalogue,
- * setup wizard, and wire conversion all build on: every operation here has a known endpoint, a
- * typed frontend parameter model, and safe conversion to/from its backend request model.
- *
- * Covers every operation the Policies frontend uses today (across all categories):
- * redact + sanitize + watermark (security), ocr + flatten (ingestion/compliance),
- * compress (routing/retention). Adding a category operation means adding it here — the catalogue
- * cannot reference an operation that isn't typed.
+ * The tool operations the Policies feature can run, each a typed {@link ToolOperationDescriptor}.
+ * Source of truth for the catalogue, wizard, and wire conversion. Add a tool here to use it in a
+ * policy - the catalogue can't reference an untyped operation.
  */
 
 import { describeToolOperation } from "@app/hooks/tools/shared/toolOperationDescriptor";
@@ -21,10 +15,6 @@ import type { ToolOperationDescriptor } from "@app/hooks/tools/shared/toolOperat
 import type { ToolApiParams, ToolEndpoint } from "@app/types/toolApiTypes";
 import type { WirePipelineStep } from "@app/policies/types";
 
-/**
- * Typed descriptor per policy tool. The key is the policy-facing tool id; the endpoint literal is
- * pinned here (redact resolves its endpoint dynamically, so it must be given explicitly).
- */
 export const POLICY_OPERATIONS = {
   redact: describeToolOperation(
     "/api/v1/security/auto-redact",
@@ -49,10 +39,8 @@ export const POLICY_OPERATIONS = {
   ),
 } as const;
 
-/** A policy tool id — the key of a typed operation in {@link POLICY_OPERATIONS}. */
 export type PolicyToolId = keyof typeof POLICY_OPERATIONS;
 
-/** The frontend parameter model for a given policy tool. */
 export type PolicyParams<Id extends PolicyToolId> =
   (typeof POLICY_OPERATIONS)[Id] extends ToolOperationDescriptor<
     ToolEndpoint,
@@ -61,15 +49,11 @@ export type PolicyParams<Id extends PolicyToolId> =
     ? P
     : never;
 
-/**
- * A configured policy step: a tool id paired with that tool's typed parameters. A discriminated
- * union over {@link PolicyToolId} so `params` is always the right shape for `toolId`.
- */
+/** Discriminated on `toolId` so `params` matches the tool. */
 export type PolicyToolStep = {
   [Id in PolicyToolId]: { toolId: Id; params: PolicyParams<Id> };
 }[PolicyToolId];
 
-/** A policy step narrowed to a single tool id. */
 export type PolicyToolStepOf<Id extends PolicyToolId> = Extract<
   PolicyToolStep,
   { toolId: Id }
@@ -81,21 +65,16 @@ const TOOL_ID_BY_ENDPOINT = new Map<string, PolicyToolId>(
   POLICY_TOOL_IDS.map((id) => [POLICY_OPERATIONS[id].endpoint, id]),
 );
 
-/** The endpoint a policy tool calls (a generated {@link ToolEndpoint} literal). */
 export function policyEndpoint(toolId: PolicyToolId): ToolEndpoint {
   return POLICY_OPERATIONS[toolId].endpoint;
 }
 
-/** Map a stored step's endpoint path back to its policy tool id, or null if it isn't a policy tool. */
+/** Tool id for an endpoint path, or null if it isn't a policy tool. */
 export function policyToolIdForEndpoint(endpoint: string): PolicyToolId | null {
   return TOOL_ID_BY_ENDPOINT.get(endpoint) ?? null;
 }
 
-/**
- * Build a policy step for `toolId`, merging the given partial params over the tool's defaults so
- * the result is always complete. Params are checked against the tool's frontend model, so a typo
- * or wrong-typed field is a compile error (not a value silently dropped at the backend).
- */
+/** A step for `toolId`, partial params merged over the tool's defaults. */
 export function policyStep<Id extends PolicyToolId>(
   toolId: Id,
   params: Partial<PolicyParams<Id>> = {},
@@ -107,17 +86,12 @@ export function policyStep<Id extends PolicyToolId>(
   } as PolicyToolStepOf<Id>;
 }
 
-/**
- * Serialize a typed policy step to the backend wire step, mapping frontend params to the endpoint's
- * request model via the tool's `toApi`. This is the single frontend->backend boundary for policies.
- */
 export function policyStepToWire(step: PolicyToolStep): WirePipelineStep {
   return serializeStep(step);
 }
 
-// Generic over the tool id to keep params correlated at the call sites. TypeScript can't correlate
-// the indexed descriptor with the indexed params through a single generic, so `op` is widened to a
-// same-params descriptor here — a contained cast at the (untyped) wire boundary.
+// Generic over the id so `params` stays correlated with the descriptor; TS can't do that through
+// the union, so `op` is widened here (a contained cast at the wire boundary).
 function serializeStep<Id extends PolicyToolId>(step: {
   toolId: Id;
   params: PolicyParams<Id>;
@@ -132,11 +106,7 @@ function serializeStep<Id extends PolicyToolId>(step: {
   };
 }
 
-/**
- * Rehydrate a stored wire step into a typed policy step via the tool's `fromApi`, or null if the
- * endpoint isn't a policy tool. This is the single backend->frontend boundary for policies; the one
- * cast lives here because wire parameters are untyped JSON from the backend.
- */
+/** Wire step -> typed policy step, or null if the endpoint isn't a policy tool. */
 export function policyStepFromWire(
   wire: WirePipelineStep,
 ): PolicyToolStep | null {
@@ -153,8 +123,7 @@ function deserializeStep<Id extends PolicyToolId>(
     ToolEndpoint,
     PolicyParams<Id>
   >;
-  // Wire parameters are untyped JSON from the backend; this cast is the single point where they
-  // enter the typed model, after which `fromApi` maps them to the tool's frontend params.
+  // Wire params are untyped JSON; this is the one point they enter the typed model.
   const params = op.fromApi(
     parameters as unknown as ToolApiParams[ToolEndpoint],
   );


### PR DESCRIPTION
# Description of Changes
The Policies page and all the frontend logic for running Policies is not making use of the bidirectional type mappings that we now have to safely convert from frontend to backend param models and vice versa. This changes the way we track the types throughout so we use the mappings properly.

Because of this, the Add Watermark settings in Policies now actually pre-populate with the defaults instead of with nothing like they previously did.

<img width="791" height="725" alt="image" src="https://github.com/user-attachments/assets/cbdf4ae0-35af-4792-bf64-89216e48d304" />
