### PR TITLE
style(sidebar): fix file sidebar button visibility spacing

### DIFF
--- a/frontend/editor/src/core/components/shared/FileSidebarFileItem.css
+++ b/frontend/editor/src/core/components/shared/FileSidebarFileItem.css
@@ -50,17 +50,16 @@
 }
 
 .file-sidebar-file-item:hover .file-sidebar-file-actions,
-.file-sidebar-file-item.viewed .file-sidebar-file-actions {
+.file-sidebar-file-item:focus-within .file-sidebar-file-actions,
+.file-sidebar-file-item.viewed .file-sidebar-file-actions,
+.file-sidebar-file-item.selected .file-sidebar-file-actions {
   pointer-events: auto;
 }
 
-/* Only shrink the name to clear the buttons while they're visible. */
+/* Always reserve space for action buttons so file name truncation dots (...)
+   never bleed under action buttons or overlap their outline/focus box. */
 .file-sidebar-file-info {
-  transition: padding-right 0.12s ease;
-}
-.file-sidebar-file-item:hover .file-sidebar-file-info,
-.file-sidebar-file-item.viewed .file-sidebar-file-info {
-  padding-right: 3.5rem;
+  padding-right: 3.75rem;
 }
 
 .file-sidebar-file-item:hover:not(.selected) {
@@ -368,8 +367,10 @@
     color 0.12s ease;
 }
 
-/* Reveal on row hover, and keep it shown while its menu is open. */
+/* Reveal on row hover/focus/selected, and keep it shown while its menu is open. */
 .file-sidebar-file-item:hover .file-sidebar-kebab-btn,
+.file-sidebar-file-item:focus-within .file-sidebar-kebab-btn,
+.file-sidebar-file-item.selected .file-sidebar-kebab-btn,
 .file-sidebar-kebab-btn[aria-expanded="true"] {
   opacity: 1;
 }


### PR DESCRIPTION
# Description of Changes

<img width="522" height="258" alt="image" src="https://github.com/user-attachments/assets/f7310ae9-3bdb-460a-a761-d593d6daafe0" />


<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
