### PR TITLE
test(fullscreen): tool picker coverage, and stop painting labels in the category hue

### DIFF
--- a/frontend/editor/src/core/components/tools/FullscreenToolList.stories.tsx
+++ b/frontend/editor/src/core/components/tools/FullscreenToolList.stories.tsx
@@ -1,0 +1,167 @@
+/**
+ * The tool list behind the fullscreen picker. It has two shapes: with no search
+ * term it shows a Quick Access block above the full catalogue; while searching
+ * it shows flat match groups and drops Quick Access entirely.
+ *
+ * Two details decide whether anything renders at all, so the fixture below is
+ * built around them: tools are grouped by `categoryId`, and Quick Access only
+ * accepts entries that carry a component or a link. An entry with neither is
+ * treated as "coming soon" and never reaches the list.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import FullscreenToolList from "@app/components/tools/FullscreenToolList";
+import {
+  ToolCategoryId,
+  SubcategoryId,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
+import type { ToolId } from "@app/types/toolId";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  ToolWorkflowContext,
+  type ToolWorkflowContextValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+
+function tool(
+  name: string,
+  categoryId: ToolCategoryId,
+  subcategoryId: SubcategoryId,
+): ToolRegistryEntry {
+  return {
+    icon: <BuildRoundedIcon />,
+    name,
+    // Entries with neither a component nor a link are filtered out of Quick
+    // Access and render disabled elsewhere.
+    component: () => null,
+    description: `${name} — what this tool does, in one line.`,
+    categoryId,
+    subcategoryId,
+    automationSettings: null,
+  } as ToolRegistryEntry;
+}
+
+const REGISTRY: Record<string, ToolRegistryEntry> = {
+  rotate: tool(
+    "Rotate pages",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.PAGE_FORMATTING,
+  ),
+  compress: tool(
+    "Compress",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.GENERAL,
+  ),
+  redact: tool(
+    "Redact",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.DOCUMENT_SECURITY,
+  ),
+  sign: tool("Sign", ToolCategoryId.STANDARD_TOOLS, SubcategoryId.SIGNING),
+  extract: tool(
+    "Extract pages",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.EXTRACTION,
+  ),
+  removeBlanks: tool(
+    "Remove blank pages",
+    ToolCategoryId.ADVANCED_TOOLS,
+    SubcategoryId.REMOVAL,
+  ),
+};
+
+const ALL_TOOLS = Object.entries(REGISTRY).map(([id, entry]) => ({
+  item: [id as ToolId, entry] as [ToolId, ToolRegistryEntry],
+}));
+
+function Harness({
+  filteredTools = ALL_TOOLS,
+  searchQuery = "",
+  showDescriptions = false,
+  selectedToolKey = null,
+  favoriteTools = [] as string[],
+}: {
+  filteredTools?: typeof ALL_TOOLS;
+  searchQuery?: string;
+  showDescriptions?: boolean;
+  selectedToolKey?: string | null;
+  favoriteTools?: string[];
+}) {
+  const workflow = {
+    toolRegistry: REGISTRY,
+    favoriteTools,
+    isFavorite: (id: string) => favoriteTools.includes(id),
+    toggleFavorite: () => {},
+    toolAvailability: {},
+  } as unknown as ToolWorkflowContextValue;
+
+  return (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled: true } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <ToolWorkflowContext.Provider value={workflow}>
+          <div style={{ width: 420 }}>
+            <FullscreenToolList
+              filteredTools={filteredTools}
+              searchQuery={searchQuery}
+              showDescriptions={showDescriptions}
+              selectedToolKey={selectedToolKey}
+              matchedTextMap={new Map()}
+              onSelect={() => {}}
+            />
+          </div>
+        </ToolWorkflowContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}
+
+const meta: Meta<typeof FullscreenToolList> = {
+  title: "Tools/Fullscreen/FullscreenToolList",
+  component: FullscreenToolList,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FullscreenToolList>;
+
+/** No search term: Quick Access above the full catalogue. */
+export const Default: Story = { render: () => <Harness /> };
+
+/** Descriptions turn each row into the taller detailed form. */
+export const WithDescriptions: Story = {
+  render: () => <Harness showDescriptions />,
+};
+
+/** Favourites join the recommended tools in the Quick Access block. */
+export const WithFavourites: Story = {
+  render: () => <Harness favoriteTools={["redact", "sign"]} />,
+};
+
+export const SelectedTool: Story = {
+  render: () => <Harness selectedToolKey="redact" />,
+};
+
+/** Searching drops Quick Access and flattens the results into match groups. */
+export const Searching: Story = {
+  render: () => (
+    <Harness
+      searchQuery="re"
+      filteredTools={ALL_TOOLS.filter(({ item }) =>
+        item[1].name.toLowerCase().includes("re"),
+      )}
+    />
+  ),
+};
+
+/** A search that matches nothing still renders its empty state. */
+export const NoMatches: Story = {
+  render: () => <Harness searchQuery="zzzz" filteredTools={[]} />,
+};

--- a/frontend/editor/src/core/components/tools/FullscreenToolList.tsx
+++ b/frontend/editor/src/core/components/tools/FullscreenToolList.tsx
@@ -255,19 +255,14 @@ const FullscreenToolList = ({
                 >
                   {getSubcategoryIcon(subcategoryId)}
                 </span>
-                <Text
-                  size="sm"
-                  fw={600}
-                  tt="uppercase"
-                  lts={0.5}
-                  style={{
-                    color: categoryColor,
-                  }}
-                >
+                {/* The icon and the section border already carry the category
+                    hue. These are decorative fills — restating one as text
+                    colour drops the label under 4.5:1 on the app surface. */}
+                <Text size="sm" fw={600} tt="uppercase" lts={0.5}>
                   {getSubcategoryLabel(t, subcategoryId)}
                 </Text>
               </div>
-              <Badge size="sm" variant="colored" color={categoryColor}>
+              <Badge size="sm" variant="default">
                 {tools.length}
               </Badge>
             </header>

--- a/frontend/editor/src/core/components/tools/fullscreen/CompactToolItem.stories.tsx
+++ b/frontend/editor/src/core/components/tools/fullscreen/CompactToolItem.stories.tsx
@@ -1,0 +1,125 @@
+/**
+ * A single row in the fullscreen tool list. What it shows beyond the name is
+ * decided elsewhere: the hotkey comes from HotkeyContext, the favourite star
+ * and availability from ToolWorkflowContext, and whether premium tools are
+ * offered at all from AppConfig.
+ *
+ * Mounting ToolWorkflowProvider would stand up the whole tool registry and its
+ * navigation chain, so the fixture supplies the three fields the row reads.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import CompactToolItem from "@app/components/tools/fullscreen/CompactToolItem";
+import type { ToolRegistryEntry } from "@app/data/toolsTaxonomy";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  ToolWorkflowContext,
+  type ToolWorkflowContextValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+
+const TOOL: ToolRegistryEntry = {
+  icon: <BuildRoundedIcon />,
+  name: "Rotate pages",
+  // A registry entry with no component and no link is treated as "coming
+  // soon" and renders disabled, which would make every story below identical.
+  component: () => null,
+  description: "Turn pages through 90, 180 or 270 degrees.",
+  categoryId: "organise" as never,
+  subcategoryId: "pageOperations" as never,
+  automationSettings: null,
+} as ToolRegistryEntry;
+
+/** Availability is keyed by tool id; anything absent counts as available. */
+function fixture({
+  isFavorite = false,
+  available = true,
+}: { isFavorite?: boolean; available?: boolean } = {}) {
+  return {
+    isFavorite: () => isFavorite,
+    toggleFavorite: () => {},
+    toolAvailability: available ? {} : { rotate: { available: false } },
+  } as unknown as ToolWorkflowContextValue;
+}
+
+function Harness({
+  tool = TOOL,
+  isSelected = false,
+  isFavorite = false,
+  available = true,
+  premiumEnabled = true,
+}: {
+  tool?: ToolRegistryEntry;
+  isSelected?: boolean;
+  isFavorite?: boolean;
+  available?: boolean;
+  premiumEnabled?: boolean;
+}) {
+  return (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      {/* The row shows a tool's hotkey when one is bound; none are here. */}
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <ToolWorkflowContext.Provider
+          value={fixture({ isFavorite, available })}
+        >
+          <div style={{ width: 320 }}>
+            <CompactToolItem
+              id="rotate"
+              tool={tool}
+              isSelected={isSelected}
+              onClick={() => {}}
+            />
+          </div>
+        </ToolWorkflowContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}
+
+const meta: Meta<typeof CompactToolItem> = {
+  title: "Tools/Fullscreen/CompactToolItem",
+  component: CompactToolItem,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof CompactToolItem>;
+
+export const Default: Story = { render: () => <Harness /> };
+
+export const Selected: Story = { render: () => <Harness isSelected /> };
+
+export const Favourited: Story = { render: () => <Harness isFavorite /> };
+
+/** Alpha tools carry a badge next to the name. */
+export const AlphaTool: Story = {
+  render: () => (
+    <Harness tool={{ ...TOOL, versionStatus: "alpha" } as ToolRegistryEntry} />
+  ),
+};
+
+/** A long name has to truncate rather than push the row wider. */
+export const LongName: Story = {
+  render: () => (
+    <Harness
+      tool={
+        {
+          ...TOOL,
+          name: "Convert scanned documents to searchable PDF with OCR",
+        } as ToolRegistryEntry
+      }
+    />
+  ),
+};
+
+/** Unavailable tools render disabled, which also hides the favourite star. */
+export const Unavailable: Story = {
+  render: () => <Harness available={false} />,
+};

--- a/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
+++ b/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
@@ -58,7 +58,7 @@ export interface CustomWorkbenchViewInstance extends CustomWorkbenchViewRegistra
   data: any;
 }
 
-interface ToolWorkflowContextValue extends ToolWorkflowState {
+export interface ToolWorkflowContextValue extends ToolWorkflowState {
   // Tool management (from hook)
   selectedToolKey: ToolId | null;
   selectedTool: ToolRegistryEntry | null;
@@ -116,7 +116,10 @@ const __GLOBAL_CONTEXT_KEY__ = "__ToolWorkflowContext__";
 const existingContext = (globalThis as any)[__GLOBAL_CONTEXT_KEY__] as
   | React.Context<ToolWorkflowContextValue | undefined>
   | undefined;
-const ToolWorkflowContext =
+// Exported so a test or story can mount a component against a slice of the
+// value. The provider itself stands up the whole tool registry and navigation
+// chain, which is far more than a component reading a few fields needs.
+export const ToolWorkflowContext =
   existingContext ??
   createContext<ToolWorkflowContextValue | undefined>(undefined);
 if (!existingContext) {


### PR DESCRIPTION
Stories for the fullscreen tool picker's list and its compact row. The list turned up the defect the whole campaign started from, still alive in a component nothing had ever rendered on its own.

### Decorative fills reused as text colour

Subcategory headings — *Signing*, *Extraction*, *Removal* — took their text colour straight from the category hue, and the count badge beside them did the same. Against the app surface:

| Colour | Contrast | Required |
|---|---|---|
| `#22c55e` green | **2.07:1** | 4.5:1 |
| `#f59e0b` amber | **1.95:1** | 4.5:1 |
| `#3b82f6` blue | **3.34:1** | 4.5:1 |
| `#ef4444` red | **3.42:1** | 4.5:1 |

These hues are designed as fills. The section icon and the group border already carry the category colour, so the coding survives intact once the label stops restating it.

### Not systemic — I checked

Every other use of these tokens in the picker is on an `aria-hidden` icon or a border. Those are decorative and answer to the 3:1 graphics threshold, not 4.5:1. These two components were the only places a category hue reached real text. Worth saying explicitly, because this class of bug sounds like it should be everywhere and here it isn't.

### Fixture rules found before writing

Two rules decide whether this list renders anything: tools group by `categoryId`, and Quick Access silently drops entries carrying neither a component nor a link. Reading those first meant the stories worked immediately — the compact row in this same PR had to be rebuilt after a `component: null` fixture quietly rendered every story as a disabled "coming soon" row, `Default` included.

### Slices, not providers

Both components reach `ToolWorkflowContext`, whose provider stands up the entire tool registry and navigation chain. The context is now exported so stories can supply just the fields each component reads.

### Verification

- 12 stories: **0 violations**, down from 5
- Story states confirmed distinct in a browser — row counts, disabled state, and the favourite control's accessible name
- Typecheck clean, `task pre-commit` green

### Full review

https://claude.ai/code/artifact/f9e63daf-4084-40ce-a64a-a7ab3cdbf59e