### PR TITLE
test(viewer): measurement overlay coverage, and keyboard access for its SVG controls

### DIFF
--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -8633,6 +8633,7 @@ title = "Rotate Settings Overview"
 
 [ruler]
 clearAll = "Clear all"
+deleteMeasurement = "Delete measurement"
 hideAllLabels = "Hide all labels"
 hideSmallLabels = "Hide small labels"
 physicalValues = "Physical"

--- a/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.stories.tsx
@@ -1,0 +1,151 @@
+/**
+ * The measurement overlay that sits above a rendered page. Everything here is
+ * SVG drawn in screen coordinates: the layer is normally mounted inside the
+ * viewer's own <svg>, so these stories supply that wrapper themselves and place
+ * measurements at fixed points rather than deriving them from a real page.
+ *
+ * The label layout is the interesting behaviour — labels are hidden, shown, or
+ * expanded depending on zoom, crowding, and which measurement is hovered — so
+ * each visibility mode gets a story rather than a control.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  RulerMeasurementLayer,
+  type RulerRenderedMeasurement,
+} from "@app/components/viewer/RulerMeasurementLayer";
+import type { MeasureScale } from "@app/utils/measurementTypes";
+
+const SCALE: MeasureScale = { factor: 0.05, ratio: 100, unit: "m" };
+
+function rendered(
+  id: string,
+  startS: { x: number; y: number },
+  endS: { x: number; y: number },
+  measureScale: MeasureScale | null = null,
+): RulerRenderedMeasurement {
+  const distPts = Math.hypot(endS.x - startS.x, endS.y - startS.y);
+  return {
+    // Screen and page coordinates coincide here: the stories render at zoom 1
+    // against a single page, so no projection is involved.
+    measurement: {
+      id,
+      start: { ...startS, pageIndex: 0 },
+      end: { ...endS, pageIndex: 0 },
+    },
+    startS,
+    endS,
+    distPts,
+    measureScale,
+  };
+}
+
+const MEASUREMENTS = [
+  rendered("a", { x: 80, y: 90 }, { x: 320, y: 90 }),
+  rendered("b", { x: 120, y: 150 }, { x: 300, y: 260 }),
+  rendered("c", { x: 360, y: 120 }, { x: 480, y: 300 }),
+];
+
+/** Close enough together that the crowding rules start dropping idle labels. */
+const CROWDED = [
+  rendered("a", { x: 60, y: 80 }, { x: 150, y: 80 }),
+  rendered("b", { x: 60, y: 110 }, { x: 150, y: 110 }),
+  rendered("c", { x: 60, y: 140 }, { x: 150, y: 140 }),
+  rendered("d", { x: 60, y: 170 }, { x: 150, y: 170 }),
+  rendered("e", { x: 170, y: 80 }, { x: 260, y: 80 }),
+  rendered("f", { x: 170, y: 110 }, { x: 260, y: 110 }),
+];
+
+const noop = () => {};
+
+const meta: Meta<typeof RulerMeasurementLayer> = {
+  title: "Viewer/RulerMeasurementLayer",
+  component: RulerMeasurementLayer,
+  parameters: { layout: "fullscreen" },
+  args: {
+    measurements: MEASUREMENTS,
+    zoom: 1,
+    selectedId: null,
+    hoveredId: null,
+    labelVisibilityMode: "hideSmall",
+    isInteractionPassthroughActive: false,
+    onSelect: noop,
+    onDelete: noop,
+    onHoverChange: noop,
+    onClearAll: noop,
+    onCycleLabelVisibilityMode: noop,
+  },
+  render: (args) => (
+    <div style={{ background: "var(--c-surface-sunken)", padding: "1rem" }}>
+      {/* Coordinates are fixed but the canvas is not, so the viewBox scales the
+          page rather than letting a narrow frame scroll it. */}
+      <svg
+        viewBox="0 0 560 360"
+        width="100%"
+        style={{
+          display: "block",
+          background: "var(--c-surface-raised)",
+          borderRadius: 4,
+        }}
+      >
+        <RulerMeasurementLayer {...args} />
+      </svg>
+    </div>
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof RulerMeasurementLayer>;
+
+export const Default: Story = {};
+
+/** Nothing measured yet: the toolbar controls are not drawn at all. */
+export const Empty: Story = { args: { measurements: [] } };
+
+export const Selected: Story = { args: { selectedId: "b" } };
+
+/** Hovering expands the label to its multi-line form. */
+export const Hovered: Story = { args: { hoveredId: "a" } };
+
+/** With a scale applied the label gains the converted real-world distance. */
+export const Scaled: Story = {
+  args: {
+    measurements: MEASUREMENTS.map((m) => ({ ...m, measureScale: SCALE })),
+    hoveredId: "a",
+  },
+};
+
+export const LabelsShowAll: Story = { args: { labelVisibilityMode: "showAll" } };
+
+export const LabelsHidden: Story = { args: { labelVisibilityMode: "hideAll" } };
+
+/** hideSmall drops idle labels that would collide; showAll forces them back. */
+export const CrowdedHideSmall: Story = { args: { measurements: CROWDED } };
+
+export const CrowdedShowAll: Story = {
+  args: { measurements: CROWDED, labelVisibilityMode: "showAll" },
+};
+
+/** Mid-draw: the first point is placed and the line follows the cursor. */
+export const DrawingInProgress: Story = {
+  args: {
+    measurements: [],
+    firstPoint: { x: 120, y: 120 },
+    cursor: { x: 380, y: 240 },
+    liveLine: {
+      startS: { x: 120, y: 120 },
+      endS: { x: 380, y: 240 },
+      measureScale: SCALE,
+    },
+  },
+};
+
+/**
+ * While another tool owns the pointer the overlay stops taking hits, so its
+ * measurements render but do not respond to hover or selection.
+ */
+export const InteractionPassthrough: Story = {
+  args: { isInteractionPassthroughActive: true },
+};
+
+/** Zoomed in, the stroke and label sizing compensate so they stay readable. */
+export const ZoomedIn: Story = { args: { zoom: 2.5 } };

--- a/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.tsx
@@ -56,6 +56,27 @@ interface LabelBox {
 interface MeasurementLineLabels {
   scaled: string;
   physical: string;
+  delete: string;
+}
+
+/**
+ * The overlay's controls live inside the SVG, where there is no <button> to
+ * inherit from: a bare <g onClick> is invisible to assistive technology and
+ * unreachable by keyboard. These props supply what the element would otherwise
+ * get for free — a role, a name, focusability, and Enter/Space activation.
+ */
+function svgButtonProps(label: string, activate: () => void) {
+  return {
+    role: "button",
+    tabIndex: 0,
+    "aria-label": label,
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key !== "Enter" && e.key !== " ") return;
+      e.preventDefault();
+      e.stopPropagation();
+      activate();
+    },
+  };
 }
 
 export const RULER_DOT_RADIUS = 5;
@@ -623,6 +644,7 @@ function MeasurementLine({
           />
           <g
             style={{ cursor: "pointer" }}
+            {...svgButtonProps(labels.delete, () => onDelete(id))}
             onClick={(e) => {
               e.stopPropagation();
               onDelete(id);
@@ -761,6 +783,7 @@ export function RulerMeasurementLayer({
     () => ({
       scaled: t("ruler.scaled", "Scaled"),
       physical: t("ruler.physicalValues", "Physical"),
+      delete: t("ruler.deleteMeasurement", "Delete measurement"),
     }),
     [t],
   );
@@ -883,6 +906,7 @@ export function RulerMeasurementLayer({
             data-ruler-interactive="true"
             data-ruler-control="true"
             style={{ pointerEvents: "all", cursor: "pointer" }}
+            {...svgButtonProps(t("ruler.clearAll", "Clear all"), onClearAll)}
             onClick={(e) => {
               e.stopPropagation();
               onClearAll();
@@ -915,6 +939,7 @@ export function RulerMeasurementLayer({
             data-ruler-interactive="true"
             data-ruler-control="true"
             style={{ pointerEvents: "all", cursor: "pointer" }}
+            {...svgButtonProps(labelModeButtonLabel, onCycleLabelVisibilityMode)}
             onClick={(e) => {
               e.stopPropagation();
               onCycleLabelVisibilityMode();

--- a/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Second half of calibration: the user has drawn a line over something of known
+ * size, and this dialog turns that into a scale. The measured page distance is
+ * given; the real-world distance is what it asks for.
+ *
+ * The chosen unit is remembered between calibrations, so `defaultUnit` only
+ * applies the first time — stories that care about the unit set it explicitly.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ScaleCalibrationDialog,
+  type ScaleCalibrationMeasurement,
+} from "@app/components/viewer/ScaleCalibrationDialog";
+
+const MEASUREMENT: ScaleCalibrationMeasurement = {
+  start: { x: 100, y: 220, pageIndex: 0 },
+  end: { x: 388, y: 220, pageIndex: 0 },
+  pdfDistancePts: 288,
+};
+
+/** Short enough that the derived ratio lands in a different order of magnitude. */
+const SHORT_MEASUREMENT: ScaleCalibrationMeasurement = {
+  start: { x: 100, y: 220, pageIndex: 0 },
+  end: { x: 118, y: 220, pageIndex: 0 },
+  pdfDistancePts: 18,
+};
+
+const noop = () => {};
+
+const meta: Meta<typeof ScaleCalibrationDialog> = {
+  title: "Viewer/ScaleCalibrationDialog",
+  component: ScaleCalibrationDialog,
+  parameters: { layout: "centered" },
+  args: {
+    opened: true,
+    measurement: MEASUREMENT,
+    defaultUnit: "m",
+    onApplyScale: noop,
+    onClose: noop,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleCalibrationDialog>;
+
+/** Waiting for input: the page distance is shown, the preview is not. */
+export const Default: Story = {};
+
+export const ImperialDefault: Story = { args: { defaultUnit: "ft" } };
+
+export const ShortMeasurement: Story = {
+  args: { measurement: SHORT_MEASUREMENT },
+};
+
+/**
+ * Applying with no distance entered is the error path — the dialog can also be
+ * opened before a measurement exists, which leaves the page distance blank.
+ */
+export const NoMeasurement: Story = { args: { measurement: null } };
+
+export const Closed: Story = { args: { opened: false } };

--- a/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.tsx
@@ -124,11 +124,14 @@ export function ScaleCalibrationDialog({
       title={t("scaleSettings.calibrationTitle", "Calibrate Scale")}
       centered
       size="sm"
+      closeButtonProps={{ "aria-label": t("common.close", "Close") }}
     >
       <Stack gap="md">
         {/* Show paper distance automatically */}
+        {/* Mantine's own "dimmed" is too light to clear 4.5:1, so muted text
+            comes from the design system's token instead. */}
         {measurement && (
-          <Text size="sm" c="dimmed">
+          <Text size="sm" c="var(--c-text-muted)">
             {t(
               "scaleSettings.calibrationPaperDistance",
               "Measured page distance: {{distance}}",
@@ -166,7 +169,7 @@ export function ScaleCalibrationDialog({
 
         {/* Preview: show calculated scale */}
         {previewScale && (
-          <Text size="sm" c="blue">
+          <Text size="sm" fw={600}>
             {t(
               "scaleSettings.calculatedScale",
               "Calculated scale (1 page unit = X real units)",

--- a/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
@@ -1,0 +1,64 @@
+/**
+ * The scale picker that opens from the measurement toolbar. Presets apply and
+ * close immediately; the custom ratio waits for Apply. The panel mirrors an
+ * incoming `currentScale` into its own fields, so the stories drive it through
+ * that prop rather than reaching into state.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ScaleSettingsPanel } from "@app/components/viewer/ScaleSettingsPanel";
+import type { MeasureScale } from "@app/utils/measurementTypes";
+
+/** 1:100 in metres — one of the presets, so the panel shows it as selected. */
+const PRESET_SCALE: MeasureScale = { factor: 0.05, ratio: 100, unit: "m" };
+
+/** A ratio no preset offers, which leaves the preset row unselected. */
+const CUSTOM_SCALE: MeasureScale = { factor: 0.0175, ratio: 35, unit: "ft" };
+
+/** Calibrated scales carry no ratio — the panel labels them "(custom)". */
+const CALIBRATED_SCALE: MeasureScale = {
+  factor: 0.0223,
+  ratio: null,
+  unit: "cm",
+};
+
+const noop = () => {};
+
+const meta: Meta<typeof ScaleSettingsPanel> = {
+  title: "Viewer/ScaleSettingsPanel",
+  component: ScaleSettingsPanel,
+  // The panel sets its own 300px floor; padded gives it room without the
+  // centred frame clipping into a scroll container.
+  parameters: { layout: "padded" },
+  args: {
+    onApplyScale: noop,
+    onResetScale: noop,
+    onStartCalibration: noop,
+    onCancelCalibration: noop,
+    onClose: noop,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleSettingsPanel>;
+
+/** No scale set: the active-scale strip is muted and Reset is not offered. */
+export const Default: Story = {};
+
+export const PresetSelected: Story = { args: { currentScale: PRESET_SCALE } };
+
+export const CustomRatio: Story = { args: { currentScale: CUSTOM_SCALE } };
+
+export const CalibratedScale: Story = {
+  args: { currentScale: CALIBRATED_SCALE },
+};
+
+/** Calibration running: the button flips to its active state. */
+export const Calibrating: Story = { args: { isCalibrationActive: true } };
+
+/**
+ * Calibration is disabled when the viewer supplies no handler for it — the
+ * panel is reachable in contexts that cannot start a calibration draw.
+ */
+export const CalibrationUnavailable: Story = {
+  args: { onStartCalibration: undefined },
+};

--- a/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.tsx
@@ -254,7 +254,9 @@ export function ScaleSettingsPanel({
             />
           </div>
         </Group>
-        <Text size="xs" c="dimmed" mt="xs">
+        {/* Mantine's own "dimmed" is too light to clear 4.5:1 at this size, so
+            muted text comes from the design system's token instead. */}
+        <Text size="xs" c="var(--c-text-muted)" mt="xs">
           {t(
             "scaleSettings.ratioHelp",
             "Ratio: 1 page unit = X real-world units",
@@ -271,12 +273,14 @@ export function ScaleSettingsPanel({
         style={{
           padding: "0.5rem",
           backgroundColor: currentScale
-            ? "rgba(30, 136, 229, 0.1)"
-            : "rgba(158, 158, 158, 0.1)",
+            ? "var(--c-primary-tint)"
+            : "var(--c-surface-sunken)",
           borderRadius: "4px",
         }}
       >
-        <Text size="xs" c={currentScale ? "blue" : "dimmed"}>
+        {/* The tint carries the "a scale is active" signal; the text stays at
+            full contrast rather than restating it in the accent hue. */}
+        <Text size="xs" c={currentScale ? undefined : "var(--c-text-muted)"}>
           <strong>{t("scaleSettings.activeScale", "Active Scale")}:</strong>{" "}
           {currentScale && currentScale.ratio
             ? generateScaleLabel(currentScale.ratio, currentScale.unit)


### PR DESCRIPTION
Storybook coverage for the viewer's measurement feature — the ruler overlay, the scale settings panel, and the calibration dialog. 1,461 lines that had no stories at all.

They were picked because the campaign's defects have clustered in hand-rolled interactive markup rather than in components built on design-system primitives. Three defects came out of it:

- **The overlay's controls were mouse-only.** Clear all, the label-mode cycle and the per-measurement delete were bare `<g onClick>` elements — no role, no accessible name, no tab stop, no key handling. A keyboard user could not delete a measurement or clear the overlay.
- **Muted text failed contrast.** Mantine's `c="dimmed"` resolves to `#868e96` and measures 3.01:1 against the app surface, below the required 4.5:1.
- **The calibration modal's close button had no accessible name.**

Also replaces two hardcoded `rgba()` tints and a raw `"blue"` text colour with theme tokens, so the active-scale strip follows the dark theme.

### Not in this PR

`--mantine-color-dimmed` is never pinned to a design-system token, so *every* `c="dimmed"` in the editor is under-contrast — not just the three call sites fixed here. Repointing it is the real fix, but it changes muted text app-wide and needs a full sweep to verify, so it follows as its own PR rather than riding inside a coverage change.

The overlay's SVG palette (`#1e88e5`, `#ef5350`, …) is likewise left alone: a theming gap rather than an accessibility one, and retheming measurement graphics is a design call.

### Verification

- 23 new stories, a11y scan: **0 violations**
- Typecheck clean (core flavour), `task pre-commit` green
- Keyboard access verified as an a11y contract — the controls expose button role, name and Enter/Space handling and axe is clean; activation was not driven by hand in a browser

### Full review

https://claude.ai/code/artifact/efa196ff-7623-412f-8628-86825ef397de

Branched from `main` — independent of the stacked coverage PRs.