### PR TITLE
Open processor "Open in browser" CTAs in a new tab

### DIFF
--- a/frontend/editor/src/portal/components/DownloadEditorModal.tsx
+++ b/frontend/editor/src/portal/components/DownloadEditorModal.tsx
@@ -255,7 +255,7 @@ export function DownloadEditorModal({ open, onClose }: Props) {
             variant="secondary"
             leftSection={<OpenInNewRounded sx={{ fontSize: 15 }} />}
             onClick={() => {
-              window.location.href = EDITOR_URL;
+              window.open(EDITOR_URL, "_blank", "noopener,noreferrer");
             }}
           >
             {t("portal.home.download.openInBrowser")}

--- a/frontend/editor/src/portal/components/WelcomeBanner.tsx
+++ b/frontend/editor/src/portal/components/WelcomeBanner.tsx
@@ -78,7 +78,7 @@ export function WelcomeBanner({ footer }: WelcomeBannerProps) {
             className="portal-welcome__cta"
             leftSection={<ExternalLinkIcon size={15} />}
             onClick={() => {
-              window.location.href = EDITOR_URL;
+              window.open(EDITOR_URL, "_blank", "noopener,noreferrer");
             }}
           >
             {t("portal.welcome.openInBrowser")}


### PR DESCRIPTION
## Description

The processor home-hero and download-editor modal "Open in browser" buttons were meant to open the editor in a new tab, but they used `window.location.href = EDITOR_URL`, which replaces the current tab.

This switches both to `window.open(EDITOR_URL, "_blank", "noopener,noreferrer")`, matching the existing behaviour of the "Open" button in `EditorStatusCard.tsx`. The `noopener,noreferrer` flags mirror that same call and prevent the new tab from getting a `window.opener` reference.

## Changes

- `WelcomeBanner.tsx` — home-hero "Open in browser" CTA
- `DownloadEditorModal.tsx` — download modal "Open in browser" CTA

## Notes

`EDITOR_URL` can resolve to a same-origin path when the editor is the same SPA, so opening in a new tab triggers a full page load of the editor app. This is the expected behaviour for "Open in browser".