### PR TITLE
Sign Mac PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,12 +174,14 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/tauri-build.yml
     secrets: inherit
-    # PR smoke build: macOS + Windows (the platforms our developers use). 
+    # PR smoke build: macOS + Windows (the platforms our developers use).
+    # sign: true only reaches macOS - tauri-build's per-platform gate keeps
+    # Windows/Linux signing on main, and an unsigned .dmg cannot be opened.
     # The full signed multi-OS matrix runs on release;
     # nightly still warms the Rust cache with all-OS defaults.
     with:
       platform: windows-macos
-      sign: false
+      sign: true
 
   ai-engine:
     if: needs.files-changed.outputs.engine == 'true'

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -108,6 +108,11 @@ jobs:
       WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
       APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
       RELEASE_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+      # Per-platform sign gate. macOS signs on any run with the cert available,
+      # PRs included: Gatekeeper blocks an unsigned .dmg, so an unsigned macOS
+      # PR build is not testable. Windows and Linux stay main-only, matching the
+      # gates on their own signing steps below.
+      SIGN_BUNDLE: ${{ inputs.sign && (matrix.platform == 'macos-15' && secrets.APPLE_CERTIFICATE != '' || github.ref == 'refs/heads/main') }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -274,7 +279,7 @@ jobs:
           }
 
       - name: Import Apple Developer Certificate
-        if: inputs.sign && matrix.platform == 'macos-15' && env.APPLE_CERTIFICATE != ''
+        if: env.SIGN_BUNDLE == 'true' && matrix.platform == 'macos-15'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -295,7 +300,7 @@ jobs:
           rm certificate.p12
 
       - name: Verify Certificate
-        if: inputs.sign && matrix.platform == 'macos-15' && env.APPLE_CERTIFICATE != ''
+        if: env.SIGN_BUNDLE == 'true' && matrix.platform == 'macos-15'
         run: |
           echo "Verifying Apple Developer Certificate..."
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
@@ -368,7 +373,7 @@ jobs:
           fi
 
       - name: Build Tauri app (signed)
-        if: inputs.sign
+        if: env.SIGN_BUNDLE == 'true'
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -403,7 +408,7 @@ jobs:
           args: ${{ matrix.platform == 'ubuntu-22.04' && (inputs.minimal && '--bundles deb' || '--bundles deb,rpm') || matrix.args }}
 
       - name: Build Tauri app (unsigned)
-        if: ${{ !inputs.sign }}
+        if: env.SIGN_BUNDLE != 'true'
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -458,7 +463,7 @@ jobs:
           fi
 
       - name: Verify notarization (macOS only)
-        if: inputs.sign && matrix.platform == 'macos-15'
+        if: env.SIGN_BUNDLE == 'true' && matrix.platform == 'macos-15'
         run: |
           echo "🔍 Verifying notarization status..."
           cd ./frontend/editor/src-tauri/target


### PR DESCRIPTION
# Description of Changes
Mac builds in PRs are not currently signed, which means you can't run them when downloaded. This restores the functionality so that Mac builds are always signed.