### PR TITLE
Fix Java tests not running headless on Mac

### DIFF
--- a/.taskfiles/backend.yml
+++ b/.taskfiles/backend.yml
@@ -114,6 +114,14 @@ tasks:
       - cmd: ./gradlew test
         platforms: [linux, darwin]
 
+  test:force:
+    desc: "Run backend tests, ignoring cached results"
+    cmds:
+      - cmd: cmd /c ".\gradlew.bat cleanTest test --no-build-cache"
+        platforms: [windows]
+      - cmd: ./gradlew cleanTest test --no-build-cache
+        platforms: [linux, darwin]
+
   format:
     desc: "Auto-fix code formatting"
     cmds:

--- a/.taskfiles/backend.yml
+++ b/.taskfiles/backend.yml
@@ -116,6 +116,7 @@ tasks:
 
   test:force:
     desc: "Run backend tests, ignoring cached results"
+    aliases: [test:no-cache]
     cmds:
       - cmd: cmd /c ".\gradlew.bat cleanTest test --no-build-cache"
         platforms: [windows]

--- a/build.gradle
+++ b/build.gradle
@@ -292,6 +292,8 @@ subprojects {
 
     tasks.withType(Test).configureEach {
         useJUnitPlatform()
+        systemProperty 'java.awt.headless', 'true'
+        systemProperty 'apple.awt.UIElement', 'true'
         finalizedBy(jacocoReport)
     }
 


### PR DESCRIPTION
# Description of Changes
The `task backend:test` command automatically spawns new Java processes in the dock on Mac as it runs, which takes the focus away from whatever the developer is doing at the time. This is because there's missing a missing `headless` tag in the `build.gradle` file (the tests don't spawn or require any windows, so they run fine headless).

Also adds a `task backend:test:force` rule to run the tests without cache because the cache was getting in the way of testing this.

<img width="175" height="98" alt="image" src="https://github.com/user-attachments/assets/d4524959-9c25-4513-bf34-9fd48310c4d3" />
