### PR TITLE
Add explicit length to member column to avoid ddl resizing

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/model/TeamMembership.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/model/TeamMembership.java
@@ -60,7 +60,7 @@ public class TeamMembership implements Serializable {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
+    @Column(name = "role", nullable = false, length = 50)
     @ToString.Include
     private TeamRole role = TeamRole.MEMBER;
 


### PR DESCRIPTION
# Description of Changes
There's currently a column size inconsistency between the SaaS v3 DB and the main Java code which causes the backend to fail to start up when connected to a fresh DB. This is because the column previously was width 255, but now it's officially width 50, but the Java type is still implicitly `varchar(255)` because there's no length attribute. If it's a fresh DB, Postgres throws an error that it can't expand the column (this doesn't error on an existing DB because the column is already wide enough behind the scenes).