### PR TITLE
test(shared): landing actions and viewer zoom controls, via context slices

### DIFF
--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -10266,6 +10266,7 @@ unknownFile = "Unknown file"
 view = "View"
 zoom = "Zoom"
 zoomIn = "Zoom In"
+zoomLevel = "Zoom level"
 zoomOut = "Zoom Out"
 
 [viewer.attachments]

--- a/frontend/editor/src/core/components/shared/LandingActions.stories.tsx
+++ b/frontend/editor/src/core/components/shared/LandingActions.stories.tsx
@@ -1,0 +1,83 @@
+/**
+ * The row of upload actions on the landing screen. Which buttons appear is
+ * decided between props, the app config, and the viewport — the mobile-upload
+ * affordance and the browse-files entry are both conditional — so the stories
+ * vary those rather than exposing them as controls.
+ *
+ * The wording and icons come from the file-action hooks, which desktop builds
+ * override; these render the web variants.
+ */
+import { useRef } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LandingActions } from "@app/components/shared/LandingActions";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+
+/** Enough of the config for the actions to decide what to offer. */
+const CONFIG = { storageEnabled: false, enableMobileUpload: true };
+
+function Harness(config: Partial<typeof CONFIG>) {
+  return function Wrapped() {
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+    return (
+      <AppConfigProvider
+        initialConfig={{ ...CONFIG, ...config } as never}
+        bootstrapMode="non-blocking"
+        autoFetch={false}
+      >
+        {/* Only openFilesModal is read. The real provider reaches FileContext
+            and NavigationContext, so a slice is supplied instead. */}
+        <FilesModalContext.Provider
+          value={
+            { openFilesModal: () => {} } as unknown as FilesModalContextType
+          }
+        >
+          <LandingActions
+            fileInputRef={fileInputRef}
+            onUploadClick={() => {}}
+            onMobileUploadClick={() => {}}
+            onFileSelect={() => {}}
+          />
+        </FilesModalContext.Provider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+const meta: Meta<typeof LandingActions> = {
+  title: "Shared/LandingActions",
+  component: LandingActions,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof LandingActions>;
+
+export const Default: Story = { render: Harness({}) };
+
+/** With storage on, the actions also offer the stored-files browser. */
+export const StorageEnabled: Story = {
+  render: Harness({ storageEnabled: true }),
+};
+
+/** Mobile upload off removes the phone affordance entirely. */
+export const NoMobileUpload: Story = {
+  render: Harness({ enableMobileUpload: false }),
+};
+
+/**
+ * Narrow viewports take the mobile branch, which reflows the row and swaps
+ * some buttons for icon-only controls.
+ */
+export const Mobile: Story = {
+  render: Harness({}),
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};
+
+export const MobileWithStorage: Story = {
+  render: Harness({ storageEnabled: true }),
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};

--- a/frontend/editor/src/core/components/shared/ViewerInlineControls.stories.tsx
+++ b/frontend/editor/src/core/components/shared/ViewerInlineControls.stories.tsx
@@ -1,0 +1,128 @@
+/**
+ * The zoom controls that appear in the workbench bar while the viewer is the
+ * active workbench. They render nothing anywhere else, so every story here has
+ * to say the workbench is "viewer".
+ *
+ * Zoom is pushed at the component rather than pulled: it seeds from
+ * getZoomState() and then subscribes for updates, so the fixture below hands
+ * back a fixed level and a subscription that never fires. The Live story wires
+ * the subscription up properly so the slider and buttons actually move.
+ */
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ViewerInlineControls } from "@app/components/shared/ViewerInlineControls";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+import {
+  NavigationStateContext,
+  type NavigationContextStateValue,
+} from "@app/contexts/NavigationContext";
+
+/** Only `workbench` is read; the rest of navigation state is irrelevant here. */
+function navState(workbench: string) {
+  return { workbench } as unknown as NavigationContextStateValue;
+}
+
+/** A viewer that reports one zoom level and never publishes another. */
+function staticViewer(zoomPercent: number) {
+  return {
+    getZoomState: () => ({ zoomPercent }),
+    registerImmediateZoomUpdate: () => () => {},
+    zoomActions: {
+      zoomIn: () => {},
+      zoomOut: () => {},
+      setZoomLevel: () => {},
+    },
+  } as unknown as ViewerContextType;
+}
+
+function Fixture({
+  zoomPercent = 100,
+  workbench = "viewer",
+}: {
+  zoomPercent?: number;
+  workbench?: string;
+}) {
+  return (
+    <NavigationStateContext.Provider value={navState(workbench)}>
+      <ViewerContext.Provider value={staticViewer(zoomPercent)}>
+        <ViewerInlineControls />
+      </ViewerContext.Provider>
+    </NavigationStateContext.Provider>
+  );
+}
+
+const meta: Meta<typeof ViewerInlineControls> = {
+  title: "Shared/ViewerInlineControls",
+  component: ViewerInlineControls,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ViewerInlineControls>;
+
+export const Default: Story = { render: () => <Fixture /> };
+
+/** The slider clamps to 20–500, so these two sit at its ends. */
+export const MinimumZoom: Story = { render: () => <Fixture zoomPercent={20} /> };
+
+export const MaximumZoom: Story = {
+  render: () => <Fixture zoomPercent={500} />,
+};
+
+/** Levels outside the slider's range still clamp rather than overflow it. */
+export const BeyondSliderRange: Story = {
+  render: () => <Fixture zoomPercent={900} />,
+};
+
+/** Any other workbench renders nothing at all. */
+export const NotViewerWorkbench: Story = {
+  render: () => <Fixture workbench="fileManager" />,
+};
+
+/**
+ * The controls driving real state: the zoom actions publish through the same
+ * subscription the component registers, which is how the app wires them.
+ */
+export const Live: Story = {
+  render: function Live() {
+    const [zoom, setZoom] = useState(100);
+    const listener = useRef<((pct: number) => void) | null>(null);
+
+    const publish = useCallback((pct: number) => {
+      const clamped = Math.min(Math.max(pct, 20), 500);
+      setZoom(clamped);
+      listener.current?.(clamped);
+    }, []);
+
+    const viewer = useMemo(
+      () =>
+        ({
+          getZoomState: () => ({ zoomPercent: zoom }),
+          registerImmediateZoomUpdate: (cb: (pct: number) => void) => {
+            listener.current = cb;
+            return () => {
+              listener.current = null;
+            };
+          },
+          zoomActions: {
+            zoomIn: () => publish(zoom + 25),
+            zoomOut: () => publish(zoom - 25),
+            setZoomLevel: (level: number) => publish(level * 100),
+          },
+          // Rebuilt per zoom so the seed value stays current.
+        }) as unknown as ViewerContextType,
+      [zoom, publish],
+    );
+
+    return (
+      <NavigationStateContext.Provider value={navState("viewer")}>
+        <ViewerContext.Provider value={viewer}>
+          <ViewerInlineControls />
+        </ViewerContext.Provider>
+      </NavigationStateContext.Provider>
+    );
+  },
+};

--- a/frontend/editor/src/core/components/shared/ViewerInlineControls.tsx
+++ b/frontend/editor/src/core/components/shared/ViewerInlineControls.tsx
@@ -62,6 +62,9 @@ export function ViewerInlineControls() {
             track: { height: 3 },
           }}
           label={null}
+          // The thumb carries role="slider"; thumbLabel is what names it, and
+          // Slider writes an empty aria-label over anything else.
+          thumbLabel={t("viewer.zoomLevel", "Zoom level")}
         />
       </div>
 

--- a/frontend/editor/src/core/contexts/FilesModalContext.tsx
+++ b/frontend/editor/src/core/contexts/FilesModalContext.tsx
@@ -26,7 +26,7 @@ import {
   readResponseHeader,
 } from "@app/services/shareBundleUtils";
 
-interface FilesModalContextType {
+export interface FilesModalContextType {
   isFilesModalOpen: boolean;
   openFilesModal: (options?: {
     insertAfterPage?: number;
@@ -41,7 +41,10 @@ interface FilesModalContextType {
   setOnModalClose: (callback: () => void) => void;
 }
 
-const FilesModalContext = createContext<FilesModalContextType | null>(null);
+// Exported so a test or story can mount a component against a slice of the
+// value: the provider itself pulls in FileContext and NavigationContext.
+export const FilesModalContext =
+  createContext<FilesModalContextType | null>(null);
 
 export const FilesModalProvider: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/frontend/editor/src/core/contexts/NavigationContext.tsx
+++ b/frontend/editor/src/core/contexts/NavigationContext.tsx
@@ -128,8 +128,11 @@ export interface NavigationContextActionsValue {
   actions: NavigationContextActions;
 }
 
-// Create contexts
-const NavigationStateContext = createContext<
+// Create contexts. The state context is exported so a test or story can mount a
+// component against a slice of it: the provider itself reaches the tool
+// registry, which is far more than a component reading one navigation field
+// needs standing up.
+export const NavigationStateContext = createContext<
   NavigationContextStateValue | undefined
 >(undefined);
 const NavigationActionsContext = createContext<


### PR DESCRIPTION
Two components off the expensive end of the coverage list, plus one defect they exposed.

### The zoom slider had no accessible name

Mantine's `Slider` renders a thumb carrying `role="slider"`. Nothing named it, so a screen reader announced an unlabelled slider between two properly labelled zoom buttons.

The fix took two wrong attempts worth recording: `thumbProps` looks like the right prop and type-checks cleanly, **and does nothing** — reading the DOM showed the thumb with `aria-label=""`, because Slider writes an empty label over anything passed that way. `thumbLabel` is the prop that names it.

### Slice, don't mount

`LandingActions` reads exactly one field from `FilesModalContext`, but mounting the real provider fails on `FileContext`, then on `NavigationContext` — a chain ending at the tool registry. `ViewerInlineControls` is the same shape: one field of navigation state, a handful of viewer methods.

Supplying slices stops the cascade at the first step, and the slice doubles as documentation of what each component actually touches. Two contexts are newly exported for this, each with a comment saying why.

This is the technique the remaining ~120 context-level gaps will need; these two are a reasonable template for it.

### Zoom is pushed, not pulled

The controls seed from `getZoomState()` then subscribe for updates, so a fixture returning a fixed number never exercises the subscription the component relies on. The `Live` story wires it up as the app does, so the slider and buttons genuinely move.

### Base

Stacked on #7319 rather than `main`, because its `preview.tsx` mounts `PreferencesProvider` and `SidebarProvider` — needed by ~100 components via `Tooltip`. Basing coverage work on `main` means re-solving that in every story file, as #7348 had to.

### Verification

- 11 new stories: **0 violations**
- Slider fix confirmed in the rendered DOM, not just by the rule passing
- Typecheck clean, `task pre-commit` green

### Full review

https://claude.ai/code/artifact/27dcd1a8-5634-4a00-8374-dc7a9b0bc437