### PR TITLE
test(fileManager): file list coverage, and two defects in its rows

### DIFF
--- a/frontend/editor/src/core/components/fileManager/EmptyFilesState.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/EmptyFilesState.stories.tsx
@@ -1,0 +1,65 @@
+/**
+ * What the file manager shows before anything has been added. The copy and
+ * icons come from the file-action hooks, which desktop builds override — these
+ * stories render the web wording.
+ *
+ * Only one context field is read (the upload click handler), so the fixture
+ * supplies that alone rather than the whole provider.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import EmptyFilesState from "@app/components/fileManager/EmptyFilesState";
+import {
+  FileManagerContext,
+  type FileManagerContextValue,
+} from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof EmptyFilesState> = {
+  title: "FileManager/EmptyFilesState",
+  component: EmptyFilesState,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    // The wordmark resolves its logo variant through PreferencesContext, which
+    // the Storybook preview does not mount, so this story supplies it.
+    (Story) => (
+      <PreferencesProvider>
+        <FileManagerContext.Provider
+          value={
+            { onLocalFileClick: () => {} } as unknown as FileManagerContextValue
+          }
+        >
+          <div style={{ height: "32rem" }}>
+            <Story />
+          </div>
+        </FileManagerContext.Provider>
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof EmptyFilesState>;
+
+export const Default: Story = {};
+
+/** The panel centres itself, so a short container crops rather than reflows. */
+export const ShortContainer: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: "18rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Narrow widths are the mobile case — the upload actions stack. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * The scrolling list that fills the file manager. Which branch it renders is
+ * decided entirely by context — the active source, whether files are loading,
+ * and whether any survive the search filter — so the stories drive it through
+ * the provider rather than through props.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileListArea from "@app/components/fileManager/FileListArea";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+import type { FileId } from "@app/types/file";
+
+const FILES = [
+  makeStub("f1", "quarterly-report.pdf"),
+  makeStub("f2", "signed-contract.pdf", { size: 840_000 }),
+  makeStub("f3", "scan-2026-03-14.pdf", { size: 12_600_000 }),
+  makeStub("f4", "minutes.pdf", { size: 96_000 }),
+];
+
+const meta: Meta<typeof FileListArea> = {
+  title: "FileManager/FileListArea",
+  component: FileListArea,
+  parameters: { layout: "padded" },
+  args: { scrollAreaHeight: "26rem" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FileListArea>;
+
+export const Default: Story = {
+  decorators: [withFileManager({ recentFiles: FILES })],
+};
+
+/** No files at all — the list gives way to the empty state. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};
+
+export const Loading: Story = {
+  decorators: [withFileManager({ recentFiles: FILES, isLoading: true })],
+};
+
+/** Files already open in the editor are marked as active in the list. */
+export const WithActiveFile: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: ["f2" as FileId],
+    }),
+  ],
+};
+
+/** Enough rows to scroll, which is the normal state for a working library. */
+export const ManyFiles: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: Array.from({ length: 24 }, (_, i) =>
+        makeStub(`many-${i}`, `document-${String(i + 1).padStart(3, "0")}.pdf`),
+      ),
+    }),
+  ],
+};
+
+/** A short frame proves the list scrolls inside its own box, not the page. */
+export const ShortFrame: Story = {
+  args: { scrollAreaHeight: "12rem" },
+  decorators: [withFileManager({ recentFiles: FILES })],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListItem.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListItem.tsx
@@ -213,6 +213,9 @@ const FileListItem: React.FC<FileListItemProps> = ({
               <Checkbox
                 checked={isSelected}
                 onChange={() => {}} // Handled by parent onClick
+                aria-label={t("fileManager.selectFile", "Select {{name}}", {
+                  name: file.name,
+                })}
                 size="sm"
                 pl="sm"
                 pr="xs"
@@ -261,12 +264,9 @@ const FileListItem: React.FC<FileListItemProps> = ({
                     : t("storageShare.roleViewer", "Viewer")}
                 </Badge>
               ) : isLocalOnly ? (
-                <Badge
-                  size="xs"
-                  variant="default"
-                  c="dimmed"
-                  style={{ opacity: 0.75 }}
-                >
+                // No extra opacity: at this size the muted colour is already at
+                // the edge of 4.5:1, and fading it drops below.
+                <Badge size="xs" variant="default" c="dimmed">
                   {t("fileManager.localOnly", "Local only")}
                 </Badge>
               ) : uploadEnabled && isOutOfSync ? (

--- a/frontend/editor/src/core/components/fileManager/SearchInput.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/SearchInput.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * The file manager's search box. It reads the term and the change handler from
+ * FileManagerContext rather than taking props, so the stories mount it against
+ * a two-field slice of that context instead of the whole provider chain.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SearchInput from "@app/components/fileManager/SearchInput";
+import {
+  FileManagerContext,
+  type FileManagerContextValue,
+} from "@app/contexts/FileManagerContext";
+
+/**
+ * SearchInput reads exactly two fields. Supplying only those keeps the fixture
+ * honest about what the component depends on; the cast is what makes a partial
+ * value acceptable in place of the full context.
+ */
+function withSearch(
+  searchTerm: string,
+  onSearchChange: (term: string) => void = () => {},
+) {
+  return (children: React.ReactNode) => (
+    <FileManagerContext.Provider
+      value={
+        { searchTerm, onSearchChange } as unknown as FileManagerContextValue
+      }
+    >
+      {children}
+    </FileManagerContext.Provider>
+  );
+}
+
+const meta: Meta<typeof SearchInput> = {
+  title: "FileManager/SearchInput",
+  component: SearchInput,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchInput>;
+
+export const Empty: Story = {
+  render: () => withSearch("")(<SearchInput />),
+};
+
+export const WithTerm: Story = {
+  render: () => withSearch("invoice")(<SearchInput />),
+};
+
+/** Long terms are not truncated by the component — the field scrolls instead. */
+export const LongTerm: Story = {
+  render: () =>
+    withSearch("quarterly-report-2026-final-revised-approved")(<SearchInput />),
+};
+
+/** The container controls width, so the box stretches to whatever it is given. */
+export const Narrow: Story = {
+  render: () => (
+    <div style={{ width: 220 }}>{withSearch("draft")(<SearchInput />)}</div>
+  ),
+};
+
+/** Typing is driven by the context handler, so state lives outside the field. */
+export const Interactive: Story = {
+  render: function Interactive() {
+    const [term, setTerm] = useState("");
+    return withSearch(term, setTerm)(<SearchInput />);
+  },
+};

--- a/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
@@ -1,0 +1,98 @@
+/**
+ * Shared fixtures for the file manager stories.
+ *
+ * These components sit deep in a provider chain — FileManagerContext needs
+ * FileContext for useFileActions/useFileManagement, list rows additionally read
+ * AppConfig — and none of it is part of the shared preview decorators. Rather
+ * than each story rebuilding that tree, they mount the real providers here over
+ * static data, so what a story exercises is the component and not a stub.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FileManagerProvider } from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+/** A grey rectangle, so thumbnail lookups short-circuit instead of reading
+ *  file bytes out of IndexedDB. */
+const THUMBNAIL =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160'%3E%3Crect width='120' height='160' fill='%23e9ecef'/%3E%3C/svg%3E";
+
+/** Fixed so stories render identically on every run. */
+const LAST_MODIFIED = Date.parse("2026-03-14T09:30:00Z");
+
+export function makeStub(
+  id: string,
+  name: string,
+  overrides: Partial<StirlingFileStub> = {},
+): StirlingFileStub {
+  return {
+    id: id as FileId,
+    name,
+    type: "application/pdf",
+    size: 2_400_000,
+    lastModified: LAST_MODIFIED,
+    isLeaf: true,
+    originalFileId: id,
+    versionNumber: 1,
+    thumbnailUrl: THUMBNAIL,
+    ...overrides,
+  };
+}
+
+export const mockFile = makeStub("story-file-1", "quarterly-report.pdf");
+
+/** Storage off keeps the row's upload and share affordances out of the way;
+ *  stories that want them pass their own config. */
+const BASE_CONFIG = {
+  storageEnabled: false,
+  storageSharingEnabled: false,
+  storageShareLinksEnabled: false,
+  frontendUrl: "https://stirling.example",
+};
+
+interface FixtureOptions {
+  recentFiles?: StirlingFileStub[];
+  activeFileIds?: FileId[];
+  isLoading?: boolean;
+  config?: Partial<typeof BASE_CONFIG>;
+}
+
+export function withFileManager({
+  recentFiles = [mockFile],
+  activeFileIds = [],
+  isLoading = false,
+  config,
+}: FixtureOptions = {}) {
+  return (Story: () => ReactElement) => (
+    <AppConfigProvider
+      initialConfig={{ ...BASE_CONFIG, ...config } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      {/* The empty state's wordmark resolves a logo variant through
+          PreferencesContext, which the preview does not mount. */}
+      <PreferencesProvider>
+        <FileContextProvider>
+          <FileManagerProvider
+            recentFiles={recentFiles}
+            onRecentFilesSelected={() => {}}
+            onNewFilesSelect={() => {}}
+            onClose={() => {}}
+            isFileSupported={() => true}
+            isOpen
+            onFileRemove={() => {}}
+            modalHeight="600px"
+            refreshRecentFiles={async () => {}}
+            isLoading={isLoading}
+            activeFileIds={activeFileIds}
+          >
+            <Story />
+          </FileManagerProvider>
+        </FileContextProvider>
+      </PreferencesProvider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/contexts/FileManagerContext.tsx
+++ b/frontend/editor/src/core/contexts/FileManagerContext.tsx
@@ -29,7 +29,7 @@ import { openFilesFromDisk } from "@app/services/openFilesFromDisk";
 export { pendingFilePathMappings } from "@app/services/pendingFilePathMappings";
 
 // Type for the context value - now contains everything directly
-interface FileManagerContextValue {
+export interface FileManagerContextValue {
   // State
   activeSource: "recent" | "local" | "drive";
   storageFilter: "all" | "local" | "sharedWithMe" | "sharedByMe";
@@ -80,8 +80,11 @@ interface FileManagerContextValue {
   modalHeight: string;
 }
 
-// Create the context
-const FileManagerContext = createContext<FileManagerContextValue | null>(null);
+// Create the context. Exported so a test or story can mount a component
+// against a slice of the value instead of the whole provider chain.
+export const FileManagerContext = createContext<FileManagerContextValue | null>(
+  null,
+);
 
 // Provider component props
 interface FileManagerProviderProps {

--- a/frontend/editor/src/core/theme/colors.css
+++ b/frontend/editor/src/core/theme/colors.css
@@ -374,3 +374,14 @@ html[data-app-theme="custom"][data-accent="default"][data-mantine-color-scheme="
   --c-border: var(--p-c-28282d);
   --c-border-subtle: var(--p-zinc-700);
 }
+
+/* ── MANTINE MUTED TEXT ───────────────────────────────────────────────────── */
+/* Mantine's stock "dimmed" is #868e96, which measures ~3:1 against the app's
+   surfaces — short of the 4.5:1 that body-size text needs. Pointing it at the
+   semantic muted token fixes every `c="dimmed"` at once, and follows the theme
+   rather than staying a fixed grey that only ever suited light mode. */
+/* Doubled selector: Mantine declares this on :root too, and its stylesheet
+   loads later, so a single :root here would lose on source order. */
+:root:root {
+  --mantine-color-dimmed: var(--c-text-muted);
+}


### PR DESCRIPTION
The file manager was the least-covered area in core — 3 of 14 surfaces. This adds stories for the search box, the empty state and the file list, and fixes two defects the rows turned out to have.

### An opacity that cancelled a colour fix

The "Local only" badge measured **3.92:1** at `#777e89` — a colour that appears nowhere in the source. It is `--c-text-muted` (`#4b5563`) at `opacity: 0.75` over the surface; blend those and you get `#777e89` exactly.

The muted colour on its own clears 4.5:1 comfortably, so **the fade was the defect** — the dimmed-token fix in the PR below this one was working and being undone one line later. Removing the opacity fixes it.

### Row checkboxes had no accessible name

Each row's selection checkbox had no `aria-label` and no associated label, so a screen reader announced "checkbox" with nothing to identify the file — once per row.

**Note for whoever lands second:** #7318 modifies the same checkbox for a different reason (giving it a working keyboard path). The two changes are complementary but touch adjacent lines, so expect a small conflict.

### How the stories are wired

These components read context rather than props. The search box and empty state get a context *slice* — only the fields each actually reads — which keeps the fixture honest about their real dependencies. The file list needs the genuine chain (`FileManagerContext` sits on `FileContext` for `useFileManagement`, rows also read `AppConfig` and `Preferences`), so a shared fixture mounts the real providers over static data rather than stubbing them.

### Why the fixture mounts PreferencesProvider

The empty state failed to render at first: its wordmark resolves a logo variant through `PreferencesContext`. #7319 adds `PreferencesProvider` to `.storybook/preview.tsx`, but this branch is based on `main`, which does not have it yet — so the fixture mounts it locally to stand alone. Once #7319 lands the local one becomes redundant (harmlessly — nesting is fine) and can be dropped.

### Verification

- 22 file manager stories (14 new, 8 existing): **0 violations**
- Typecheck clean, `task pre-commit` green
- Render failures checked separately — an unrendered story reports zero violations, which is not the same as passing

### Full review

https://claude.ai/code/artifact/af670027-0652-481c-be99-6edf9c97f550

Stacked on `fix/mantine-dimmed-contrast` (#7347), which the badge finding depends on.
