### PR TITLE
test(addPageNumbers): cover both settings panels

### DIFF
--- a/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings.stories.tsx
@@ -1,0 +1,92 @@
+/**
+ * How the page number looks: margin, size, face, zero padding and the optional
+ * text wrapped around it. This is the other half of the Add Page Numbers
+ * settings — the position panel places the number, this one styles it — and
+ * every parameter here is one that panel does not render.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddPageNumbersAppearanceSettings from "@app/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings";
+import {
+  defaultParameters,
+  type AddPageNumbersParameters,
+} from "@app/components/tools/addPageNumbers/useAddPageNumbersParameters";
+
+function Demo({
+  overrides,
+  disabled,
+}: {
+  overrides?: Partial<AddPageNumbersParameters>;
+  disabled?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddPageNumbersParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <AddPageNumbersAppearanceSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+    />
+  );
+}
+
+const meta: Meta<typeof AddPageNumbersAppearanceSettings> = {
+  title: "Tools/AddPageNumbers/AppearanceSettings",
+  component: AddPageNumbersAppearanceSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AddPageNumbersAppearanceSettings>;
+
+/** Defaults: medium margin, 12pt Times, no padding, no custom text. */
+export const Default: Story = { render: () => <Demo /> };
+
+/** The margin extremes, which decide how far the number sits from the edge. */
+export const SmallMargin: Story = {
+  render: () => <Demo overrides={{ customMargin: "small" }} />,
+};
+
+export const ExtraLargeMargin: Story = {
+  render: () => <Demo overrides={{ customMargin: "x-large" }} />,
+};
+
+export const CourierFace: Story = {
+  render: () => <Demo overrides={{ fontType: "Courier" }} />,
+};
+
+export const LargeType: Story = {
+  render: () => <Demo overrides={{ fontSize: 24 }} />,
+};
+
+/** Padding to a fixed width, for documents whose numbers must sort as text. */
+export const ZeroPadded: Story = {
+  render: () => <Demo overrides={{ zeroPad: 3 }} />,
+};
+
+/** `{n}` is the placeholder the number is substituted into. */
+export const CustomText: Story = {
+  render: () => <Demo overrides={{ customText: "Page {n}" }} />,
+};
+
+/** Everything at once, which is where the fields crowd if they are going to. */
+export const FullyCustomised: Story = {
+  render: () => (
+    <Demo
+      overrides={{
+        customMargin: "large",
+        fontType: "Helvetica",
+        fontSize: 18,
+        zeroPad: 4,
+        customText: "Section 3 — page {n}",
+      }}
+    />
+  ),
+};
+
+/** Disabled while the tool is running. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersPositionSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersPositionSettings.stories.tsx
@@ -1,0 +1,87 @@
+/**
+ * Where the page number lands, and what it says. The position is a 1–9 grid
+ * read like a numeric keypad — 1 is bottom-left, 9 is top-right — so the
+ * stories walk the corners rather than exposing position as a control.
+ *
+ * With no file the preview falls back to a blank page outline; passing a real
+ * document is what makes it render a thumbnail, which stories cannot do.
+ *
+ * The preview reads only the position and the page range, so the appearance
+ * parameters (font, margin, custom text, zero padding) are deliberately not
+ * varied here — this panel does not render them, and a story that set them
+ * would be indistinguishable from the default.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddPageNumbersPositionSettings from "@app/components/tools/addPageNumbers/AddPageNumbersPositionSettings";
+import {
+  defaultParameters,
+  type AddPageNumbersParameters,
+} from "@app/components/tools/addPageNumbers/useAddPageNumbersParameters";
+
+function Demo({
+  overrides,
+  disabled,
+  showQuickGrid,
+}: {
+  overrides?: Partial<AddPageNumbersParameters>;
+  disabled?: boolean;
+  showQuickGrid?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddPageNumbersParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <AddPageNumbersPositionSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+      showQuickGrid={showQuickGrid}
+    />
+  );
+}
+
+const meta: Meta<typeof AddPageNumbersPositionSettings> = {
+  title: "Tools/AddPageNumbers/PositionSettings",
+  component: AddPageNumbersPositionSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AddPageNumbersPositionSettings>;
+
+/** Bottom centre — where numbering conventionally sits, and the default. */
+export const Default: Story = { render: () => <Demo /> };
+
+export const TopLeft: Story = {
+  render: () => <Demo overrides={{ position: 7 }} />,
+};
+
+export const TopRight: Story = {
+  render: () => <Demo overrides={{ position: 9 }} />,
+};
+
+export const BottomLeft: Story = {
+  render: () => <Demo overrides={{ position: 1 }} />,
+};
+
+/** Numbering that starts partway through, for a document split across files. */
+export const StartingNumber: Story = {
+  render: () => <Demo overrides={{ startingNumber: 42 }} />,
+};
+
+/** A range rather than the whole document. */
+export const PageRange: Story = {
+  render: () => <Demo overrides={{ pagesToNumber: "2-8,10" }} />,
+};
+
+/** Without the quick grid the position is set from the preview alone. */
+export const NoQuickGrid: Story = {
+  render: () => <Demo showQuickGrid={false} />,
+};
+
+/** Disabled while the tool is running. */
+export const Disabled: Story = { render: () => <Demo disabled /> };


### PR DESCRIPTION
Stories for both halves of the Add Page Numbers settings. No defects — both panels are built from design-system inputs with labels attached and pass `disabled` to every control, which is the profile that has stayed clean all campaign.

### A parameter set is not a parameter rendered

Both panels take the whole `AddPageNumbersParameters` object, so a story can set any field and it type-checks.

I wrote twelve stories for the position panel — margin, font, custom text, zero padding among them — before checking what it actually draws. It renders `pagesToNumber` and `startingNumber`, and delegates the rest to `PageNumberPreview`, which reads **only position and page range**.

Those four stories would have rendered pixel-identical to the default while advertising coverage that did not exist. They are deleted, and the file header records why so they do not come back. The parameters they covered are all rendered by the *appearance* panel, which is where they now live.

### How the panels divide

- **Position** places the number: a 1–9 grid read like a numeric keypad, plus which pages get numbered and where the count starts.
- **Appearance** styles it: margin, size, face, zero padding, and the optional text wrapped around the number.

Nothing is duplicated between the two files.

### What the stories cannot show

The position preview renders a real page thumbnail when given a file and falls back to a blank outline without one. These take the fallback — supplying a genuine PDF would mean shipping a fixture document and waiting on thumbnail generation, for a background image behind the control actually under test.

### Verification

- 17 stories: **0 violations**
- Every story checked as distinguishable against what the panel renders, not what its props allow
- Typecheck clean, `task pre-commit` green

### Full review

https://claude.ai/code/artifact/b4965e3e-7339-4cba-a5b0-cc9f7756e483