### PR TITLE
refactor(pdfjson): extract PDF rewrite helpers

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -115,6 +115,7 @@ import stirling.software.SPDF.model.json.PdfJsonStream;
 import stirling.software.SPDF.model.json.PdfJsonTextColor;
 import stirling.software.SPDF.model.json.PdfJsonTextElement;
 import stirling.software.SPDF.service.pdfjson.PdfJsonFontService;
+import stirling.software.SPDF.service.pdfjson.PdfTextMergeHelper;
 import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
 import stirling.software.SPDF.service.pdfjson.font.PdfFontResolver;
 import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
@@ -4061,7 +4062,7 @@ public class PdfJsonConversionService {
             tokens.set(tokenIndex, new COSString(new byte[0]));
             return true;
         }
-        MergedText replacement = mergeText(consumed);
+        PdfTextMergeHelper.MergedText replacement = PdfTextMergeHelper.mergeText(consumed);
         try {
             byte[] encoded =
                     PdfTextEncoder.encode(
@@ -4116,7 +4117,7 @@ public class PdfJsonConversionService {
                     array.set(i, new COSString(new byte[0]));
                     continue;
                 }
-                MergedText replacement = mergeText(consumed);
+                PdfTextMergeHelper.MergedText replacement = PdfTextMergeHelper.mergeText(consumed);
                 try {
                     byte[] encoded =
                             PdfTextEncoder.encode(
@@ -4143,23 +4144,6 @@ public class PdfJsonConversionService {
         }
         return true;
     }
-
-    private MergedText mergeText(List<PdfJsonTextElement> elements) {
-        StringBuilder builder = new StringBuilder();
-        List<Integer> combinedCodes = new ArrayList<>();
-        for (PdfJsonTextElement element : elements) {
-            builder.append(Objects.toString(element.getText(), ""));
-            int[] codes = element.getCharCodes();
-            if (codes != null && codes.length > 0) {
-                for (int code : codes) {
-                    combinedCodes.add(code);
-                }
-            }
-        }
-        return new MergedText(builder.toString(), combinedCodes.isEmpty() ? null : combinedCodes);
-    }
-
-    private record MergedText(String text, List<Integer> charCodes) {}
 
     private static class TextElementCursor {
         private final List<PdfJsonTextElement> elements;

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -115,6 +115,7 @@ import stirling.software.SPDF.model.json.PdfJsonStream;
 import stirling.software.SPDF.model.json.PdfJsonTextColor;
 import stirling.software.SPDF.model.json.PdfJsonTextElement;
 import stirling.software.SPDF.service.pdfjson.PdfJsonFontService;
+import stirling.software.SPDF.service.pdfjson.PdfTextElementCursor;
 import stirling.software.SPDF.service.pdfjson.PdfTextMergeHelper;
 import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
 import stirling.software.SPDF.service.pdfjson.font.PdfFontResolver;
@@ -3919,7 +3920,7 @@ public class PdfJsonConversionService {
             PDFStreamParser parser = new PDFStreamParser(page);
             List<Object> tokens = parser.parse();
             log.debug("Parsed {} tokens for rewrite", tokens.size());
-            TextElementCursor cursor = new TextElementCursor(elements);
+            PdfTextElementCursor cursor = new PdfTextElementCursor(elements);
             PDFont currentFont = null;
             String currentFontName = null;
             PdfJsonFont currentFontModel = null;
@@ -4033,7 +4034,7 @@ public class PdfJsonConversionService {
             PDFont font,
             PdfJsonFont fontModel,
             String expectedFontName,
-            TextElementCursor cursor,
+            PdfTextElementCursor cursor,
             boolean removeOnly)
             throws IOException {
         if (font == null) {
@@ -4047,7 +4048,7 @@ public class PdfJsonConversionService {
         log.trace(
                 "rewriteShowText consuming {} glyphs at cursor index {} for font {}",
                 glyphCount,
-                cursor.index,
+                cursor.getIndex(),
                 expectedFontName);
         List<PdfJsonTextElement> consumed = cursor.consume(expectedFontName, glyphCount);
         if (consumed == null) {
@@ -4090,7 +4091,7 @@ public class PdfJsonConversionService {
             PDFont font,
             PdfJsonFont fontModel,
             String expectedFontName,
-            TextElementCursor cursor,
+            PdfTextElementCursor cursor,
             boolean removeOnly)
             throws IOException {
         if (font == null) {
@@ -4143,76 +4144,6 @@ public class PdfJsonConversionService {
             }
         }
         return true;
-    }
-
-    private static class TextElementCursor {
-        private final List<PdfJsonTextElement> elements;
-        private int index = 0;
-
-        TextElementCursor(List<PdfJsonTextElement> elements) {
-            this.elements = elements;
-        }
-
-        boolean hasRemaining() {
-            return index < elements.size();
-        }
-
-        int remaining() {
-            return Math.max(0, elements.size() - index);
-        }
-
-        List<PdfJsonTextElement> consume(String expectedFontName, int glyphCount) {
-            if (glyphCount <= 0) {
-                return Collections.emptyList();
-            }
-            List<PdfJsonTextElement> consumed = new ArrayList<>();
-            int remaining = glyphCount;
-            while (remaining > 0 && index < elements.size()) {
-                PdfJsonTextElement element = elements.get(index);
-                if (!fontMatches(expectedFontName, element.getFontId())) {
-                    log.debug(
-                            "Cursor consume failed: font mismatch (expected={}, actual={}) at element {}",
-                            expectedFontName,
-                            element.getFontId(),
-                            index);
-                    return null;
-                }
-                consumed.add(element);
-                remaining -= countGlyphs(element);
-                index++;
-            }
-            if (remaining > 0) {
-                log.debug(
-                        "Cursor consume failed: ran out of elements (remaining={}, currentIndex={}, total={})",
-                        remaining,
-                        index,
-                        elements.size());
-                return null;
-            }
-            return consumed;
-        }
-
-        private boolean fontMatches(String expected, String actual) {
-            if (expected == null || expected.isEmpty()) {
-                return true;
-            }
-            if (actual == null) {
-                return false;
-            }
-            return Objects.equals(expected, actual);
-        }
-
-        private int countGlyphs(PdfJsonTextElement element) {
-            int[] codes = element.getCharCodes();
-            if (codes != null && codes.length > 0) {
-                return codes.length;
-            }
-            String text = element.getText();
-            if (text != null && !text.isEmpty()) {
-                return Math.max(1, text.codePointCount(0, text.length()));
-            }
-            return 1;
-        }
     }
 
     private Map<String, PDFont> buildFontMap(

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -115,9 +115,9 @@ import stirling.software.SPDF.model.json.PdfJsonStream;
 import stirling.software.SPDF.model.json.PdfJsonTextColor;
 import stirling.software.SPDF.model.json.PdfJsonTextElement;
 import stirling.software.SPDF.service.pdfjson.PdfJsonFontService;
+import stirling.software.SPDF.service.pdfjson.PdfShowTextArrayRewriter;
 import stirling.software.SPDF.service.pdfjson.PdfShowTextRewriter;
 import stirling.software.SPDF.service.pdfjson.PdfTextElementCursor;
-import stirling.software.SPDF.service.pdfjson.PdfTextMergeHelper;
 import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
 import stirling.software.SPDF.service.pdfjson.font.PdfFontResolver;
 import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
@@ -3990,13 +3990,14 @@ public class PdfJsonConversionService {
                                 currentFontName,
                                 i,
                                 cursor.remaining());
-                        if (!rewriteShowTextArray(
+                        if (!PdfShowTextArrayRewriter.rewriteShowTextArray(
                                 array,
                                 currentFont,
                                 currentFontModel,
                                 currentFontName,
                                 cursor,
-                                removeOnly)) {
+                                removeOnly,
+                                pdfGlyphCounter)) {
                             log.debug("Failed to rewrite TJ operator; aborting rewrite");
                             return false;
                         }
@@ -4028,66 +4029,6 @@ public class PdfJsonConversionService {
             log.debug("Failed to rewrite content stream: {}", ex.getMessage());
             return false;
         }
-    }
-
-    private boolean rewriteShowTextArray(
-            COSArray array,
-            PDFont font,
-            PdfJsonFont fontModel,
-            String expectedFontName,
-            PdfTextElementCursor cursor,
-            boolean removeOnly)
-            throws IOException {
-        if (font == null) {
-            log.debug(
-                    "rewriteShowTextArray aborted: no active font for expected resource {}",
-                    expectedFontName);
-            return false;
-        }
-        for (int i = 0; i < array.size(); i++) {
-            COSBase element = array.get(i);
-            if (element instanceof COSString cosString) {
-                int glyphCount = pdfGlyphCounter.countGlyphs(cosString, font);
-                List<PdfJsonTextElement> consumed = cursor.consume(expectedFontName, glyphCount);
-                if (consumed == null) {
-                    log.debug(
-                            "Failed to consume {} glyphs for font {} in TJ segment {} (cursor remaining {})",
-                            glyphCount,
-                            expectedFontName,
-                            i,
-                            cursor.remaining());
-                    return false;
-                }
-                if (removeOnly) {
-                    array.set(i, new COSString(new byte[0]));
-                    continue;
-                }
-                PdfTextMergeHelper.MergedText replacement = PdfTextMergeHelper.mergeText(consumed);
-                try {
-                    byte[] encoded =
-                            PdfTextEncoder.encode(
-                                    font, fontModel, replacement.text(), replacement.charCodes());
-                    if (encoded == null) {
-                        log.debug(
-                                "Failed to map replacement text in TJ array for font {} segment {}",
-                                expectedFontName,
-                                i);
-                        return false;
-                    }
-                    array.set(i, new COSString(encoded));
-                } catch (IOException
-                        | IllegalArgumentException
-                        | UnsupportedOperationException ex) {
-                    log.debug(
-                            "Failed to encode replacement text in TJ array for font {} segment {}: {}",
-                            expectedFontName,
-                            i,
-                            ex.getMessage());
-                    return false;
-                }
-            }
-        }
-        return true;
     }
 
     private Map<String, PDFont> buildFontMap(

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -3268,7 +3268,7 @@ public class PdfJsonConversionService {
                                 if (run.font() instanceof PDType3Font
                                         && run.charCodes() != null
                                         && !run.charCodes().isEmpty()) {
-                                    encoded = encodeType3CharCodes(run.charCodes());
+                                    encoded = PdfTextEncoder.encodeType3CharCodes(run.charCodes());
                                     if (encoded == null || encoded.length == 0) {
                                         log.warn(
                                                 "[FONT-DEBUG] Failed to emit raw Type3 char codes for font {} on page {}",
@@ -4268,20 +4268,6 @@ public class PdfJsonConversionService {
             }
         }
         return null;
-    }
-
-    private byte[] encodeType3CharCodes(List<Integer> charCodes) {
-        if (charCodes == null || charCodes.isEmpty()) {
-            return null;
-        }
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(charCodes.size());
-        for (Integer code : charCodes) {
-            if (code == null || code < 0 || code > 0xFF) {
-                return null;
-            }
-            baos.write(code);
-        }
-        return baos.toByteArray();
     }
 
     private MergedText mergeText(List<PdfJsonTextElement> elements) {

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -115,6 +115,8 @@ import stirling.software.SPDF.model.json.PdfJsonStream;
 import stirling.software.SPDF.model.json.PdfJsonTextColor;
 import stirling.software.SPDF.model.json.PdfJsonTextElement;
 import stirling.software.SPDF.service.pdfjson.PdfJsonFontService;
+import stirling.software.SPDF.service.pdfjson.font.PdfFontResolver;
+import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
 import stirling.software.SPDF.service.pdfjson.type3.Type3ConversionRequest;
 import stirling.software.SPDF.service.pdfjson.type3.Type3FontConversionService;
 import stirling.software.SPDF.service.pdfjson.type3.Type3GlyphExtractor;
@@ -147,6 +149,8 @@ public class PdfJsonConversionService {
     private final PdfJsonFontService fontService;
     private final Type3FontConversionService type3FontConversionService;
     private final Type3GlyphExtractor type3GlyphExtractor;
+    private final PdfFontResolver pdfFontResolver;
+    private final PdfGlyphCounter pdfGlyphCounter;
     private final stirling.software.common.model.ApplicationProperties applicationProperties;
     private final Map<String, PDFont> type3NormalizedFontCache = new ConcurrentHashMap<>();
     private final Map<String, Set<Integer>> type3GlyphCoverageCache = new ConcurrentHashMap<>();
@@ -938,14 +942,11 @@ public class PdfJsonConversionService {
     }
 
     private String buildFontKey(String jobId, int pageNumber, String fontId) {
-        // Include jobId to ensure font UIDs are globally unique across concurrent jobs
-        String jobPrefix = (jobId != null && !jobId.isEmpty()) ? jobId + ":" : "";
-        return jobPrefix + pageNumber + ":" + fontId;
+        return pdfFontResolver.buildFontKey(jobId, pageNumber, fontId);
     }
 
     private String buildFontKey(String jobId, Integer pageNumber, String fontId) {
-        int page = pageNumber != null ? pageNumber : -1;
-        return buildFontKey(jobId, page, fontId);
+        return pdfFontResolver.buildFontKey(jobId, pageNumber, fontId);
     }
 
     private String resolveFontCacheKey(PdfJsonFont font) {
@@ -975,19 +976,6 @@ public class PdfJsonConversionService {
             lookup.put(buildFontKey(null, font.getPageNumber(), font.getId()), font);
         }
         return lookup;
-    }
-
-    private PdfJsonFont resolveFontModel(
-            Map<String, PdfJsonFont> lookup, int pageNumber, String fontId) {
-        if (lookup == null || fontId == null) {
-            return null;
-        }
-        // JSON->PDF conversion: no jobId context, pass null
-        PdfJsonFont model = lookup.get(buildFontKey(null, pageNumber, fontId));
-        if (model != null) {
-            return model;
-        }
-        return lookup.get(buildFontKey(null, -1, fontId));
     }
 
     private List<PdfJsonFont> cloneFontList(Collection<PdfJsonFont> source) {
@@ -1856,7 +1844,8 @@ public class PdfJsonConversionService {
                 continue;
             }
 
-            PdfJsonFont fontModel = resolveFontModel(fontLookup, pageNumber, element.getFontId());
+            PdfJsonFont fontModel =
+                    pdfFontResolver.resolve(fontLookup, pageNumber, element.getFontId());
             if (font instanceof PDType3Font && fontModel != null) {
                 Set<Integer> supportedGlyphs =
                         type3GlyphCache.computeIfAbsent(
@@ -3245,11 +3234,13 @@ public class PdfJsonConversionService {
                                 activeFont = run.font();
                             }
                             PdfJsonFont runFontModel =
-                                    resolveFontModel(runFontLookup, pageNumber, run.fontId());
+                                    pdfFontResolver.resolve(
+                                            runFontLookup, pageNumber, run.fontId());
                             if (runFontModel == null) {
                                 runFontLookup = buildFontModelLookup(fontModels);
                                 runFontModel =
-                                        resolveFontModel(runFontLookup, pageNumber, run.fontId());
+                                        pdfFontResolver.resolve(
+                                                runFontLookup, pageNumber, run.fontId());
                             }
                             // Check if this is a normalized Type3 font (has Type3 metadata but is
                             // not PDType3Font)
@@ -3386,7 +3377,7 @@ public class PdfJsonConversionService {
         }
 
         Map<String, PdfJsonFont> runFontLookup = buildFontModelLookup(fontModels);
-        PdfJsonFont baseFontModel = resolveFontModel(runFontLookup, pageNumber, baseFontId);
+        PdfJsonFont baseFontModel = pdfFontResolver.resolve(runFontLookup, pageNumber, baseFontId);
         boolean baseIsType3 =
                 baseFontModel != null
                         && baseFontModel.getSubtype() != null
@@ -3945,7 +3936,8 @@ public class PdfJsonConversionService {
                             currentFont = resources.getFont(fontResourceName);
                             currentFontName = fontResourceName.getName();
                             currentFontModel =
-                                    resolveFontModel(fontLookup, pageNumber, currentFontName);
+                                    pdfFontResolver.resolve(
+                                            fontLookup, pageNumber, currentFontName);
                             log.trace(
                                     "Encountered Tf operator; switching to font resource {}",
                                     currentFontName);
@@ -4049,7 +4041,7 @@ public class PdfJsonConversionService {
             return false;
         }
         COSString cosString = (COSString) tokens.get(tokenIndex);
-        int glyphCount = countGlyphs(cosString, font);
+        int glyphCount = pdfGlyphCounter.countGlyphs(cosString, font);
         log.trace(
                 "rewriteShowText consuming {} glyphs at cursor index {} for font {}",
                 glyphCount,
@@ -4108,7 +4100,7 @@ public class PdfJsonConversionService {
         for (int i = 0; i < array.size(); i++) {
             COSBase element = array.get(i);
             if (element instanceof COSString cosString) {
-                int glyphCount = countGlyphs(cosString, font);
+                int glyphCount = pdfGlyphCounter.countGlyphs(cosString, font);
                 List<PdfJsonTextElement> consumed = cursor.consume(expectedFontName, glyphCount);
                 if (consumed == null) {
                     log.debug(
@@ -4318,67 +4310,6 @@ public class PdfJsonConversionService {
             return !(unsigned == 0x09 || unsigned == 0x0A || unsigned == 0x0D);
         }
         return false;
-    }
-
-    private int countGlyphs(COSString value, PDFont font) {
-        if (value == null) {
-            return 0;
-        }
-        if (font != null) {
-            try (ByteArrayInputStream inputStream = new ByteArrayInputStream(value.getBytes())) {
-                int count = countCodesProtected(inputStream, font::readCode);
-                if (count > 0) {
-                    return count;
-                }
-            } catch (IOException ex) {
-                log.debug("Failed to decode glyphs: {}", ex.getMessage());
-            }
-        }
-        byte[] bytes = value.getBytes();
-        return Math.max(1, bytes.length);
-    }
-
-    /**
-     * Functional accessor for {@link PDFont#readCode(InputStream)} so the bounded counting loop can
-     * be exercised in isolation without instantiating a {@link PDFont}.
-     */
-    @FunctionalInterface
-    interface CodeReader {
-        int readCode(InputStream stream) throws IOException;
-    }
-
-    /**
-     * Count how many codes the supplied {@code reader} can extract from {@code inputStream}, with
-     * two safety nets that PDFBox's raw {@link PDFont#readCode(InputStream)} loop lacks:
-     *
-     * <ol>
-     *   <li>Stop when the stream is empty (a corrupt CMap can otherwise loop forever returning
-     *       successfully-matched zero-bytes from an exhausted {@link ByteArrayInputStream}).
-     *   <li>Stop when a {@code readCode} call did not consume any bytes, even if it returned a
-     *       non-{@code -1} value.
-     * </ol>
-     *
-     * <p>Both conditions were observed in the wild on round-tripped fallback fonts where the
-     * embedded ToUnicode CMap matched 0x00 sequences, hanging the JSON&rarr;PDF rebuild.
-     */
-    static int countCodesProtected(ByteArrayInputStream inputStream, CodeReader reader)
-            throws IOException {
-        int count = 0;
-        int previousAvailable = inputStream.available();
-        while (previousAvailable > 0) {
-            int code = reader.readCode(inputStream);
-            if (code == -1) {
-                break;
-            }
-            int currentAvailable = inputStream.available();
-            if (currentAvailable >= previousAvailable) {
-                // No progress made; break to avoid infinite loop on corrupt CMaps.
-                break;
-            }
-            count++;
-            previousAvailable = currentAvailable;
-        }
-        return count;
     }
 
     private MergedText mergeText(List<PdfJsonTextElement> elements) {

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -3287,7 +3287,7 @@ public class PdfJsonConversionService {
                                                         ? runFontModel.getId()
                                                         : "null");
                                         encoded =
-                                                encodeTextWithFont(
+                                                PdfTextEncoder.encode(
                                                         run.font(),
                                                         runFontModel,
                                                         run.text(),
@@ -4064,7 +4064,7 @@ public class PdfJsonConversionService {
         MergedText replacement = mergeText(consumed);
         try {
             byte[] encoded =
-                    encodeTextWithFont(
+                    PdfTextEncoder.encode(
                             font, fontModel, replacement.text(), replacement.charCodes());
             if (encoded == null) {
                 log.debug(
@@ -4119,7 +4119,7 @@ public class PdfJsonConversionService {
                 MergedText replacement = mergeText(consumed);
                 try {
                     byte[] encoded =
-                            encodeTextWithFont(
+                            PdfTextEncoder.encode(
                                     font, fontModel, replacement.text(), replacement.charCodes());
                     if (encoded == null) {
                         log.debug(
@@ -4142,132 +4142,6 @@ public class PdfJsonConversionService {
             }
         }
         return true;
-    }
-
-    private byte[] encodeTextWithFont(
-            PDFont font, PdfJsonFont fontModel, String text, List<Integer> rawCharCodes)
-            throws IOException {
-        boolean isType3Font = font instanceof PDType3Font;
-        boolean hasType3Metadata =
-                fontModel != null
-                        && fontModel.getType3Glyphs() != null
-                        && !fontModel.getType3Glyphs().isEmpty();
-
-        // For normalized Type3 fonts (font is NOT Type3 but has Type3 metadata)
-        if (!isType3Font && hasType3Metadata) {
-            // If loaded as full font (not subset), use standard Unicode encoding
-            // Try standard encoding first - this works when the font has all glyphs
-            try {
-                byte[] encoded = font.encode(text);
-                // NOTE: Do NOT sanitize encoded bytes for normalized Type3 fonts
-                // Multi-byte encodings (UTF-16BE, CID fonts) have null bytes that are essential
-                // Removing them corrupts the byte boundaries and produces garbled text
-                log.debug(
-                        "[TYPE3] Encoded text '{}' for normalized font {}: encoded={} bytes",
-                        text.length() > 20 ? text.substring(0, 20) + "..." : text,
-                        fontModel.getId(),
-                        encoded != null ? encoded.length : 0);
-                if (encoded != null && encoded.length > 0) {
-                    log.debug(
-                            "[TYPE3] Successfully encoded text for normalized Type3 font {} using standard encoding",
-                            fontModel.getId());
-                    return encoded;
-                }
-                log.debug(
-                        "[TYPE3] Standard encoding produced empty result for normalized Type3 font {}, falling through to Type3 mapping",
-                        fontModel.getId());
-            } catch (IOException | IllegalArgumentException ex) {
-                log.debug(
-                        "[TYPE3] Standard encoding failed for normalized Type3 font {}: {}",
-                        fontModel.getId(),
-                        ex.getMessage());
-            }
-            // If standard encoding failed, fall through to Type3 glyph mapping (for subset fonts)
-            // or return null to trigger fallback font
-        } else if (!isType3Font || fontModel == null) {
-            // For non-Type3 fonts without Type3 metadata, use standard encoding
-            try {
-                byte[] encoded = font.encode(text);
-                return PdfTextEncoder.sanitizeEncoded(encoded);
-            } catch (IllegalArgumentException ex) {
-                log.debug(
-                        "[FONT-DEBUG] Font {} cannot encode text '{}': {}",
-                        font.getName(),
-                        text,
-                        ex.getMessage());
-                // Return null to trigger fallback font mechanism
-                return null;
-            }
-        }
-
-        // Type3 glyph mapping logic (for actual Type3 fonts AND normalized Type3 fonts)
-        List<PdfJsonFontType3Glyph> glyphs = fontModel.getType3Glyphs();
-        if (glyphs == null || glyphs.isEmpty()) {
-            return null;
-        }
-
-        // For normalized Type3 fonts, DO NOT use rawCharCodes because:
-        // 1. They may be stale if text was edited
-        // 2. The subset font only has glyphs from the original PDF
-        // Instead, try Type3 glyph mapping and return null if glyphs are missing
-        // (null will trigger fallback font usage in the calling code)
-
-        // Build Unicode to character code mapping from Type3 glyphs
-        Map<Integer, Integer> unicodeToCode = new HashMap<>();
-        for (PdfJsonFontType3Glyph glyph : glyphs) {
-            if (glyph == null) {
-                continue;
-            }
-            Integer unicode = glyph.getUnicode();
-            Integer charCode = glyph.getCharCode();
-            if (unicode == null || charCode == null) {
-                continue;
-            }
-            unicodeToCode.putIfAbsent(unicode, charCode);
-        }
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        boolean mappedAll = true;
-        for (int offset = 0; offset < text.length(); ) {
-            int codePoint = text.codePointAt(offset);
-            offset += Character.charCount(codePoint);
-            Integer charCode = unicodeToCode.get(codePoint);
-            if (charCode == null) {
-                log.debug(
-                        "[TYPE3] Missing glyph mapping for code point U+{} in font {}",
-                        Integer.toHexString(codePoint).toUpperCase(Locale.ROOT),
-                        fontModel.getId());
-                mappedAll = false;
-                break;
-            }
-            if (charCode < 0 || charCode > 0xFF) {
-                log.debug(
-                        "[TYPE3] Unsupported Type3 charCode {} for font {} (only 1-byte codes supported)",
-                        charCode,
-                        fontModel.getId());
-                mappedAll = false;
-                break;
-            }
-            baos.write(charCode);
-        }
-        if (mappedAll) {
-            return PdfTextEncoder.sanitizeEncoded(baos.toByteArray());
-        }
-        // Fallback to rawCharCodes for actual Type3 fonts if mapping failed
-        if (rawCharCodes != null && !rawCharCodes.isEmpty()) {
-            boolean valid = true;
-            ByteArrayOutputStream fallbackBytes = new ByteArrayOutputStream(rawCharCodes.size());
-            for (Integer code : rawCharCodes) {
-                if (code == null || code < 0 || code > 0xFF) {
-                    valid = false;
-                    break;
-                }
-                fallbackBytes.write(code);
-            }
-            if (valid) {
-                return fallbackBytes.toByteArray();
-            }
-        }
-        return null;
     }
 
     private MergedText mergeText(List<PdfJsonTextElement> elements) {

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -115,6 +115,7 @@ import stirling.software.SPDF.model.json.PdfJsonStream;
 import stirling.software.SPDF.model.json.PdfJsonTextColor;
 import stirling.software.SPDF.model.json.PdfJsonTextElement;
 import stirling.software.SPDF.service.pdfjson.PdfJsonFontService;
+import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
 import stirling.software.SPDF.service.pdfjson.font.PdfFontResolver;
 import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
 import stirling.software.SPDF.service.pdfjson.type3.Type3ConversionRequest;
@@ -4187,7 +4188,7 @@ public class PdfJsonConversionService {
             // For non-Type3 fonts without Type3 metadata, use standard encoding
             try {
                 byte[] encoded = font.encode(text);
-                return sanitizeEncoded(encoded);
+                return PdfTextEncoder.sanitizeEncoded(encoded);
             } catch (IllegalArgumentException ex) {
                 log.debug(
                         "[FONT-DEBUG] Font {} cannot encode text '{}': {}",
@@ -4249,7 +4250,7 @@ public class PdfJsonConversionService {
             baos.write(charCode);
         }
         if (mappedAll) {
-            return sanitizeEncoded(baos.toByteArray());
+            return PdfTextEncoder.sanitizeEncoded(baos.toByteArray());
         }
         // Fallback to rawCharCodes for actual Type3 fonts if mapping failed
         if (rawCharCodes != null && !rawCharCodes.isEmpty()) {
@@ -4281,35 +4282,6 @@ public class PdfJsonConversionService {
             baos.write(code);
         }
         return baos.toByteArray();
-    }
-
-    private byte[] sanitizeEncoded(byte[] encoded) {
-        if (encoded == null || encoded.length == 0) {
-            return new byte[0];
-        }
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(encoded.length);
-        for (byte b : encoded) {
-            if (isStrippedControlByte(b)) {
-                continue;
-            }
-            baos.write(b);
-        }
-        byte[] sanitized = baos.toByteArray();
-        if (sanitized.length == 0) {
-            return sanitized;
-        }
-        return sanitized;
-    }
-
-    private boolean isStrippedControlByte(byte value) {
-        if (value == 0) {
-            return true;
-        }
-        int unsigned = Byte.toUnsignedInt(value);
-        if (unsigned <= 0x1F) {
-            return !(unsigned == 0x09 || unsigned == 0x0A || unsigned == 0x0D);
-        }
-        return false;
     }
 
     private MergedText mergeText(List<PdfJsonTextElement> elements) {

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -3784,17 +3784,6 @@ public class PdfJsonConversionService {
         }
     }
 
-    private String abbreviate(String value) {
-        if (value == null) {
-            return "";
-        }
-        String trimmed = WHITESPACE_PATTERN.matcher(value).replaceAll(" ").trim();
-        if (trimmed.length() <= 32) {
-            return trimmed;
-        }
-        return trimmed.substring(0, 29) + "...";
-    }
-
     private static class FontProgramData {
         private final String base64;
         private final String format;
@@ -5390,20 +5379,6 @@ public class PdfJsonConversionService {
                     .colorSpace(colorSpaceName)
                     .components(effective)
                     .build();
-        }
-
-        private String sanitizeForLog(String value) {
-            if (value == null) {
-                return "null";
-            }
-            return value.replace("\n", "\\n").replace("\r", "\\r");
-        }
-
-        private String describeColor(PdfJsonTextColor color) {
-            if (color == null || color.getComponents() == null) {
-                return "null";
-            }
-            return color.getColorSpace() + "=" + color.getComponents();
         }
     }
 

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -115,6 +115,7 @@ import stirling.software.SPDF.model.json.PdfJsonStream;
 import stirling.software.SPDF.model.json.PdfJsonTextColor;
 import stirling.software.SPDF.model.json.PdfJsonTextElement;
 import stirling.software.SPDF.service.pdfjson.PdfJsonFontService;
+import stirling.software.SPDF.service.pdfjson.PdfShowTextRewriter;
 import stirling.software.SPDF.service.pdfjson.PdfTextElementCursor;
 import stirling.software.SPDF.service.pdfjson.PdfTextMergeHelper;
 import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
@@ -3966,14 +3967,15 @@ public class PdfJsonConversionService {
                                 currentFontName,
                                 i,
                                 cursor.remaining());
-                        if (!rewriteShowText(
+                        if (!PdfShowTextRewriter.rewriteShowText(
                                 tokens,
                                 i - 1,
                                 currentFont,
                                 currentFontModel,
                                 currentFontName,
                                 cursor,
-                                removeOnly)) {
+                                removeOnly,
+                                pdfGlyphCounter)) {
                             log.debug("Failed to rewrite Tj operator; aborting rewrite");
                             return false;
                         }
@@ -4024,64 +4026,6 @@ public class PdfJsonConversionService {
             return true;
         } catch (IOException ex) {
             log.debug("Failed to rewrite content stream: {}", ex.getMessage());
-            return false;
-        }
-    }
-
-    private boolean rewriteShowText(
-            List<Object> tokens,
-            int tokenIndex,
-            PDFont font,
-            PdfJsonFont fontModel,
-            String expectedFontName,
-            PdfTextElementCursor cursor,
-            boolean removeOnly)
-            throws IOException {
-        if (font == null) {
-            log.debug(
-                    "rewriteShowText aborted: no active font for expected resource {}",
-                    expectedFontName);
-            return false;
-        }
-        COSString cosString = (COSString) tokens.get(tokenIndex);
-        int glyphCount = pdfGlyphCounter.countGlyphs(cosString, font);
-        log.trace(
-                "rewriteShowText consuming {} glyphs at cursor index {} for font {}",
-                glyphCount,
-                cursor.getIndex(),
-                expectedFontName);
-        List<PdfJsonTextElement> consumed = cursor.consume(expectedFontName, glyphCount);
-        if (consumed == null) {
-            log.debug(
-                    "Failed to consume {} glyphs for font {} (cursor remaining {})",
-                    glyphCount,
-                    expectedFontName,
-                    cursor.remaining());
-            return false;
-        }
-        if (removeOnly) {
-            tokens.set(tokenIndex, new COSString(new byte[0]));
-            return true;
-        }
-        PdfTextMergeHelper.MergedText replacement = PdfTextMergeHelper.mergeText(consumed);
-        try {
-            byte[] encoded =
-                    PdfTextEncoder.encode(
-                            font, fontModel, replacement.text(), replacement.charCodes());
-            if (encoded == null) {
-                log.debug(
-                        "Failed to map replacement text to glyphs for font {} (text='{}')",
-                        expectedFontName,
-                        replacement.text());
-                return false;
-            }
-            tokens.set(tokenIndex, new COSString(encoded));
-            return true;
-        } catch (IOException | IllegalArgumentException | UnsupportedOperationException ex) {
-            log.debug(
-                    "Failed to encode replacement text with font {}: {}",
-                    expectedFontName,
-                    ex.getMessage());
             return false;
         }
     }

--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -115,9 +115,7 @@ import stirling.software.SPDF.model.json.PdfJsonStream;
 import stirling.software.SPDF.model.json.PdfJsonTextColor;
 import stirling.software.SPDF.model.json.PdfJsonTextElement;
 import stirling.software.SPDF.service.pdfjson.PdfJsonFontService;
-import stirling.software.SPDF.service.pdfjson.PdfShowTextArrayRewriter;
-import stirling.software.SPDF.service.pdfjson.PdfShowTextRewriter;
-import stirling.software.SPDF.service.pdfjson.PdfTextElementCursor;
+import stirling.software.SPDF.service.pdfjson.PdfTokenRewriteEngine;
 import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
 import stirling.software.SPDF.service.pdfjson.font.PdfFontResolver;
 import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
@@ -749,14 +747,16 @@ public class PdfJsonConversionService {
                     } else if (!preservedStreams.isEmpty()) {
                         log.debug("Attempting token rewrite for page {}", pageNumberValue);
                         rewriteSucceeded =
-                                rewriteTextOperators(
+                                PdfTokenRewriteEngine.rewriteTextOperators(
                                         document,
                                         page,
                                         elements,
                                         false,
                                         false,
                                         fontLookup,
-                                        pageNumberValue);
+                                        pageNumberValue,
+                                        pdfFontResolver,
+                                        pdfGlyphCounter);
                         if (!rewriteSucceeded) {
                             log.debug(
                                     "Token rewrite failed for page {}, regenerating text stream",
@@ -3897,140 +3897,6 @@ public class PdfJsonConversionService {
         }
     }
 
-    private boolean rewriteTextOperators(
-            PDDocument document,
-            PDPage page,
-            List<PdfJsonTextElement> elements,
-            boolean removeOnly,
-            boolean forceRegenerate,
-            Map<String, PdfJsonFont> fontLookup,
-            int pageNumber) {
-        if (forceRegenerate) {
-            log.debug("forceRegenerate flag set; skipping token rewrite for page");
-            return false;
-        }
-        if (elements == null || elements.isEmpty()) {
-            return true;
-        }
-        PDResources resources = page.getResources();
-        if (resources == null) {
-            return false;
-        }
-        try {
-            log.debug("Attempting token-level rewrite for page");
-            PDFStreamParser parser = new PDFStreamParser(page);
-            List<Object> tokens = parser.parse();
-            log.debug("Parsed {} tokens for rewrite", tokens.size());
-            PdfTextElementCursor cursor = new PdfTextElementCursor(elements);
-            PDFont currentFont = null;
-            String currentFontName = null;
-            PdfJsonFont currentFontModel = null;
-
-            boolean encounteredModifiedFont = false;
-
-            for (int i = 0; i < tokens.size(); i++) {
-                Object token = tokens.get(i);
-                if (!(token instanceof Operator operator)) {
-                    continue;
-                }
-                String operatorName = operator.getName();
-                switch (operatorName) {
-                    case "Tf":
-                        if (i >= 2 && tokens.get(i - 2) instanceof COSName fontResourceName) {
-                            currentFont = resources.getFont(fontResourceName);
-                            currentFontName = fontResourceName.getName();
-                            currentFontModel =
-                                    pdfFontResolver.resolve(
-                                            fontLookup, pageNumber, currentFontName);
-                            log.trace(
-                                    "Encountered Tf operator; switching to font resource {}",
-                                    currentFontName);
-                            if (forceRegenerate) {
-                                encounteredModifiedFont = true;
-                            }
-                        } else {
-                            currentFont = null;
-                            currentFontName = null;
-                            currentFontModel = null;
-                            log.debug(
-                                    "Tf operator missing resource operand; clearing current font");
-                        }
-                        break;
-                    case "Tj":
-                        if (i == 0 || !(tokens.get(i - 1) instanceof COSString)) {
-                            log.debug(
-                                    "Encountered Tj without preceding string operand; aborting rewrite");
-                            return false;
-                        }
-                        log.trace(
-                                "Rewriting Tj operator using font {} (token index {}, cursor remaining {})",
-                                currentFontName,
-                                i,
-                                cursor.remaining());
-                        if (!PdfShowTextRewriter.rewriteShowText(
-                                tokens,
-                                i - 1,
-                                currentFont,
-                                currentFontModel,
-                                currentFontName,
-                                cursor,
-                                removeOnly,
-                                pdfGlyphCounter)) {
-                            log.debug("Failed to rewrite Tj operator; aborting rewrite");
-                            return false;
-                        }
-                        break;
-                    case "TJ":
-                        if (i == 0 || !(tokens.get(i - 1) instanceof COSArray array)) {
-                            log.debug("Encountered TJ without array operand; aborting rewrite");
-                            return false;
-                        }
-                        log.trace(
-                                "Rewriting TJ operator using font {} (token index {}, cursor remaining {})",
-                                currentFontName,
-                                i,
-                                cursor.remaining());
-                        if (!PdfShowTextArrayRewriter.rewriteShowTextArray(
-                                array,
-                                currentFont,
-                                currentFontModel,
-                                currentFontName,
-                                cursor,
-                                removeOnly,
-                                pdfGlyphCounter)) {
-                            log.debug("Failed to rewrite TJ operator; aborting rewrite");
-                            return false;
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            if (cursor.hasRemaining()) {
-                log.debug("Rewrite cursor still has {} elements; falling back", cursor.remaining());
-                return false;
-            }
-
-            if (forceRegenerate && encounteredModifiedFont) {
-                log.debug(
-                        "Rewrite succeeded but forceRegenerate=true, returning false to trigger rebuild");
-                return false;
-            }
-
-            PDStream newStream = new PDStream(document);
-            try (OutputStream outputStream = newStream.createOutputStream(COSName.FLATE_DECODE)) {
-                new ContentStreamWriter(outputStream).writeTokens(tokens);
-            }
-            page.setContents(newStream);
-            log.debug("Token rewrite completed successfully");
-            return true;
-        } catch (IOException ex) {
-            log.debug("Failed to rewrite content stream: {}", ex.getMessage());
-            return false;
-        }
-    }
-
     private Map<String, PDFont> buildFontMap(
             PDDocument document, List<PdfJsonFont> fonts, String jobId) throws IOException {
         Map<String, PDFont> fontMap = new HashMap<>();
@@ -6394,8 +6260,16 @@ public class PdfJsonConversionService {
 
         if (hasText && !preflightResult.usesFallback()) {
             boolean rewriteSucceeded =
-                    rewriteTextOperators(
-                            document, page, textElements, false, true, fontLookup, pageNumberValue);
+                    PdfTokenRewriteEngine.rewriteTextOperators(
+                            document,
+                            page,
+                            textElements,
+                            false,
+                            true,
+                            fontLookup,
+                            pageNumberValue,
+                            pdfFontResolver,
+                            pdfGlyphCounter);
             if (rewriteSucceeded) {
                 return RegenerateMode.REUSE_EXISTING;
             }

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfShowTextArrayRewriter.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfShowTextArrayRewriter.java
@@ -1,0 +1,82 @@
+package stirling.software.SPDF.service.pdfjson;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+
+import lombok.extern.slf4j.Slf4j;
+
+import stirling.software.SPDF.model.json.PdfJsonFont;
+import stirling.software.SPDF.model.json.PdfJsonTextElement;
+import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
+import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
+
+@Slf4j
+public final class PdfShowTextArrayRewriter {
+    private PdfShowTextArrayRewriter() {}
+
+    public static boolean rewriteShowTextArray(
+            COSArray array,
+            PDFont font,
+            PdfJsonFont fontModel,
+            String expectedFontName,
+            PdfTextElementCursor cursor,
+            boolean removeOnly,
+            PdfGlyphCounter pdfGlyphCounter)
+            throws IOException {
+        if (font == null) {
+            log.debug(
+                    "rewriteShowTextArray aborted: no active font for expected resource {}",
+                    expectedFontName);
+            return false;
+        }
+        for (int i = 0; i < array.size(); i++) {
+            COSBase element = array.get(i);
+            if (element instanceof COSString cosString) {
+                int glyphCount = pdfGlyphCounter.countGlyphs(cosString, font);
+                List<PdfJsonTextElement> consumed = cursor.consume(expectedFontName, glyphCount);
+                if (consumed == null) {
+                    log.debug(
+                            "Failed to consume {} glyphs for font {} in TJ segment {} (cursor remaining {})",
+                            glyphCount,
+                            expectedFontName,
+                            i,
+                            cursor.remaining());
+                    return false;
+                }
+                if (removeOnly) {
+                    array.set(i, new COSString(new byte[0]));
+                    continue;
+                }
+                PdfTextMergeHelper.MergedText replacement = PdfTextMergeHelper.mergeText(consumed);
+                try {
+                    byte[] encoded =
+                            PdfTextEncoder.encode(
+                                    font, fontModel, replacement.text(), replacement.charCodes());
+                    if (encoded == null) {
+                        log.debug(
+                                "Failed to map replacement text in TJ array for font {} segment {}",
+                                expectedFontName,
+                                i);
+                        return false;
+                    }
+                    array.set(i, new COSString(encoded));
+                } catch (IOException
+                        | IllegalArgumentException
+                        | UnsupportedOperationException ex) {
+                    log.debug(
+                            "Failed to encode replacement text in TJ array for font {} segment {}: {}",
+                            expectedFontName,
+                            i,
+                            ex.getMessage());
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfShowTextRewriter.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfShowTextRewriter.java
@@ -1,0 +1,78 @@
+package stirling.software.SPDF.service.pdfjson;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+
+import lombok.extern.slf4j.Slf4j;
+
+import stirling.software.SPDF.model.json.PdfJsonFont;
+import stirling.software.SPDF.model.json.PdfJsonTextElement;
+import stirling.software.SPDF.service.pdfjson.encoding.PdfTextEncoder;
+import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
+
+@Slf4j
+public final class PdfShowTextRewriter {
+    private PdfShowTextRewriter() {}
+
+    public static boolean rewriteShowText(
+            List<Object> tokens,
+            int tokenIndex,
+            PDFont font,
+            PdfJsonFont fontModel,
+            String expectedFontName,
+            PdfTextElementCursor cursor,
+            boolean removeOnly,
+            PdfGlyphCounter pdfGlyphCounter)
+            throws IOException {
+        if (font == null) {
+            log.debug(
+                    "rewriteShowText aborted: no active font for expected resource {}",
+                    expectedFontName);
+            return false;
+        }
+        COSString cosString = (COSString) tokens.get(tokenIndex);
+        int glyphCount = pdfGlyphCounter.countGlyphs(cosString, font);
+        log.trace(
+                "rewriteShowText consuming {} glyphs at cursor index {} for font {}",
+                glyphCount,
+                cursor.getIndex(),
+                expectedFontName);
+        List<PdfJsonTextElement> consumed = cursor.consume(expectedFontName, glyphCount);
+        if (consumed == null) {
+            log.debug(
+                    "Failed to consume {} glyphs for font {} (cursor remaining {})",
+                    glyphCount,
+                    expectedFontName,
+                    cursor.remaining());
+            return false;
+        }
+        if (removeOnly) {
+            tokens.set(tokenIndex, new COSString(new byte[0]));
+            return true;
+        }
+        PdfTextMergeHelper.MergedText replacement = PdfTextMergeHelper.mergeText(consumed);
+        try {
+            byte[] encoded =
+                    PdfTextEncoder.encode(
+                            font, fontModel, replacement.text(), replacement.charCodes());
+            if (encoded == null) {
+                log.debug(
+                        "Failed to map replacement text to glyphs for font {} (text='{}')",
+                        expectedFontName,
+                        replacement.text());
+                return false;
+            }
+            tokens.set(tokenIndex, new COSString(encoded));
+            return true;
+        } catch (IOException | IllegalArgumentException | UnsupportedOperationException ex) {
+            log.debug(
+                    "Failed to encode replacement text with font {}: {}",
+                    expectedFontName,
+                    ex.getMessage());
+            return false;
+        }
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfTextElementCursor.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfTextElementCursor.java
@@ -1,0 +1,85 @@
+package stirling.software.SPDF.service.pdfjson;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import lombok.extern.slf4j.Slf4j;
+
+import stirling.software.SPDF.model.json.PdfJsonTextElement;
+
+@Slf4j
+public final class PdfTextElementCursor {
+    private final List<PdfJsonTextElement> elements;
+    private int index = 0;
+
+    public PdfTextElementCursor(List<PdfJsonTextElement> elements) {
+        this.elements = elements;
+    }
+
+    public int remaining() {
+        return Math.max(0, elements.size() - index);
+    }
+
+    public boolean hasRemaining() {
+        return index < elements.size();
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public List<PdfJsonTextElement> consume(String expectedFontName, int glyphCount) {
+        if (glyphCount <= 0) {
+            return Collections.emptyList();
+        }
+        List<PdfJsonTextElement> consumed = new ArrayList<>();
+        int remaining = glyphCount;
+        while (remaining > 0 && index < elements.size()) {
+            PdfJsonTextElement element = elements.get(index);
+            if (!fontMatches(expectedFontName, element.getFontId())) {
+                log.debug(
+                        "Cursor consume failed: font mismatch (expected={}, actual={}) at element {}",
+                        expectedFontName,
+                        element.getFontId(),
+                        index);
+                return null;
+            }
+            consumed.add(element);
+            remaining -= countGlyphs(element);
+            index++;
+        }
+        if (remaining > 0) {
+            log.debug(
+                    "Cursor consume failed: ran out of elements (remaining={}, currentIndex={}, total={})",
+                    remaining,
+                    index,
+                    elements.size());
+            return null;
+        }
+        return consumed;
+    }
+
+    private boolean fontMatches(String expected, String actual) {
+        if (expected == null || expected.isEmpty()) {
+            return true;
+        }
+        if (actual == null) {
+            return false;
+        }
+        return Objects.equals(expected, actual);
+    }
+
+    private int countGlyphs(PdfJsonTextElement element) {
+        int[] codes = element.getCharCodes();
+        if (codes != null && codes.length > 0) {
+            return codes.length;
+        }
+        String text = element.getText();
+        if (text != null && !text.isEmpty()) {
+            return Math.max(1, text.codePointCount(0, text.length()));
+        }
+        return 1;
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfTextMergeHelper.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfTextMergeHelper.java
@@ -1,0 +1,28 @@
+package stirling.software.SPDF.service.pdfjson;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import stirling.software.SPDF.model.json.PdfJsonTextElement;
+
+public final class PdfTextMergeHelper {
+    private PdfTextMergeHelper() {}
+
+    public static MergedText mergeText(List<PdfJsonTextElement> elements) {
+        StringBuilder builder = new StringBuilder();
+        List<Integer> combinedCodes = new ArrayList<>();
+        for (PdfJsonTextElement element : elements) {
+            builder.append(Objects.toString(element.getText(), ""));
+            int[] codes = element.getCharCodes();
+            if (codes != null && codes.length > 0) {
+                for (int code : codes) {
+                    combinedCodes.add(code);
+                }
+            }
+        }
+        return new MergedText(builder.toString(), combinedCodes.isEmpty() ? null : combinedCodes);
+    }
+
+    public static record MergedText(String text, List<Integer> charCodes) {}
+}

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfTokenRewriteEngine.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/PdfTokenRewriteEngine.java
@@ -1,0 +1,167 @@
+package stirling.software.SPDF.service.pdfjson;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.pdfbox.contentstream.operator.Operator;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.pdfparser.PDFStreamParser;
+import org.apache.pdfbox.pdfwriter.ContentStreamWriter;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.common.PDStream;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+
+import lombok.extern.slf4j.Slf4j;
+
+import stirling.software.SPDF.model.json.PdfJsonFont;
+import stirling.software.SPDF.model.json.PdfJsonTextElement;
+import stirling.software.SPDF.service.pdfjson.font.PdfFontResolver;
+import stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter;
+
+@Slf4j
+public final class PdfTokenRewriteEngine {
+    private PdfTokenRewriteEngine() {}
+
+    public static boolean rewriteTextOperators(
+            PDDocument document,
+            PDPage page,
+            List<PdfJsonTextElement> elements,
+            boolean removeOnly,
+            boolean forceRegenerate,
+            Map<String, PdfJsonFont> fontLookup,
+            int pageNumber,
+            PdfFontResolver pdfFontResolver,
+            PdfGlyphCounter pdfGlyphCounter)
+            throws IOException {
+        if (forceRegenerate) {
+            log.debug("forceRegenerate flag set; skipping token rewrite for page");
+            return false;
+        }
+        if (elements == null || elements.isEmpty()) {
+            return true;
+        }
+        PDResources resources = page.getResources();
+        if (resources == null) {
+            return false;
+        }
+        try {
+            log.debug("Attempting token-level rewrite for page");
+            PDFStreamParser parser = new PDFStreamParser(page);
+            List<Object> tokens = parser.parse();
+            log.debug("Parsed {} tokens for rewrite", tokens.size());
+            PdfTextElementCursor cursor = new PdfTextElementCursor(elements);
+            PDFont currentFont = null;
+            String currentFontName = null;
+            PdfJsonFont currentFontModel = null;
+
+            boolean encounteredModifiedFont = false;
+
+            for (int i = 0; i < tokens.size(); i++) {
+                Object token = tokens.get(i);
+                if (!(token instanceof Operator operator)) {
+                    continue;
+                }
+                String operatorName = operator.getName();
+                switch (operatorName) {
+                    case "Tf":
+                        if (i >= 2 && tokens.get(i - 2) instanceof COSName fontResourceName) {
+                            currentFont = resources.getFont(fontResourceName);
+                            currentFontName = fontResourceName.getName();
+                            currentFontModel =
+                                    pdfFontResolver.resolve(
+                                            fontLookup, pageNumber, currentFontName);
+                            log.trace(
+                                    "Encountered Tf operator; switching to font resource {}",
+                                    currentFontName);
+                            if (forceRegenerate) {
+                                encounteredModifiedFont = true;
+                            }
+                        } else {
+                            currentFont = null;
+                            currentFontName = null;
+                            currentFontModel = null;
+                            log.debug(
+                                    "Tf operator missing resource operand; clearing current font");
+                        }
+                        break;
+                    case "Tj":
+                        if (i == 0 || !(tokens.get(i - 1) instanceof COSString)) {
+                            log.debug(
+                                    "Encountered Tj without preceding string operand; aborting rewrite");
+                            return false;
+                        }
+                        log.trace(
+                                "Rewriting Tj operator using font {} (token index {}, cursor remaining {})",
+                                currentFontName,
+                                i,
+                                cursor.remaining());
+                        if (!PdfShowTextRewriter.rewriteShowText(
+                                tokens,
+                                i - 1,
+                                currentFont,
+                                currentFontModel,
+                                currentFontName,
+                                cursor,
+                                removeOnly,
+                                pdfGlyphCounter)) {
+                            log.debug("Failed to rewrite Tj operator; aborting rewrite");
+                            return false;
+                        }
+                        break;
+                    case "TJ":
+                        if (i == 0 || !(tokens.get(i - 1) instanceof COSArray array)) {
+                            log.debug("Encountered TJ without array operand; aborting rewrite");
+                            return false;
+                        }
+                        log.trace(
+                                "Rewriting TJ operator using font {} (token index {}, cursor remaining {})",
+                                currentFontName,
+                                i,
+                                cursor.remaining());
+                        if (!PdfShowTextArrayRewriter.rewriteShowTextArray(
+                                array,
+                                currentFont,
+                                currentFontModel,
+                                currentFontName,
+                                cursor,
+                                removeOnly,
+                                pdfGlyphCounter)) {
+                            log.debug("Failed to rewrite TJ operator; aborting rewrite");
+                            return false;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            if (cursor.hasRemaining()) {
+                log.debug("Rewrite cursor still has {} elements; falling back", cursor.remaining());
+                return false;
+            }
+
+            if (forceRegenerate && encounteredModifiedFont) {
+                log.debug(
+                        "Rewrite succeeded but forceRegenerate=true, returning false to trigger rebuild");
+                return false;
+            }
+
+            PDStream newStream = new PDStream(document);
+            try (OutputStream outputStream = newStream.createOutputStream(COSName.FLATE_DECODE)) {
+                new ContentStreamWriter(outputStream).writeTokens(tokens);
+            }
+            page.setContents(newStream);
+            log.debug("Token rewrite completed successfully");
+            return true;
+        } catch (IOException ex) {
+            log.debug("Failed to rewrite content stream: {}", ex.getMessage());
+            return false;
+        }
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/encoding/PdfTextEncoder.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/encoding/PdfTextEncoder.java
@@ -7,6 +7,7 @@
 package stirling.software.SPDF.service.pdfjson.encoding;
 
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,5 +45,19 @@ public class PdfTextEncoder {
             return !(unsigned == 0x09 || unsigned == 0x0A || unsigned == 0x0D);
         }
         return false;
+    }
+
+    public static byte[] encodeType3CharCodes(List<Integer> charCodes) {
+        if (charCodes == null || charCodes.isEmpty()) {
+            return null;
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(charCodes.size());
+        for (Integer code : charCodes) {
+            if (code == null || code < 0 || code > 0xFF) {
+                return null;
+            }
+            baos.write(code);
+        }
+        return baos.toByteArray();
     }
 }

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/encoding/PdfTextEncoder.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/encoding/PdfTextEncoder.java
@@ -1,0 +1,48 @@
+/**
+ * Responsible for text encoding behavior used by the PDF JSON conversion workflow.
+ *
+ * <p>This class is intentionally empty for now. It exists to own the text encoding package and to
+ * provide a stable extension point for future extraction of PDF text encoding logic.
+ */
+package stirling.software.SPDF.service.pdfjson.encoding;
+
+import java.io.ByteArrayOutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PdfTextEncoder {
+
+    private static final Logger log = LoggerFactory.getLogger(PdfTextEncoder.class);
+
+    /** Remove control bytes from encoded PDF text sequences while preserving valid whitespace. */
+    public static byte[] sanitizeEncoded(byte[] encoded) {
+        if (encoded == null || encoded.length == 0) {
+            return new byte[0];
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(encoded.length);
+        for (byte b : encoded) {
+            if (isStrippedControlByte(b)) {
+                continue;
+            }
+            baos.write(b);
+        }
+        byte[] sanitized = baos.toByteArray();
+        if (sanitized.length == 0) {
+            return sanitized;
+        }
+        return sanitized;
+    }
+
+    /** Returns true for control bytes that should be stripped from PDF text streams. */
+    public static boolean isStrippedControlByte(byte value) {
+        if (value == 0) {
+            return true;
+        }
+        int unsigned = Byte.toUnsignedInt(value);
+        if (unsigned <= 0x1F) {
+            return !(unsigned == 0x09 || unsigned == 0x0A || unsigned == 0x0D);
+        }
+        return false;
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/encoding/PdfTextEncoder.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/encoding/PdfTextEncoder.java
@@ -7,10 +7,19 @@
 package stirling.software.SPDF.service.pdfjson.encoding;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType3Font;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import stirling.software.SPDF.model.json.PdfJsonFont;
+import stirling.software.SPDF.model.json.PdfJsonFontType3Glyph;
 
 public class PdfTextEncoder {
 
@@ -59,5 +68,137 @@ public class PdfTextEncoder {
             baos.write(code);
         }
         return baos.toByteArray();
+    }
+
+    public static byte[] encode(
+            PDFont font, PdfJsonFont fontModel, String text, List<Integer> rawCharCodes)
+            throws IOException {
+        return encodeTextWithFont(font, fontModel, text, rawCharCodes);
+    }
+
+    private static byte[] encodeTextWithFont(
+            PDFont font, PdfJsonFont fontModel, String text, List<Integer> rawCharCodes)
+            throws IOException {
+        boolean isType3Font = font instanceof PDType3Font;
+        boolean hasType3Metadata =
+                fontModel != null
+                        && fontModel.getType3Glyphs() != null
+                        && !fontModel.getType3Glyphs().isEmpty();
+
+        // For normalized Type3 fonts (font is NOT Type3 but has Type3 metadata)
+        if (!isType3Font && hasType3Metadata) {
+            // If loaded as full font (not subset), use standard Unicode encoding
+            // Try standard encoding first - this works when the font has all glyphs
+            try {
+                byte[] encoded = font.encode(text);
+                // NOTE: Do NOT sanitize encoded bytes for normalized Type3 fonts
+                // Multi-byte encodings (UTF-16BE, CID fonts) have null bytes that are essential
+                // Removing them corrupts the byte boundaries and produces garbled text
+                log.debug(
+                        "[TYPE3] Encoded text '{}' for normalized font {}: encoded={} bytes",
+                        text.length() > 20 ? text.substring(0, 20) + "..." : text,
+                        fontModel.getId(),
+                        encoded != null ? encoded.length : 0);
+                if (encoded != null && encoded.length > 0) {
+                    log.debug(
+                            "[TYPE3] Successfully encoded text for normalized Type3 font {} using standard encoding",
+                            fontModel.getId());
+                    return encoded;
+                }
+                log.debug(
+                        "[TYPE3] Standard encoding produced empty result for normalized Type3 font {}, falling through to Type3 mapping",
+                        fontModel.getId());
+            } catch (IOException | IllegalArgumentException ex) {
+                log.debug(
+                        "[TYPE3] Standard encoding failed for normalized Type3 font {}: {}",
+                        fontModel.getId(),
+                        ex.getMessage());
+            }
+            // If standard encoding failed, fall through to Type3 glyph mapping (for subset fonts)
+            // or return null to trigger fallback font
+        } else if (!isType3Font || fontModel == null) {
+            // For non-Type3 fonts without Type3 metadata, use standard encoding
+            try {
+                byte[] encoded = font.encode(text);
+                return sanitizeEncoded(encoded);
+            } catch (IllegalArgumentException ex) {
+                log.debug(
+                        "[FONT-DEBUG] Font {} cannot encode text '{}': {}",
+                        font.getName(),
+                        text,
+                        ex.getMessage());
+                // Return null to trigger fallback font mechanism
+                return null;
+            }
+        }
+
+        // Type3 glyph mapping logic (for actual Type3 fonts AND normalized Type3 fonts)
+        List<PdfJsonFontType3Glyph> glyphs = fontModel.getType3Glyphs();
+        if (glyphs == null || glyphs.isEmpty()) {
+            return null;
+        }
+
+        // For normalized Type3 fonts, DO NOT use rawCharCodes because:
+        // 1. They may be stale if text was edited
+        // 2. The subset font only has glyphs from the original PDF
+        // Instead, try Type3 glyph mapping and return null if glyphs are missing
+        // (null will trigger fallback font usage in the calling code)
+
+        // Build Unicode to character code mapping from Type3 glyphs
+        Map<Integer, Integer> unicodeToCode = new HashMap<>();
+        for (PdfJsonFontType3Glyph glyph : glyphs) {
+            if (glyph == null) {
+                continue;
+            }
+            Integer unicode = glyph.getUnicode();
+            Integer charCode = glyph.getCharCode();
+            if (unicode == null || charCode == null) {
+                continue;
+            }
+            unicodeToCode.putIfAbsent(unicode, charCode);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        boolean mappedAll = true;
+        for (int offset = 0; offset < text.length(); ) {
+            int codePoint = text.codePointAt(offset);
+            offset += Character.charCount(codePoint);
+            Integer charCode = unicodeToCode.get(codePoint);
+            if (charCode == null) {
+                log.debug(
+                        "[TYPE3] Missing glyph mapping for code point U+{} in font {}",
+                        Integer.toHexString(codePoint).toUpperCase(Locale.ROOT),
+                        fontModel.getId());
+                mappedAll = false;
+                break;
+            }
+            if (charCode < 0 || charCode > 0xFF) {
+                log.debug(
+                        "[TYPE3] Unsupported Type3 charCode {} for font {} (only 1-byte codes supported)",
+                        charCode,
+                        fontModel.getId());
+                mappedAll = false;
+                break;
+            }
+            baos.write(charCode);
+        }
+        if (mappedAll) {
+            return sanitizeEncoded(baos.toByteArray());
+        }
+        // Fallback to rawCharCodes for actual Type3 fonts if mapping failed
+        if (rawCharCodes != null && !rawCharCodes.isEmpty()) {
+            boolean valid = true;
+            ByteArrayOutputStream fallbackBytes = new ByteArrayOutputStream(rawCharCodes.size());
+            for (Integer code : rawCharCodes) {
+                if (code == null || code < 0 || code > 0xFF) {
+                    valid = false;
+                    break;
+                }
+                fallbackBytes.write(code);
+            }
+            if (valid) {
+                return fallbackBytes.toByteArray();
+            }
+        }
+        return null;
     }
 }

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/font/PdfFontResolver.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/font/PdfFontResolver.java
@@ -1,0 +1,41 @@
+package stirling.software.SPDF.service.pdfjson.font;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import stirling.software.SPDF.model.json.PdfJsonFont;
+
+@Component
+public class PdfFontResolver {
+
+    /**
+     * Build a font key used across the PDF JSON conversion code. Includes optional jobId prefix to
+     * ensure uniqueness across concurrent jobs.
+     */
+    public String buildFontKey(String jobId, int pageNumber, String fontId) {
+        String jobPrefix = (jobId != null && !jobId.isEmpty()) ? jobId + ":" : "";
+        return jobPrefix + pageNumber + ":" + fontId;
+    }
+
+    /** Overload accepting nullable Integer pageNumber. */
+    public String buildFontKey(String jobId, Integer pageNumber, String fontId) {
+        int page = pageNumber != null ? pageNumber : -1;
+        return buildFontKey(jobId, page, fontId);
+    }
+
+    /**
+     * Resolve a PdfJsonFont from a lookup map using a page-scoped key first, then falling back to
+     * an unscoped (-1) key. This preserves the original lookup behavior.
+     */
+    public PdfJsonFont resolve(Map<String, PdfJsonFont> lookup, int pageNumber, String fontId) {
+        if (lookup == null || fontId == null) {
+            return null;
+        }
+        PdfJsonFont model = lookup.get(buildFontKey(null, pageNumber, fontId));
+        if (model != null) {
+            return model;
+        }
+        return lookup.get(buildFontKey(null, -1, fontId));
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/parsing/PdfGlyphCounter.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/pdfjson/parsing/PdfGlyphCounter.java
@@ -1,0 +1,88 @@
+package stirling.software.SPDF.service.pdfjson.parsing;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Component owning glyph-counting utilities extracted from PdfJsonConversionService.
+ *
+ * <p>Behavior, logging, and exception semantics are preserved exactly.
+ */
+@Component
+public class PdfGlyphCounter {
+
+    private static final Logger log = LoggerFactory.getLogger(PdfGlyphCounter.class);
+
+    /**
+     * Count how many codes the supplied {@code reader} can extract from {@code inputStream}, with
+     * two safety nets that PDFBox's raw {@link
+     * org.apache.pdfbox.pdmodel.font.PDFont#readCode(InputStream)} loop lacks:
+     *
+     * <ol>
+     *   <li>Stop when the stream is empty (a corrupt CMap can otherwise loop forever returning
+     *       successfully-matched zero-bytes from an exhausted {@link ByteArrayInputStream}).
+     *   <li>Stop when a {@code readCode} call did not consume any bytes, even if it returned a
+     *       non-{@code -1} value.
+     * </ol>
+     *
+     * Both conditions were observed in the wild on round-tripped fallback fonts where the embedded
+     * ToUnicode CMap matched 0x00 sequences, hanging the JSON&rarr;PDF rebuild.
+     */
+    public static int countCodesProtected(ByteArrayInputStream inputStream, CodeReader reader)
+            throws IOException {
+        int count = 0;
+        int previousAvailable = inputStream.available();
+        while (previousAvailable > 0) {
+            int code = reader.readCode(inputStream);
+            if (code == -1) {
+                break;
+            }
+            int currentAvailable = inputStream.available();
+            if (currentAvailable >= previousAvailable) {
+                // No progress made; break to avoid infinite loop on corrupt CMaps.
+                break;
+            }
+            count++;
+            previousAvailable = currentAvailable;
+        }
+        return count;
+    }
+
+    /**
+     * Functional accessor for {@link PDFont#readCode(InputStream)} so the bounded counting loop can
+     * be exercised in isolation without instantiating a {@link PDFont}.
+     */
+    @FunctionalInterface
+    public interface CodeReader {
+        int readCode(InputStream stream) throws IOException;
+    }
+
+    /**
+     * Count glyphs in the provided COSString value using the provided PDFont. Mirrors the original
+     * implementation in PdfJsonConversionService.
+     */
+    public int countGlyphs(COSString value, PDFont font) {
+        if (value == null) {
+            return 0;
+        }
+        if (font != null) {
+            try (ByteArrayInputStream inputStream = new ByteArrayInputStream(value.getBytes())) {
+                int count = PdfGlyphCounter.countCodesProtected(inputStream, font::readCode);
+                if (count > 0) {
+                    return count;
+                }
+            } catch (IOException ex) {
+                log.debug("Failed to decode glyphs: {}", ex.getMessage());
+            }
+        }
+        byte[] bytes = value.getBytes();
+        return Math.max(1, bytes.length);
+    }
+}

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceCoverageTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceCoverageTest.java
@@ -123,6 +123,8 @@ class PdfJsonConversionServiceCoverageTest {
                         fontService,
                         type3FontConversionService,
                         type3GlyphExtractor,
+                        new stirling.software.SPDF.service.pdfjson.font.PdfFontResolver(),
+                        new stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter(),
                         applicationProperties);
 
         when(tempFileManager.createTempFile(anyString()))

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceDeepTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceDeepTest.java
@@ -124,6 +124,8 @@ class PdfJsonConversionServiceDeepTest {
                         fontService,
                         type3FontConversionService,
                         type3GlyphExtractor,
+                        new stirling.software.SPDF.service.pdfjson.font.PdfFontResolver(),
+                        new stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter(),
                         applicationProperties);
 
         when(tempFileManager.createTempFile(anyString()))

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceExtraTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceExtraTest.java
@@ -126,6 +126,8 @@ class PdfJsonConversionServiceExtraTest {
                         fontService,
                         type3FontConversionService,
                         type3GlyphExtractor,
+                        new stirling.software.SPDF.service.pdfjson.font.PdfFontResolver(),
+                        new stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter(),
                         applicationProperties);
 
         when(tempFileManager.createTempFile(anyString()))

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceGapTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceGapTest.java
@@ -116,6 +116,8 @@ class PdfJsonConversionServiceGapTest {
                         fontService,
                         type3FontConversionService,
                         type3GlyphExtractor,
+                        new stirling.software.SPDF.service.pdfjson.font.PdfFontResolver(),
+                        new stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter(),
                         applicationProperties);
 
         // The TempFile wrapper delegates straight to the manager; back it with real temp files so

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceMore2Test.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceMore2Test.java
@@ -129,6 +129,8 @@ class PdfJsonConversionServiceMore2Test {
                         fontService,
                         type3FontConversionService,
                         type3GlyphExtractor,
+                        new stirling.software.SPDF.service.pdfjson.font.PdfFontResolver(),
+                        new stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter(),
                         applicationProperties);
 
         when(tempFileManager.createTempFile(anyString()))

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceRoundTripTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceRoundTripTest.java
@@ -104,6 +104,8 @@ class PdfJsonConversionServiceRoundTripTest {
                         fontService,
                         type3FontConversionService,
                         type3GlyphExtractor,
+                        new stirling.software.SPDF.service.pdfjson.font.PdfFontResolver(),
+                        new stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter(),
                         applicationProperties);
 
         when(tempFileManager.createTempFile(anyString()))

--- a/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceUnicodeParsingTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/service/PdfJsonConversionServiceUnicodeParsingTest.java
@@ -91,12 +91,15 @@ class PdfJsonConversionServiceUnicodeParsingTest {
         // the buffer's uninitialized region after EOF). Without the no-progress guard, the
         // counting loop in countGlyphs ran forever.
         ByteArrayInputStream stream = new ByteArrayInputStream(new byte[] {1, 2, 3, 4});
-        PdfJsonConversionService.CodeReader reader = in -> 0; // never reads, always "succeeds"
+        stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter.CodeReader reader =
+                in -> 0; // never reads, always "succeeds"
 
         int count =
                 assertTimeoutPreemptively(
                         Duration.ofSeconds(2),
-                        () -> PdfJsonConversionService.countCodesProtected(stream, reader));
+                        () ->
+                                stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter
+                                        .countCodesProtected(stream, reader));
 
         // First iteration sees no progress and breaks immediately.
         assertEquals(0, count);
@@ -105,7 +108,7 @@ class PdfJsonConversionServiceUnicodeParsingTest {
     @Test
     void countCodesProtectedTerminatesOnEmptyStream() {
         ByteArrayInputStream stream = new ByteArrayInputStream(new byte[0]);
-        PdfJsonConversionService.CodeReader reader =
+        stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter.CodeReader reader =
                 in -> {
                     throw new AssertionError("reader must not be called when stream is empty");
                 };
@@ -113,7 +116,9 @@ class PdfJsonConversionServiceUnicodeParsingTest {
         int count =
                 assertTimeoutPreemptively(
                         Duration.ofSeconds(2),
-                        () -> PdfJsonConversionService.countCodesProtected(stream, reader));
+                        () ->
+                                stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter
+                                        .countCodesProtected(stream, reader));
 
         assertEquals(0, count);
     }
@@ -121,13 +126,15 @@ class PdfJsonConversionServiceUnicodeParsingTest {
     @Test
     void countCodesProtectedHonorsExplicitMinusOneReturn() throws IOException {
         ByteArrayInputStream stream = new ByteArrayInputStream(new byte[] {1, 2, 3});
-        PdfJsonConversionService.CodeReader reader =
+        stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter.CodeReader reader =
                 in -> {
                     int b = in.read();
                     return b == -1 ? -1 : b;
                 };
 
-        int count = PdfJsonConversionService.countCodesProtected(stream, reader);
+        int count =
+                stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter.countCodesProtected(
+                        stream, reader);
 
         assertEquals(3, count);
     }
@@ -137,8 +144,8 @@ class PdfJsonConversionServiceUnicodeParsingTest {
         // A reader that consumes one byte then hits a corrupt-CMap pattern returning 0 without
         // consuming further must still terminate after counting the consumed bytes.
         ByteArrayInputStream stream = new ByteArrayInputStream(new byte[] {1, 2, 3, 4});
-        PdfJsonConversionService.CodeReader reader =
-                new PdfJsonConversionService.CodeReader() {
+        stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter.CodeReader reader =
+                new stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter.CodeReader() {
                     boolean firstCall = true;
 
                     @Override
@@ -154,7 +161,9 @@ class PdfJsonConversionServiceUnicodeParsingTest {
         int count =
                 assertTimeoutPreemptively(
                         Duration.ofSeconds(2),
-                        () -> PdfJsonConversionService.countCodesProtected(stream, reader));
+                        () ->
+                                stirling.software.SPDF.service.pdfjson.parsing.PdfGlyphCounter
+                                        .countCodesProtected(stream, reader));
 
         assertEquals(1, count);
     }


### PR DESCRIPTION
## Summary

Refactors the PDF JSON rewrite pipeline by extracting focused helper classes from `PdfJsonConversionService`.

### Extracted
- PdfFontResolver
- PdfGlyphCounter
- PdfTextEncoder
- PdfTextMergeHelper
- PdfTextElementCursor
- PdfShowTextRewriter
- PdfShowTextArrayRewriter
- PdfTokenRewriteEngine

### Cleanup
- Removed unused helper methods.

### Verification
- ✅ compileJava
- ✅ compileTestJava
- ✅ ./gradlew build

No functional changes intended.