### PR TITLE
Move CODEOWNERS to review teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,28 @@
-# All PRs must be approved by Frooodle or Ludy87
-* @Frooodle @Ludy87 @jbrunton96 @ConnorYoh
+# Review ownership is assigned to teams where possible.
+# Teams can only contain org members, so outside collaborators are listed by hand.
+#
+#   @Stirling-Tools/maintainers          - Frooodle, jbrunton96, ConnorYoh
+#   @Stirling-Tools/backend-reviewers    - Frooodle, jbrunton96, ConnorYoh
+#   @Stirling-Tools/frontend-reviewers   - Frooodle, jbrunton96, ConnorYoh, reecebrowne, EthanHealy01
+#   @Stirling-Tools/devops-reviewers     - Frooodle, jbrunton96, ConnorYoh
+#   @Stirling-Tools/all                  - all of the above
+#
+# Outside collaborators (need Write access to count as owners): @Ludy87 @balazs-szucs
+
+# Default owners for everything
+* @Stirling-Tools/maintainers @Ludy87
 
 # Backend
-/app/** @DarioGii @Frooodle @Ludy87 @jbrunton96 @ConnorYoh @balazs-szucs
+/app/** @Stirling-Tools/backend-reviewers @Ludy87 @balazs-szucs
 
-#V2 frontend
-/frontend/** @reecebrowne @ConnorYoh @EthanHealy01 @jbrunton96 @Frooodle @balazs-szucs
-/app/core/src/main/resources/static/** @reecebrowne @ConnorYoh @EthanHealy01 @jbrunton96 @Frooodle @Ludy87 @balazs-szucs
+# V2 frontend
+/frontend/** @Stirling-Tools/frontend-reviewers @balazs-szucs
+/app/core/src/main/resources/static/** @Stirling-Tools/frontend-reviewers @Ludy87 @balazs-szucs
 
-#V2 docker
-/docker/backend/** @Frooodle @Ludy87 @DarioGii
-/docker/frontend/** @reecebrowne @ConnorYoh @EthanHealy01 @jbrunton96 @Frooodle @Ludy87
-/docker/compose/** @reecebrowne @ConnorYoh @EthanHealy01 @DarioGii @jbrunton96 @Frooodle @Ludy87
+# V2 docker
+/docker/backend/** @Stirling-Tools/devops-reviewers @Ludy87
+/docker/frontend/** @Stirling-Tools/frontend-reviewers @Stirling-Tools/devops-reviewers @Ludy87
+/docker/compose/** @Stirling-Tools/frontend-reviewers @Stirling-Tools/devops-reviewers @Ludy87
 
-
-#GHA (All users)
-/.github/** @reecebrowne @ConnorYoh @EthanHealy01 @DarioGii @jbrunton96 @Frooodle @Ludy87 @balazs-szucs
+# GHA (all users)
+/.github/** @Stirling-Tools/all @Ludy87 @balazs-szucs

--- a/.github/config/repo_devs.json
+++ b/.github/config/repo_devs.json
@@ -11,7 +11,6 @@
     "LaserKaspar",
     "sbplat",
     "reecebrowne",
-    "DarioGii",
     "ConnorYoh",
     "EthanHealy01",
     "jbrunton96",

--- a/.github/workflows/PR-Auto-Deploy-V2.yml
+++ b/.github/workflows/PR-Auto-Deploy-V2.yml
@@ -86,7 +86,7 @@ jobs:
               fi
             fi
           else
-            auth_users=("Frooodle" "sf298" "Ludy87" "LaserKaspar" "sbplat" "reecebrowne" "DarioGii" "ConnorYoh" "EthanHealy01" "jbrunton96" "balazs-szucs")
+            auth_users=("Frooodle" "sf298" "Ludy87" "LaserKaspar" "sbplat" "reecebrowne" "ConnorYoh" "EthanHealy01" "jbrunton96" "balazs-szucs")
             is_auth=false; for u in "${auth_users[@]}"; do [ "$u" = "$PR_AUTHOR" ] && is_auth=true && break; done
             if [ "$is_auth" = true ]; then
               should=true

--- a/.github/workflows/PR-Demo-Comment-with-react.yml
+++ b/.github/workflows/PR-Demo-Comment-with-react.yml
@@ -54,7 +54,6 @@ jobs:
             github.event.comment.user.login == 'Ludy87' ||
             github.event.comment.user.login == 'balazs-szucs' ||
             github.event.comment.user.login == 'reecebrowne' ||
-            github.event.comment.user.login == 'DarioGii' ||
             github.event.comment.user.login == 'EthanHealy01' ||
             github.event.comment.user.login == 'jbrunton96' ||
             github.event.comment.user.login == 'ConnorYoh'


### PR DESCRIPTION
# Description of Changes

CODEOWNERS now points at review teams (`maintainers`, `backend-reviewers`, `frontend-reviewers`, `devops-reviewers`, `all`) instead of individual usernames, so membership is managed in the org rather than in this file. Ludy87 and balazs-szucs stay listed by hand since outside collaborators cannot be team members. including the deploy and demo-comment allowlists.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
