### PR TITLE
Make classification async: non-blocking, no version bump, runs last

### DIFF
--- a/frontend/editor/src/proprietary/components/policies/classificationLabelTargets.test.ts
+++ b/frontend/editor/src/proprietary/components/policies/classificationLabelTargets.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { classificationLabelTargets } from "@app/components/policies/usePolicyAutoRun";
+import type { StirlingFileStub } from "@app/types/fileContext";
+
+const stub = (s: Partial<StirlingFileStub>): StirlingFileStub =>
+  ({ id: "x", ...s }) as StirlingFileStub;
+
+describe("classificationLabelTargets", () => {
+  it("targets the run's own file when it's still the leaf", () => {
+    const stubs = [stub({ id: "a" }), stub({ id: "b" })];
+    expect(classificationLabelTargets("a", stubs)).toEqual(["a"]);
+  });
+
+  it("targets a descendant leaf when the file was edited during the run", () => {
+    // "a" was consumed into leaf "a2" (edit forked a new version mid-run).
+    const stubs = [stub({ id: "a2", sourceFileIds: ["a"] })];
+    expect(classificationLabelTargets("a", stubs)).toEqual(["a2"]);
+  });
+
+  it("targets a direct child via parentFileId", () => {
+    const stubs = [stub({ id: "a2", parentFileId: "a" })];
+    expect(classificationLabelTargets("a", stubs)).toEqual(["a2"]);
+  });
+
+  it("falls back to the run's file id when nothing matches (file closed)", () => {
+    expect(classificationLabelTargets("a", [stub({ id: "z" })])).toEqual(["a"]);
+  });
+});

--- a/frontend/editor/src/proprietary/components/policies/classificationLabelTargets.test.ts
+++ b/frontend/editor/src/proprietary/components/policies/classificationLabelTargets.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect } from "vitest";
 import { classificationLabelTargets } from "@app/components/policies/usePolicyAutoRun";
 import type { StirlingFileStub } from "@app/types/fileContext";
 
-const stub = (s: Partial<StirlingFileStub>): StirlingFileStub =>
-  ({ id: "x", ...s }) as StirlingFileStub;
+// Loosely-typed builder: FileId is a branded string, so accept plain string ids
+// in tests and cast — classificationLabelTargets only reads id/parent/sources.
+const stub = (s: {
+  id: string;
+  parentFileId?: string;
+  sourceFileIds?: string[];
+}): StirlingFileStub => s as unknown as StirlingFileStub;
 
 describe("classificationLabelTargets", () => {
   it("targets the run's own file when it's still the leaf", () => {

--- a/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.batch.test.tsx
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.batch.test.tsx
@@ -3,20 +3,26 @@ import { renderHook, act } from "@testing-library/react";
 
 /**
  * Batch integration test for the policy auto-run orchestration, at the scale the
- * user hit the bug: 61 files uploaded at once, two active upload policies
- * (Classification → Security) chained. Drives the REAL policyRunStore + the REAL
- * hook effects (dispatch → poll → import → chain), mocking only the IO boundaries
- * (network, storage, thumbnail/stub creation).
+ * user hit the bug: 61 files uploaded at once, two active upload policies chained.
+ * Drives the REAL policyRunStore + the REAL hook effects (dispatch → poll →
+ * import → chain), mocking only the IO boundaries (network, storage,
+ * thumbnail/stub creation).
+ *
+ * Classification is forced to run LAST (even though it's configured order 0),
+ * because it's metadata-only and non-blocking: the chain is Security →
+ * Classification. Security versions in place; Classification only tags.
  *
  * Proves the invariants the user asked for:
- *  - 61 files ⇒ exactly 122 runs (61 classification, then 61 security).
- *  - Delivery is SILENT + in place (consumeFiles called with { silent: true }),
+ *  - 61 files ⇒ exactly 122 runs (61 security, then 61 classification).
+ *  - Security delivers SILENTLY + in place (consumeFiles with { silent: true }),
  *    never adding a second copy — the workspace never grows past 61.
+ *  - Classification NEVER forks a version: no consumeFiles, no new file — it just
+ *    stamps the labels onto the existing stub (updateStirlingFileStub).
  *  - No runaway: if the loop guard regressed, the run count would blow past 122
  *    (or the test would time out), so an exact 122 is a hard regression gate.
  *  - Closing all files mid-run does NOT re-open them: with the workspace emptied,
- *    outputs are delivered to storage (persistVersionedOutputs), never re-added
- *    to the workspace via consumeFiles.
+ *    security outputs go to storage (persistVersionedOutputs), never re-added to
+ *    the workspace via consumeFiles.
  */
 
 const FILE_COUNT = 61;
@@ -61,7 +67,8 @@ vi.mock("@app/contexts/IndexedDBContext", () => ({
 vi.mock("@app/hooks/usePolicies", () => ({
   usePolicies: () => ({
     policies: {
-      // Classification runs first (order 0), Security second (order 1).
+      // Classification is configured first (order 0) but is FORCED to run last
+      // by the orchestrator; Security (order 1) therefore runs first.
       classification: {
         configured: true,
         status: "active",
@@ -102,7 +109,9 @@ vi.mock("@app/services/fileStubHelpers", () => ({
   createStirlingFilesAndStubs: mocks.createStirlingFilesAndStubs,
 }));
 vi.mock("@app/services/fileClassification", () => ({
-  readClassificationLabelsFromFile: vi.fn().mockResolvedValue(null),
+  // Classification always resolves labels here, so the metadata-only import path
+  // stamps them onto the stub.
+  readClassificationLabelsFromFile: vi.fn().mockResolvedValue(["Invoice"]),
 }));
 
 import { usePolicyAutoRun } from "@app/components/policies/usePolicyAutoRun";
@@ -150,7 +159,7 @@ beforeEach(() => {
   mocks.persistVersionedOutputs.mockImplementation(async () => {
     mocks.persistCalls += 1;
   });
-  mocks.updateFileMetadata.mockResolvedValue(false);
+  mocks.updateFileMetadata.mockResolvedValue(true);
   mocks.downloadPolicyOutput.mockResolvedValue(
     new Blob(["x"], { type: "application/pdf" }),
   );
@@ -220,8 +229,8 @@ async function runUntilSettled(expectedRuns: number) {
   });
 }
 
-describe("policy auto-run — 61-file batch through a Classification → Security chain", () => {
-  it("produces exactly 122 runs (61 classification, then 61 security)", async () => {
+describe("policy auto-run — 61-file batch through a Security → Classification chain", () => {
+  it("produces exactly 122 runs (61 security, then 61 classification)", async () => {
     await runUntilSettled(FILE_COUNT * 2);
 
     const classification = latestRuns.filter(
@@ -234,15 +243,20 @@ describe("policy auto-run — 61-file batch through a Classification → Securit
     expect(latestRuns).toHaveLength(FILE_COUNT * 2);
   });
 
-  it("delivers every output SILENTLY in place — workspace never grows past 61", async () => {
+  it("versions on Security in place, tags on Classification — workspace never grows past 61", async () => {
     await runUntilSettled(FILE_COUNT * 2);
 
-    // 122 deliveries, all silent (background), none via the disruptive path.
-    expect(mocks.consumeSilentCalls).toBe(FILE_COUNT * 2);
+    // Only the 61 Security runs fork a version, and every one silently in place.
+    expect(mocks.consumeSilentCalls).toBe(FILE_COUNT);
     expect(mocks.consumeNonSilentCalls).toBe(0);
+    // Classification never forks a version — it only stamps labels onto the stub.
+    expect(mocks.updateStirlingFileStub).toHaveBeenCalledTimes(FILE_COUNT);
+    for (const call of mocks.updateStirlingFileStub.mock.calls) {
+      expect(call[1]).toEqual({ classificationLabels: ["Invoice"] });
+    }
     // Never added as brand-new files either.
     expect(mocks.addFilesCalls).toBe(0);
-    // In-place versioning: each file replaced twice, count unchanged.
+    // In-place versioning + metadata-only tagging: count unchanged.
     expect(mocks.workspace).toHaveLength(FILE_COUNT);
   });
 
@@ -268,8 +282,8 @@ describe("policy auto-run — 61-file batch through a Classification → Securit
       );
     });
 
-    // Still fully processed (chain intact), but delivered to STORAGE, never
-    // re-added to the workbench — the workspace stays empty.
+    // Still fully processed (chain intact), but Security's versions went to
+    // STORAGE, never re-added to the workbench — the workspace stays empty.
     expect(latestRuns).toHaveLength(FILE_COUNT * 2);
     expect(mocks.workspace).toHaveLength(0);
     expect(mocks.consumeSilentCalls).toBe(0);

--- a/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.batch.test.tsx
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.batch.test.tsx
@@ -2,27 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
 /**
- * Batch integration test for the policy auto-run orchestration, at the scale the
- * user hit the bug: 61 files uploaded at once, two active upload policies chained.
- * Drives the REAL policyRunStore + the REAL hook effects (dispatch → poll →
- * import → chain), mocking only the IO boundaries (network, storage,
- * thumbnail/stub creation).
- *
- * Classification is forced to run LAST (even though it's configured order 0),
- * because it's metadata-only and non-blocking: the chain is Security →
- * Classification. Security versions in place; Classification only tags.
- *
- * Proves the invariants the user asked for:
- *  - 61 files ⇒ exactly 122 runs (61 security, then 61 classification).
- *  - Security delivers SILENTLY + in place (consumeFiles with { silent: true }),
- *    never adding a second copy — the workspace never grows past 61.
- *  - Classification NEVER forks a version: no consumeFiles, no new file — it just
- *    stamps the labels onto the existing stub (updateStirlingFileStub).
- *  - No runaway: if the loop guard regressed, the run count would blow past 122
- *    (or the test would time out), so an exact 122 is a hard regression gate.
- *  - Closing all files mid-run does NOT re-open them: with the workspace emptied,
- *    security outputs go to storage (persistVersionedOutputs), never re-added to
- *    the workspace via consumeFiles.
+ * Batch integration test (61 files, two chained upload policies) driving the real
+ * store + hook effects, IO mocked. Classification is forced last (see the sort).
  */
 
 const FILE_COUNT = 61;

--- a/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
@@ -333,19 +333,26 @@ export function usePolicyAutoRun(): void {
   // so the enforced file appears in the app rather than only on the backend.
   useEffect(() => {
     for (const run of runs) {
+      const classification = isClassificationCategory(run.categoryId);
       if (
         run.status !== "COMPLETED" ||
         run.imported ||
-        !run.outputs?.length ||
-        importing.current.has(run.runId)
+        importing.current.has(run.runId) ||
+        // Classification settles even with no outputs (nothing to tag); other
+        // policies need an output to import.
+        (!run.outputs?.length && !classification)
       ) {
         continue;
       }
       importing.current.add(run.runId);
-      // Classification is metadata-only: stamp labels onto the existing stub in
-      // place, no version fork (see importClassificationLabels).
-      if (isClassificationCategory(run.categoryId)) {
-        void importClassificationLabels(run, {
+      // Classification is metadata-only: stamp labels onto the current leaf of
+      // the file it ran on (no version fork). See importClassificationLabels.
+      if (classification) {
+        const targetIds = classificationLabelTargets(
+          run.fileId,
+          fileStubsRef.current,
+        );
+        void importClassificationLabels(run, targetIds, {
           updateStirlingFileStub,
           bumpRevision,
         }).finally(() => importing.current.delete(run.runId));
@@ -521,22 +528,41 @@ interface ClassificationImportContext {
   bumpRevision: () => void;
 }
 
+/** Workspace stubs to tag with a classification run's labels: the file it ran
+ *  on plus any live descendants, so an edit made during the async run (which
+ *  forks a new leaf) still shows the tags. Falls back to the run's own file. */
+export function classificationLabelTargets(
+  runFileId: string,
+  stubs: ReadonlyArray<StirlingFileStub>,
+): FileId[] {
+  const targets = stubs
+    .filter(
+      (s) =>
+        (s.id as string) === runFileId ||
+        s.parentFileId === runFileId ||
+        s.sourceFileIds?.includes(runFileId as FileId),
+    )
+    .map((s) => s.id as FileId);
+  return targets.length > 0 ? targets : [runFileId as FileId];
+}
+
 /**
- * Stamp a classification run's labels onto the file's existing stub in place
- * (workspace + storage) — no versioned child, no history entry, only tags.
+ * Stamp a classification run's labels onto the target stubs in place (workspace
+ * + storage) — no versioned child, no history entry, only tags.
  */
 async function importClassificationLabels(
   run: PolicyRunRecord,
+  targetIds: FileId[],
   ctx: ClassificationImportContext,
 ): Promise<void> {
-  const targetId = run.fileId as FileId;
-  if (!targetId) {
-    // A server-reconciled run with no local input link — nothing to tag.
+  if (targetIds.length === 0) {
+    // Server-reconciled run with no local input link — nothing to tag.
     updateRun(run.runId, { imported: true });
     return;
   }
   // Read labels from the returned PDF. A non-404 failure is transient — bail and
-  // retry next tick; a 404 (output aged out) just skips that output.
+  // retry next tick; a 404 (output aged out) just skips that output. Empty
+  // outputs (nothing to read) fall through and settle the run below.
   let labels: string[] | null = null;
   for (const out of run.outputs) {
     try {
@@ -552,9 +578,12 @@ async function importClassificationLabels(
   }
   if (labels && labels.length > 0) {
     const updates = { classificationLabels: labels };
-    ctx.updateStirlingFileStub(targetId, updates);
-    const ok = await fileStorage.updateFileMetadata(targetId, updates);
-    if (ok) ctx.bumpRevision();
+    let mutated = false;
+    for (const id of targetIds) {
+      ctx.updateStirlingFileStub(id, updates);
+      if (await fileStorage.updateFileMetadata(id, updates)) mutated = true;
+    }
+    if (mutated) ctx.bumpRevision();
   }
   // Settle either way so it stops re-importing. No outputFileIds: classification
   // produces no workspace file, so it gets no version badge.

--- a/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
@@ -171,11 +171,8 @@ export function usePolicyAutoRun(): void {
               s.sources.includes("editor")) &&
             (s.runOn ?? "upload") === "upload",
         )
-        // Classification always runs LAST, regardless of its configured order:
-        // it's non-blocking and metadata-only, so it must come after every
-        // enforcement policy has finished forking its versions — otherwise it
-        // could let the user in first, then a later enforcement policy would fork
-        // a new version and drop the edits they made in the meantime.
+        // Classification runs last: it's non-blocking, so an enforcement policy
+        // running after it would fork a new version and drop the user's edits.
         .sort(([idA, a], [idB, b]) => {
           const ca = isClassificationCategory(idA) ? 1 : 0;
           const cb = isClassificationCategory(idB) ? 1 : 0;
@@ -345,10 +342,8 @@ export function usePolicyAutoRun(): void {
         continue;
       }
       importing.current.add(run.runId);
-      // Classification is metadata-only: it never forks a version or shows up in
-      // history. Read the labels the classify step wrote and stamp them onto the
-      // file's existing stub in place, leaving the document the user is editing
-      // untouched.
+      // Classification is metadata-only: stamp labels onto the existing stub in
+      // place, no version fork (see importClassificationLabels).
       if (isClassificationCategory(run.categoryId)) {
         void importClassificationLabels(run, {
           updateStirlingFileStub,
@@ -527,17 +522,8 @@ interface ClassificationImportContext {
 }
 
 /**
- * Import a completed classification run's result as metadata only. The classify
- * step returns the document with its labels written into the
- * StirlingPDFClassification key; we read those labels and stamp them onto the
- * file's existing stub (workspace + storage) IN PLACE — no versioned child, no
- * consumeFiles, no history entry. The file the user is viewing/editing is left
- * exactly as it was; only its tags appear.
- *
- * The stub is keyed by the file the run executed on (the leaf of the enforcement
- * chain, since classification always runs last). Later edits inherit the labels
- * through createChildStub / the CONSUME_FILES reducer, just like an enforcement
- * policy's labels do.
+ * Stamp a classification run's labels onto the file's existing stub in place
+ * (workspace + storage) — no versioned child, no history entry, only tags.
  */
 async function importClassificationLabels(
   run: PolicyRunRecord,
@@ -549,10 +535,8 @@ async function importClassificationLabels(
     updateRun(run.runId, { imported: true });
     return;
   }
-  // Read the labels from the returned PDF's metadata. Try each output until one
-  // yields labels; a non-404 failure is transient, so bail without marking
-  // imported and let it retry next tick. A 404 (output aged out) just skips that
-  // output — nothing left to retry, so we settle below.
+  // Read labels from the returned PDF. A non-404 failure is transient — bail and
+  // retry next tick; a 404 (output aged out) just skips that output.
   let labels: string[] | null = null;
   for (const out of run.outputs) {
     try {
@@ -572,9 +556,8 @@ async function importClassificationLabels(
     const ok = await fileStorage.updateFileMetadata(targetId, updates);
     if (ok) ctx.bumpRevision();
   }
-  // Settle the run either way (labels found, none found, or output gone), so it
-  // stops polling/re-importing. No outputFileIds — classification produces no
-  // workspace file, so it never gets a version badge; the labels are the result.
+  // Settle either way so it stops re-importing. No outputFileIds: classification
+  // produces no workspace file, so it gets no version badge.
   updateRun(run.runId, {
     imported: true,
     importedFileIds: run.outputs.map((o) => o.fileId),

--- a/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
@@ -39,6 +39,7 @@ import { dispatchPaygLimitReached } from "@app/services/usageLimitBridge";
 import type { FileId } from "@app/types/file";
 import { createStirlingFilesAndStubs } from "@app/services/fileStubHelpers";
 import { readClassificationLabelsFromFile } from "@app/services/fileClassification";
+import { isClassificationCategory } from "@app/data/policyCategories";
 import type { StirlingFile, StirlingFileStub } from "@app/types/fileContext";
 import type { PoliciesByCategory } from "@app/types/policies";
 import { usePolicies } from "@app/hooks/usePolicies";
@@ -170,7 +171,17 @@ export function usePolicyAutoRun(): void {
               s.sources.includes("editor")) &&
             (s.runOn ?? "upload") === "upload",
         )
-        .sort(([, a], [, b]) => (a.order ?? 0) - (b.order ?? 0))
+        // Classification always runs LAST, regardless of its configured order:
+        // it's non-blocking and metadata-only, so it must come after every
+        // enforcement policy has finished forking its versions — otherwise it
+        // could let the user in first, then a later enforcement policy would fork
+        // a new version and drop the edits they made in the meantime.
+        .sort(([idA, a], [idB, b]) => {
+          const ca = isClassificationCategory(idA) ? 1 : 0;
+          const cb = isClassificationCategory(idB) ? 1 : 0;
+          if (ca !== cb) return ca - cb;
+          return (a.order ?? 0) - (b.order ?? 0);
+        })
         .map(([id]) => id),
     [policies],
   );
@@ -334,6 +345,17 @@ export function usePolicyAutoRun(): void {
         continue;
       }
       importing.current.add(run.runId);
+      // Classification is metadata-only: it never forks a version or shows up in
+      // history. Read the labels the classify step wrote and stamp them onto the
+      // file's existing stub in place, leaving the document the user is editing
+      // untouched.
+      if (isClassificationCategory(run.categoryId)) {
+        void importClassificationLabels(run, {
+          updateStirlingFileStub,
+          bumpRevision,
+        }).finally(() => importing.current.delete(run.runId));
+        continue;
+      }
       // Honour the policy's output mode: a new file, or a new version of the
       // input file it ran on (needs that input's stub, still in the workspace).
       const outputMode = policies[run.categoryId]?.outputMode ?? "new_version";
@@ -494,6 +516,69 @@ function categoryForPolicy(
   return Object.entries(policies).find(
     ([, s]) => s.backendId === policyId,
   )?.[0];
+}
+
+interface ClassificationImportContext {
+  updateStirlingFileStub: (
+    fileId: FileId,
+    updates: Partial<StirlingFileStub>,
+  ) => void;
+  bumpRevision: () => void;
+}
+
+/**
+ * Import a completed classification run's result as metadata only. The classify
+ * step returns the document with its labels written into the
+ * StirlingPDFClassification key; we read those labels and stamp them onto the
+ * file's existing stub (workspace + storage) IN PLACE — no versioned child, no
+ * consumeFiles, no history entry. The file the user is viewing/editing is left
+ * exactly as it was; only its tags appear.
+ *
+ * The stub is keyed by the file the run executed on (the leaf of the enforcement
+ * chain, since classification always runs last). Later edits inherit the labels
+ * through createChildStub / the CONSUME_FILES reducer, just like an enforcement
+ * policy's labels do.
+ */
+async function importClassificationLabels(
+  run: PolicyRunRecord,
+  ctx: ClassificationImportContext,
+): Promise<void> {
+  const targetId = run.fileId as FileId;
+  if (!targetId) {
+    // A server-reconciled run with no local input link — nothing to tag.
+    updateRun(run.runId, { imported: true });
+    return;
+  }
+  // Read the labels from the returned PDF's metadata. Try each output until one
+  // yields labels; a non-404 failure is transient, so bail without marking
+  // imported and let it retry next tick. A 404 (output aged out) just skips that
+  // output — nothing left to retry, so we settle below.
+  let labels: string[] | null = null;
+  for (const out of run.outputs) {
+    try {
+      const blob = await downloadPolicyOutput(out.fileId, run.target);
+      const file = new File([blob], out.fileName ?? run.fileName, {
+        type: blob.type || "application/pdf",
+      });
+      labels = await readClassificationLabelsFromFile(file);
+      if (labels && labels.length > 0) break;
+    } catch (err) {
+      if (!isNotFoundError(err)) return; // transient — retry on a later tick.
+    }
+  }
+  if (labels && labels.length > 0) {
+    const updates = { classificationLabels: labels };
+    ctx.updateStirlingFileStub(targetId, updates);
+    const ok = await fileStorage.updateFileMetadata(targetId, updates);
+    if (ok) ctx.bumpRevision();
+  }
+  // Settle the run either way (labels found, none found, or output gone), so it
+  // stops polling/re-importing. No outputFileIds — classification produces no
+  // workspace file, so it never gets a version badge; the labels are the result.
+  updateRun(run.runId, {
+    imported: true,
+    importedFileIds: run.outputs.map((o) => o.fileId),
+  });
 }
 
 /**

--- a/frontend/editor/src/proprietary/components/viewer/Viewer.tsx
+++ b/frontend/editor/src/proprietary/components/viewer/Viewer.tsx
@@ -8,6 +8,7 @@ import {
   usePolicyRuns,
   type PolicyRunRecord,
 } from "@app/components/policies/policyRunStore";
+import { isClassificationCategory } from "@app/data/policyCategories";
 import { PolicyEnforcementOverlay } from "@app/components/viewer/PolicyEnforcementOverlay";
 
 type SignatureOverlayPassThrough = Pick<
@@ -29,6 +30,8 @@ const Viewer = (props: ViewerProps & SignatureOverlayPassThrough) => {
     ? allRuns.filter(
         (r: PolicyRunRecord) =>
           r.fileId === activeFileId &&
+          // Classification runs async and must never block the viewer.
+          !isClassificationCategory(r.categoryId) &&
           (POLICY_IN_FLIGHT_STATUSES.includes(r.status) || r.retrying === true),
       )
     : [];

--- a/frontend/editor/src/proprietary/data/policyCategories.test.ts
+++ b/frontend/editor/src/proprietary/data/policyCategories.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  isClassificationCategory,
+  pinClassificationLast,
+} from "@app/data/policyCategories";
+
+describe("isClassificationCategory", () => {
+  it("recognises the classification category and nothing else", () => {
+    expect(isClassificationCategory("classification")).toBe(true);
+    expect(isClassificationCategory("security")).toBe(false);
+    expect(isClassificationCategory("")).toBe(false);
+  });
+});
+
+describe("pinClassificationLast", () => {
+  it("moves classification to the end, preserving other order", () => {
+    expect(
+      pinClassificationLast(["classification", "security", "compliance"]),
+    ).toEqual(["security", "compliance", "classification"]);
+  });
+
+  it("leaves an order without classification untouched", () => {
+    expect(pinClassificationLast(["security", "compliance"])).toEqual([
+      "security",
+      "compliance",
+    ]);
+  });
+
+  it("is a no-op when classification is already last", () => {
+    expect(pinClassificationLast(["security", "classification"])).toEqual([
+      "security",
+      "classification",
+    ]);
+  });
+
+  it("handles classification as the only policy", () => {
+    expect(pinClassificationLast(["classification"])).toEqual([
+      "classification",
+    ]);
+  });
+});

--- a/frontend/editor/src/proprietary/data/policyCategories.ts
+++ b/frontend/editor/src/proprietary/data/policyCategories.ts
@@ -1,30 +1,17 @@
-/**
- * Stable policy-catalog category ids that need special-case handling in the
- * enforcement flow.
- */
-
 /** The classification policy's catalog category id. */
 export const CLASSIFICATION_CATEGORY_ID = "classification";
 
 /**
- * Classification is metadata-only. Unlike enforcement policies (redact,
- * sanitize, encrypt, …) it never rewrites the document — it just reads it and
- * records labels. So it runs fully async to what the user is doing: it doesn't
- * block viewing/editing, doesn't fork a new file version, and doesn't appear in
- * version history; it only tags the file once it finishes. It also always runs
- * LAST in an enforcement chain, so it never lets the user in before an
- * enforcement policy that would fork a new version and drop their edits.
+ * Classification is metadata-only: it runs async (never blocks), never forks a
+ * version, and always runs last. This predicate gates that special handling.
  */
 export function isClassificationCategory(categoryId: string): boolean {
   return categoryId === CLASSIFICATION_CATEGORY_ID;
 }
 
 /**
- * Normalise a policy execution order so classification always sits last, keeping
- * every other category's relative order. The auto-run enforces this at execution
- * time regardless (see usePolicyAutoRun), but pinning it here — at the point an
- * order is persisted — means a reorder UI can never store or show classification
- * anywhere but last, so what the user sees matches when it actually runs.
+ * Move classification to the end of an execution order (others keep their order),
+ * so a persisted/displayed order can't place it anywhere but last.
  */
 export function pinClassificationLast(orderedCategoryIds: string[]): string[] {
   return [

--- a/frontend/editor/src/proprietary/data/policyCategories.ts
+++ b/frontend/editor/src/proprietary/data/policyCategories.ts
@@ -18,3 +18,17 @@ export const CLASSIFICATION_CATEGORY_ID = "classification";
 export function isClassificationCategory(categoryId: string): boolean {
   return categoryId === CLASSIFICATION_CATEGORY_ID;
 }
+
+/**
+ * Normalise a policy execution order so classification always sits last, keeping
+ * every other category's relative order. The auto-run enforces this at execution
+ * time regardless (see usePolicyAutoRun), but pinning it here — at the point an
+ * order is persisted — means a reorder UI can never store or show classification
+ * anywhere but last, so what the user sees matches when it actually runs.
+ */
+export function pinClassificationLast(orderedCategoryIds: string[]): string[] {
+  return [
+    ...orderedCategoryIds.filter((id) => !isClassificationCategory(id)),
+    ...orderedCategoryIds.filter((id) => isClassificationCategory(id)),
+  ];
+}

--- a/frontend/editor/src/proprietary/data/policyCategories.ts
+++ b/frontend/editor/src/proprietary/data/policyCategories.ts
@@ -1,0 +1,20 @@
+/**
+ * Stable policy-catalog category ids that need special-case handling in the
+ * enforcement flow.
+ */
+
+/** The classification policy's catalog category id. */
+export const CLASSIFICATION_CATEGORY_ID = "classification";
+
+/**
+ * Classification is metadata-only. Unlike enforcement policies (redact,
+ * sanitize, encrypt, …) it never rewrites the document — it just reads it and
+ * records labels. So it runs fully async to what the user is doing: it doesn't
+ * block viewing/editing, doesn't fork a new file version, and doesn't appear in
+ * version history; it only tags the file once it finishes. It also always runs
+ * LAST in an enforcement chain, so it never lets the user in before an
+ * enforcement policy that would fork a new version and drop their edits.
+ */
+export function isClassificationCategory(categoryId: string): boolean {
+  return categoryId === CLASSIFICATION_CATEGORY_ID;
+}

--- a/frontend/editor/src/proprietary/hooks/usePolicies.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicies.ts
@@ -327,9 +327,8 @@ export function usePolicies() {
    * first for an instant re-render; the next reconcile re-reads the server order.
    */
   const reorderPolicies = useCallback((orderedCategoryIds: string[]) => {
-    // Classification is metadata-only and always runs last (see usePolicyAutoRun).
-    // Pin it to the end of any requested order so the persisted + server-side
-    // order matches when it actually runs — a reorder UI can't misplace it.
+    // Pin classification last so the persisted/server order matches execution
+    // (it always runs last — see usePolicyAutoRun).
     const ordered = pinClassificationLast(orderedCategoryIds);
     persistPolicyOrder(ordered);
     const current = loadPolicies();

--- a/frontend/editor/src/proprietary/hooks/usePolicies.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicies.ts
@@ -35,6 +35,7 @@ import {
   removePolicy,
 } from "@app/services/policyBackend";
 import { reorderPolicies as reorderBackendPolicies } from "@app/services/policyApi";
+import { pinClassificationLast } from "@app/data/policyCategories";
 import type { PolicyToStore } from "@app/services/policyPipeline";
 import type {
   PoliciesByCategory,
@@ -326,9 +327,13 @@ export function usePolicies() {
    * first for an instant re-render; the next reconcile re-reads the server order.
    */
   const reorderPolicies = useCallback((orderedCategoryIds: string[]) => {
-    persistPolicyOrder(orderedCategoryIds);
+    // Classification is metadata-only and always runs last (see usePolicyAutoRun).
+    // Pin it to the end of any requested order so the persisted + server-side
+    // order matches when it actually runs — a reorder UI can't misplace it.
+    const ordered = pinClassificationLast(orderedCategoryIds);
+    persistPolicyOrder(ordered);
     const current = loadPolicies();
-    const backendIds = orderedCategoryIds
+    const backendIds = ordered
       .map((categoryId) => current[categoryId]?.backendId)
       .filter((id): id is string => !!id);
     if (backendIds.length > 0) {

--- a/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.test.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.test.ts
@@ -186,7 +186,13 @@ describe("buildPolicyBadgeMap — enforcing spinner while a run is in flight", (
     // Classification is metadata-only, so even mid-run it must not block the
     // file — no enforcing spinner, no gated actions.
     const map = buildPolicyBadgeMap(
-      [run({ categoryId: "classification", status: "RUNNING", outputFileIds: [] })],
+      [
+        run({
+          categoryId: "classification",
+          status: "RUNNING",
+          outputFileIds: [],
+        }),
+      ],
       [{ id: "in" }],
       labels,
       NOW,

--- a/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.test.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.test.ts
@@ -6,6 +6,7 @@ const NOW = 1_000_000;
 const labels = new Map([
   ["security", "Security"],
   ["watermark", "Watermark"],
+  ["classification", "Classification"],
 ]);
 
 function run(overrides: Partial<PolicyRunRecord>): PolicyRunRecord {
@@ -174,6 +175,18 @@ describe("buildPolicyBadgeMap — enforcing spinner while a run is in flight", (
   it("skips runs with no input fileId (server-reconciled orphans)", () => {
     const map = buildPolicyBadgeMap(
       [run({ status: "RUNNING", fileId: "", outputFileIds: [] })],
+      [{ id: "in" }],
+      labels,
+      NOW,
+    );
+    expect(enforcingOn(map, "in")).toBe(false);
+  });
+
+  it("never marks a classification run enforcing (it runs fully async)", () => {
+    // Classification is metadata-only, so even mid-run it must not block the
+    // file — no enforcing spinner, no gated actions.
+    const map = buildPolicyBadgeMap(
+      [run({ categoryId: "classification", status: "RUNNING", outputFileIds: [] })],
       [{ id: "in" }],
       labels,
       NOW,

--- a/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.ts
@@ -4,6 +4,7 @@ import type { PolicyRunRecord } from "@app/components/policies/policyRunStore";
 import { useAllFiles } from "@app/contexts/FileContext";
 import { loadPolicyCatalog } from "@app/services/policyCatalog";
 import { policyAccentVar } from "@app/components/policies/policyStatus";
+import { isClassificationCategory } from "@app/data/policyCategories";
 import type { FileItemPolicyRef } from "@app/components/shared/PolicyBadges";
 
 /** How long after a run a badge counts as "recent" (drives the one-off glow).
@@ -107,6 +108,10 @@ export function buildPolicyBadgeMap(
   // status alone would drop the badge during that async gap.
   for (const run of runs) {
     if (!run.fileId) continue;
+    // Classification is metadata-only and runs fully async — it must never mark
+    // the file "enforcing", which is what blocks viewing/editing. It surfaces
+    // its labels once done instead of gating the file while it runs.
+    if (isClassificationCategory(run.categoryId)) continue;
     const settled =
       run.imported || run.status === "FAILED" || run.status === "CANCELLED";
     if (settled && !run.retrying) continue;

--- a/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.ts
+++ b/frontend/editor/src/proprietary/hooks/usePolicyFileBadges.ts
@@ -108,9 +108,8 @@ export function buildPolicyBadgeMap(
   // status alone would drop the badge during that async gap.
   for (const run of runs) {
     if (!run.fileId) continue;
-    // Classification is metadata-only and runs fully async — it must never mark
-    // the file "enforcing", which is what blocks viewing/editing. It surfaces
-    // its labels once done instead of gating the file while it runs.
+    // Classification runs async and must never mark the file "enforcing" (that
+    // flag blocks viewing/editing); it only surfaces labels when done.
     if (isClassificationCategory(run.categoryId)) continue;
     const settled =
       run.imported || run.status === "FAILED" || run.status === "CANCELLED";


### PR DESCRIPTION
## What & why

Classification is **metadata-only** — it reads a document and records labels. It never rewrites the file, unlike enforcement policies (redact, sanitize, encrypt, …) which do.

Previously it ran in the enforcement chain like any other policy, which caused the problem described in the issue:

- It **blocked** viewing/editing behind the "Enforcing policy…" overlay while it ran.
- It **forked a new versioned child** of the file, recorded as an `automate` step in **version history**.
- It could run **before** other policies — letting the user in, and then a later enforcement policy would fork a new version and **drop the edits** the user made in the meantime.

## What changed

Classification is now treated as fully async and metadata-only:

1. **Never blocks.** A classification run never marks a file `enforcing`, so the overlay never shows and no file actions are disabled while it runs. The file is fully viewable/editable throughout.
2. **No version bump, no history entry.** Its import path reads the labels the classify step wrote and stamps them onto the file's **existing stub in place** (workspace + IndexedDB) — no versioned child, no `consumeFiles`, no `automate` entry in version history. The labels still surface as tags (details panel + sidebar grouping).
3. **Always runs last.** In an enforcement chain, classification is forced to the end regardless of its configured order, so every enforcement policy finishes forking its versions before the user is let in — closing the "let in, then kicked out and lose edits" gap.

## Files

- `proprietary/data/policyCategories.ts` *(new)* — `isClassificationCategory()` / `CLASSIFICATION_CATEGORY_ID`, the single signal the flow keys off.
- `proprietary/components/policies/usePolicyAutoRun.ts` — force classification last in `orderedUploadCategories`; route classification runs to a new `importClassificationLabels()` (metadata-only, in place, no version).
- `proprietary/hooks/usePolicyFileBadges.ts` — skip classification in the in-flight pass so it never sets `enforcing`.
- Tests updated/added: badge map never marks classification enforcing; the 61-file batch integration test now asserts the Security → Classification order, Security-only versioning, and Classification tagging without forking a version.

## Verification

- `task frontend:test` — all 1354 tests pass (incl. the rewritten batch integration test that drives the real dispatch → poll → import → chain effects).
- `task frontend:typecheck` and `task frontend:lint` — clean.

## Known edge

If a user edits the file *during* the (brief) async classification window — after the last enforcement policy unblocks but before classification finishes — the labels land on the version classify ran on, not the newly-edited leaf, so tags may not show on that new version. Classification runs last and is typically fast, so this window is small; forward inheritance covers edits made after labels are stamped.
