### PR TITLE
Set PRs to build Mac and Windows binaries when building desktop code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,13 +174,12 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/tauri-build.yml
     secrets: inherit
-    # PR smoke build: Linux only (fastest + cheapest to compile), unsigned,
-    # deb-only, no AppImage. The full signed multi-OS matrix runs on release;
+    # PR smoke build: macOS + Windows (the platforms our developers use). 
+    # The full signed multi-OS matrix runs on release;
     # nightly still warms the Rust cache with all-OS defaults.
     with:
-      platform: linux
+      platform: windows-macos
       sign: false
-      minimal: true
 
   ai-engine:
     if: needs.files-changed.outputs.engine == 'true'

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -12,7 +12,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: "Platform to build (windows, macos, linux, or all)."
+        description: "Platform to build (windows, macos, linux, windows-macos, or all)."
         required: false
         type: string
         default: "all"
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
     inputs:
       platform:
-        description: "Platform to build (windows, macos, linux, or all)"
+        description: "Platform to build (windows, macos, linux, windows-macos, or all)"
         required: true
         default: "all"
         type: choice
@@ -38,6 +38,7 @@ on:
           - windows
           - macos
           - linux
+          - windows-macos
       sign:
         description: "Sign and notarize the bundles."
         required: false
@@ -76,10 +77,11 @@ jobs:
           LINUX='{"platform":"ubuntu-22.04","args":"","name":"linux-x86_64","jpdfium_platforms":"linux-x64"}'
 
           case "$PLATFORM" in
-            windows) ENTRIES=("$WINDOWS") ;;
-            macos)   ENTRIES=("$MACOS") ;;
-            linux)   ENTRIES=("$LINUX") ;;
-            *)       ENTRIES=("$WINDOWS" "$MACOS" "$LINUX") ;;
+            windows)       ENTRIES=("$WINDOWS") ;;
+            macos)         ENTRIES=("$MACOS") ;;
+            linux)         ENTRIES=("$LINUX") ;;
+            windows-macos) ENTRIES=("$WINDOWS" "$MACOS") ;;
+            *)             ENTRIES=("$WINDOWS" "$MACOS" "$LINUX") ;;
           esac
 
           # Drop macOS entries when Apple certificate secret is unavailable


### PR DESCRIPTION
# Description of Changes
Currently, desktop PRs only build on Linux, which none of the core maintainers currently use. Change it so that desktop PRs build Mac and Windows, so core maintainers can test the built version.