### PR TITLE
test(addStamp): cover the position and formatting panel, and fix three defects

### DIFF
--- a/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.stories.tsx
@@ -1,0 +1,96 @@
+/**
+ * Placement and formatting for the stamp tool. The three formatting controls —
+ * size, rotation, opacity — share one slider, and `_activePill` decides which
+ * of them is showing, so each pill gets its own story rather than a control.
+ *
+ * Position is the same 1–9 keypad grid the page-number tool uses.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StampPositionFormattingSettings from "@app/components/tools/addStamp/StampPositionFormattingSettings";
+import {
+  defaultParameters,
+  type AddStampParameters,
+} from "@app/components/tools/addStamp/useAddStampParameters";
+
+function Demo({
+  overrides,
+  disabled,
+  showPositionGrid = true,
+}: {
+  overrides?: Partial<AddStampParameters>;
+  disabled?: boolean;
+  showPositionGrid?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddStampParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <StampPositionFormattingSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+      showPositionGrid={showPositionGrid}
+    />
+  );
+}
+
+const meta: Meta<typeof StampPositionFormattingSettings> = {
+  title: "Tools/AddStamp/PositionFormattingSettings",
+  component: StampPositionFormattingSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof StampPositionFormattingSettings>;
+
+export const Default: Story = { render: () => <Demo /> };
+
+/** The formatting pills each swap in a different slider. */
+export const RotationActive: Story = {
+  render: () => <Demo overrides={{ _activePill: "rotation" }} />,
+};
+
+export const OpacityActive: Story = {
+  render: () => <Demo overrides={{ _activePill: "opacity" }} />,
+};
+
+/** An image stamp has no font size, so that control becomes a scale instead. */
+export const ImageStamp: Story = {
+  render: () => <Demo overrides={{ stampType: "image" }} />,
+};
+
+export const ImageStampRotated: Story = {
+  render: () => (
+    <Demo overrides={{ stampType: "image", _activePill: "rotation" }} />
+  ),
+};
+
+/** Corners of the placement grid. */
+export const TopLeftPosition: Story = {
+  render: () => <Demo overrides={{ position: 7 }} />,
+};
+
+export const CentrePosition: Story = {
+  render: () => <Demo overrides={{ position: 5 }} />,
+};
+
+/** Values at the ends of their ranges, where the sliders sit hard over. */
+export const FullyRotated: Story = {
+  render: () => <Demo overrides={{ _activePill: "rotation", rotation: 180 }} />,
+};
+
+export const NearlyTransparent: Story = {
+  render: () => <Demo overrides={{ _activePill: "opacity", opacity: 10 }} />,
+};
+
+/** Automation drives position numerically, so the grid is hidden there. */
+export const WithoutPositionGrid: Story = {
+  render: () => <Demo showPositionGrid={false} />,
+};
+
+/** Disabled while the tool is running. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.tsx
@@ -34,6 +34,16 @@ const StampPositionFormattingSettings = ({
 }: StampPositionFormattingSettingsProps) => {
   const { t } = useTranslation();
 
+  // Each formatting pill shows a number field and a slider driving the same
+  // value. The heading above them is plain text, so both controls carry the
+  // label themselves rather than being left unnamed.
+  const sizeLabel =
+    parameters.stampType === "image"
+      ? t("AddStampRequest.imageSize", "Image Size")
+      : t("AddStampRequest.fontSize", "Font Size");
+  const rotationLabel = t("AddStampRequest.rotation", "Rotation");
+  const opacityLabel = t("AddStampRequest.opacity", "Opacity");
+
   return (
     <Stack gap="md" justify="space-between">
       {/* Position Grid - shown in automation settings */}
@@ -144,11 +154,7 @@ const StampPositionFormattingSettings = ({
       {/* Single slider bound to selected pill */}
       {parameters._activePill === "fontSize" && (
         <Stack gap="xs">
-          <Text className={styles.labelText}>
-            {parameters.stampType === "image"
-              ? t("AddStampRequest.imageSize", "Image Size")
-              : t("AddStampRequest.fontSize", "Font Size")}
-          </Text>
+          <Text className={styles.labelText}>{sizeLabel}</Text>
           <Group className={styles.sliderGroup} align="center">
             <NumberInput
               value={parameters.fontSize}
@@ -164,6 +170,7 @@ const StampPositionFormattingSettings = ({
               size="sm"
               className={styles.numberInput}
               disabled={disabled}
+              aria-label={sizeLabel}
             />
             <Slider
               value={parameters.fontSize}
@@ -173,15 +180,14 @@ const StampPositionFormattingSettings = ({
               step={1}
               className={styles.slider}
               disabled={disabled}
+              thumbLabel={sizeLabel}
             />
           </Group>
         </Stack>
       )}
       {parameters._activePill === "rotation" && (
         <Stack gap="xs">
-          <Text className={styles.labelText}>
-            {t("AddStampRequest.rotation", "Rotation")}
-          </Text>
+          <Text className={styles.labelText}>{rotationLabel}</Text>
           <Group className={styles.sliderGroup} align="center">
             <NumberInput
               value={parameters.rotation}
@@ -195,6 +201,7 @@ const StampPositionFormattingSettings = ({
               className={styles.numberInput}
               hideControls
               disabled={disabled}
+              aria-label={rotationLabel}
             />
             <Slider
               value={parameters.rotation}
@@ -203,15 +210,15 @@ const StampPositionFormattingSettings = ({
               max={180}
               step={1}
               className={styles.sliderWide}
+              disabled={disabled}
+              thumbLabel={rotationLabel}
             />
           </Group>
         </Stack>
       )}
       {parameters._activePill === "opacity" && (
         <Stack gap="xs">
-          <Text className={styles.labelText}>
-            {t("AddStampRequest.opacity", "Opacity")}
-          </Text>
+          <Text className={styles.labelText}>{opacityLabel}</Text>
           <Group className={styles.sliderGroup} align="center">
             <NumberInput
               value={parameters.opacity}
@@ -224,6 +231,7 @@ const StampPositionFormattingSettings = ({
               size="sm"
               className={styles.numberInput}
               disabled={disabled}
+              aria-label={opacityLabel}
             />
             <Slider
               value={parameters.opacity}
@@ -232,6 +240,8 @@ const StampPositionFormattingSettings = ({
               max={100}
               step={1}
               className={styles.slider}
+              disabled={disabled}
+              thumbLabel={opacityLabel}
             />
           </Group>
         </Stack>


### PR DESCRIPTION
The stamp tool's three formatting pills — size, rotation, opacity — share one slider, with `_activePill` deciding which renders. Giving each pill its own story put three near-identical blocks side by side for the first time, which is how these turned up.

### Two of the three sliders ignore `disabled`

All three number fields honour `disabled`. The size slider honours it. **The rotation and opacity sliders do not** — while the tool is running, two of the three stay fully draggable.

This is a functional bug, not an accessibility one, and no axe rule would have reported it. It only became visible because the stories rendered the three blocks next to each other, where one differing line stands out.

### Neither control in any pill had an accessible name

The heading above each pair is plain `<Text>` with no association, so assistive tech got a bare spinbutton beside an unlabelled slider, three times over. Both now carry the label — the slider via `thumbLabel`, since Mantine writes an empty `aria-label` over anything passed through `thumbProps`.

### A pattern, not an incident

The same unlabelled-thumb defect appeared independently in the viewer's zoom controls in #7349. Two instances was enough to stop finding them one at a time — #7351 sweeps all 28 `Slider` usages and names the seventeen others.

### Why pills are stories, not a control

`_activePill` is UI state that decides which slider renders at all. As an argument control it would be one dropdown concealing three genuinely different renders; as three stories the difference is visible in the gallery.

### Verification

- 11 stories: **0 violations**, down from 21
- Typecheck clean, `task pre-commit` green
- The `disabled` fix verified by reading all three blocks side by side — the two sliders now take it exactly as their number fields already did

### Full review

https://claude.ai/code/artifact/55e23638-832b-4a82-ac76-12bc48d456d7