### PR TITLE
Fix Wayland rendering on Linux AppImages

### DIFF
--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -453,6 +453,16 @@ jobs:
             exit 1
           fi
 
+      - name: Verify AppImage Wayland compatibility hook
+        if: matrix.platform == 'ubuntu-22.04'
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_file="./frontend/editor/src-tauri/src/lib.rs"
+          grep -q 'APPIMAGE' "$source_file"
+          grep -q 'LD_PRELOAD' "$source_file"
+          echo "AppImage-only Wayland compatibility hook is present"
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -365,6 +365,16 @@ jobs:
             exit 1
           fi
 
+      - name: Verify AppImage Wayland compatibility hook
+        if: matrix.platform == 'ubuntu-22.04'
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_file="./frontend/editor/src-tauri/src/lib.rs"
+          grep -q 'APPIMAGE' "$source_file"
+          grep -q 'LD_PRELOAD' "$source_file"
+          echo "AppImage-only Wayland compatibility hook is present"
+
       - name: Build Tauri app (signed)
         if: inputs.sign
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2

--- a/frontend/editor/src-tauri/src/lib.rs
+++ b/frontend/editor/src-tauri/src/lib.rs
@@ -71,8 +71,85 @@ fn parse_launch_files(args: &[String]) -> Vec<String> {
     .collect()
 }
 
+#[cfg(target_os = "linux")]
+fn configure_wayland_environment() {
+  use std::path::Path;
+
+  // APPIMAGE and APPDIR are provided by the AppImage runtime. Keep this
+  // workaround scoped to AppImages so deb/rpm packages and development
+  // builds retain their normal WebKitGTK environment.
+  let is_appimage = std::env::var_os("APPIMAGE").is_some()
+    || std::env::var_os("APPDIR").is_some();
+  if !is_appimage {
+    return;
+  }
+
+  let is_wayland = std::env::var_os("WAYLAND_DISPLAY").is_some()
+    || std::env::var("XDG_SESSION_TYPE")
+      .map(|session_type| session_type.eq_ignore_ascii_case("wayland"))
+      .unwrap_or(false);
+
+  if !is_wayland {
+    return;
+  }
+
+  // WebKitGTK runs in a child process. Set these before Tauri creates the
+  // webview so the child inherits them. This works around AppImages that
+  // bundle an incompatible libwayland-client on some Wayland distributions.
+  if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+  }
+  if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+  }
+
+  if std::env::var_os("LD_PRELOAD").is_some() {
+    return;
+  }
+
+  // Use architecture-specific candidates instead of distro checks. The
+  // AppImage may run on Fedora, Debian/Ubuntu, Arch, or another distribution,
+  // each of which can place the system library in a different directory.
+  let library_candidates: &[&str] = match std::env::consts::ARCH {
+    "x86_64" => &[
+      "/lib64/libwayland-client.so.0",
+      "/usr/lib64/libwayland-client.so.0",
+      "/lib/x86_64-linux-gnu/libwayland-client.so.0",
+      "/usr/lib/x86_64-linux-gnu/libwayland-client.so.0",
+      "/usr/lib/libwayland-client.so.0",
+    ],
+    "aarch64" => &[
+      "/lib64/libwayland-client.so.0",
+      "/usr/lib64/libwayland-client.so.0",
+      "/lib/aarch64-linux-gnu/libwayland-client.so.0",
+      "/usr/lib/aarch64-linux-gnu/libwayland-client.so.0",
+      "/usr/lib/libwayland-client.so.0",
+    ],
+    "arm" => &[
+      "/lib/arm-linux-gnueabihf/libwayland-client.so.0",
+      "/usr/lib/arm-linux-gnueabihf/libwayland-client.so.0",
+      "/usr/lib/libwayland-client.so.0",
+    ],
+    _ => &[],
+  };
+
+  let system_wayland_client = library_candidates
+    .iter()
+    .map(|path| Path::new(path))
+    .find(|path| path.is_file());
+
+  if let Some(path) = system_wayland_client {
+    std::env::set_var("LD_PRELOAD", path);
+  }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_wayland_environment() {}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+  configure_wayland_environment();
+
   tauri::Builder::default()
     .plugin(
       tauri_plugin_log::Builder::new()


### PR DESCRIPTION
# Description of Changes

Add AppImage-specific Wayland compatibility configuration that:

- Detects AppImage runtime environment and Wayland display server
- Disables problematic WebKitGTK rendering modes (DMABUF, compositing)
- Preloads the system libwayland-client.so.0 library instead of bundled version
- Supports x86_64, aarch64, and arm architectures with distro-agnostic library search paths
- Only activates for AppImages; dev builds and deb/rpm packages use normal WebKitGTK environment

Also adds CI verification in both tauri-build.yml and multiOSReleases.yml to ensure the compatibility hook is present during builds.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
