### PR TITLE
ci: trigger frontend accessibility workflow only for Storybook-related changes

### DIFF
--- a/.github/config/.files.yaml
+++ b/.github/config/.files.yaml
@@ -88,6 +88,18 @@ frontend: &frontend
   - .github/workflows/e2e-stubbed.yml
   - .github/workflows/e2e-live.yml
 
+storybook: &storybook
+  - *ci
+  - frontend/.storybook/**
+  - frontend/editor/src/**/*.stories.@(ts|tsx|mdx)
+  - frontend/package.json
+  - frontend/package-lock.json
+  - .taskfiles/frontend.yml
+  - Taskfile.yml
+  - .github/workflows/frontend-a11y.yml
+  - .github/workflows/nightly.yml
+  - .github/workflows/PR-Auto-Deploy-V2.yml
+
 # Files that affect the Tauri desktop bundle. Gate the multi-OS Tauri build
 # job on changes to any of these.
 tauri: &tauri

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       project: ${{ steps.changes.outputs.project }}
       openapi: ${{ steps.changes.outputs.openapi }}
       frontend: ${{ steps.changes.outputs.frontend }}
+      storybook: ${{ steps.changes.outputs.storybook }}
       docker-base: ${{ steps.changes.outputs.docker-base }}
       dockerfiles: ${{ steps.changes.outputs.dockerfiles }}
       tauri: ${{ steps.changes.outputs.tauri }}
@@ -103,7 +104,7 @@ jobs:
   # branch touches so a regression is visible in review, but a browser scan is
   # too new here to block merges on. Promote it once its pass/fail proves stable.
   frontend-a11y:
-    if: needs.files-changed.outputs.frontend == 'true'
+    if: needs.files-changed.outputs.storybook == 'true'
     needs: [files-changed]
     permissions:
       contents: read

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -242,7 +242,7 @@ tasks:
             echo "a11y: no story files affected vs {{.BASE}} — nothing to check"
             exit 0
           fi
-          node .storybook/a11y-scan.mjs {{.CHANGED}}
+          node .storybook/a11y-scan.mjs {{.CHANGED | replace "\n" " "}}
           node .storybook/a11y-check.mjs --in .a11y-scan --manifest .a11y-scan/manifest.txt
 
   storybook:a11y:record:

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -242,7 +242,7 @@ tasks:
             echo "a11y: no story files affected vs {{.BASE}} — nothing to check"
             exit 0
           fi
-          node .storybook/a11y-scan.mjs {{.CHANGED | replace "\n" " "}}
+          node .storybook/a11y-scan.mjs {{.CHANGED}}
           node .storybook/a11y-check.mjs --in .a11y-scan --manifest .a11y-scan/manifest.txt
 
   storybook:a11y:record:


### PR DESCRIPTION
# Description of Changes

This change introduces a dedicated `storybook` file group for change detection and updates the frontend accessibility workflow to use it instead of the broader `frontend` group.

### What was changed

- Added a new `storybook` file group to `.github/config/.files.yaml`.
- Included Storybook configuration, story files, frontend package manifests, relevant task definitions, and workflows that can affect Storybook or accessibility testing.
- Exposed the new `storybook` output from the `files-changed` job in `build.yml`.
- Updated the `frontend-a11y` job to run only when files in the `storybook` group have changed.

### Why the change was made

Previously, the frontend accessibility workflow was triggered by any frontend-related change, causing unnecessary workflow executions. By introducing a dedicated Storybook change group, accessibility checks now run only when changes can impact Storybook stories or the accessibility testing pipeline, improving CI efficiency while maintaining appropriate coverage.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
