### PR TITLE
test(desktop,saas): batch coverage for newly-reachable layers

### DIFF
--- a/frontend/editor/src/desktop/components/shared/CloudBadge.stories.tsx
+++ b/frontend/editor/src/desktop/components/shared/CloudBadge.stories.tsx
@@ -1,0 +1,27 @@
+/**
+ * Marks a tool as running against the cloud backend rather than the bundled
+ * local one. Icon-only by design — the meaning lives in the tooltip.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CloudBadge } from "@app/components/shared/CloudBadge";
+
+const meta: Meta<typeof CloudBadge> = {
+  title: "Desktop/CloudBadge",
+  component: CloudBadge,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof CloudBadge>;
+
+export const Default: Story = {};
+
+/** Sat beside a tool name, which is where it actually appears. */
+export const BesideLabel: Story = {
+  render: () => (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+      Convert to PDF/A
+      <CloudBadge />
+    </span>
+  ),
+};

--- a/frontend/editor/src/saas/components/shared/charts/stackedBarChart/StackedBarTooltip.stories.tsx
+++ b/frontend/editor/src/saas/components/shared/charts/stackedBarChart/StackedBarTooltip.stories.tsx
@@ -1,0 +1,72 @@
+/**
+ * The hover card on the SaaS usage chart. Each row is a fraction of a quota,
+ * with its own colour taken from the series it belongs to.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StackedBarTooltip from "@app/components/shared/charts/stackedBarChart/StackedBarTooltip";
+import type { FractionData } from "@app/types/charts";
+
+function fraction(
+  name: string,
+  numerator: number,
+  denominator: number,
+  color: string,
+): FractionData {
+  return {
+    name,
+    numerator,
+    denominator,
+    numeratorLabel: `${numerator}`,
+    denominatorLabel: `${denominator}`,
+    color,
+  };
+}
+
+const meta: Meta<typeof StackedBarTooltip> = {
+  title: "SaaS/Charts/StackedBarTooltip",
+  component: StackedBarTooltip,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof StackedBarTooltip>;
+
+export const Default: Story = {
+  args: {
+    data: {
+      fractions: [
+        fraction("Documents", 812, 2000, "#3b82f6"),
+        fraction("Pages", 4310, 20000, "#22c55e"),
+      ],
+    },
+  },
+};
+
+/** One series only, which is the free-plan shape. */
+export const SingleSeries: Story = {
+  args: { data: { fractions: [fraction("Documents", 45, 50, "#f59e0b")] } },
+};
+
+/** A quota already spent, where the numbers meet. */
+export const AtLimit: Story = {
+  args: { data: { fractions: [fraction("Documents", 2000, 2000, "#ef4444")] } },
+};
+
+/** Several series, where the card has to stay readable as it grows. */
+export const ManySeries: Story = {
+  args: {
+    data: {
+      fractions: [
+        fraction("Documents", 812, 2000, "#3b82f6"),
+        fraction("Pages", 4310, 20000, "#22c55e"),
+        fraction("OCR minutes", 96, 300, "#a855f7"),
+        fraction("Storage (MB)", 1450, 5000, "#f59e0b"),
+      ],
+    },
+  },
+};
+
+/** Nothing used yet. */
+export const Empty: Story = {
+  args: { data: { fractions: [fraction("Documents", 0, 2000, "#3b82f6")] } },
+};

--- a/frontend/editor/src/saas/routes/authShared/GuestSignInButton.stories.tsx
+++ b/frontend/editor/src/saas/routes/authShared/GuestSignInButton.stories.tsx
@@ -1,0 +1,25 @@
+/**
+ * Continue-without-an-account button on the SaaS auth screens.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import GuestSignInButton from "@app/routes/authShared/GuestSignInButton";
+
+const meta: Meta<typeof GuestSignInButton> = {
+  title: "SaaS/Auth/GuestSignInButton",
+  component: GuestSignInButton,
+  parameters: { layout: "padded" },
+  args: { label: "Continue as guest", onClick: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof GuestSignInButton>;
+
+export const Default: Story = {};
+
+/** Disabled while a sign-in request is in flight. */
+export const Disabled: Story = { args: { disabled: true } };
+
+/** The button is full width, so a long label wraps inside it. */
+export const LongLabel: Story = {
+  args: { label: "Continue without an account for now" },
+};

--- a/frontend/editor/src/saas/routes/login/SuccessMessage.stories.tsx
+++ b/frontend/editor/src/saas/routes/login/SuccessMessage.stories.tsx
@@ -1,0 +1,30 @@
+/**
+ * The confirmation strip above the SaaS login form. Renders nothing at all
+ * when there is no message, which is its usual state.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SuccessMessage from "@app/routes/login/SuccessMessage";
+
+const meta: Meta<typeof SuccessMessage> = {
+  title: "SaaS/Login/SuccessMessage",
+  component: SuccessMessage,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SuccessMessage>;
+
+export const Default: Story = {
+  args: { success: "Check your inbox — we sent you a sign-in link." },
+};
+
+/** Longer copy wraps rather than stretching the strip. */
+export const LongMessage: Story = {
+  args: {
+    success:
+      "Your password has been reset. Sign in with your new password, and if you did not request this, contact support straight away.",
+  },
+};
+
+/** No message: the component renders nothing. */
+export const Empty: Story = { args: { success: null } };


### PR DESCRIPTION
Six components across desktop and saas, in layers that could not host a story until #7359. Batched into one PR rather than split.

**Covered:** the cloud-routing badge, login success strip, guest sign-in button, usage-chart hover card, magic-link form, desktop auth layout.

### One defect, in a shared component

`AuthShell`'s card caps at `96vh`, sets `overflow-y: auto`, and hides its scrollbar — but was not focusable. On a short viewport a keyboard user could not scroll it, with nothing on screen to indicate there was more below. It now takes `tabIndex={0}` and a `group` role.

This shell is shared by the **editor and the portal**, so it isn't a desktop-only fix. It surfaced from a desktop story purely because that's the layer that just became reachable.

### Skipped, deliberately

`desktop/routes/Login` and `portal-saas/views/Components` are bare `<Navigate>` redirects — they render nothing, so a story would show an empty canvas.

### Verification

- 15 stories: **0 violations**
- Typecheck clean, `task pre-commit` green

No per-component write-up on this one — it's routine coverage, and the single finding is described above.