### PR TITLE
a11y job: emit the affected-story list on one line

### DIFF
--- a/frontend/.storybook/a11y-changed.mjs
+++ b/frontend/.storybook/a11y-changed.mjs
@@ -45,7 +45,12 @@ for (const f of changed) {
     if (existsSync(s)) stories.add(s);
 }
 
-// Space-separated on one line: the output is interpolated into a task command,
-// and a newline there would end the command — the shell then tries to execute
-// the second story path as a program.
-process.stdout.write([...stories].sort().join(" "));
+// One line, each path quoted: the output is interpolated into a task command,
+// where a newline would end the command after the first story and an unquoted
+// space would split a path into two arguments.
+process.stdout.write(
+  [...stories]
+    .sort()
+    .map((s) => `"${s}"`)
+    .join(" "),
+);

--- a/frontend/.storybook/a11y-changed.mjs
+++ b/frontend/.storybook/a11y-changed.mjs
@@ -45,4 +45,7 @@ for (const f of changed) {
     if (existsSync(s)) stories.add(s);
 }
 
-process.stdout.write([...stories].sort().join("\n"));
+// Space-separated on one line: the output is interpolated into a task command,
+// and a newline there would end the command — the shell then tries to execute
+// the second story path as a program.
+process.stdout.write([...stories].sort().join(" "));


### PR DESCRIPTION
## What

Fixes the a11y check failing with `permission denied` on any PR that touches more than one story (currently hitting #7163).

The script that lists which stories to scan printed one path per line. That list gets pasted into a shell command, so everything after the first line fell out of the command — the shell treated the second path as a command of its own and failed.

One-line fix: print the list on a single line.

## Testing

Changed two components and ran the task from both git-bash and PowerShell — both stories scanned, check passes. #7163's red check should go green on re-run once this is in.
