### PR TITLE
Detect encryption on PDFs too large to fully parse

### DIFF
--- a/frontend/editor/src/core/utils/thumbnailUtils.test.ts
+++ b/frontend/editor/src/core/utils/thumbnailUtils.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { containsEncryptMarker } from "@app/utils/thumbnailUtils";
+
+/**
+ * The only signal that a PDF too large to fully parse is password-protected.
+ * Tested over raw bytes because jsdom's Blob does not return its own contents
+ * from arrayBuffer(), so the slicing wrapper cannot be exercised here.
+ */
+
+/** PDF-shaped bytes with `trailer` written at the very end. */
+function bytesEndingWith(trailer: string, size: number): Uint8Array {
+  const bytes = new Uint8Array(size).fill(0x20); // padding
+  const tail = new TextEncoder().encode(trailer);
+  bytes.set(tail, size - tail.length);
+  return bytes;
+}
+
+describe("containsEncryptMarker — trailer probe for large PDFs", () => {
+  it("detects /Encrypt in a trailer dictionary", () => {
+    const bytes = bytesEndingWith(
+      "trailer\n<< /Size 9 /Root 1 0 R /Encrypt 8 0 R >>\nstartxref\n1234\n%%EOF\n",
+      4096,
+    );
+    expect(containsEncryptMarker(bytes)).toBe(true);
+  });
+
+  it("leaves an unencrypted document alone", () => {
+    const bytes = bytesEndingWith(
+      "trailer\n<< /Size 9 /Root 1 0 R >>\nstartxref\n1234\n%%EOF\n",
+      4096,
+    );
+    expect(containsEncryptMarker(bytes)).toBe(false);
+  });
+
+  it("does not match longer keys that merely start the same way", () => {
+    const bytes = bytesEndingWith("<< /EncryptionAware true >>\n%%EOF\n", 512);
+    expect(containsEncryptMarker(bytes)).toBe(false);
+  });
+
+  it("survives binary bytes around the marker", () => {
+    // Under UTF-8 these become replacement characters and consume the marker.
+    const prefix = new Uint8Array([0xff, 0xfe, 0x80, 0x00, 0x9d]);
+    const marker = new TextEncoder().encode(" /Encrypt 8 0 R >>");
+    const bytes = new Uint8Array(prefix.length + marker.length);
+    bytes.set(prefix);
+    bytes.set(marker, prefix.length);
+    expect(containsEncryptMarker(bytes)).toBe(true);
+  });
+
+  it("reports nothing for an empty read", () => {
+    expect(containsEncryptMarker(new Uint8Array(0))).toBe(false);
+  });
+});

--- a/frontend/editor/src/core/utils/thumbnailUtils.ts
+++ b/frontend/editor/src/core/utils/thumbnailUtils.ts
@@ -39,6 +39,24 @@ export const LARGE_PDF_PARSE_LIMIT = 100 * 1024 * 1024;
  * prefix is often enough to render a thumbnail without reading the file. */
 const LINEARIZED_PREFIX_BYTES = 2 * 1024 * 1024;
 
+/** Window at the end of the file searched for an /Encrypt entry. */
+const TRAILER_PROBE_BYTES = 64 * 1024;
+
+/** Decoded latin1 because the input is binary - UTF-8 replacement characters
+ * can swallow the marker. \b excludes longer keys like /Encryption. */
+export function containsEncryptMarker(bytes: Uint8Array): boolean {
+  return /\/Encrypt\b/.test(new TextDecoder("latin1").decode(bytes));
+}
+
+/** /Encrypt is referenced from the trailer, which the prefix never contains, so
+ * encryption can only be read from the tail. Heuristic: a false positive offers
+ * unlock on a file that did not need it, a false negative leaves it unopenable. */
+async function looksEncryptedFromTrailer(file: File): Promise<boolean> {
+  const start = Math.max(0, file.size - TRAILER_PROBE_BYTES);
+  const tail = await file.slice(start).arrayBuffer();
+  return containsEncryptMarker(new Uint8Array(tail));
+}
+
 interface PdfiumRenderResult {
   thumbnail: string;
   pageCount: number;
@@ -269,6 +287,9 @@ export async function generateThumbnailWithMetadata(
   // Never full-parse huge PDFs client-side - the renderer process OOMs long
   // before system RAM runs out. The prefix succeeds for linearized PDFs.
   if (file.size >= LARGE_PDF_PARSE_LIMIT) {
+    if (await looksEncryptedFromTrailer(file)) {
+      return { thumbnail: "", pageCount: 1, isEncrypted: true };
+    }
     try {
       const chunk = await file.slice(0, LINEARIZED_PREFIX_BYTES).arrayBuffer();
       const result = await renderPdfThumbnailPdfium(
@@ -331,8 +352,16 @@ export async function generateThumbnailPairWithMetadata(file: File): Promise<{
   rotated: ThumbnailWithMetadata;
 }> {
   const scale = calculateScaleFromFileSize(file.size);
+  const isLarge = file.size >= LARGE_PDF_PARSE_LIMIT;
+  if (isLarge && (await looksEncryptedFromTrailer(file))) {
+    const encrypted: ThumbnailWithMetadata = {
+      thumbnail: "",
+      pageCount: 1,
+      isEncrypted: true,
+    };
+    return { unrotated: encrypted, rotated: { ...encrypted } };
+  }
   try {
-    const isLarge = file.size >= LARGE_PDF_PARSE_LIMIT;
     const buffer = isLarge
       ? await file.slice(0, LINEARIZED_PREFIX_BYTES).arrayBuffer()
       : await file.arrayBuffer();


### PR DESCRIPTION
#7175 only hands PDFium the first 2MB of a big PDF so the renderer stops OOMing. Trouble is `/Encrypt` lives in the trailer at the end of the file, so the prefix never has it. PDFium just says the file is unreadable rather than locked, and an encrypted PDF over 200MB often ends up with no metadata, no unlock prompt, and a card that spins forever.

Fix is to check the last 64KB for `/Encrypt` before bothering with the prefix parse. Doesn't touch the memory work.