### PR TITLE
fix(ui): handle 404 policy error on upload without toast popup

### DIFF
--- a/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
@@ -778,10 +778,14 @@ async function runPolicyOnFile(
       error: null,
       startedAt: Date.now(),
     });
-  } catch {
-    // Dispatch failed (offline / backend error). Mark dispatched so we don't hammer;
+  } catch (err) {
+    // Dispatch failed (e.g. policy deleted/404 or backend offline). Mark dispatched so we don't hammer;
     // the absent run simply won't appear in the activity feed. If the backend did
     // start a run we never recorded, reconcileServerRuns rediscovers it.
+    console.debug(
+      `[PolicyAutoRun] Failed to dispatch policy ${categoryId} (${backendId}):`,
+      err,
+    );
     markDispatched(categoryId, fileId);
   }
 }

--- a/frontend/editor/src/proprietary/services/policyApi.ts
+++ b/frontend/editor/src/proprietary/services/policyApi.ts
@@ -73,6 +73,7 @@ export async function runStoredPolicy(
   const res = await apiClient.post<JobResponse>(
     `/api/v1/policies/${encodeURIComponent(id)}/run`,
     form,
+    { suppressErrorToast: true },
   );
   return res.data.jobId;
 }


### PR DESCRIPTION
# Description of Changes

Fixes policy error pop-ups that sometimes happen upon upload.

Changes:
- Improved the error handling in `runPolicyOnFile` to log detailed debug information when policy dispatch fails, making it easier to trace issues such as missing policies or backend errors.
- Updated the `runStoredPolicy` function to pass `{ suppressErrorToast: true }` to the API client, preventing error toasts from appearing in the UI when the policy run fails.

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have run `task check` to verify linters, typechecks, and tests pass
- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
