### PR TITLE
style(scanner-effect): remove padding from ToolButton of Scanner-effect

### DIFF
--- a/frontend/editor/src/core/components/tools/toolPicker/ToolButton.tsx
+++ b/frontend/editor/src/core/components/tools/toolPicker/ToolButton.tsx
@@ -286,7 +286,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({
       accent="neutral"
       onClick={() => handleClick(id)}
       size="sm"
-      p="sm"
+      p="none"
       fullWidth
       justify="start"
       className="tool-button"
@@ -297,6 +297,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({
         borderRadius: 0,
         cursor: visuallyUnavailable ? "not-allowed" : undefined,
         overflow: "visible",
+        ...selectedBg,
       }}
     >
       {buttonContent}


### PR DESCRIPTION


# Description of Changes


### New
<img width="1650" height="612" alt="image" src="https://github.com/user-attachments/assets/3046ad8e-b7a5-4fb6-b941-04ae7dcda4e4" />



### Old
<img width="1756" height="730" alt="image" src="https://github.com/user-attachments/assets/e722146e-bebb-4744-9e95-4eee11444623" />

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [X] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have run `task check` to verify linters, typechecks, and tests pass
- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
