### PR TITLE
Fix Calendly scheduler: blank on first open + slow load

### DIFF
--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -7876,7 +7876,7 @@ viewInvoice = "View & pay invoice"
 [portal.procurement.schedule]
 fallback = "Couldn't load the scheduler."
 fallbackLink = "Open scheduling in a new tab"
-loading = "Loading scheduler…"
+loading = "Loading scheduler..."
 subtitle = "Your solutions engineer will walk your team through the rollout. Pick a time that suits you."
 title = "Schedule a call"
 

--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -7876,6 +7876,7 @@ viewInvoice = "View & pay invoice"
 [portal.procurement.schedule]
 fallback = "Couldn't load the scheduler."
 fallbackLink = "Open scheduling in a new tab"
+loading = "Loading scheduler…"
 subtitle = "Your solutions engineer will walk your team through the rollout. Pick a time that suits you."
 title = "Schedule a call"
 

--- a/frontend/editor/src/core/utils/scriptLoader.test.ts
+++ b/frontend/editor/src/core/utils/scriptLoader.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { loadScript, isScriptLoaded } from "@app/utils/scriptLoader";
+
+/** jsdom doesn't fetch external scripts, so we drive the load/error events ourselves. */
+function scriptEl(id: string): HTMLScriptElement {
+  const el = document.getElementById(id) as HTMLScriptElement | null;
+  if (!el) throw new Error(`no script tag #${id}`);
+  return el;
+}
+
+describe("loadScript", () => {
+  it("overlapping loads share one tag and resolve only after the script actually loads", async () => {
+    const id = "test-script-overlap";
+    const src = "https://example.test/overlap.js";
+
+    let firstResolved = false;
+    let secondResolved = false;
+    const p1 = loadScript({ src, id }).then(() => {
+      firstResolved = true;
+    });
+    // Second, overlapping call (e.g. a StrictMode double-effect or a remount before the
+    // first load settled). It must reuse the in-flight load, not resolve on tag existence.
+    const p2 = loadScript({ src, id }).then(() => {
+      secondResolved = true;
+    });
+
+    // Only one tag despite two calls.
+    expect(document.querySelectorAll(`#${id}`)).toHaveLength(1);
+
+    // Regression guard: before the script executes, neither promise resolves — previously
+    // the second call resolved immediately because the tag existed, so callers ran before
+    // the script's globals were defined (the "blank until you reopen" bug).
+    await Promise.resolve();
+    expect(firstResolved).toBe(false);
+    expect(secondResolved).toBe(false);
+    expect(isScriptLoaded(id)).toBe(false);
+
+    scriptEl(id).dispatchEvent(new Event("load"));
+    await Promise.all([p1, p2]);
+    expect(firstResolved).toBe(true);
+    expect(secondResolved).toBe(true);
+    expect(isScriptLoaded(id)).toBe(true);
+  });
+
+  it("resolves immediately once the script has already loaded", async () => {
+    const id = "test-script-cached";
+    const src = "https://example.test/cached.js";
+
+    const first = loadScript({ src, id });
+    scriptEl(id).dispatchEvent(new Event("load"));
+    await first;
+
+    // A later call must resolve from cache without waiting for a fresh load event (which
+    // would never come) and without adding a second tag.
+    await loadScript({ src, id });
+    expect(document.querySelectorAll(`#${id}`)).toHaveLength(1);
+  });
+
+  it("rejects when the script fails to load", async () => {
+    const id = "test-script-error";
+    const src = "https://example.test/error.js";
+
+    const p = loadScript({ src, id });
+    scriptEl(id).dispatchEvent(new Event("error"));
+    await expect(p).rejects.toThrow(/Failed to load script/);
+  });
+});

--- a/frontend/editor/src/core/utils/scriptLoader.test.ts
+++ b/frontend/editor/src/core/utils/scriptLoader.test.ts
@@ -64,4 +64,23 @@ describe("loadScript", () => {
     scriptEl(id).dispatchEvent(new Event("error"));
     await expect(p).rejects.toThrow(/Failed to load script/);
   });
+
+  it("drops the failed tag so a retry re-attempts instead of hanging", async () => {
+    const id = "test-script-retry";
+    const src = "https://example.test/retry.js";
+
+    // First attempt (e.g. a warm-up) fails.
+    const first = loadScript({ src, id });
+    scriptEl(id).dispatchEvent(new Event("error"));
+    await expect(first).rejects.toThrow(/Failed to load script/);
+    // The poisoned tag must be gone — otherwise a retry would attach to a dead tag.
+    expect(document.querySelectorAll(`#${id}`)).toHaveLength(0);
+
+    // Retry (e.g. the modal opening) creates a fresh tag and can now succeed.
+    const second = loadScript({ src, id });
+    expect(document.querySelectorAll(`#${id}`)).toHaveLength(1);
+    scriptEl(id).dispatchEvent(new Event("load"));
+    await expect(second).resolves.toBeUndefined();
+    expect(isScriptLoaded(id)).toBe(true);
+  });
 });

--- a/frontend/editor/src/core/utils/scriptLoader.ts
+++ b/frontend/editor/src/core/utils/scriptLoader.ts
@@ -47,8 +47,12 @@ export function loadScript({
       onLoad?.();
       resolve();
     };
-    const settleError = () => {
+    const settleError = (el: HTMLScriptElement) => {
       pendingScripts.delete(scriptId);
+      // Drop the failed tag so a later retry (e.g. the modal after a warm-up that was
+      // blocked by an extension) creates a fresh one and re-attempts, rather than
+      // attaching to a dead tag whose error event won't fire again and hanging forever.
+      el.remove();
       reject(new Error(`Failed to load script: ${src}`));
     };
 
@@ -71,7 +75,9 @@ export function loadScript({
       existing.addEventListener("load", () => settleLoaded(existing), {
         once: true,
       });
-      existing.addEventListener("error", settleError, { once: true });
+      existing.addEventListener("error", () => settleError(existing), {
+        once: true,
+      });
       return;
     }
 
@@ -81,7 +87,7 @@ export function loadScript({
     script.async = async;
     script.defer = defer;
     script.addEventListener("load", () => settleLoaded(script), { once: true });
-    script.addEventListener("error", settleError, { once: true });
+    script.addEventListener("error", () => settleError(script), { once: true });
     document.head.appendChild(script);
   });
 

--- a/frontend/editor/src/core/utils/scriptLoader.ts
+++ b/frontend/editor/src/core/utils/scriptLoader.ts
@@ -11,6 +11,11 @@ interface ScriptLoadOptions {
 }
 
 const loadedScripts = new Set<string>();
+// Loads that have started but not yet finished, keyed by script id/src. Overlapping
+// callers (e.g. a React StrictMode double-effect, or a component that remounts before
+// the previous load settled) reuse the same promise so they all resolve only when the
+// script has actually executed — never on tag existence alone.
+const pendingScripts = new Map<string, Promise<void>>();
 
 export function loadScript({
   src,
@@ -19,43 +24,69 @@ export function loadScript({
   defer = false,
   onLoad,
 }: ScriptLoadOptions): Promise<void> {
-  return new Promise((resolve, reject) => {
-    // Check if already loaded
-    const scriptId = id || src;
-    if (loadedScripts.has(scriptId)) {
-      resolve();
-      return;
-    }
+  const scriptId = id || src;
 
-    // Check if script already exists in DOM
-    const existingScript = id
-      ? document.getElementById(id)
-      : document.querySelector(`script[src="${src}"]`);
-    if (existingScript) {
+  // Already fully loaded and executed.
+  if (loadedScripts.has(scriptId)) {
+    onLoad?.();
+    return Promise.resolve();
+  }
+
+  // A load for the same script is already in flight — wait for it rather than kicking
+  // off a second one (and, critically, don't resolve just because the tag is present).
+  const inFlight = pendingScripts.get(scriptId);
+  if (inFlight) {
+    return onLoad ? inFlight.then(() => onLoad()) : inFlight;
+  }
+
+  const promise = new Promise<void>((resolve, reject) => {
+    const settleLoaded = (script: HTMLScriptElement) => {
+      script.dataset.loaded = "true";
       loadedScripts.add(scriptId);
+      pendingScripts.delete(scriptId);
+      onLoad?.();
       resolve();
+    };
+    const settleError = () => {
+      pendingScripts.delete(scriptId);
+      reject(new Error(`Failed to load script: ${src}`));
+    };
+
+    // A matching tag may already be in the DOM (added by an earlier load whose Set/Map
+    // state was lost, or injected elsewhere). If our own loader finished it, the
+    // data-loaded flag is set and we can resolve immediately; otherwise attach to its
+    // load lifecycle instead of assuming it is ready.
+    const existing = (
+      id
+        ? document.getElementById(id)
+        : document.querySelector(`script[src="${src}"]`)
+    ) as HTMLScriptElement | null;
+    if (existing) {
+      if (existing.dataset.loaded === "true") {
+        loadedScripts.add(scriptId);
+        onLoad?.();
+        resolve();
+        return;
+      }
+      existing.addEventListener("load", () => settleLoaded(existing), {
+        once: true,
+      });
+      existing.addEventListener("error", settleError, { once: true });
       return;
     }
 
-    // Create and append script
     const script = document.createElement("script");
     script.src = src;
     if (id) script.id = id;
     script.async = async;
     script.defer = defer;
-
-    script.onload = () => {
-      loadedScripts.add(scriptId);
-      if (onLoad) onLoad();
-      resolve();
-    };
-
-    script.onerror = () => {
-      reject(new Error(`Failed to load script: ${src}`));
-    };
-
+    script.addEventListener("load", () => settleLoaded(script), { once: true });
+    script.addEventListener("error", settleError, { once: true });
     document.head.appendChild(script);
   });
+
+  pendingScripts.set(scriptId, promise);
+  return promise;
 }
 
 export function isScriptLoaded(idOrSrc: string): boolean {

--- a/frontend/editor/src/portal/components/procurement/CalendlyInline.tsx
+++ b/frontend/editor/src/portal/components/procurement/CalendlyInline.tsx
@@ -10,6 +10,9 @@ import { loadScript } from "@app/utils/scriptLoader";
 
 const CALENDLY_SCRIPT = "https://assets.calendly.com/assets/external/widget.js";
 
+// If the embed hasn't loaded within this window, give up and show the fallback link.
+const LOAD_TIMEOUT_MS = 15000;
+
 // Base scheduling link; overridable per-environment without a code change.
 export const CALENDLY_URL: string =
   import.meta.env.VITE_CALENDLY_URL ||
@@ -89,7 +92,23 @@ export function CalendlyInline({
   useEffect(() => {
     let cancelled = false;
     setFailed(false);
-    loadScript({ src: CALENDLY_SCRIPT, id: "calendly-widget-script" })
+
+    // Race the load against a timeout so a request that never settles (a blocked or
+    // black-holed script whose load/error never fires) still surfaces the fallback link
+    // rather than leaving an empty modal open indefinitely.
+    let timer: ReturnType<typeof setTimeout>;
+    const load = new Promise<void>((resolve, reject) => {
+      timer = setTimeout(
+        () => reject(new Error("Calendly load timed out")),
+        LOAD_TIMEOUT_MS,
+      );
+      loadScript({ src: CALENDLY_SCRIPT, id: "calendly-widget-script" }).then(
+        resolve,
+        reject,
+      );
+    });
+
+    load
       .then(() => {
         const el = containerRef.current;
         const calendly = (window as CalendlyWindow).Calendly;
@@ -109,9 +128,12 @@ export function CalendlyInline({
           prefill: email ? { email } : undefined,
         });
       })
-      .catch(() => !cancelled && setFailed(true));
+      .catch(() => !cancelled && setFailed(true))
+      .finally(() => clearTimeout(timer));
+
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
   }, [fullUrl, email]);
 

--- a/frontend/editor/src/portal/components/procurement/CalendlyInline.tsx
+++ b/frontend/editor/src/portal/components/procurement/CalendlyInline.tsx
@@ -40,6 +40,36 @@ function buildUrl(base: string): string {
   return `${base}${sep}hide_event_type_details=1&background_color=${WIDGET_COLORS.background}&text_color=${WIDGET_COLORS.text}&primary_color=${WIDGET_COLORS.primary}`;
 }
 
+// Origins the embed fetches from: the widget script, then the scheduler iframe.
+const CALENDLY_ORIGINS = [
+  "https://assets.calendly.com",
+  "https://calendly.com",
+];
+
+function preconnect(origin: string): void {
+  if (typeof document === "undefined") return;
+  if (document.querySelector(`link[rel="preconnect"][href="${origin}"]`))
+    return;
+  const link = document.createElement("link");
+  link.rel = "preconnect";
+  link.href = origin;
+  link.crossOrigin = "anonymous";
+  document.head.appendChild(link);
+}
+
+/**
+ * Warm the Calendly embed ahead of use: open connections to its origins and start fetching
+ * widget.js, so opening the scheduler initialises near-instantly instead of paying a cold
+ * script + iframe fetch on click. Idempotent and safe to call repeatedly; failures are left
+ * for the modal's own load to surface as the fallback link.
+ */
+export function warmCalendly(): void {
+  CALENDLY_ORIGINS.forEach(preconnect);
+  void loadScript({ src: CALENDLY_SCRIPT, id: "calendly-widget-script" }).catch(
+    () => {},
+  );
+}
+
 export function CalendlyInline({
   url = CALENDLY_URL,
   height = 760,
@@ -63,7 +93,13 @@ export function CalendlyInline({
       .then(() => {
         const el = containerRef.current;
         const calendly = (window as CalendlyWindow).Calendly;
-        if (cancelled || !el || !calendly) return;
+        if (cancelled || !el) return;
+        // Script resolved but the global never materialised (blocked/altered by an
+        // extension, etc.) — show the fallback link rather than an empty modal.
+        if (!calendly) {
+          setFailed(true);
+          return;
+        }
         // Re-init explicitly (rather than relying on widget.js auto-scan) so the widget rebuilds on
         // reopen and whenever the URL or prefill changes.
         el.innerHTML = "";

--- a/frontend/editor/src/portal/components/procurement/CalendlyInline.tsx
+++ b/frontend/editor/src/portal/components/procurement/CalendlyInline.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Spinner } from "@app/ui";
 import { loadScript } from "@app/utils/scriptLoader";
 
 /**
  * Inline Calendly scheduler. Lazily loads Calendly's widget.js (only once the embed mounts, i.e. when
- * the modal opens) and initialises an inline widget. Falls back to a plain "open in a new tab" link if
- * the script can't load (offline, blocked, etc.).
+ * the modal opens) and initialises an inline widget. Shows a spinner while the (external, sometimes
+ * slow) script loads, and falls back to a plain "open in a new tab" link if the script can't load
+ * (offline, blocked, etc.). A real load failure fires the script's error event, so the fallback is
+ * shown immediately rather than after a fixed timeout — a slow-but-working connection is never
+ * abandoned, it just spins until the widget arrives.
  */
 
 const CALENDLY_SCRIPT = "https://assets.calendly.com/assets/external/widget.js";
-
-// If the embed hasn't loaded within this window, give up and show the fallback link.
-const LOAD_TIMEOUT_MS = 15000;
 
 // Base scheduling link; overridable per-environment without a code change.
 export const CALENDLY_URL: string =
@@ -86,29 +87,15 @@ export function CalendlyInline({
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [failed, setFailed] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const fullUrl = buildUrl(url);
 
   useEffect(() => {
     let cancelled = false;
     setFailed(false);
-
-    // Race the load against a timeout so a request that never settles (a blocked or
-    // black-holed script whose load/error never fires) still surfaces the fallback link
-    // rather than leaving an empty modal open indefinitely.
-    let timer: ReturnType<typeof setTimeout>;
-    const load = new Promise<void>((resolve, reject) => {
-      timer = setTimeout(
-        () => reject(new Error("Calendly load timed out")),
-        LOAD_TIMEOUT_MS,
-      );
-      loadScript({ src: CALENDLY_SCRIPT, id: "calendly-widget-script" }).then(
-        resolve,
-        reject,
-      );
-    });
-
-    load
+    setLoading(true);
+    loadScript({ src: CALENDLY_SCRIPT, id: "calendly-widget-script" })
       .then(() => {
         const el = containerRef.current;
         const calendly = (window as CalendlyWindow).Calendly;
@@ -127,13 +114,11 @@ export function CalendlyInline({
           parentElement: el,
           prefill: email ? { email } : undefined,
         });
+        setLoading(false);
       })
-      .catch(() => !cancelled && setFailed(true))
-      .finally(() => clearTimeout(timer));
-
+      .catch(() => !cancelled && setFailed(true));
     return () => {
       cancelled = true;
-      clearTimeout(timer);
     };
   }, [fullUrl, email]);
 
@@ -149,10 +134,14 @@ export function CalendlyInline({
   }
 
   return (
-    <div
-      ref={containerRef}
-      className="portal-calendly"
-      style={{ minWidth: 320, height }}
-    />
+    <div className="portal-calendly" style={{ minWidth: 320, height }}>
+      {loading && (
+        <div className="portal-calendly__loading">
+          <Spinner size="lg" label={t("portal.procurement.schedule.loading")} />
+        </div>
+      )}
+      {/* Calendly injects its iframe here; the spinner overlays until the widget is initialised. */}
+      <div ref={containerRef} className="portal-calendly__embed" />
+    </div>
   );
 }

--- a/frontend/editor/src/portal/components/procurement/DealStatusHero.tsx
+++ b/frontend/editor/src/portal/components/procurement/DealStatusHero.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@app/ui";
 import type { ViewId } from "@portal/contexts/ViewContext";
@@ -6,6 +7,7 @@ import {
   type ProcurementSnapshot,
 } from "@portal/api/procurement";
 import { StageStepper } from "@portal/components/procurement/StageStepper";
+import { warmCalendly } from "@portal/components/procurement/CalendlyInline";
 import "@portal/views/Procurement.css";
 
 /**
@@ -38,6 +40,13 @@ export function DealStatusHero({
   onNavigate: (view: ViewId) => void;
 }) {
   const { t } = useTranslation();
+
+  // Warm Calendly's connections + widget script as soon as the "Schedule a call" action is
+  // available, so opening the scheduler initialises quickly instead of paying a cold fetch.
+  useEffect(() => {
+    if (canSchedule) warmCalendly();
+  }, [canSchedule]);
+
   const stage = snapshot.stage ?? "trial";
   const inTrial = stage === "trial";
   const cta =

--- a/frontend/editor/src/portal/views/Procurement.css
+++ b/frontend/editor/src/portal/views/Procurement.css
@@ -1396,9 +1396,25 @@
 /* Calendly scheduler embed (Schedule a call). The widget is always light (Calendly renders inputs on
    white), so give it a white surface — it reads as a clean card even inside the dark-mode modal. */
 .portal-calendly {
+  position: relative;
   border-radius: 10px;
   overflow: hidden;
   background: #ffffff;
+}
+
+/* Fills the surface; Calendly injects its iframe in here. */
+.portal-calendly__embed {
+  height: 100%;
+}
+
+/* Centred spinner shown over the white surface until the widget initialises. */
+.portal-calendly__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
 }
 
 /* ── Agreement (security) step ────────────────────────────────────────────── */


### PR DESCRIPTION
## What was wrong

Opening the procurement **Schedule a call** modal had two problems:

1. **Blank the first time, works the second time.** The first open showed nothing; closing and reopening eventually loaded Calendly.
2. **Slow to load** even when it did work.

## Why

1. Our script loader treated a script as "ready" the moment its `<script>` tag was added to the page — not when it had actually finished downloading. On the first open, two loads overlap (React re-runs the effect in dev), and the second one returned "ready" too early, before Calendly's code existed, so nothing rendered. Reopening worked because by then the script had finished.
2. Nothing was loaded until you clicked, so the first open waited on a cold download of Calendly's script and then its booking page.

## The fix

- Make the script loader wait for the script to **actually finish loading**, and have overlapping loads share the same wait. This fixes the blank-first-open (and helps every other lazy-loaded script too).
- **Warm up Calendly early**: open the connection and start fetching its script as soon as the "Schedule a call" button appears, so the modal opens quickly instead of downloading everything on click.
- If Calendly still can't load (e.g. blocked by an extension), show the existing "open in a new tab" link instead of an empty modal.

## Testing

Added a unit test proving the loader only reports "ready" after the script truly loads. Type-check, lint, and formatting all pass.

Note: I couldn't click through the live modal here (needs a linked procurement deal running locally) — happy to do a manual open/close/open pass before merge if you'd like.