### PR TITLE
style(people): Fix convert dropdown single-category formatting and admin table header styling

### DIFF
--- a/frontend/editor/src/proprietary/components/shared/config/configSections/PeopleSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/PeopleSection.tsx
@@ -588,38 +588,22 @@ export default function PeopleSection() {
       </Group>
 
       {/* Members Table */}
-      <Table
-        horizontalSpacing="md"
-        verticalSpacing="sm"
-        withRowBorders
-        style={
-          {
-            "--table-border-color": "var(--mantine-color-gray-3)",
-          } as React.CSSProperties
-        }
-      >
+      <Table horizontalSpacing="md" verticalSpacing="sm" withRowBorders>
         <Table.Thead>
-          <Table.Tr style={{ backgroundColor: "var(--mantine-color-gray-0)" }}>
-            <Table.Th
-              style={{ fontWeight: 600, color: "var(--mantine-color-gray-7)" }}
-              fz="sm"
-            >
+          <Table.Tr>
+            <Table.Th style={{ fontWeight: 600 }} fz="sm">
               {t("workspace.people.user")}
             </Table.Th>
             <Table.Th
               style={{
                 fontWeight: 600,
-                color: "var(--mantine-color-gray-7)",
                 whiteSpace: "nowrap",
               }}
               fz="sm"
             >
               {t("workspace.people.role")}
             </Table.Th>
-            <Table.Th
-              style={{ fontWeight: 600, color: "var(--mantine-color-gray-7)" }}
-              fz="sm"
-            >
+            <Table.Th style={{ fontWeight: 600 }} fz="sm">
               {t("workspace.people.team")}
             </Table.Th>
             <Table.Th w={50}></Table.Th>

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/TeamDetailsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/TeamDetailsSection.tsx
@@ -408,29 +408,13 @@ export default function TeamDetailsSection({
       </Group>
 
       {/* Members Table */}
-      <Table
-        horizontalSpacing="md"
-        verticalSpacing="sm"
-        withRowBorders
-        style={
-          {
-            "--table-border-color": "var(--mantine-color-gray-3)",
-          } as React.CSSProperties
-        }
-      >
+      <Table horizontalSpacing="md" verticalSpacing="sm" withRowBorders>
         <Table.Thead>
-          <Table.Tr style={{ backgroundColor: "var(--mantine-color-gray-0)" }}>
-            <Table.Th
-              style={{ fontWeight: 600, color: "var(--mantine-color-gray-7)" }}
-              fz="sm"
-            >
+          <Table.Tr>
+            <Table.Th style={{ fontWeight: 600 }} fz="sm">
               {t("workspace.people.user")}
             </Table.Th>
-            <Table.Th
-              style={{ fontWeight: 600, color: "var(--mantine-color-gray-7)" }}
-              fz="sm"
-              w={100}
-            >
+            <Table.Th style={{ fontWeight: 600 }} fz="sm" w={100}>
               {t("workspace.people.role")}
             </Table.Th>
             <Table.Th w={50}></Table.Th>

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/TeamsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/TeamsSection.tsx
@@ -298,19 +298,13 @@ export default function TeamsSection() {
         verticalSpacing="sm"
         withRowBorders
         highlightOnHover
-        style={
-          {
-            "--table-border-color": "var(--mantine-color-gray-3)",
-          } as React.CSSProperties
-        }
       >
         <Table.Thead>
-          <Table.Tr style={{ backgroundColor: "var(--mantine-color-gray-0)" }}>
+          <Table.Tr>
             <Table.Th
               style={{
                 fontWeight: 600,
                 fontSize: "0.875rem",
-                color: "var(--mantine-color-gray-7)",
               }}
             >
               {t("workspace.teams.teamName")}
@@ -319,7 +313,6 @@ export default function TeamsSection() {
               style={{
                 fontWeight: 600,
                 fontSize: "0.875rem",
-                color: "var(--mantine-color-gray-7)",
               }}
             >
               {t("workspace.teams.totalMembers")}


### PR DESCRIPTION
# Description of Changes

The dropdown table with the people looked out-place mainly due to the blue, i think... this simplifies and make more consistent with the rest of the "new" UI and not so aggresive with the colour schema.


### New:

<img width="2204" height="852" alt="image" src="https://github.com/user-attachments/assets/0e329092-a532-445b-a27d-7afbd0a16d4c" />


### Old:

<img width="2210" height="838" alt="image" src="https://github.com/user-attachments/assets/6e251d6f-f22c-4b9e-aebf-96e7fea40144" />



<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [X] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have run `task check` to verify linters, typechecks, and tests pass
- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
