### PR TITLE
fix(saas): provision a new user and their personal team atomically

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/policy/seed/DefaultClassificationPolicySeeder.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/policy/seed/DefaultClassificationPolicySeeder.java
@@ -46,9 +46,12 @@ public class DefaultClassificationPolicySeeder {
                 .ifPresent(team -> seedIfMissing(team.getId(), team.getName()));
     }
 
-    // Any team created at runtime (admin-created, SaaS sign-ups); after the team's commit so a
-    // rolled-back team never leaves a policy behind.
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    // Any team created at runtime (admin-created, SaaS sign-ups). Seeds inside the team's own
+    // transaction: a rolled-back team still leaves no policy behind, and the pessimistic lock the
+    // policy store takes needs a live transaction, which AFTER_COMMIT cannot offer (the completed
+    // transaction is still bound to the thread, so the store joins it instead of starting a fresh
+    // one). Staying in the one transaction also keeps this to a single pooled connection.
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTeamCreated(TeamCreatedEvent event) {
         seedIfMissing(event.teamId(), event.teamName());
     }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/policy/seed/DefaultClassificationPolicySeeder.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/policy/seed/DefaultClassificationPolicySeeder.java
@@ -47,10 +47,8 @@ public class DefaultClassificationPolicySeeder {
     }
 
     // Any team created at runtime (admin-created, SaaS sign-ups). Seeds inside the team's own
-    // transaction: a rolled-back team still leaves no policy behind, and the pessimistic lock the
-    // policy store takes needs a live transaction, which AFTER_COMMIT cannot offer (the completed
-    // transaction is still bound to the thread, so the store joins it instead of starting a fresh
-    // one). Staying in the one transaction also keeps this to a single pooled connection.
+    // transaction: rollback still leaves no policy behind, and the store's pessimistic lock needs a
+    // live transaction, which AFTER_COMMIT cannot offer.
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTeamCreated(TeamCreatedEvent event) {
         seedIfMissing(event.teamId(), event.teamName());

--- a/app/saas/src/main/java/stirling/software/saas/model/SaasUserExtensions.java
+++ b/app/saas/src/main/java/stirling/software/saas/model/SaasUserExtensions.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.domain.Persistable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,6 +17,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,7 +39,7 @@ import stirling.software.proprietary.security.model.User;
 @NoArgsConstructor
 @Getter
 @Setter
-public class SaasUserExtensions implements Serializable {
+public class SaasUserExtensions implements Serializable, Persistable<Long> {
 
     private static final long serialVersionUID = 1L;
 
@@ -79,5 +81,23 @@ public class SaasUserExtensions implements Serializable {
 
     public boolean isMeteredBillingEnabled() {
         return Boolean.TRUE.equals(hasMeteredBillingEnabled);
+    }
+
+    @Override
+    public Long getId() {
+        return userId;
+    }
+
+    /**
+     * The constructor pre-sets the @MapsId id, so Spring Data's id-based check would call this row
+     * "existing" and route save() to merge() — which fails with "null identifier" while resolving
+     * the shared-PK association for a row that isn't in the DB yet. Decide on the creation
+     * timestamp instead: Hibernate sets it on insert, so only a row that has never been written
+     * looks new.
+     */
+    @Override
+    @Transient
+    public boolean isNew() {
+        return createdAt == null;
     }
 }

--- a/app/saas/src/main/java/stirling/software/saas/model/SaasUserExtensions.java
+++ b/app/saas/src/main/java/stirling/software/saas/model/SaasUserExtensions.java
@@ -88,13 +88,8 @@ public class SaasUserExtensions implements Serializable, Persistable<Long> {
         return userId;
     }
 
-    /**
-     * The constructor pre-sets the @MapsId id, so Spring Data's id-based check would call this row
-     * "existing" and route save() to merge() — which fails with "null identifier" while resolving
-     * the shared-PK association for a row that isn't in the DB yet. Decide on the creation
-     * timestamp instead: Hibernate sets it on insert, so only a row that has never been written
-     * looks new.
-     */
+    // Decided on the timestamp, not the id: the constructor pre-sets the @MapsId id, so an
+    // id-based check would route a new row to merge() and fail with "null identifier".
     @Override
     @Transient
     public boolean isNew() {

--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseAuthenticationFilter.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseAuthenticationFilter.java
@@ -239,7 +239,7 @@ public class SupabaseAuthenticationFilter extends OncePerRequestFilter {
                         && !supabaseUser.isAnonymous()) {
                     user = upgradeAnonymousUser(user, supabaseUser, jwt);
                 }
-                return recoverMissingTeam(user);
+                return user;
             }
 
             return createUser(jwt, supabaseId, email, appMetadata);
@@ -271,10 +271,8 @@ public class SupabaseAuthenticationFilter extends OncePerRequestFilter {
             user.setUsername(supabaseUser.getEmail());
         }
         try {
-            User saved = userService.saveUser(user);
             // Give the account its own team rather than the shared Default team.
-            saved.setTeam(saasTeamService.ensurePersonalTeam(saved));
-            return saved;
+            return saasTeamService.saveUserWithPersonalTeam(user);
         } catch (DataIntegrityViolationException e) {
             log.warn(
                     "Email collision upgrading anonymous user {} to {}: {}",
@@ -372,60 +370,23 @@ public class SupabaseAuthenticationFilter extends OncePerRequestFilter {
             throw new AuthenticationFailureException("Failed to create SupabaseUser", e);
         }
 
-        User savedUser;
-        boolean weCreatedThisUser = true;
+        // Guests (anonymous sessions) get NO team: the editor is free and needs none, and
+        // automation requires a real account. Everyone else is provisioned atomically with their
+        // team, so any user visible to a parallel request already has one.
         try {
-            savedUser = userService.saveUser(newUser);
+            return isAnonymous(jwt)
+                    ? userService.saveUser(newUser)
+                    : saasTeamService.saveUserWithPersonalTeam(newUser);
         } catch (DataIntegrityViolationException dup) {
             // Parallel filter won the race; fetch the winning row.
-            weCreatedThisUser = false;
-            savedUser =
-                    userService
-                            .findBySupabaseId(supabaseId)
-                            .orElseThrow(
-                                    () ->
-                                            new AuthenticationFailureException(
-                                                    "User creation conflict, but unable to find existing user",
-                                                    dup));
+            return userService
+                    .findBySupabaseId(supabaseId)
+                    .orElseThrow(
+                            () ->
+                                    new AuthenticationFailureException(
+                                            "User creation conflict, but unable to find existing user",
+                                            dup));
         }
-
-        // Only the DB-race winner runs first-time init; the losers skip it. Guests (anonymous
-        // sessions) get NO team: the editor is free and needs none, and automation requires a
-        // real account.
-        if (weCreatedThisUser && !isAnonymous(jwt)) {
-            try {
-                savedUser.setTeam(saasTeamService.ensurePersonalTeam(savedUser));
-            } catch (Exception e) {
-                log.warn(
-                        "Failed to create personal team for new user {} ({}): {}",
-                        LogRedactionUtils.redactSupabaseId(supabaseId),
-                        LogRedactionUtils.redactEmail(savedUser.getUsername()),
-                        e.getMessage());
-            }
-        }
-        return savedUser;
-    }
-
-    /**
-     * Recover an account stranded without a team: signup is the only other place one is assigned,
-     * so a null team_id is otherwise permanent — and portal access derives from leading a team.
-     * Guests get none by design.
-     */
-    private User recoverMissingTeam(User user) {
-        if (user.getTeam() != null
-                || ANONYMOUS.toString().equalsIgnoreCase(user.getAuthenticationType())) {
-            return user;
-        }
-        try {
-            user.setTeam(saasTeamService.ensurePersonalTeam(user));
-            log.info("Assigned a personal team to user {} which had none", user.getId());
-        } catch (Exception e) {
-            log.warn(
-                    "Could not assign a personal team to user {}: {}",
-                    user.getId(),
-                    e.getMessage());
-        }
-        return user;
     }
 
     private boolean apiKeyAuthenticated(HttpServletRequest request) throws AuthenticationException {

--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseAuthenticationFilter.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseAuthenticationFilter.java
@@ -370,9 +370,8 @@ public class SupabaseAuthenticationFilter extends OncePerRequestFilter {
             throw new AuthenticationFailureException("Failed to create SupabaseUser", e);
         }
 
-        // Guests (anonymous sessions) get NO team: the editor is free and needs none, and
-        // automation requires a real account. Everyone else is provisioned atomically with their
-        // team, so any user visible to a parallel request already has one.
+        // Guests get NO team: the editor is free and needs none. Everyone else is provisioned
+        // atomically, so a user visible to a parallel request always already has one.
         try {
             return isAnonymous(jwt)
                     ? userService.saveUser(newUser)

--- a/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
@@ -54,10 +54,9 @@ public class SaasTeamService {
     public static final String INTERNAL_TEAM_NAME = "Internal";
 
     /**
-     * Persist a user together with their personal team, atomically. An account with no team has no
-     * portal access and no path to acquiring one, so a user must never be committed without one: if
-     * the team cannot be created the user write rolls back too and the caller sees the failure.
-     * Constraint violations (the concurrent-signup race) propagate for the caller to resolve.
+     * Persist a user and their personal team atomically: an account with no team has no portal
+     * access and no way to acquire one, so a teamless user must never be committed. Constraint
+     * violations (the concurrent-signup race) propagate for the caller to resolve.
      */
     @Transactional
     public User saveUserWithPersonalTeam(User user) {
@@ -73,9 +72,8 @@ public class SaasTeamService {
         if (existing != null && saasTeamExtensionService.isPersonal(existing)) {
             return existing;
         }
-        // An empty users.team_id does not mean there is no personal team: four call sites provision
-        // one, so a parallel request may already have minted it. Adopt it instead of creating a
-        // second.
+        // An empty users.team_id does not prove there is no personal team; adopt one the user
+        // already owns rather than minting a second.
         Team owned = existingPersonalTeam(user);
         if (owned != null) {
             user.setTeam(owned);

--- a/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
@@ -53,6 +53,19 @@ public class SaasTeamService {
     public static final String DEFAULT_TEAM_NAME = "Default";
     public static final String INTERNAL_TEAM_NAME = "Internal";
 
+    /**
+     * Persist a user together with their personal team, atomically. An account with no team has no
+     * portal access and no path to acquiring one, so a user must never be committed without one: if
+     * the team cannot be created the user write rolls back too and the caller sees the failure.
+     * Constraint violations (the concurrent-signup race) propagate for the caller to resolve.
+     */
+    @Transactional
+    public User saveUserWithPersonalTeam(User user) {
+        User saved = userService.saveUser(user);
+        saved.setTeam(ensurePersonalTeam(saved));
+        return saved;
+    }
+
     /** Returns the user's personal team, creating one if they have none. Idempotent. */
     @Transactional
     public Team ensurePersonalTeam(User user) {
@@ -60,7 +73,36 @@ public class SaasTeamService {
         if (existing != null && saasTeamExtensionService.isPersonal(existing)) {
             return existing;
         }
+        // An empty users.team_id does not mean there is no personal team: four call sites provision
+        // one, so a parallel request may already have minted it. Adopt it instead of creating a
+        // second.
+        Team owned = existingPersonalTeam(user);
+        if (owned != null) {
+            user.setTeam(owned);
+            userService.saveUser(user);
+            return owned;
+        }
         return createPersonalTeam(user);
+    }
+
+    /**
+     * The personal team the user already owns — their recorded home, else a solo team they lead.
+     */
+    private Team existingPersonalTeam(User user) {
+        Long homeId = saasUserExtensionService.getHomeTeamId(user);
+        if (homeId != null) {
+            Team home = teamRepository.findById(homeId).orElse(null);
+            if (home != null) {
+                return home;
+            }
+        }
+        for (TeamMembership membership : membershipRepository.findByUserId(user.getId())) {
+            Team team = membership.getTeam();
+            if (membership.isLeader() && membershipRepository.countByTeamId(team.getId()) == 1) {
+                return team;
+            }
+        }
+        return null;
     }
 
     /**

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterMoreTest.java
@@ -315,14 +315,13 @@ class SupabaseAuthenticationFilterMoreTest {
             local.setSupabaseId(supabaseId);
             local.setAuthenticationType(AuthenticationType.ANONYMOUS);
             when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.of(local));
-            when(userService.saveUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
-            when(saasTeamService.ensurePersonalTeam(any(User.class))).thenReturn(new Team());
+            when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
 
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            verify(userService).saveUser(any(User.class));
-            verify(saasTeamService).ensurePersonalTeam(any(User.class));
+            verify(saasTeamService).saveUserWithPersonalTeam(any(User.class));
             assertThat(local.getEmail()).isEqualTo("real@example.com");
             assertThat(local.getUsername()).isEqualTo("real@example.com");
             assertThat(local.getAuthenticationType())
@@ -342,8 +341,8 @@ class SupabaseAuthenticationFilterMoreTest {
             local.setSupabaseId(supabaseId);
             local.setAuthenticationType(AuthenticationType.ANONYMOUS);
             when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.of(local));
-            when(userService.saveUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
-            when(saasTeamService.ensurePersonalTeam(any(User.class))).thenReturn(new Team());
+            when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
 
             bearer("tok");
             filter.doFilter(request, response, chain);
@@ -365,7 +364,7 @@ class SupabaseAuthenticationFilterMoreTest {
             local.setSupabaseId(supabaseId);
             local.setAuthenticationType(AuthenticationType.ANONYMOUS);
             when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.of(local));
-            when(userService.saveUser(any(User.class)))
+            when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
                     .thenThrow(new DataIntegrityViolationException("email exists"));
 
             bearer("tok");
@@ -489,12 +488,13 @@ class SupabaseAuthenticationFilterMoreTest {
             org.mockito.Mockito.doThrow(new DataIntegrityViolationException("dup"))
                     .when(supabaseUserService)
                     .createSupabaseUser(eq(supabaseId), any(), eq(false));
-            when(userService.saveUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
 
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            verify(userService, times(1)).saveUser(any(User.class));
+            verify(saasTeamService, times(1)).saveUserWithPersonalTeam(any(User.class));
             assertThat(SecurityContextHolder.getContext().getAuthentication())
                     .isInstanceOf(EnhancedJwtAuthenticationToken.class);
         }
@@ -516,7 +516,7 @@ class SupabaseAuthenticationFilterMoreTest {
             filter.doFilter(request, response, chain);
 
             assertThat(response.getStatus()).isEqualTo(401);
-            verify(userService, never()).saveUser(any());
+            verify(saasTeamService, never()).saveUserWithPersonalTeam(any());
         }
 
         @Test
@@ -533,13 +533,14 @@ class SupabaseAuthenticationFilterMoreTest {
             when(userService.findBySupabaseId(supabaseId))
                     .thenReturn(Optional.empty())
                     .thenReturn(Optional.of(winner));
-            when(userService.saveUser(any(User.class)))
+            when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
                     .thenThrow(new DataIntegrityViolationException("dup user"));
 
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            // Race loser does not run first-time init (ensurePersonalTeam).
+            // The loser provisions nothing: the winner committed user and team together, so it
+            // simply adopts the winning row.
             verify(saasTeamService, never()).ensurePersonalTeam(any());
             assertThat(SecurityContextHolder.getContext().getAuthentication())
                     .isInstanceOf(EnhancedJwtAuthenticationToken.class);
@@ -554,7 +555,7 @@ class SupabaseAuthenticationFilterMoreTest {
             when(supabaseUserService.getUser(supabaseId))
                     .thenReturn(supabaseUser(supabaseId, "lost@example.com", false));
             when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.empty());
-            when(userService.saveUser(any(User.class)))
+            when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
                     .thenThrow(new DataIntegrityViolationException("dup user"));
 
             bearer("tok");
@@ -564,31 +565,31 @@ class SupabaseAuthenticationFilterMoreTest {
         }
 
         @Test
-        @DisplayName("personal team creation failure for a new user is swallowed")
-        void personalTeamFailureSwallowed() throws Exception {
+        @DisplayName("personal team creation failure fails the request, it is not swallowed")
+        void personalTeamFailureFailsAuth() throws Exception {
             UUID supabaseId = UUID.randomUUID();
             Jwt jwt = fullJwt(supabaseId, "team@example.com", false, "email");
             when(jwtDecoder.decode("tok")).thenReturn(jwt);
             when(supabaseUserService.getUser(supabaseId))
                     .thenReturn(supabaseUser(supabaseId, "team@example.com", false));
             when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.empty());
-            when(userService.saveUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
-            when(saasTeamService.ensurePersonalTeam(any(User.class)))
+            when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
                     .thenThrow(new IllegalStateException("team boom"));
 
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            // Auth still succeeds even though team creation failed.
-            assertThat(SecurityContextHolder.getContext().getAuthentication())
-                    .isInstanceOf(EnhancedJwtAuthenticationToken.class);
-            verify(userService, times(1)).saveUser(any(User.class));
+            // An account with no team has no portal access and no path to acquiring one, so a
+            // failed provision must surface instead of admitting a half-built user; the shared
+            // transaction leaves nothing behind to retry around.
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
         }
     }
 
     @Nested
-    @DisplayName("Team recovery for existing accounts")
-    class TeamRecovery {
+    @DisplayName("Existing accounts are never re-provisioned on the request path")
+    class ExistingAccountProvisioning {
 
         private User existingWebUser(UUID supabaseId) {
             User local = newUser("real@example.com");
@@ -598,8 +599,8 @@ class SupabaseAuthenticationFilterMoreTest {
         }
 
         @Test
-        @DisplayName("an existing account with no team is given a personal team")
-        void assignsTeamWhenMissing() throws Exception {
+        @DisplayName("a teamless account is left alone, not healed on every request")
+        void teamlessAccountIsNotHealed() throws Exception {
             UUID supabaseId = UUID.randomUUID();
             when(jwtDecoder.decode("tok"))
                     .thenReturn(fullJwt(supabaseId, "real@example.com", false, "email"));
@@ -607,15 +608,16 @@ class SupabaseAuthenticationFilterMoreTest {
                     .thenReturn(supabaseUser(supabaseId, "real@example.com", false));
 
             User local = existingWebUser(supabaseId);
-            Team recovered = new Team();
             when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.of(local));
-            when(saasTeamService.ensurePersonalTeam(local)).thenReturn(recovered);
 
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            verify(saasTeamService).ensurePersonalTeam(local);
-            assertThat(local.getTeam()).isSameAs(recovered);
+            // Provisioning belongs to signup alone. Healing here would run on every authenticated
+            // request with no mutual exclusion, so parallel requests would mint duplicate teams.
+            verify(saasTeamService, never()).ensurePersonalTeam(any(User.class));
+            verify(saasTeamService, never()).saveUserWithPersonalTeam(any(User.class));
+            assertThat(local.getTeam()).isNull();
         }
 
         @Test

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterMoreTest.java
@@ -539,8 +539,7 @@ class SupabaseAuthenticationFilterMoreTest {
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            // The loser provisions nothing: the winner committed user and team together, so it
-            // simply adopts the winning row.
+            // The winner committed user and team together, so the loser just adopts its row.
             verify(saasTeamService, never()).ensurePersonalTeam(any());
             assertThat(SecurityContextHolder.getContext().getAuthentication())
                     .isInstanceOf(EnhancedJwtAuthenticationToken.class);
@@ -579,9 +578,8 @@ class SupabaseAuthenticationFilterMoreTest {
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            // An account with no team has no portal access and no path to acquiring one, so a
-            // failed provision must surface instead of admitting a half-built user; the shared
-            // transaction leaves nothing behind to retry around.
+            // A teamless account has no portal access, so a failed provision must surface
+            // rather than admit a half-built user.
             assertThat(response.getStatus()).isEqualTo(401);
             assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
         }
@@ -613,8 +611,8 @@ class SupabaseAuthenticationFilterMoreTest {
             bearer("tok");
             filter.doFilter(request, response, chain);
 
-            // Provisioning belongs to signup alone. Healing here would run on every authenticated
-            // request with no mutual exclusion, so parallel requests would mint duplicate teams.
+            // Healing here would run per request with no mutual exclusion, so parallel
+            // requests would mint duplicate teams. Provisioning belongs to signup alone.
             verify(saasTeamService, never()).ensurePersonalTeam(any(User.class));
             verify(saasTeamService, never()).saveUserWithPersonalTeam(any(User.class));
             assertThat(local.getTeam()).isNull();

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterTest.java
@@ -177,8 +177,7 @@ class SupabaseAuthenticationFilterTest {
         filter.doFilter(request, response, chain);
 
         verify(supabaseUserService).createSupabaseUser(supabaseId, "bob@example.com", false);
-        // New users get their own personal team, never the shared Default team, and the two are
-        // written together so an account is never committed teamless.
+        // Own personal team, never the shared Default team, written with the user.
         verify(saasTeamService, times(1)).saveUserWithPersonalTeam(any(User.class));
         verify(teamService, never()).getOrCreateDefaultTeam();
         assertThat(SecurityContextHolder.getContext().getAuthentication())

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseAuthenticationFilterTest.java
@@ -168,7 +168,7 @@ class SupabaseAuthenticationFilterTest {
         when(supabaseUserService.getUser(supabaseId))
                 .thenReturn(supabaseUserMatching(supabaseId, "bob@example.com", false));
         when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.empty());
-        when(userService.saveUser(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(saasTeamService.saveUserWithPersonalTeam(any())).thenAnswer(inv -> inv.getArgument(0));
 
         request.setRequestURI("/api/v1/something");
         request.setMethod("POST");
@@ -176,10 +176,10 @@ class SupabaseAuthenticationFilterTest {
 
         filter.doFilter(request, response, chain);
 
-        verify(userService, times(1)).saveUser(any(User.class));
         verify(supabaseUserService).createSupabaseUser(supabaseId, "bob@example.com", false);
-        // New users get their own personal team, never the shared Default team.
-        verify(saasTeamService).ensurePersonalTeam(any(User.class));
+        // New users get their own personal team, never the shared Default team, and the two are
+        // written together so an account is never committed teamless.
+        verify(saasTeamService, times(1)).saveUserWithPersonalTeam(any(User.class));
         verify(teamService, never()).getOrCreateDefaultTeam();
         assertThat(SecurityContextHolder.getContext().getAuthentication())
                 .isInstanceOf(EnhancedJwtAuthenticationToken.class);
@@ -194,7 +194,7 @@ class SupabaseAuthenticationFilterTest {
         when(supabaseUserService.getUser(supabaseId))
                 .thenReturn(supabaseUserMatching(supabaseId, "carol@example.com", false));
         when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.empty());
-        when(userService.saveUser(any(User.class)))
+        when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
                 .thenAnswer(
                         inv -> {
                             User u = inv.getArgument(0);
@@ -210,7 +210,7 @@ class SupabaseAuthenticationFilterTest {
 
         filter.doFilter(request, response, chain);
 
-        verify(userService, times(1)).saveUser(any(User.class));
+        verify(saasTeamService, times(1)).saveUserWithPersonalTeam(any(User.class));
     }
 
     @Test
@@ -222,7 +222,7 @@ class SupabaseAuthenticationFilterTest {
         when(supabaseUserService.getUser(supabaseId))
                 .thenReturn(supabaseUserMatching(supabaseId, "dave@example.com", false));
         when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.empty());
-        when(userService.saveUser(any(User.class)))
+        when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
                 .thenAnswer(
                         inv -> {
                             User u = inv.getArgument(0);
@@ -238,7 +238,7 @@ class SupabaseAuthenticationFilterTest {
 
         filter.doFilter(request, response, chain);
 
-        verify(userService, times(1)).saveUser(any(User.class));
+        verify(saasTeamService, times(1)).saveUserWithPersonalTeam(any(User.class));
     }
 
     @Test
@@ -250,7 +250,7 @@ class SupabaseAuthenticationFilterTest {
         when(supabaseUserService.getUser(supabaseId))
                 .thenReturn(supabaseUserMatching(supabaseId, "eve@example.com", false));
         when(userService.findBySupabaseId(supabaseId)).thenReturn(Optional.empty());
-        when(userService.saveUser(any(User.class)))
+        when(saasTeamService.saveUserWithPersonalTeam(any(User.class)))
                 .thenAnswer(
                         inv -> {
                             User u = inv.getArgument(0);
@@ -266,7 +266,7 @@ class SupabaseAuthenticationFilterTest {
 
         filter.doFilter(request, response, chain);
 
-        verify(userService, times(1)).saveUser(any(User.class));
+        verify(saasTeamService, times(1)).saveUserWithPersonalTeam(any(User.class));
     }
 
     @Test


### PR DESCRIPTION
New SaaS accounts were landing with `team_id = null`. That state is unrecoverable: portal access derives from leading a team, and signup is the only place one is assigned.

Five things had to be fixed, all on the signup path. Only the last is a behaviour change you'd notice.

### 1. Shared-PK entity was routed to `merge()`
`SaasUserExtensions` pre-sets its `@MapsId` id in the constructor, so Spring Data's id-nullness check treated a brand-new row as existing and `save()` failed with `AssertionFailure: null identifier`. Now implements `Persistable` and decides on the creation timestamp — the idiom already used by `ProcessedFileEntity` and `SourceDocCountEntity`.

This was the blocker. It threw on every signup, and because the failure was swallowed (see 3) every new account was stranded.

### 2. User and team were committed separately
`createUser()` is annotated `@Transactional` but is called as `this.createUser(...)`, and self-invocation bypasses the proxy — so the annotation did nothing. `saveUser()` and `ensurePersonalTeam()` each committed in their own transaction, leaving a window where a **committed user was visible with `team_id = null`**. Parallel requests entering that window each provisioned a team, producing duplicates (observed: teams 160/161 and 162/163 for one user).

Both writes now happen in one transaction via `SaasTeamService.saveUserWithPersonalTeam()`. The window is gone, so there is nothing left to race over.

### 3. A failed team create was swallowed
The old code logged at WARN and committed the user anyway. It now propagates: the shared transaction rolls the user back, the request 401s, and a retry starts clean. Nothing half-built is committed.

This is the deliberate trade — a transient failure now surfaces instead of silently producing an account that can never reach the portal.

### 4. Per-request healing removed
`recoverMissingTeam` (added in #7180) ran on **every authenticated request** whose user had no team, with no mutual exclusion. Under a burst of parallel requests it was itself a source of concurrent provisioning. Provisioning belongs to signup alone.

### 5. Policy seeding could not run
`@TransactionalEventListener(AFTER_COMMIT)` leaves the *completed* transaction bound to the thread, so `JpaPolicyStore.save`'s `@Transactional` joined it instead of opening a live one — and its `FOR UPDATE` lock threw `TransactionRequiredException`. Now seeded in `BEFORE_COMMIT`: the lock has a live transaction, rollback safety is unchanged (a rolled-back team still leaves no policy), and it stays on a single pooled connection.

## Verified

`:saas:test` green, both spotless gates green, on top of current `main`.

Manually on a live signup: **one** team per user, and the concurrent-signup race resolves correctly through the pre-existing unique-constraint catch (`users_supabase_auth_id_key` violation → refetch the winner).

12 filter tests needed updating. Two of them asserted behaviour this PR deliberately removes (`personalTeamFailureSwallowed`, `assignsTeamWhenMissing`), so they were rewritten to assert the new contract rather than re-stubbed into passing.

## Not in scope

- **Existing stranded accounts** are not repaired — with the healer gone, nothing fixes them on the request path. They need a one-off backfill or deletion.
- **A DB-level invariant.** A partial unique index (`UNIQUE(created_by_user_id) WHERE is_personal`) would make duplicate personal teams impossible rather than merely unreachable. Wanted, but it is a Supabase migration in the SaaS repo, so it is deliberately separate.
- **Per-request auth cost.** The filter still does two remote-Postgres round-trips per authenticated request; a frontend request storm makes that expensive. Being handled separately.