### PR TITLE
Fix image signature sizing across zoom and repeated placements

### DIFF
--- a/frontend/editor/src/core/components/viewer/SignatureAPIBridge.tsx
+++ b/frontend/editor/src/core/components/viewer/SignatureAPIBridge.tsx
@@ -3,8 +3,8 @@ import {
   forwardRef,
   useEffect,
   useCallback,
+  useMemo,
   useRef,
-  useState,
 } from "react";
 import { useAnnotationCapability } from "@embedpdf/plugin-annotation/react";
 import { PdfAnnotationSubtype, uuidV4 } from "@embedpdf/models";
@@ -14,7 +14,6 @@ import type {
   AnnotationRect,
 } from "@app/components/viewer/viewerTypes";
 import type { SignParameters } from "@app/hooks/tools/sign/useSignParameters";
-import { useViewer } from "@app/contexts/ViewerContext";
 import { useDocumentReady } from "@app/components/viewer/hooks/useDocumentReady";
 
 /**
@@ -183,25 +182,32 @@ export const SignatureAPIBridge = forwardRef<
     signatureConfig,
     storeImageData,
     isPlacementMode,
-    placementPreviewSize,
+    placementSize,
+    setPlacementSize,
     setSignaturesApplied,
   } = useSignature();
-  const { getZoomState, registerImmediateZoomUpdate } = useViewer();
   const documentReady = useDocumentReady();
-  const [currentZoom, setCurrentZoom] = useState(
-    () => getZoomState()?.currentZoom ?? 1,
-  );
   const lastStampImageRef = useRef<string | null>(null);
+  const placedSignatureIdsRef = useRef(new Set<string>());
+  const signatureSizeKey = useMemo(
+    () =>
+      signatureConfig
+        ? JSON.stringify({
+            signatureType: signatureConfig.signatureType,
+            signatureData: signatureConfig.signatureData,
+            signerName: signatureConfig.signerName,
+            fontFamily: signatureConfig.fontFamily,
+            fontSize: signatureConfig.fontSize,
+            textColor: signatureConfig.textColor,
+            textAlign: signatureConfig.textAlign,
+          })
+        : null,
+    [signatureConfig],
+  );
 
   useEffect(() => {
-    setCurrentZoom(getZoomState()?.currentZoom ?? 1);
-    const unregister = registerImmediateZoomUpdate((percent) => {
-      setCurrentZoom(Math.max(percent / 100, 0.01));
-    });
-    return () => {
-      unregister?.();
-    };
-  }, [getZoomState, registerImmediateZoomUpdate]);
+    placedSignatureIdsRef.current.clear();
+  }, [signatureSizeKey]);
 
   // When entering sign mode, deactivate any active annotation tool immediately.
   // Only signature-specific tools (signatureInk, stamp) should be usable.
@@ -210,18 +216,6 @@ export const SignatureAPIBridge = forwardRef<
       annotationApi.setActiveTool(null);
     }
   }, [isSignMode, annotationApi, documentReady]);
-
-  const cssToPdfSize = useCallback(
-    (size: { width: number; height: number }) => {
-      const zoom = currentZoom || 1;
-      const factor = 1 / zoom;
-      return {
-        width: size.width * factor,
-        height: size.height * factor,
-      };
-    },
-    [currentZoom],
-  );
 
   const applyStampDefaults = useCallback(
     (
@@ -257,48 +251,35 @@ export const SignatureAPIBridge = forwardRef<
         signatureConfig.signatureType === "text" &&
         signatureConfig.signerName
       ) {
-        const textStamp = createTextStampImage(
-          signatureConfig,
-          placementPreviewSize,
-        );
+        const textStamp = createTextStampImage(signatureConfig, placementSize);
         if (textStamp) {
-          const displaySize = placementPreviewSize ?? {
+          const displaySize = placementSize ?? {
             width: textStamp.displayWidth,
             height: textStamp.displayHeight,
           };
-          const pdfSize = cssToPdfSize(displaySize);
           lastStampImageRef.current = textStamp.dataUrl;
           applyStampDefaults(
             textStamp.dataUrl,
             `Text Signature - ${signatureConfig.signerName}`,
-            pdfSize,
+            displaySize,
           );
         }
         return;
       }
 
       if (signatureConfig.signatureData) {
-        const pdfSize = placementPreviewSize
-          ? cssToPdfSize(placementPreviewSize)
-          : undefined;
         lastStampImageRef.current = signatureConfig.signatureData;
         applyStampDefaults(
           signatureConfig.signatureData,
           `Digital Signature - ${signatureConfig.reason || "Document signing"}`,
-          pdfSize,
+          placementSize ?? undefined,
         );
         return;
       }
     } catch (error) {
       console.error("Error preparing signature defaults:", error);
     }
-  }, [
-    annotationApi,
-    signatureConfig,
-    placementPreviewSize,
-    applyStampDefaults,
-    cssToPdfSize,
-  ]);
+  }, [annotationApi, signatureConfig, placementSize, applyStampDefaults]);
 
   // Enable keyboard deletion of selected annotations
   useEffect(() => {
@@ -533,7 +514,7 @@ export const SignatureAPIBridge = forwardRef<
         );
       },
     }),
-    [annotationApi, signatureConfig, placementPreviewSize, applyStampDefaults],
+    [annotationApi, signatureConfig, placementSize, applyStampDefaults],
   );
 
   useEffect(() => {
@@ -553,8 +534,19 @@ export const SignatureAPIBridge = forwardRef<
       }
 
       // Mark signatures as not applied when a new signature is placed
-      if (event.type === "create") {
+      const isSignatureStamp =
+        annotation?.type === PdfAnnotationSubtype.STAMP &&
+        isPlacementMode &&
+        signatureConfig !== null;
+
+      if (event.type === "create" && isSignatureStamp) {
         setSignaturesApplied(false);
+        placedSignatureIdsRef.current.add(annotationId);
+      } else if (placedSignatureIdsRef.current.has(annotationId)) {
+        const size = annotation?.rect?.size;
+        if (size?.width > 0 && size?.height > 0) {
+          setPlacementSize({ width: size.width, height: size.height });
+        }
       }
 
       const directData =
@@ -576,7 +568,15 @@ export const SignatureAPIBridge = forwardRef<
     return () => {
       unsubscribe?.();
     };
-  }, [annotationApi, storeImageData, setSignaturesApplied, documentReady]);
+  }, [
+    annotationApi,
+    storeImageData,
+    setSignaturesApplied,
+    setPlacementSize,
+    isPlacementMode,
+    signatureConfig,
+    documentReady,
+  ]);
 
   useEffect(() => {
     if (!isPlacementMode || !documentReady) {
@@ -596,7 +596,7 @@ export const SignatureAPIBridge = forwardRef<
   }, [
     isPlacementMode,
     configureStampDefaults,
-    placementPreviewSize,
+    placementSize,
     signatureConfig,
     documentReady,
   ]);

--- a/frontend/editor/src/core/components/viewer/SignatureAPIBridge.tsx
+++ b/frontend/editor/src/core/components/viewer/SignatureAPIBridge.tsx
@@ -3,7 +3,6 @@ import {
   forwardRef,
   useEffect,
   useCallback,
-  useMemo,
   useRef,
 } from "react";
 import { useAnnotationCapability } from "@embedpdf/plugin-annotation/react";
@@ -189,25 +188,18 @@ export const SignatureAPIBridge = forwardRef<
   const documentReady = useDocumentReady();
   const lastStampImageRef = useRef<string | null>(null);
   const placedSignatureIdsRef = useRef(new Set<string>());
-  const signatureSizeKey = useMemo(
-    () =>
-      signatureConfig
-        ? JSON.stringify({
-            signatureType: signatureConfig.signatureType,
-            signatureData: signatureConfig.signatureData,
-            signerName: signatureConfig.signerName,
-            fontFamily: signatureConfig.fontFamily,
-            fontSize: signatureConfig.fontSize,
-            textColor: signatureConfig.textColor,
-            textAlign: signatureConfig.textAlign,
-          })
-        : null,
-    [signatureConfig],
-  );
 
   useEffect(() => {
     placedSignatureIdsRef.current.clear();
-  }, [signatureSizeKey]);
+  }, [
+    signatureConfig?.signatureType,
+    signatureConfig?.signatureData,
+    signatureConfig?.signerName,
+    signatureConfig?.fontFamily,
+    signatureConfig?.fontSize,
+    signatureConfig?.textColor,
+    signatureConfig?.textAlign,
+  ]);
 
   // When entering sign mode, deactivate any active annotation tool immediately.
   // Only signature-specific tools (signatureInk, stamp) should be usable.

--- a/frontend/editor/src/core/components/viewer/SignaturePlacementOverlay.tsx
+++ b/frontend/editor/src/core/components/viewer/SignaturePlacementOverlay.tsx
@@ -6,6 +6,7 @@ import {
   SignaturePreview,
 } from "@app/utils/signaturePreview";
 import { useSignature } from "@app/contexts/SignatureContext";
+import { useViewer } from "@app/contexts/ViewerContext";
 import {
   MAX_PREVIEW_WIDTH_RATIO,
   MAX_PREVIEW_HEIGHT_RATIO,
@@ -30,7 +31,18 @@ export const SignaturePlacementOverlay: React.FC<
 > = ({ containerRef, isActive, signatureConfig }) => {
   const [preview, setPreview] = useState<SignaturePreview | null>(null);
   const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
-  const { setPlacementPreviewSize } = useSignature();
+  const { placementSize, setPlacementSize } = useSignature();
+  const { getZoomState, registerImmediateZoomUpdate } = useViewer();
+  const [currentZoom, setCurrentZoom] = useState(
+    () => getZoomState()?.currentZoom ?? 1,
+  );
+
+  useEffect(() => {
+    setCurrentZoom(getZoomState()?.currentZoom ?? 1);
+    return registerImmediateZoomUpdate((percent) => {
+      setCurrentZoom(Math.max(percent / 100, 0.01));
+    });
+  }, [getZoomState, registerImmediateZoomUpdate]);
 
   useEffect(() => {
     let cancelled = false;
@@ -91,6 +103,13 @@ export const SignaturePlacementOverlay: React.FC<
     const containerWidth = container.clientWidth || 1;
     const containerHeight = container.clientHeight || 1;
 
+    if (placementSize) {
+      return {
+        width: placementSize.width * currentZoom,
+        height: placementSize.height * currentZoom,
+      };
+    }
+
     const maxWidth = Math.min(
       containerWidth * MAX_PREVIEW_WIDTH_RATIO,
       remToPx(MAX_PREVIEW_WIDTH_REM),
@@ -116,21 +135,16 @@ export const SignaturePlacementOverlay: React.FC<
         preview.height * scale,
       ),
     };
-  }, [preview, containerRef]);
+  }, [preview, containerRef, placementSize, currentZoom]);
 
   useEffect(() => {
-    if (!isActive || !scaledSize) {
-      setPlacementPreviewSize(null);
-    } else {
-      setPlacementPreviewSize(scaledSize);
+    if (isActive && scaledSize && !placementSize) {
+      setPlacementSize({
+        width: scaledSize.width / currentZoom,
+        height: scaledSize.height / currentZoom,
+      });
     }
-  }, [isActive, scaledSize, setPlacementPreviewSize]);
-
-  useEffect(() => {
-    return () => {
-      setPlacementPreviewSize(null);
-    };
-  }, [setPlacementPreviewSize]);
+  }, [isActive, scaledSize, placementSize, currentZoom, setPlacementSize]);
 
   const display = useMemo(() => {
     if (!preview || !scaledSize || !cursor || !containerRef.current) {

--- a/frontend/editor/src/core/contexts/SignatureContext.tsx
+++ b/frontend/editor/src/core/contexts/SignatureContext.tsx
@@ -68,19 +68,17 @@ const initialState: SignatureState = {
   placementPreviewSize: null,
 };
 
-const getSignatureSizeKey = (config: SignParameters | null): string | null => {
-  if (!config) return null;
-
-  return JSON.stringify({
-    signatureType: config.signatureType,
-    signatureData: config.signatureData,
-    signerName: config.signerName,
-    fontFamily: config.fontFamily,
-    fontSize: config.fontSize,
-    textColor: config.textColor,
-    textAlign: config.textAlign,
-  });
-};
+const hasSameSignatureAppearance = (
+  previous: SignParameters | null,
+  next: SignParameters | null,
+): boolean =>
+  previous?.signatureType === next?.signatureType &&
+  previous?.signatureData === next?.signatureData &&
+  previous?.signerName === next?.signerName &&
+  previous?.fontFamily === next?.fontFamily &&
+  previous?.fontSize === next?.fontSize &&
+  previous?.textColor === next?.textColor &&
+  previous?.textAlign === next?.textAlign;
 
 // Provider component
 export const SignatureProvider: React.FC<{ children: ReactNode }> = ({
@@ -97,11 +95,9 @@ export const SignatureProvider: React.FC<{ children: ReactNode }> = ({
     setState((prev) => ({
       ...prev,
       signatureConfig: config,
-      placementSize:
-        getSignatureSizeKey(prev.signatureConfig) ===
-        getSignatureSizeKey(config)
-          ? prev.placementSize
-          : null,
+      placementSize: hasSameSignatureAppearance(prev.signatureConfig, config)
+        ? prev.placementSize
+        : null,
     }));
   }, []);
 

--- a/frontend/editor/src/core/contexts/SignatureContext.tsx
+++ b/frontend/editor/src/core/contexts/SignatureContext.tsx
@@ -21,7 +21,9 @@ interface SignatureState {
   isPlacementMode: boolean;
   // Whether signatures have been applied (allows export)
   signaturesApplied: boolean;
-  // Size (in screen units) we want newly placed signatures to use
+  // Size (in PDF units) we want newly placed signatures to use
+  placementSize: { width: number; height: number } | null;
+  // Size (in screen units) used by the general annotation stamp flow
   placementPreviewSize: { width: number; height: number } | null;
 }
 
@@ -39,6 +41,7 @@ interface SignatureActions {
   storeImageData: (id: string, data: string) => void;
   getImageData: (id: string) => string | undefined;
   setSignaturesApplied: (applied: boolean) => void;
+  setPlacementSize: (size: { width: number; height: number } | null) => void;
   setPlacementPreviewSize: (
     size: { width: number; height: number } | null,
   ) => void;
@@ -61,7 +64,22 @@ const initialState: SignatureState = {
   signatureConfig: null,
   isPlacementMode: false,
   signaturesApplied: true, // Start as true (no signatures placed yet)
+  placementSize: null,
   placementPreviewSize: null,
+};
+
+const getSignatureSizeKey = (config: SignParameters | null): string | null => {
+  if (!config) return null;
+
+  return JSON.stringify({
+    signatureType: config.signatureType,
+    signatureData: config.signatureData,
+    signerName: config.signerName,
+    fontFamily: config.fontFamily,
+    fontSize: config.fontSize,
+    textColor: config.textColor,
+    textAlign: config.textAlign,
+  });
 };
 
 // Provider component
@@ -79,6 +97,11 @@ export const SignatureProvider: React.FC<{ children: ReactNode }> = ({
     setState((prev) => ({
       ...prev,
       signatureConfig: config,
+      placementSize:
+        getSignatureSizeKey(prev.signatureConfig) ===
+        getSignatureSizeKey(config)
+          ? prev.placementSize
+          : null,
     }));
   }, []);
 
@@ -150,10 +173,10 @@ export const SignatureProvider: React.FC<{ children: ReactNode }> = ({
     }));
   }, []);
 
-  const setPlacementPreviewSize = useCallback(
+  const setPlacementSize = useCallback(
     (size: { width: number; height: number } | null) => {
       setState((prev) => {
-        const prevSize = prev.placementPreviewSize;
+        const prevSize = prev.placementSize;
         const same =
           (prevSize === null && size === null) ||
           (prevSize !== null &&
@@ -167,9 +190,16 @@ export const SignatureProvider: React.FC<{ children: ReactNode }> = ({
 
         return {
           ...prev,
-          placementPreviewSize: size,
+          placementSize: size,
         };
       });
+    },
+    [],
+  );
+
+  const setPlacementPreviewSize = useCallback(
+    (size: { width: number; height: number } | null) => {
+      setState((prev) => ({ ...prev, placementPreviewSize: size }));
     },
     [],
   );
@@ -193,6 +223,7 @@ export const SignatureProvider: React.FC<{ children: ReactNode }> = ({
     storeImageData,
     getImageData,
     setSignaturesApplied,
+    setPlacementSize,
     setPlacementPreviewSize,
   };
 


### PR DESCRIPTION
# Description of Changes

Fixes image signature sizing so signatures retain consistent PDF dimensions regardless of the viewer zoom level.

- Store image signature placement dimensions in PDF units instead of screen pixels.
- Scale the placement preview according to the current viewer zoom.
- Reuse a signature’s resized dimensions for subsequent placements.
- Reset retained dimensions when the selected signature or its visual settings change.
- Track only signatures created by the active signing flow, preventing unrelated stamps from changing the retained size.
- Preserve the existing screen-space sizing behavior of the general annotation stamp flow.

The main challenge was separating signature sizing from the shared annotation stamp sizing. Signatures now use PDF-space dimensions while ordinary annotation stamps continue using the existing screen-space preview state.

Closes #6928

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

### Verification performed

- [x] Frontend typecheck passed
- [x] ESLint passed
- [x] Circular dependency check passed
- [x] Prettier formatting passed
- [x] `git diff --check` passed

The complete frontend check reached the Vitest stage but exceeded the command capture timeout. The background test process completed afterward, but its final exit status was unavailable.