### PR TITLE
Fix hidden circular dependency in watched folders code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ pipeline/
 customFiles/
 configs/
 watchedFolders/
+# The rule above targets the app's runtime watched-folders working dir, but it
+# also matches this frontend source component dir; keep the source tracked.
+!frontend/editor/src/proprietary/components/watchedFolders/
 clientWebUI/
 # Scratch dir used by local fixture-regeneration runs (see
 # app/proprietary/src/test/resources/db-migration-fixtures/README.md).

--- a/frontend/editor/src/proprietary/components/watchedFolders/WatchedFolderHomePage.tsx
+++ b/frontend/editor/src/proprietary/components/watchedFolders/WatchedFolderHomePage.tsx
@@ -32,18 +32,9 @@ import { useNavigationActions } from "@app/contexts/NavigationContext";
 import {
   WATCHED_FOLDER_VIEW_ID,
   WATCHED_FOLDER_WORKBENCH_ID,
-} from "@app/components/watchedFolders/WatchedFoldersRegistration";
-import { timeAgo } from "@app/components/watchedFolders/WatchedFolderWorkbenchView";
+  timeAgo,
+} from "@app/components/watchedFolders/watchedFolderShared";
 import "@app/components/watchedFolders/WatchedFolders.css";
-
-export function humaniseOp(op: string): string {
-  return op
-    .replace(/-pdf$|-pages$|-documents?$/i, "")
-    .replace(/[-_]/g, " ")
-    .replace(/\bocr\b/gi, "OCR")
-    .replace(/\b\w/g, (c) => c.toUpperCase())
-    .trim();
-}
 
 interface FolderCardProps {
   folder: WatchedFolder;

--- a/frontend/editor/src/proprietary/components/watchedFolders/WatchedFolderSection.tsx
+++ b/frontend/editor/src/proprietary/components/watchedFolders/WatchedFolderSection.tsx
@@ -16,7 +16,7 @@ import { automationStorage } from "@app/services/automationStorage";
 import {
   WATCHED_FOLDER_VIEW_ID,
   WATCHED_FOLDER_WORKBENCH_ID,
-} from "@app/components/watchedFolders/WatchedFoldersRegistration";
+} from "@app/components/watchedFolders/watchedFolderShared";
 
 export function WatchedFolderSection() {
   const { t } = useTranslation();

--- a/frontend/editor/src/proprietary/components/watchedFolders/WatchedFolderWorkbenchView.tsx
+++ b/frontend/editor/src/proprietary/components/watchedFolders/WatchedFolderWorkbenchView.tsx
@@ -47,7 +47,9 @@ import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
 import {
   WATCHED_FOLDER_VIEW_ID,
   WATCHED_FOLDER_WORKBENCH_ID,
-} from "@app/components/watchedFolders/WatchedFoldersRegistration";
+  timeAgo,
+  humaniseOp,
+} from "@app/components/watchedFolders/watchedFolderShared";
 import { automationStorage } from "@app/services/automationStorage";
 import {
   useFolderAutomation,
@@ -58,10 +60,7 @@ import { AutomationConfig } from "@app/types/automation";
 import { iconMap } from "@app/components/tools/automate/iconMap";
 import { fileStorage } from "@app/services/fileStorage";
 import { FileId, StirlingFile } from "@app/types/fileContext";
-import {
-  WatchedFolderHomePage,
-  humaniseOp,
-} from "@app/components/watchedFolders/WatchedFolderHomePage";
+import { WatchedFolderHomePage } from "@app/components/watchedFolders/WatchedFolderHomePage";
 import { useNavigationActions } from "@app/contexts/NavigationContext";
 import { FilePreviewModal } from "@app/components/watchedFolders/FilePreviewModal";
 import { folderDirectoryHandleStorage } from "@app/services/folderDirectoryHandleStorage";
@@ -172,28 +171,6 @@ interface WatchedFolderWorkbenchViewProps {
     pendingFileId?: string;
     pendingFileIds?: string[];
   };
-}
-
-export function timeAgo(date: Date, t: TFunction): string {
-  const secs = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (secs < 60) return t("watchedFolders.time.justNow", "just now");
-  const mins = Math.floor(secs / 60);
-  if (mins < 60)
-    return t("watchedFolders.time.minutesAgo", {
-      count: mins,
-      defaultValue: `${mins}m ago`,
-    });
-  const hours = Math.floor(mins / 60);
-  if (hours < 24)
-    return t("watchedFolders.time.hoursAgo", {
-      count: hours,
-      defaultValue: `${hours}h ago`,
-    });
-  const days = Math.floor(hours / 24);
-  return t("watchedFolders.time.daysAgo", {
-    count: days,
-    defaultValue: `${days}d ago`,
-  });
 }
 
 function RetryCountdown({

--- a/frontend/editor/src/proprietary/components/watchedFolders/WatchedFoldersRegistration.tsx
+++ b/frontend/editor/src/proprietary/components/watchedFolders/WatchedFoldersRegistration.tsx
@@ -4,9 +4,10 @@ import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
 import { WatchedFolderWorkbenchView } from "@app/components/watchedFolders/WatchedFolderWorkbenchView";
 import { seedDefaultFolders } from "@app/data/watchedFolderPresets";
 import { useWatchedFolderUrlSync } from "@app/hooks/useWatchedFolderUrlSync";
-
-export const WATCHED_FOLDER_VIEW_ID = "watchedFolder";
-export const WATCHED_FOLDER_WORKBENCH_ID = "custom:watchedFolder" as const;
+import {
+  WATCHED_FOLDER_VIEW_ID,
+  WATCHED_FOLDER_WORKBENCH_ID,
+} from "@app/components/watchedFolders/watchedFolderShared";
 
 export default function WatchedFoldersRegistration() {
   const { t } = useTranslation();

--- a/frontend/editor/src/proprietary/components/watchedFolders/watchedFolderShared.ts
+++ b/frontend/editor/src/proprietary/components/watchedFolders/watchedFolderShared.ts
@@ -1,0 +1,38 @@
+// Leaf module for the watched-folders trio (registration, workbench view, home
+// page): the shared view IDs plus small pure formatters. Kept dependency-free so
+// those three components don't have to import one another and form a cycle.
+import type { TFunction } from "i18next";
+
+export const WATCHED_FOLDER_VIEW_ID = "watchedFolder";
+export const WATCHED_FOLDER_WORKBENCH_ID = "custom:watchedFolder" as const;
+
+export function timeAgo(date: Date, t: TFunction): string {
+  const secs = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (secs < 60) return t("watchedFolders.time.justNow", "just now");
+  const mins = Math.floor(secs / 60);
+  if (mins < 60)
+    return t("watchedFolders.time.minutesAgo", {
+      count: mins,
+      defaultValue: `${mins}m ago`,
+    });
+  const hours = Math.floor(mins / 60);
+  if (hours < 24)
+    return t("watchedFolders.time.hoursAgo", {
+      count: hours,
+      defaultValue: `${hours}h ago`,
+    });
+  const days = Math.floor(hours / 24);
+  return t("watchedFolders.time.daysAgo", {
+    count: days,
+    defaultValue: `${days}d ago`,
+  });
+}
+
+export function humaniseOp(op: string): string {
+  return op
+    .replace(/-pdf$|-pages$|-documents?$/i, "")
+    .replace(/[-_]/g, " ")
+    .replace(/\bocr\b/gi, "OCR")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}


### PR DESCRIPTION
# Description of Changes
The restructuring of the frontend PR (#7062) has highlighted a couple of issues with the source which are currently hidden due to the structure of the code. This PR fixes the issues in Watched Folders: 
- There's a circular dependency in TS code
- The `.gitignore` file excludes the watched folders dir by accident