### PR TITLE
Fetch portal access per identity, with no module-level cache

### DIFF
--- a/frontend/editor/src/saas/hooks/usePortalAccess.test.tsx
+++ b/frontend/editor/src/saas/hooks/usePortalAccess.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const get = vi.fn();
+let currentUserId: string | null = null;
+
+vi.mock("@app/services/apiClient", () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+  },
+}));
+
+vi.mock("@app/auth/UseSession", () => ({
+  useAuth: () => ({ user: currentUserId ? { id: currentUserId } : null }),
+}));
+
+const { usePortalAccess } = await import("@app/hooks/usePortalAccess");
+
+function meReturning(portalAccess: boolean) {
+  return { data: { user: { portalAccess } } };
+}
+
+describe("usePortalAccess", () => {
+  beforeEach(() => {
+    get.mockReset();
+    currentUserId = null;
+  });
+
+  it("reports the backend's answer for the signed-in user", async () => {
+    currentUserId = "admin-1";
+    get.mockResolvedValue(meReturning(true));
+
+    const { result } = renderHook(() => usePortalAccess());
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("re-asks the backend when a different user signs in without a reload", async () => {
+    // An admin gets a yes...
+    currentUserId = "admin-1";
+    get.mockResolvedValue(meReturning(true));
+    const { result, rerender } = renderHook(() => usePortalAccess());
+    await waitFor(() => expect(result.current).toBe(true));
+
+    // ...then Supabase swaps the identity in place (signed out in another
+    // tab, revoked session, new sign-in) — no page load in between.
+    currentUserId = "member-2";
+    get.mockResolvedValue(meReturning(false));
+    rerender();
+
+    // The member must not inherit the admin's answer.
+    await waitFor(() => expect(result.current).toBe(false));
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops the answer when the user signs out", async () => {
+    currentUserId = "admin-1";
+    get.mockResolvedValue(meReturning(true));
+    const { result, rerender } = renderHook(() => usePortalAccess());
+    await waitFor(() => expect(result.current).toBe(true));
+
+    currentUserId = null;
+    rerender();
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("reports no access, and asks nothing, for a guest", () => {
+    currentUserId = null;
+
+    const { result } = renderHook(() => usePortalAccess());
+
+    expect(result.current).toBe(false);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("treats a failed lookup as no access, and a later mount asks again", async () => {
+    currentUserId = "admin-1";
+    get.mockRejectedValueOnce(new Error("401"));
+    const first = renderHook(() => usePortalAccess());
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(1));
+    expect(first.result.current).toBe(false);
+    first.unmount();
+
+    // The failure isn't sticky.
+    get.mockResolvedValue(meReturning(true));
+    const second = renderHook(() => usePortalAccess());
+    await waitFor(() => expect(second.result.current).toBe(true));
+  });
+
+  it("ignores a response that lands after unmount", async () => {
+    currentUserId = "admin-1";
+    let resolveMe: (v: unknown) => void = () => {};
+    get.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMe = resolve;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => usePortalAccess());
+    unmount();
+    resolveMe(meReturning(true));
+
+    // No state update on an unmounted hook (React would warn); the stale
+    // answer is simply dropped.
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/editor/src/saas/hooks/usePortalAccess.ts
+++ b/frontend/editor/src/saas/hooks/usePortalAccess.ts
@@ -1,45 +1,52 @@
 import { useEffect, useState } from "react";
 import apiClient from "@app/services/apiClient";
-
-// Module-level cache: the answer is per-login, not per-mount, so every
-// consumer shares one /me request per page load.
-let cached: boolean | null = null;
-let inflight: Promise<boolean> | null = null;
-
-function fetchPortalAccess(): Promise<boolean> {
-  inflight ??= apiClient
-    .get<{ user?: { portalAccess?: boolean } }>("/api/v1/auth/me")
-    .then((res) => {
-      cached = res.data.user?.portalAccess === true;
-      return cached;
-    })
-    .catch(() => {
-      // Backend unreachable or guest (401): no access now; allow a retry on
-      // the next consumer mount rather than caching the failure forever.
-      inflight = null;
-      return false;
-    });
-  return inflight;
-}
+import { useAuth } from "@app/auth/UseSession";
 
 /**
  * Whether the current user can open the processor (admin portal), straight
  * from the backend (`/api/v1/auth/me` → `portalAccess`) — the same signal the
- * processor's own SaasPortalGate uses. The editor's Supabase auth context
- * can't answer this (it never fetches /me), so components that must mirror
- * processor access (e.g. the sidebar's editor⇄processor switcher) ask here.
+ * processor's own SaasPortalGate uses. Components that must mirror processor
+ * access (e.g. the sidebar's editor⇄processor switcher) ask here.
+ *
+ * The editor's Supabase auth context can't *answer* this — it never fetches
+ * /me — so it is used only to identify who is asking. Keying the effect on
+ * that identity is what keeps the answer per-user: the SPA can swap users
+ * without a reload (Supabase fires SIGNED_OUT/SIGNED_IN in place; only the
+ * settings Logout button hard-navigates), so any answer held beyond the
+ * current identity would leak to whoever signs in next.
+ *
+ * Deliberately unmemoised beyond the mount: the one consumer (the sidebar
+ * switcher) mounts once, so a cross-mount cache would only add user-scoped
+ * state that has to be invalidated on identity change — the bug class this
+ * hook already had once. Guests skip the request entirely.
  */
 export function usePortalAccess(): boolean {
-  const [access, setAccess] = useState(cached === true);
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const [access, setAccess] = useState(false);
+
   useEffect(() => {
-    if (cached !== null) return;
-    let mounted = true;
-    void fetchPortalAccess().then((v) => {
-      if (mounted) setAccess(v);
-    });
+    // Signed out: nothing to ask, and any previous answer is void.
+    if (userId === null) {
+      setAccess(false);
+      return;
+    }
+
+    let cancelled = false;
+    apiClient
+      .get<{ user?: { portalAccess?: boolean } }>("/api/v1/auth/me")
+      .then((res) => {
+        if (!cancelled) setAccess(res.data.user?.portalAccess === true);
+      })
+      .catch(() => {
+        // Backend unreachable or guest (401): no access now; a remount or
+        // identity change asks again rather than trusting a failure.
+        if (!cancelled) setAccess(false);
+      });
     return () => {
-      mounted = false;
+      cancelled = true;
     };
-  }, []);
+  }, [userId]);
+
   return access;
 }


### PR DESCRIPTION
Follow-up to a review comment on #7163. Small, self-contained; stacked on `UI/new-design` because `usePortalAccess` is introduced there.

## The bug

`usePortalAccess` held its answer in module state for the lifetime of the page load. That assumed one user per page load, which the SPA doesn't guarantee: Supabase fires `SIGNED_OUT`/`SIGNED_IN` **in place** (session revoked, signed out in another tab, or a failed token refresh), and only the settings Logout button does a hard `window.location.assign`. On those in-place paths the module state survives, so an admin's cached `true` carried into the next user's session and offered them the editor⇄processor switcher.

Not an access hole: the processor is still gated server-side by `SaasPortalGate`, so it was a misleading affordance rather than an escalation. It also meant signed-out users re-requested `/api/v1/auth/me` on every mount, since the guest path deliberately cached nothing.

## The fix

No module-level cache at all — this also resolves the Aikido finding about user-specific state in module globals, by removing the pattern rather than suppressing the alert. The hook keeps its answer in React state and the effect is keyed on the Supabase user id, so an identity change (or sign-out) re-fetches or clears it structurally instead of via hand-rolled invalidation. The auth context still doesn't *answer* the question — it never fetches `/me`, the backend remains the authority — it only identifies who is asking.

Why this is safe to leave uncached: the hook has exactly one consumer (the sidebar switcher, mounted once), so the old cache bought one deduped request per page load at the cost of user-scoped globals that must be invalidated correctly — the exact bug class above. Guests now skip the request entirely.

## Tests

`usePortalAccess.test.tsx` covers the identity swap, sign-out, the guest case, a failed lookup, and a response landing after unmount. **Five of the six fail against the previous implementation**, so they pin the actual regression rather than just the new shape.

`task frontend:check:all` is green.