### PR TITLE
Avoid uv cache reservation collisions in CI by adding per-workflow cache-suffix

### DIFF
--- a/.github/workflows/ai-engine.yml
+++ b/.github/workflows/ai-engine.yml
@@ -33,6 +33,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
+          cache-suffix: ai-engine
 
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0

--- a/.github/workflows/check-generated-models.yml
+++ b/.github/workflows/check-generated-models.yml
@@ -36,6 +36,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
+          cache-suffix: generated-models
 
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -28,6 +28,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
+          cache-suffix: pre-commit
 
       - name: Install Task
         uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0

--- a/.github/workflows/sync_files_v2.yml
+++ b/.github/workflows/sync_files_v2.yml
@@ -64,6 +64,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
+          cache-suffix: sync-files
 
       - name: Install Task
         uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0


### PR DESCRIPTION
### Motivation
- Prevent concurrent GitHub Actions jobs from attempting to reserve the same `setup-uv` cache key and failing with "Unable to reserve cache ... another job may be creating this cache" when multiple workflows run at once.
- Target workflows that enable `setup-uv` caching and have run concurrently in CI: pre-commit, check-generated-models, ai-engine, and sync_files_v2.

### Description
- Added a `cache-suffix` value to the `astral-sh/setup-uv` step in `.github/workflows/pre_commit.yml`, `.github/workflows/check-generated-models.yml`, `.github/workflows/ai-engine.yml`, and `.github/workflows/sync_files_v2.yml` to create unique cache keys (`pre-commit`, `generated-models`, `ai-engine`, `sync-files`).
- No behavior changes beyond isolating the uv cache keys per-workflow and no other workflow steps were modified.

### Testing
- Ran `git diff --check` which completed with no reported whitespace or index issues.
- Verified each modified workflow is valid YAML by loading them with a Ruby YAML parser which succeeded for all four files.
- Attempted to run `task --list` to exercise the Taskfile locally but `task` is not installed in this environment so that check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58b399a33083259d65e0614fcc35d2)