### PR TITLE
Fix `any` type usages in frontend code

### DIFF
--- a/frontend/editor/src/core/components/pageEditor/commands/pageCommands.ts
+++ b/frontend/editor/src/core/components/pageEditor/commands/pageCommands.ts
@@ -686,7 +686,6 @@ export class InsertFilesCommand extends DOMCommand {
   private insertedPages: PDFPage[] = [];
   private originalDocument: PDFDocument | null = null;
   private fileDataMap = new Map<FileId, ArrayBuffer>(); // Store file data for thumbnail generation
-  private originalProcessedFile: any = null; // Store original ProcessedFile for undo
   private insertedFileMap = new Map<FileId, File>(); // Store inserted files for export
 
   constructor(

--- a/frontend/editor/src/core/components/pageEditor/hooks/useEditorCommands.ts
+++ b/frontend/editor/src/core/components/pageEditor/hooks/useEditorCommands.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from "react";
 import {
   BulkRotateCommand,
   DeletePagesCommand,
+  DOMCommand,
   PageBreakCommand,
   ReorderPagesCommand,
   SplitCommand,
@@ -24,7 +25,7 @@ interface UsePageEditorCommandsParams {
   selectedPageIds: string[];
   setSelectedPageIds: (ids: string[]) => void;
   getPageNumbersFromIds: (pageIds: string[]) => number[];
-  executeCommandWithTracking: (command: any) => void;
+  executeCommandWithTracking: (command: DOMCommand) => void;
   updateFileOrderFromPages: (pages: PDFPage[]) => void;
   actions: FileActions;
   selectors: FileSelectors;
@@ -145,10 +146,8 @@ export const usePageEditorCommands = ({
     [executeCommandWithTracking, setSplitPositions],
   );
 
-  const executeCommand = useCallback((command: any) => {
-    if (command && typeof command.execute === "function") {
-      command.execute();
-    }
+  const executeCommand = useCallback((command: { execute: () => void }) => {
+    command.execute();
   }, []);
 
   const handleRotate = useCallback(

--- a/frontend/editor/src/core/components/pageEditor/hooks/useUndoManagerState.ts
+++ b/frontend/editor/src/core/components/pageEditor/hooks/useUndoManagerState.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { UndoManager } from "@app/components/pageEditor/commands/pageCommands";
+import {
+  DOMCommand,
+  UndoManager,
+} from "@app/components/pageEditor/commands/pageCommands";
 
 interface UseUndoManagerStateParams {
   setHasUnsavedChanges: (dirty: boolean) => void;
@@ -29,7 +32,7 @@ export const useUndoManagerState = ({
   }, [updateUndoRedoState]);
 
   const executeCommandWithTracking = useCallback(
-    (command: any) => {
+    (command: DOMCommand) => {
       undoManagerRef.current.executeCommand(command);
       setHasUnsavedChanges(true);
     },

--- a/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
+++ b/frontend/editor/src/core/components/shared/config/SettingsSearchBar.tsx
@@ -138,7 +138,7 @@ export const SettingsSearchBar: React.FC<SettingsSearchBarProps> = ({
           const translationPrefixes = getTranslationPrefixesForNavKey(item.key);
           const translationContent = translationPrefixes.flatMap((prefix) =>
             flattenTranslationStrings(
-              t(prefix, { returnObjects: true, defaultValue: {} } as any),
+              t(prefix, { returnObjects: true, defaultValue: {} }),
             ),
           );
 

--- a/frontend/editor/src/core/components/shared/pageEditor/useFileItemDragDrop.ts
+++ b/frontend/editor/src/core/components/shared/pageEditor/useFileItemDragDrop.ts
@@ -111,8 +111,7 @@ export const useFileItemDragDrop = ({
         if (!element) return;
 
         const rect = element.getBoundingClientRect();
-        const clientY =
-          (source as any).element?.getBoundingClientRect().top || 0;
+        const clientY = source.element?.getBoundingClientRect().top || 0;
         const midpoint = rect.top + rect.height / 2;
 
         setDropPosition(clientY < midpoint ? "below" : "above");
@@ -121,7 +120,10 @@ export const useFileItemDragDrop = ({
         setIsDragOver(false);
         const dropPos = dropPositionRef.current;
         setDropPosition("below");
-        const sourceData = source.data as any;
+        const sourceData = source.data as {
+          type?: string;
+          fromIndex?: number;
+        };
         if (sourceData?.type === "file-item") {
           const fromIndex = sourceData.fromIndex as number;
           let toIndex = indexRef.current;

--- a/frontend/editor/src/core/components/tools/bookletImposition/BookletImpositionSettings.tsx
+++ b/frontend/editor/src/core/components/tools/bookletImposition/BookletImpositionSettings.tsx
@@ -14,9 +14,9 @@ import ButtonSelector from "@app/components/shared/ButtonSelector";
 
 interface BookletImpositionSettingsProps {
   parameters: BookletImpositionParameters;
-  onParameterChange: (
-    key: keyof BookletImpositionParameters,
-    value: any,
+  onParameterChange: <K extends keyof BookletImpositionParameters>(
+    key: K,
+    value: BookletImpositionParameters[K],
   ) => void;
   disabled?: boolean;
 }
@@ -214,7 +214,10 @@ const BookletImpositionSettings = ({
                   )}
                   value={parameters.gutterSize}
                   onChange={(value) =>
-                    onParameterChange("gutterSize", value || 12)
+                    onParameterChange(
+                      "gutterSize",
+                      typeof value === "number" ? value : 12,
+                    )
                   }
                   min={6}
                   max={72}

--- a/frontend/editor/src/core/components/tools/shared/ToolWorkflowTitle.tsx
+++ b/frontend/editor/src/core/components/tools/shared/ToolWorkflowTitle.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { Flex, Text, Divider } from "@mantine/core";
 import LocalIcon from "@app/components/shared/LocalIcon";
 import { Tooltip } from "@app/components/shared/Tooltip";
+import { TooltipTip } from "@app/types/tips";
 
 export interface ToolWorkflowTitleProps {
   title: string;
   description?: string;
   tooltip?: {
     content?: React.ReactNode;
-    tips?: any[];
+    tips?: TooltipTip[];
     header?: {
       title: string;
       logo?: React.ReactNode;

--- a/frontend/editor/src/core/components/tools/shared/renderToolButtons.tsx
+++ b/frontend/editor/src/core/components/tools/shared/renderToolButtons.tsx
@@ -2,7 +2,10 @@ import { Box } from "@mantine/core";
 import ToolButton from "@app/components/tools/toolPicker/ToolButton";
 import SubcategoryHeader from "@app/components/tools/shared/SubcategoryHeader";
 
-import { getSubcategoryLabel } from "@app/data/toolsTaxonomy";
+import {
+  getSubcategoryLabel,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
 import { TFunction } from "i18next";
 import { SubcategoryGroup } from "@app/hooks/useToolSections";
 import { ToolId } from "@app/types/toolId";
@@ -15,7 +18,10 @@ export const renderToolButtons = (
   onSelect: (id: ToolId) => void,
   showSubcategoryHeader: boolean = true,
   disableNavigation: boolean = false,
-  searchResults?: Array<{ item: [string, any]; matchedText?: string }>,
+  searchResults?: Array<{
+    item: [ToolId, ToolRegistryEntry];
+    matchedText?: string;
+  }>,
   hasStars: boolean = false,
 ) => {
   // Create a map of matched text for quick lookup

--- a/frontend/editor/src/core/hooks/signing/useSigningSessionController.ts
+++ b/frontend/editor/src/core/hooks/signing/useSigningSessionController.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { isAxiosError } from "axios";
 import apiClient from "@app/services/apiClient";
 import { alert } from "@app/components/toast";
 import { fileStorage } from "@app/services/fileStorage";
@@ -333,8 +334,8 @@ export function useSigningSessionController(enabled: boolean) {
           pdfFile = new File([pdfResponse.data], session.documentName, {
             type: "application/pdf",
           });
-        } catch (pdfError: any) {
-          if (pdfError?.response?.status === 404) {
+        } catch (pdfError) {
+          if (isAxiosError(pdfError) && pdfError.response?.status === 404) {
             alert({
               alertType: "warning",
               title: t("certSign.sessions.pdfNotReady", "PDF Not Ready"),

--- a/frontend/editor/src/core/hooks/tools/adjustContrast/useAdjustContrastOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/adjustContrast/useAdjustContrastOperation.ts
@@ -13,9 +13,10 @@ import { pdfWorkerManager } from "@app/services/pdfWorkerManager";
 import { createFileFromApiResponse } from "@app/utils/fileResponseUtils";
 import { getPdfiumModule, saveRawDocument } from "@app/services/pdfiumService";
 import { copyRgbaToBgraHeap } from "@app/utils/pdfiumBitmapUtils";
+import type { PDFDocumentProxy } from "pdfjs-dist";
 
 async function renderPdfPageToCanvas(
-  pdf: any,
+  pdf: PDFDocumentProxy,
   pageNumber: number,
   scale: number,
 ): Promise<HTMLCanvasElement> {
@@ -26,7 +27,7 @@ async function renderPdfPageToCanvas(
   canvas.height = viewport.height;
   const ctx = canvas.getContext("2d");
   if (!ctx) throw new Error("Canvas 2D context unavailable");
-  await page.render({ canvasContext: ctx, viewport }).promise;
+  await page.render({ canvasContext: ctx, canvas, viewport }).promise;
   return canvas;
 }
 

--- a/frontend/editor/src/core/hooks/tools/convert/useConvertOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/convert/useConvertOperation.ts
@@ -210,8 +210,8 @@ export const buildConvertFormData = (
 
 // Static function that can be used by both the hook and automation executor
 export const createFileFromResponse = (
-  responseData: any,
-  headers: any,
+  responseData: Blob,
+  headers: Record<string, unknown>,
   originalFileName: string,
   targetExtension: string,
 ): File => {

--- a/frontend/editor/src/core/hooks/tools/removePassword/useRemovePasswordOperation.test.ts
+++ b/frontend/editor/src/core/hooks/tools/removePassword/useRemovePasswordOperation.test.ts
@@ -85,7 +85,7 @@ describe("useRemovePasswordOperation", () => {
     const testFile = new File(["test content"], "test.pdf", {
       type: "application/pdf",
     });
-    const formData = buildFormData(testParameters, testFile as any);
+    const formData = buildFormData(testParameters, testFile);
 
     // Verify the form data contains the file
     expect(formData.get("fileInput")).toBe(testFile);

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -292,7 +292,6 @@ export default defineConfig(
       "editor/src/core/components/tools/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/addStamp/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/automate/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/components/tools/bookletImposition/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/certSign/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/pdfTextEditor/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/shared/*.{js,mjs,jsx,ts,tsx}",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -287,7 +287,6 @@ export default defineConfig(
       "editor/src/core/components/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/config/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/config/configSections/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/components/shared/pageEditor/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/addStamp/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/automate/*.{js,mjs,jsx,ts,tsx}",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -302,7 +302,6 @@ export default defineConfig(
       "editor/src/core/contexts/viewer/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/signing/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/hooks/tools/adjustContrast/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/tools/convert/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/tools/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/services/*.{js,mjs,jsx,ts,tsx}",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -284,7 +284,6 @@ export default defineConfig(
     ignores: [
       "editor/src/core/components/annotation/**/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/pageEditor/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/components/pageEditor/commands/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/pageEditor/hooks/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/config/*.{js,mjs,jsx,ts,tsx}",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -284,7 +284,6 @@ export default defineConfig(
     ignores: [
       "editor/src/core/components/annotation/**/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/pageEditor/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/components/pageEditor/hooks/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/config/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/config/configSections/*.{js,mjs,jsx,ts,tsx}",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -294,7 +294,6 @@ export default defineConfig(
       "editor/src/core/components/tools/automate/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/certSign/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/pdfTextEditor/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/components/tools/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/viewer/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/contexts/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/contexts/file/*.{js,mjs,jsx,ts,tsx}",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -298,7 +298,6 @@ export default defineConfig(
       "editor/src/core/contexts/file/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/contexts/viewer/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/hooks/signing/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/tools/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/services/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/tools/annotate/useAnnotationSelection.ts",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -299,7 +299,6 @@ export default defineConfig(
       "editor/src/core/contexts/viewer/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/signing/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/hooks/tools/convert/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/tools/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/services/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/tools/annotate/useAnnotationSelection.ts",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -285,7 +285,6 @@ export default defineConfig(
       "editor/src/core/components/annotation/**/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/pageEditor/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/components/shared/config/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/shared/config/configSections/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/components/tools/addStamp/*.{js,mjs,jsx,ts,tsx}",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -305,7 +305,6 @@ export default defineConfig(
       "editor/src/core/hooks/signing/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/tools/adjustContrast/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/tools/convert/*.{js,mjs,jsx,ts,tsx}",
-      "editor/src/core/hooks/tools/removePassword/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/hooks/tools/shared/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/services/*.{js,mjs,jsx,ts,tsx}",
       "editor/src/core/tools/annotate/useAnnotationSelection.ts",


### PR DESCRIPTION
# Description of Changes
Continued effort towards removing all uses of the `any` type in our frontend code. This PR fixes 10 more folders and removes them from the exclude list. All of them were really simple fixes.