### PR TITLE
chore(i18n): localize hardcoded UI strings across editor components

### DIFF
--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -2931,8 +2931,12 @@ close = "Close chat"
 open = "Open Stirling AI assistant"
 
 [chat.header]
+assistant = "AI Assistant"
 agentMenu = "Stirling agent options"
 clearChat = "Clear chat"
+
+[chat.emptyState]
+text = "Ask a question about your documents or get help with PDF tools."
 
 [chat.input]
 disclaimer = "AI can make mistakes. Be sure to verify the output before sharing."
@@ -2990,6 +2994,9 @@ unknownTool = "Unknown tool"
 [cloudBadge]
 tooltip = "This operation will use your cloud credits"
 
+[toolRenderer]
+notFound = "Tool not found: {{tool}}"
+
 [color.eyeDropper]
 tooltip = "Pick color from screen"
 
@@ -3000,6 +3007,7 @@ title = "Choose color"
 back = "Back"
 cancel = "Cancel"
 close = "Close"
+enterValue = "Enter value"
 collapse = "Collapse"
 confirm = "Confirm"
 continue = "Continue"
@@ -3575,7 +3583,11 @@ tags = "automation,folder,scanning,watch folder,hot folder,automatic processing,
 tags = "SSO,single sign-on,authentication,SAML,OAuth,OIDC,login,enterprise,identity provider,IdP"
 
 [dropdownList]
+noItems = "No items available"
+noResults = "No results found"
 searchPlaceholder = "Search..."
+selectLanguages = "Select languages"
+selectOption = "Select an option"
 
 [editableSecretField]
 edit = "Edit"
@@ -10056,6 +10068,7 @@ title = "Extracted JavaScript"
 activate = "Activate Signature Placement"
 add = "Add"
 addToAll = "Add to all pages"
+penSizePlaceholder = "Type or select pen size (1-200)"
 applySignatures = "Apply Signatures"
 clear = "Clear"
 deactivate = "Stop Placing Signatures"

--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -2926,17 +2926,17 @@ text = "To make these permissions unchangeable, use the Add Password tool to set
 [chat.actions]
 copy = "Copy message"
 
+[chat.emptyState]
+text = "Ask a question about your documents or get help with PDF tools."
+
 [chat.fab]
 close = "Close chat"
 open = "Open Stirling AI assistant"
 
 [chat.header]
-assistant = "AI Assistant"
 agentMenu = "Stirling agent options"
+assistant = "AI Assistant"
 clearChat = "Clear chat"
-
-[chat.emptyState]
-text = "Ask a question about your documents or get help with PDF tools."
 
 [chat.input]
 disclaimer = "AI can make mistakes. Be sure to verify the output before sharing."
@@ -2994,9 +2994,6 @@ unknownTool = "Unknown tool"
 [cloudBadge]
 tooltip = "This operation will use your cloud credits"
 
-[toolRenderer]
-notFound = "Tool not found: {{tool}}"
-
 [color.eyeDropper]
 tooltip = "Pick color from screen"
 
@@ -3007,13 +3004,13 @@ title = "Choose color"
 back = "Back"
 cancel = "Cancel"
 close = "Close"
-enterValue = "Enter value"
 collapse = "Collapse"
 confirm = "Confirm"
 continue = "Continue"
 copied = "Copied!"
 copy = "Copy"
 done = "Done"
+enterValue = "Enter value"
 error = "Error"
 expand = "Expand"
 loading = "Loading..."
@@ -10068,7 +10065,6 @@ title = "Extracted JavaScript"
 activate = "Activate Signature Placement"
 add = "Add"
 addToAll = "Add to all pages"
-penSizePlaceholder = "Type or select pen size (1-200)"
 applySignatures = "Apply Signatures"
 clear = "Clear"
 deactivate = "Stop Placing Signatures"
@@ -10079,6 +10075,7 @@ last = "Last page"
 maintainRatio = "Toggle maintain aspect ratio"
 next = "Next page"
 noSavedSigs = "No saved signatures found"
+penSizePlaceholder = "Type or select pen size (1-200)"
 personalSigs = "Personal Signatures"
 previous = "Previous page"
 redo = "Redo"
@@ -10749,6 +10746,9 @@ pageFormatting = "Page Formatting"
 removal = "Removal"
 signing = "Signing"
 verification = "Verification"
+
+[toolRenderer]
+notFound = "Tool not found: {{tool}}"
 
 [tools]
 noSearchResults = "No tools found"

--- a/frontend/editor/src/core/components/shared/DropdownListWithFooter.tsx
+++ b/frontend/editor/src/core/components/shared/DropdownListWithFooter.tsx
@@ -56,7 +56,7 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
   value,
   onChange,
   items,
-  placeholder = "Select option",
+  placeholder,
   disabled = false,
   label,
   header,
@@ -73,6 +73,7 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
   zIndex = Z_INDEX_AUTOMATE_DROPDOWN,
 }) => {
   const { t } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t("dropdownList.selectOption");
   const [searchTerm, setSearchTerm] = useState("");
 
   const isMultiValue = Array.isArray(value);
@@ -101,7 +102,7 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
 
   const getDisplayText = () => {
     if (selectedValues.length === 0) {
-      return placeholder;
+      return resolvedPlaceholder;
     } else if (selectedValues.length === 1) {
       const selectedItem = items.find(
         (item) => item.value === selectedValues[0],
@@ -201,8 +202,8 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
                 <Box style={{ padding: "12px", textAlign: "center" }}>
                   <Text size="sm" c="dimmed">
                     {searchable && searchTerm
-                      ? "No results found"
-                      : "No items available"}
+                      ? t("dropdownList.noResults")
+                      : t("dropdownList.noItems")}
                   </Text>
                 </Box>
               ) : (

--- a/frontend/editor/src/core/components/shared/EditableSecretField.tsx
+++ b/frontend/editor/src/core/components/shared/EditableSecretField.tsx
@@ -27,11 +27,12 @@ export default function EditableSecretField({
   description,
   value,
   onChange,
-  placeholder = "Enter value",
+  placeholder,
   disabled = false,
   error,
 }: EditableSecretFieldProps) {
   const { t } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t("common.enterValue");
   const [isEditing, setIsEditing] = useState(false);
   const [tempValue, setTempValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -113,7 +114,7 @@ export default function EditableSecretField({
           ref={inputRef}
           value={tempValue}
           onChange={(e) => setTempValue(e.currentTarget.value)}
-          placeholder={placeholder}
+          placeholder={resolvedPlaceholder}
           disabled={disabled}
           error={error}
           autoComplete="new-password"
@@ -127,7 +128,7 @@ export default function EditableSecretField({
         <PasswordInput
           value={value}
           onChange={(e) => onChange(e.currentTarget.value)}
-          placeholder={placeholder}
+          placeholder={resolvedPlaceholder}
           disabled={disabled}
           error={error}
           autoComplete="new-password"

--- a/frontend/editor/src/core/components/tools/ToolRenderer.tsx
+++ b/frontend/editor/src/core/components/tools/ToolRenderer.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { useTranslation } from "react-i18next";
 import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
 import { BaseToolProps } from "@app/types/tool";
 import { ToolId } from "@app/types/toolId";
@@ -14,6 +15,7 @@ const ToolRenderer = ({
   onComplete,
   onError,
 }: ToolRendererProps) => {
+  const { t } = useTranslation();
   // Get the tool from context (instead of direct hook call)
   const { toolRegistry } = useToolWorkflow();
   const selectedTool =
@@ -27,7 +29,7 @@ const ToolRenderer = ({
   }
 
   if (!selectedTool || !selectedTool.component) {
-    return <div>Tool not found: {selectedToolKey}</div>;
+    return <div>{t("toolRenderer.notFound", { tool: selectedToolKey })}</div>;
   }
 
   const ToolComponent = selectedTool.component;

--- a/frontend/editor/src/core/components/tools/convert/GroupedFormatDropdown.tsx
+++ b/frontend/editor/src/core/components/tools/convert/GroupedFormatDropdown.tsx
@@ -8,6 +8,7 @@ import {
   useMantineTheme,
 } from "@mantine/core";
 import { Button } from "@app/ui/Button";
+import { useTranslation } from "react-i18next";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import CloudOutlinedIcon from "@mui/icons-material/CloudOutlined";
 import { Z_INDEX_AUTOMATE_DROPDOWN } from "@app/styles/zIndex";
@@ -34,7 +35,7 @@ interface GroupedFormatDropdownProps {
 
 const GroupedFormatDropdown = ({
   value,
-  placeholder = "Select an option",
+  placeholder,
   options,
   onChange,
   disabled = false,
@@ -43,6 +44,8 @@ const GroupedFormatDropdown = ({
   withinPortal = true,
   zIndex = Z_INDEX_AUTOMATE_DROPDOWN,
 }: GroupedFormatDropdownProps) => {
+  const { t } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t("dropdownList.selectOption");
   const [dropdownOpened, setDropdownOpened] = useState(false);
   const theme = useMantineTheme();
 
@@ -60,12 +63,12 @@ const GroupedFormatDropdown = ({
   }, [options]);
 
   const selectedLabel = useMemo(() => {
-    if (!value) return placeholder;
+    if (!value) return resolvedPlaceholder;
     const selected = options.find((opt) => opt.value === value);
     return selected
       ? `${selected.group} (${selected.label})`
       : value.toUpperCase();
-  }, [value, options, placeholder]);
+  }, [value, options, resolvedPlaceholder]);
 
   const handleOptionSelect = (selectedValue: string) => {
     onChange(selectedValue);

--- a/frontend/editor/src/core/components/tools/ocr/LanguagePicker.tsx
+++ b/frontend/editor/src/core/components/tools/ocr/LanguagePicker.tsx
@@ -29,13 +29,14 @@ export interface LanguagePickerProps {
 const LanguagePicker: React.FC<LanguagePickerProps> = ({
   value,
   onChange,
-  placeholder = "Select languages",
+  placeholder,
   disabled = false,
   label,
   languagesEndpoint = "/api/v1/ui-data/ocr-pdf",
   autoFillFromBrowserLanguage = true,
 }) => {
   const { t, i18n } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t("dropdownList.selectLanguages");
   const [availableLanguages, setAvailableLanguages] = useState<DropdownItem[]>(
     [],
   );
@@ -181,7 +182,7 @@ const LanguagePicker: React.FC<LanguagePickerProps> = ({
       value={value}
       onChange={(newValue) => onChange(newValue as string[])}
       items={availableLanguages}
-      placeholder={placeholder}
+      placeholder={resolvedPlaceholder}
       disabled={disabled}
       label={label}
       footer={footer}

--- a/frontend/editor/src/core/components/tools/sign/PenSizeSelector.tsx
+++ b/frontend/editor/src/core/components/tools/sign/PenSizeSelector.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { TextInput, Combobox, useCombobox } from "@mantine/core";
 
 interface PenSizeSelectorProps {
@@ -18,10 +19,12 @@ const PenSizeSelector = ({
   onValueChange,
   onInputChange,
   disabled = false,
-  placeholder = "Type or select pen size (1-200)",
+  placeholder,
   style,
   size,
 }: PenSizeSelectorProps) => {
+  const { t } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t("sign.penSizePlaceholder");
   const combobox = useCombobox();
 
   const penSizeOptions = ["1", "2", "3", "4", "5", "8", "10", "12", "15", "20"];
@@ -41,7 +44,7 @@ const PenSizeSelector = ({
     >
       <Combobox.Target>
         <TextInput
-          placeholder={placeholder}
+          placeholder={resolvedPlaceholder}
           size={size}
           value={inputValue}
           onChange={(event) => {

--- a/frontend/editor/src/prototypes/components/chat/ChatPanel.tsx
+++ b/frontend/editor/src/prototypes/components/chat/ChatPanel.tsx
@@ -281,7 +281,7 @@ export function ChatPanel(_props: ChatPanelProps = {}) {
             {/* Header */}
             <div className="chat-panel-header">
               <Text fw={600} size="sm">
-                AI Assistant
+                {t("chat.header.assistant")}
               </Text>
               <ActionIcon
                 variant="subtle"
@@ -298,8 +298,7 @@ export function ChatPanel(_props: ChatPanelProps = {}) {
               <Stack gap="sm" p="sm">
                 {messages.length === 0 && (
                   <Text size="sm" c="dimmed" ta="center" py="xl">
-                    Ask a question about your documents or get help with PDF
-                    tools.
+                    {t("chat.emptyState.text")}
                   </Text>
                 )}
                 {messages.map((msg) => (
@@ -337,7 +336,7 @@ export function ChatPanel(_props: ChatPanelProps = {}) {
             <div className="chat-panel-input">
               <TextInput
                 ref={inputRef}
-                placeholder="Type a message..."
+                placeholder={t("chat.input.placeholder")}
                 value={input}
                 onChange={(e) => setInput(e.currentTarget.value)}
                 onKeyDown={handleKeyDown}


### PR DESCRIPTION
# Description of Changes

This PR replaces multiple hardcoded English UI strings with translation keys to improve localization consistency throughout the editor.

### What was changed

- Added new translation entries for:
  - AI chat panel header and empty state
  - Generic dropdown placeholders and empty states
  - Generic input placeholder (`Enter value`)
  - Tool renderer "tool not found" message
  - Signature pen size placeholder
- Updated shared components to use translated fallback placeholders instead of hardcoded English text:
  - `DropdownListWithFooter`
  - `EditableSecretField`
  - `GroupedFormatDropdown`
  - `LanguagePicker`
  - `PenSizeSelector`
- Localized the AI chat panel:
  - Assistant title
  - Empty state message
  - Input placeholder
- Localized the fallback error message displayed when a tool cannot be resolved.

### Why the change was made

Several shared UI components and the AI assistant interface contained hardcoded English strings, preventing proper localization and creating an inconsistent multilingual experience. Moving these strings into the translation system ensures they can be translated alongside the rest of the application and provides reusable defaults for shared components.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
