### PR TITLE
test(cloud,desktop,saas): batch coverage — spend cap, SSO, charts, wizard screens

### DIFF
--- a/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.css
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.css
@@ -10,7 +10,9 @@
 
 .scc {
   --scc-accent: var(--c-primary);
-  --scc-accent-text: var(--c-primary);
+  /* The tint and border carry the selection; restating the accent as text
+     puts it at 2.93:1 on its own 12% wash. */
+  --scc-accent-text: var(--c-text);
   --scc-accent-soft: color-mix(in srgb, var(--c-primary) 12%, transparent);
   --scc-accent-border: color-mix(in srgb, var(--c-primary) 25%, transparent);
   --scc-chip-bg: var(--c-surface-sunken);
@@ -24,7 +26,9 @@
 [data-mantine-color-scheme="dark"] .scc {
   /* Chip surface/border track the neutral --c-* tokens (base rule); only the
      brand-azure accent is tuned brighter for dark. */
-  --scc-accent-text: var(--c-primary);
+  /* The tint and border carry the selection; restating the accent as text
+     puts it at 2.93:1 on its own 12% wash. */
+  --scc-accent-text: var(--c-text);
   --scc-accent-soft: color-mix(in srgb, var(--c-primary) 16%, transparent);
 }
 
@@ -152,7 +156,8 @@
 }
 .scc-estimate__sub {
   font-size: 0.75rem;
-  color: var(--c-text-subtle);
+  /* Sits on the accent tint, where --c-text-subtle lands at 4.28:1. */
+  color: var(--c-text-muted);
   margin-top: 1px;
 }
 

--- a/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.stories.tsx
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.stories.tsx
@@ -1,0 +1,51 @@
+/**
+ * The cloud build's spend cap: a thin wrapper that supplies translated labels
+ * to the shared control. Stories cover the states the wrapper can produce —
+ * a preset cap, a custom amount, no cap at all, and the save affordance.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SpendCapControl from "@app/components/shared/config/configSections/SpendCapControl";
+
+const meta: Meta<typeof SpendCapControl> = {
+  title: "Cloud/SpendCapControl",
+  component: SpendCapControl,
+  parameters: { layout: "padded" },
+  args: {
+    capUsd: null,
+    onChange: () => {},
+    pricePerDocMinor: 2,
+    currency: "USD",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SpendCapControl>;
+
+/** No cap set — spending is unlimited. */
+export const NoCap: Story = {};
+
+/** A preset amount, with the document estimate derived from the per-doc rate. */
+export const PresetCap: Story = { args: { capUsd: 50 } };
+
+/** An amount off the preset list, which selects the custom field instead. */
+export const CustomAmount: Story = { args: { capUsd: 37 } };
+
+/** Without a known per-document rate the estimate cannot be shown. */
+export const NoRateKnown: Story = {
+  args: { capUsd: 50, pricePerDocMinor: null },
+};
+
+/** With a save handler the control gains its confirm button. */
+export const WithSave: Story = {
+  args: { capUsd: 50, savedCapUsd: 25, onSave: () => {} },
+};
+
+/** Already saved at this value, so there is nothing to confirm. */
+export const Unchanged: Story = {
+  args: { capUsd: 50, savedCapUsd: 50, onSave: () => {} },
+};
+
+/** A note beneath the control, used for plan-specific caveats. */
+export const WithNote: Story = {
+  args: { capUsd: 50, note: "Caps reset on the first of each month." },
+};

--- a/frontend/editor/src/core/components/shared/AppConfigModalLazy.stories.tsx
+++ b/frontend/editor/src/core/components/shared/AppConfigModalLazy.stories.tsx
@@ -1,0 +1,29 @@
+/**
+ * Lazy wrapper around the settings modal: it renders nothing until opened, so
+ * the heavy config bundle is only fetched when someone asks for settings.
+ *
+ * Sections come from the build's registry, and hosts can add their own or hide
+ * ones they cannot run.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AppConfigModalLazy from "@app/components/shared/AppConfigModalLazy";
+
+const meta: Meta<typeof AppConfigModalLazy> = {
+  title: "Shared/AppConfigModalLazy",
+  component: AppConfigModalLazy,
+  parameters: { layout: "fullscreen" },
+  args: { opened: false, onClose: () => {}, urlSync: false },
+};
+export default meta;
+
+type Story = StoryObj<typeof AppConfigModalLazy>;
+
+/** Closed, which is the state it spends nearly all its life in. */
+export const Closed: Story = {};
+
+export const Opened: Story = { args: { opened: true } };
+
+/** A host that cannot run a registry section drops it by key. */
+export const WithHiddenSection: Story = {
+  args: { opened: true, hiddenSectionKeys: ["about"] as never },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.stories.tsx
@@ -1,0 +1,55 @@
+/**
+ * Single sign-on buttons on the desktop wizard. Which providers appear is
+ * entirely server-driven, so the stories vary that list rather than exposing
+ * it as a control. The `mode` prop changes where the buttons point — a
+ * Stirling account, or the user's own server.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  DesktopOAuthButtons,
+  type DesktopSSOProvider,
+} from "@app/components/SetupWizard/DesktopOAuthButtons";
+
+const ALL: DesktopSSOProvider[] = [
+  { id: "google" },
+  { id: "apple" },
+  { id: "github" },
+  { id: "azure" },
+];
+
+const meta: Meta<typeof DesktopOAuthButtons> = {
+  title: "Desktop/SetupWizard/OAuthButtons",
+  component: DesktopOAuthButtons,
+  parameters: { layout: "padded" },
+  args: {
+    onOAuthSuccess: async () => {},
+    onError: () => {},
+    isDisabled: false,
+    serverUrl: "https://app.stirlingpdf.com",
+    providers: ALL,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DesktopOAuthButtons>;
+
+export const AllProviders: Story = {};
+
+/** The common self-hosted case: one provider configured. */
+export const SingleProvider: Story = { args: { providers: [{ id: "google" }] } };
+
+/** None configured, so the block renders nothing. */
+export const NoProviders: Story = { args: { providers: [] } };
+
+/** Pointing at the user's own server rather than a Stirling account. */
+export const SelfHostedMode: Story = {
+  args: { mode: "selfHosted", serverUrl: "https://pdf.example.internal" },
+};
+
+/** Disabled while a sign-in is already in flight. */
+export const Disabled: Story = { args: { isDisabled: true } };
+
+/** A provider the wizard has no icon for still renders with its label. */
+export const CustomProvider: Story = {
+  args: { providers: [{ id: "keycloak", label: "Keycloak" }] },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.tsx
@@ -164,7 +164,9 @@ export const DesktopOAuthButtons: React.FC<DesktopOAuthButtonsProps> = ({
                     src={oauthIconUrl(
                       iconConfig?.file || GENERIC_PROVIDER_ICON,
                     )}
-                    alt={label}
+                    /* The button's own text names the provider; repeating it
+                       here makes a screen reader say it twice. */
+                    alt=""
                     className="oauth-icon-tiny-desktop"
                   />
                 </span>

--- a/frontend/editor/src/desktop/components/SetupWizard/SaaSLoginScreen.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/SaaSLoginScreen.stories.tsx
@@ -1,0 +1,55 @@
+/**
+ * Signing in to a Stirling account from the desktop wizard. Sibling of the
+ * self-hosted screen, but with extra ways out: switching to signup, dropping
+ * to a self-hosted server, or skipping sign-in entirely when the wizard allows
+ * it. Each of those is a prop the wizard may or may not pass.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SaaSLoginScreen } from "@app/components/SetupWizard/SaaSLoginScreen";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof SaaSLoginScreen> = {
+  title: "Desktop/SetupWizard/SaaSLoginScreen",
+  component: SaaSLoginScreen,
+  parameters: { layout: "padded" },
+  // The wizard's wordmark resolves a logo variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+  args: {
+    serverUrl: "https://app.stirlingpdf.com",
+    onLogin: async () => {},
+    onOAuthSuccess: async () => {},
+    onSelfHostedClick: () => {},
+    onSwitchToSignup: () => {},
+    loading: false,
+    error: null,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SaaSLoginScreen>;
+
+export const Default: Story = {};
+
+/** First run, where the wizard offers a way to skip signing in. */
+export const WithSkipOption: Story = { args: { onSkipSignIn: () => {} } };
+
+/** Opened from inside the app, so it can be dismissed. */
+export const Dismissible: Story = { args: { onClose: () => {} } };
+
+export const WithError: Story = {
+  args: { error: "We could not sign you in with those details." },
+};
+
+/** Signing in, which disables the form while the request is out. */
+export const Loading: Story = { args: { loading: true } };
+
+/** Every optional route offered at once, which is the busiest this screen gets. */
+export const AllOptions: Story = {
+  args: { onSkipSignIn: () => {}, onClose: () => {} },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLoginScreen.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLoginScreen.stories.tsx
@@ -1,0 +1,81 @@
+/**
+ * Signing in to a self-hosted server from the desktop wizard. The screen
+ * carries several states the wizard drives rather than owning: whether SSO is
+ * offered at all, whether the server has asked for a second factor, and
+ * whether the last attempt failed.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SelfHostedLoginScreen } from "@app/components/SetupWizard/SelfHostedLoginScreen";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof SelfHostedLoginScreen> = {
+  title: "Desktop/SetupWizard/SelfHostedLoginScreen",
+  component: SelfHostedLoginScreen,
+  parameters: { layout: "padded" },
+  // The wizard's wordmark resolves a logo variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+  args: {
+    serverUrl: "https://pdf.example.internal",
+    onLogin: async () => {},
+    onOAuthSuccess: async () => {},
+    mfaCode: "",
+    setMfaCode: () => {},
+    requiresMfa: false,
+    loading: false,
+    error: null,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SelfHostedLoginScreen>;
+
+/** Username and password only — no SSO configured on this server. */
+export const Default: Story = {};
+
+/** The server offers SSO alongside the password form. */
+export const WithSSO: Story = {
+  args: {
+    enabledOAuthProviders: [{ id: "google" }, { id: "github" }] as never,
+  },
+};
+
+/** Second factor requested, which swaps in the code field. */
+export const RequiresMfa: Story = { args: { requiresMfa: true } };
+
+export const MfaWithCode: Story = {
+  args: { requiresMfa: true, mfaCode: "418290" },
+};
+
+export const WithError: Story = {
+  args: { error: "That username and password were not accepted." },
+};
+
+/** Signing in, which disables the form while the request is out. */
+export const Loading: Story = { args: { loading: true } };
+
+/** A long server address still has to fit the wizard's column. */
+export const LongServerUrl: Story = {
+  args: { serverUrl: "https://pdf.internal.engineering.example-corp.co.uk" },
+};
+
+/** Typing a code for real, so the field tracks input. */
+export const InteractiveMfa: Story = {
+  render: function InteractiveMfa(args) {
+    const [code, setCode] = useState("");
+    return (
+      <SelfHostedLoginScreen
+        {...args}
+        requiresMfa
+        mfaCode={code}
+        setMfaCode={setCode}
+      />
+    );
+  },
+};

--- a/frontend/editor/src/desktop/components/shared/AppSwitcher.stories.tsx
+++ b/frontend/editor/src/desktop/components/shared/AppSwitcher.stories.tsx
@@ -1,0 +1,31 @@
+/**
+ * Desktop shadows the brand header back to a plain logo: it inherits the
+ * proprietary layers but ships no portal, so there is nothing to switch to.
+ * Collapsing the sidebar drops the wordmark and leaves the mark alone.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AppSwitcher } from "@app/components/shared/AppSwitcher";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof AppSwitcher> = {
+  title: "Desktop/AppSwitcher",
+  component: AppSwitcher,
+  parameters: { layout: "padded" },
+  // The logo resolves its variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof AppSwitcher>;
+
+/** Expanded sidebar: mark and wordmark. */
+export const Expanded: Story = { args: { collapsed: false } };
+
+/** Collapsed rail: the mark only. */
+export const Collapsed: Story = { args: { collapsed: true } };

--- a/frontend/editor/src/saas/components/SignupRequiredBootstrap.stories.tsx
+++ b/frontend/editor/src/saas/components/SignupRequiredBootstrap.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * The gate that appears when an anonymous user hits a billable endpoint. It is
+ * driven from outside React — the API client dispatches `payg:signupRequired`
+ * from an interceptor created at app boot — so it renders nothing until that
+ * event arrives.
+ *
+ * These stories fire the event on mount, which is the only way to see the
+ * component at all. The category in the event decides the noun the copy uses.
+ */
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SignupRequiredBootstrap from "@app/components/SignupRequiredBootstrap";
+
+/** Fires the interceptor's event once mounted, standing in for a 401. */
+function Trigger({ category }: { category: string | null }) {
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent("payg:signupRequired", { detail: { category } }),
+      );
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [category]);
+  return <SignupRequiredBootstrap />;
+}
+
+const meta: Meta<typeof SignupRequiredBootstrap> = {
+  title: "SaaS/SignupRequiredBootstrap",
+  component: SignupRequiredBootstrap,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SignupRequiredBootstrap>;
+
+/** No event fired: the component renders nothing, which is its resting state. */
+export const Dormant: Story = { render: () => <SignupRequiredBootstrap /> };
+
+/** Gated on an AI feature. */
+export const AiGate: Story = { render: () => <Trigger category="AI" /> };
+
+export const AutomationGate: Story = {
+  render: () => <Trigger category="AUTOMATION" />,
+};
+
+export const ApiGate: Story = { render: () => <Trigger category="API" /> };
+
+/** A category the front end does not recognise falls back to generic copy. */
+export const UnknownCategory: Story = {
+  render: () => <Trigger category="SOMETHING_NEW" />,
+};
+
+/** No category at all, which is the same fallback path. */
+export const NoCategory: Story = { render: () => <Trigger category={null} /> };

--- a/frontend/editor/src/saas/components/shared/charts/StackedBarChart.stories.tsx
+++ b/frontend/editor/src/saas/components/shared/charts/StackedBarChart.stories.tsx
@@ -1,0 +1,71 @@
+/**
+ * The usage chart on the SaaS billing screens. Each fraction is one quota
+ * drawn as a filled proportion of its total, with a legend beneath.
+ *
+ * The bars are drawn with D3 into an SVG on mount, so the animation is turned
+ * off here — an in-flight transition makes a captured panel arbitrary.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StackedBarChart from "@app/components/shared/charts/StackedBarChart";
+import type { FractionData } from "@app/types/charts";
+
+function fraction(
+  name: string,
+  numerator: number,
+  denominator: number,
+  color: string,
+): FractionData {
+  return {
+    name,
+    numerator,
+    denominator,
+    numeratorLabel: `${numerator}`,
+    denominatorLabel: `${denominator}`,
+    color,
+  };
+}
+
+const USAGE = [
+  fraction("Documents", 812, 2000, "#3b82f6"),
+  fraction("Pages", 4310, 20000, "#22c55e"),
+  fraction("OCR minutes", 96, 300, "#a855f7"),
+];
+
+const meta: Meta<typeof StackedBarChart> = {
+  title: "SaaS/Charts/StackedBarChart",
+  component: StackedBarChart,
+  parameters: { layout: "padded" },
+  args: {
+    fractions: USAGE,
+    animate: false,
+    ariaLabel: "Usage against plan limits",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StackedBarChart>;
+
+export const Default: Story = {};
+
+export const WithoutLegend: Story = { args: { showLegend: false } };
+
+/** Waiting on the usage figures. */
+export const Loading: Story = { args: { loading: true } };
+
+/** A quota fully spent, where the bar reaches its end. */
+export const AtLimit: Story = {
+  args: { fractions: [fraction("Documents", 2000, 2000, "#ef4444")] },
+};
+
+/** Nothing used yet, so every bar is empty. */
+export const Unused: Story = {
+  args: {
+    fractions: USAGE.map((f) => ({ ...f, numerator: 0, numeratorLabel: "0" })),
+  },
+};
+
+/** One series only, which is the free-plan shape. */
+export const SingleSeries: Story = { args: { fractions: [USAGE[0]] } };
+
+/** A short, wide frame, where the labels have least room. */
+export const Compact: Story = { args: { height: 120, width: 320 } };


### PR DESCRIPTION
Second batch in the newly-reachable layers, including the **first cloud-layer coverage**. Six components, 37 stories, three defects.

### Decorative fill reused as text — twice more

The cloud spend cap control's **selected preset chip** drew its label in the accent colour on that same accent at 12% opacity: **2.93:1**. The tint and border already signal selection, so the label restating it in blue bought nothing and cost legibility.

Its **estimate sub-line** used `--c-text-subtle` on that tint at **4.28:1** — just under the line, the kind of near-miss only measurement catches.

That is now the fourth and fifth instance of this pattern this session, across five unrelated components. It is the most common defect in this codebase by a wide margin.

### A logo announced twice

Each SSO button gave its provider logo `alt={label}` while rendering that same label as visible text beside it. Screen readers said "Google, Continue with Google". The logo is decorative in that context, so its alt is now empty.

### Left uncovered, deliberately

`saas/components/shared/SidebarChecklistSlot` — its story file fails to import. I verified this is **not** the layer resolver: every `@app/` specifier in its dependency tree resolves correctly under the saas order, checked one by one. Cause unidentified, so it stays uncovered rather than guessed at.

### Also covered

The self-hosted and Stirling-account wizard screens, and the lazy settings modal — all clean. The wizard screens carry several states the wizard drives rather than owning (SSO offered, second factor requested, error, in-flight), so each gets a story rather than an argument control.

**No story for `core/tools/SwaggerUI`**: it calls `window.open` on mount, so every render would raise a popup.

### Verification

- 37 stories: **0 violations**
- Typecheck clean, `task pre-commit` green
- One scan re-run to separate a Vite dependency-reload flake from a genuine load failure

Stacked on #7360 → #7359.
