### PR TITLE
Support non-root Docker containers using --user

### DIFF
--- a/scripts/init-without-ocr.sh
+++ b/scripts/init-without-ocr.sh
@@ -177,7 +177,7 @@ UNOSERVER_PIDS=()
 UNOSERVER_PORTS=()
 UNOSERVER_UNO_PORTS=()
 
-CURRENT_USER="$(id -un)"
+CURRENT_USER="$(id -un 2>/dev/null || id -u)"
 CURRENT_UID="$(id -u)"
 SWITCH_USER_WARNING_EMITTED=false
 
@@ -844,9 +844,9 @@ if id -u "$RUNTIME_USER" >/dev/null 2>&1; then
 else
   RUID="$(id -u)"
   RGRP="$(id -gn)"
-  RUNTIME_USER="$(id -un)"
+  RUNTIME_USER="$(id -un 2>/dev/null || id -u)"
 fi
-CURRENT_USER="$(id -un)"
+CURRENT_USER="$(id -un 2>/dev/null || id -u)"
 CURRENT_UID="$(id -u)"
 
 export XDG_RUNTIME_DIR="/tmp/xdg-${RUID}"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -94,7 +94,9 @@ log_warn "Using TESSDATA_PREFIX=$TESSDATA_PREFIX"
 # === Temp dir ===
 # Ensure the temporary directory exists and has proper permissions.
 mkdir -p /tmp/stirling-pdf
-chown -R stirlingpdfuser:stirlingpdfgroup /tmp/stirling-pdf || true
+if [ "$(id -u)" -eq 0 ]; then
+  chown -R stirlingpdfuser:stirlingpdfgroup /tmp/stirling-pdf || true
+fi
 chmod -R 755 /tmp/stirling-pdf || true
 
 # === Start application ===


### PR DESCRIPTION
**Summary**:
Allow Stirling-PDF Docker containers to run as arbitrary non-root users.
- Avoid running `chown` when the current user is not root.
- Fall back to the numeric UID when no username exists for the current user.

Resolves issue #1516 "_[Bug]: Running Stirling-PDF in docker with --user (rootless, unprivileged)_":
> the current way requiring PUID and PGID is not fitting those requirements, because it does not allow to run this container rootless.
> To run the container without root permissions, the following command should work:
> docker run -it --user 2000 frooodle/s-pdf:latest

---

**Description of Changes**:

`init.sh`:
- The initialization script assumes it has permission to run `chown`.
- `chown` exits with error `Operation not permitted`.
  - Only attempt ownership changes when running as root.
```bash
if [ "$(id -u)" -eq 0 ]; then
  chown -R stirlingpdfuser:stirlingpdfgroup /tmp/stirling-pdf || true
fi
```

`init-without-ocr.sh`:
- The initialization script assumes the current UID has an associated username.
- `id` exits with error `no such user`.
  - Fall back to the numeric UID.
```bash
$(id -un 2>/dev/null || id -u)
```

---

**Notes**:
When running as a non-root user, some paths inside the container image are no longer writable.
Writable paths must be provided through mounts (volumes, tmpfs, etc.).

`init-without-ocr.sh`:
- Diagnostic helper symlinks are created in a populated root-owned directory `/usr/local/bin`.
- `ln` exits with error `Permission denied`.
  - The user must provide writable bind mounts for these helper paths.

```yaml
volumes:
    - /mnt/apps/stirling-pdf/tessdata:/usr/share/tessdata   # Tesseract OCR language data files
    - /mnt/apps/stirling-pdf/configs:/configs               # Application configuration, settings.yml, database (H2), keys
    - /mnt/apps/stirling-pdf/logs:/logs                     # Application log files
    - /mnt/apps/stirling-pdf/pipeline:/pipeline             # Pipeline automation definitions/workflows
    - /mnt/apps/stirling-pdf/storage:/storage               # Persistent user file storage (when storage feature is enabled)
    - /mnt/apps/stirling-pdf/home:/home/stirlingpdfuser     # Persistent application user home directory (LibreOffice profile, caches, user files)
    - /mnt/apps/stirling-pdf/customFiles:/customFiles       # Custom files (branding assets, templates, custom static content)
    - /mnt/apps/stirling-pdf/bin/debug:/usr/local/bin/debug                                 # Required writable path for init (non-root)
    - /mnt/apps/stirling-pdf/bin/diag:/usr/local/bin/diag                                   # Required writable path for init (non-root)
    - /mnt/apps/stirling-pdf/bin/diagnostic:/usr/local/bin/diagnostic                       # Required writable path for init (non-root)
    - /mnt/apps/stirling-pdf/bin/diagnostics:/usr/local/bin/diagnostics                     # Required writable path for init (non-root)
    - /mnt/apps/stirling-pdf/bin/stirling-diagnostics:/usr/local/bin/stirling-diagnostics   # Required writable path for init (non-root)
tmpfs:
    - /tmp
```

---

**Testing**:

Tested on TrueNAS as a Custom App.

<details>
<summary>Docker Compose used for validation:</summary>

```docker-compose.yml
name: stirling-pdf

networks:
  lan-dhcp:
    external: true

services:
  stirling-pdf:
    user: '568:568'
    image: stirlingtools/stirling-pdf:latest-fat
    restart: unless-stopped

    environment:
      SERVER_PORT: 80                                                    # Set server port
      PUID: 568                                                          # Set user ID
      PGID: 568                                                          # Set group ID

    security_opt:
      - no-new-privileges:true

    networks:
      lan-dhcp:
        mac_address: '02:00:00:00:00:00'                                 # https://github.com/claymore666/docker-net-dhcp

    volumes:
      - /mnt/zpool/apps/stirling-pdf/tessdata:/usr/share/tessdata        # Tesseract OCR language data files
      - /mnt/zpool/apps/stirling-pdf/configs:/configs                    # Application configuration, settings.yml, database (H2), keys
      - /mnt/zpool/apps/stirling-pdf/logs:/logs                          # Application log files
      - /mnt/zpool/apps/stirling-pdf/pipeline:/pipeline                  # Pipeline automation definitions/workflows
      - /mnt/zpool/apps/stirling-pdf/storage:/storage                    # Persistent user file storage (when storage feature is enabled)
      - /mnt/zpool/apps/stirling-pdf/home:/home/stirlingpdfuser          # Persistent application user home directory (LibreOffice profile, caches, user files)
      - /mnt/zpool/apps/stirling-pdf/customFiles:/customFiles            # Custom files (branding assets, templates, custom static content)
      - /mnt/zpool/apps/stirling-pdf/bin/rar:/usr/local/bin/rar:ro       # Enable the PDF to CBR conversion feature
      - /mnt/DatumAbysm/apps/stirling-pdf/bin/debug:/usr/local/bin/debug                                 # Required writable path for init (non-root)
      - /mnt/DatumAbysm/apps/stirling-pdf/bin/diag:/usr/local/bin/diag                                   # Required writable path for init (non-root)
      - /mnt/DatumAbysm/apps/stirling-pdf/bin/diagnostic:/usr/local/bin/diagnostic                       # Required writable path for init (non-root)
      - /mnt/DatumAbysm/apps/stirling-pdf/bin/diagnostics:/usr/local/bin/diagnostics                     # Required writable path for init (non-root)
      - /mnt/DatumAbysm/apps/stirling-pdf/bin/stirling-diagnostics:/usr/local/bin/stirling-diagnostics   # Required writable path for init (non-root)

    tmpfs:
      - /tmp

    logging:
      driver: json-file
      options:
        max-file: 3
        max-size: 10m

    healthcheck:
      test:
        - CMD-SHELL
        - "curl -fs --max-time 10 http://localhost:$${SERVER_PORT:-8080}$${SYSTEM_ROOTURIPATH:-''}/api/v1/info/status || exit 1"
      interval: 30s
      timeout: 10s
      retries: 5
      start_period: 60s
```

</details>

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
