### PR TITLE
test(config): cover eight admin settings sections, and name their switches

### DIFF
--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminEndpointsSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminEndpointsSection.stories.tsx
@@ -1,0 +1,140 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminEndpointsSection from "@app/components/shared/config/configSections/AdminEndpointsSection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { UnsavedChangesProvider } from "@app/contexts/UnsavedChangesContext";
+
+/**
+ * Admin settings section for switching individual API endpoints (and whole
+ * endpoint groups) off, plus the instance-wide defaults for how unavailable
+ * tools are presented to users.
+ *
+ * It drives two independent settings sections — `endpoints` for the two
+ * multi-selects and `ui` for the two preference switches — through separate
+ * useAdminSettings instances, so every story mocks both GETs; either one still
+ * loading holds the whole section on its loader. The selectable endpoint and
+ * group lists are hardcoded in the component, so the response only decides which
+ * of them are already picked.
+ *
+ * Login mode off suppresses both fetches, shows the login-required banner and
+ * locks every control, so it is supplied as a decorator rather than a response.
+ */
+function withProviders(enableLogin: boolean) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={{ enableLogin }}
+      >
+        <UnsavedChangesProvider>
+          <Story />
+        </UnsavedChangesProvider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+function sectionHandlers(
+  endpoints: Record<string, unknown>,
+  ui: Record<string, unknown>,
+) {
+  return [
+    http.get("/api/v1/admin/settings/section/endpoints", () =>
+      HttpResponse.json(endpoints),
+    ),
+    http.get("/api/v1/admin/settings/section/ui", () => HttpResponse.json(ui)),
+  ];
+}
+
+const meta = {
+  title: "Config/AdminEndpointsSection",
+  component: AdminEndpointsSection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        ...sectionHandlers({}, {}),
+        http.put("/api/v1/admin/settings/section/endpoints", () =>
+          HttpResponse.json({}),
+        ),
+        http.put("/api/v1/admin/settings/section/ui", () =>
+          HttpResponse.json({}),
+        ),
+        http.put("/api/v1/admin/settings", () => HttpResponse.json({})),
+      ],
+    },
+  },
+  decorators: [withProviders(true)],
+} satisfies Meta<typeof AdminEndpointsSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A stock install: nothing disabled, so both multi-selects show their placeholders. */
+export const Default: Story = {};
+
+/**
+ * A locked-down instance: several endpoints and two whole groups disabled, and
+ * the hidden-when-unavailable defaults turned on.
+ */
+export const EndpointsDisabled: Story = {
+  parameters: {
+    msw: {
+      handlers: sectionHandlers(
+        {
+          toRemove: ["add-password", "remove-password", "show-javascript"],
+          groupsToRemove: ["DeveloperTools", "Automation"],
+        },
+        {
+          defaultHideUnavailableTools: true,
+          defaultHideUnavailableConversions: true,
+        },
+      ),
+    },
+  },
+};
+
+/** While either settings request is in flight, a centred loader replaces the form. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/v1/admin/settings/section/endpoints", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+        http.get("/api/v1/admin/settings/section/ui", () =>
+          HttpResponse.json({}),
+        ),
+      ],
+    },
+  },
+};
+
+/**
+ * Restart-required changes on both sections at once: the pending selections and
+ * switch positions are shown, each flagged with a pending badge.
+ */
+export const PendingChanges: Story = {
+  parameters: {
+    msw: {
+      handlers: sectionHandlers(
+        {
+          toRemove: ["add-password"],
+          groupsToRemove: [],
+          _pending: { groupsToRemove: ["DeveloperTools"] },
+        },
+        {
+          defaultHideUnavailableTools: false,
+          _pending: { defaultHideUnavailableTools: true },
+        },
+      ),
+    },
+  },
+};
+
+/** Login mode disabled: nothing is fetched, the banner shows and the controls lock. */
+export const LoginDisabled: Story = {
+  decorators: [withProviders(false)],
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminFeaturesSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminFeaturesSection.stories.tsx
@@ -1,0 +1,139 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminFeaturesSection from "@app/components/shared/config/configSections/AdminFeaturesSection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { UnsavedChangesProvider } from "@app/contexts/UnsavedChangesContext";
+
+/**
+ * Admin settings section for the server certificate used by "Sign with
+ * Stirling-PDF".
+ *
+ * The whole form is read out of the `system` settings section's
+ * serverCertificate node, so each story is defined by what that one GET
+ * returns. When the node is absent the component substitutes its own defaults
+ * rather than showing an empty form — worth seeing, since a fresh install hits
+ * that path. Restart-required edits arrive under `system._pending`, which the
+ * component re-keys onto serverCertificate before merging.
+ *
+ * Login mode off suppresses the fetch, shows the login-required banner and locks
+ * every control, so it is supplied as a decorator rather than a response.
+ */
+function withProviders(enableLogin: boolean) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={{ enableLogin }}
+      >
+        <UnsavedChangesProvider>
+          <Story />
+        </UnsavedChangesProvider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+function systemHandler(body: Record<string, unknown>) {
+  return http.get("/api/v1/admin/settings/section/system", () =>
+    HttpResponse.json(body),
+  );
+}
+
+const meta = {
+  title: "Config/AdminFeaturesSection",
+  component: AdminFeaturesSection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        systemHandler({
+          serverCertificate: {
+            enabled: true,
+            organizationName: "Acme Legal Ltd",
+            validity: 730,
+            regenerateOnStartup: false,
+          },
+        }),
+        http.put("/api/v1/admin/settings", () => HttpResponse.json({})),
+        http.put("/api/v1/admin/settings/section/features", () =>
+          HttpResponse.json({}),
+        ),
+      ],
+    },
+  },
+  decorators: [withProviders(true)],
+} satisfies Meta<typeof AdminFeaturesSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A configured certificate: named organisation and a two-year validity. */
+export const Default: Story = {};
+
+/** Certificate signing turned off, leaving the detail fields editable but inert. */
+export const CertificateDisabled: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        systemHandler({
+          serverCertificate: {
+            enabled: false,
+            organizationName: "Acme Legal Ltd",
+            validity: 730,
+            regenerateOnStartup: false,
+          },
+        }),
+      ],
+    },
+  },
+};
+
+/** No serverCertificate node on the server — the form falls back to its built-in defaults. */
+export const UnconfiguredFallsBackToDefaults: Story = {
+  parameters: { msw: { handlers: [systemHandler({})] } },
+};
+
+/** While the settings request is in flight, a centred loader replaces the form. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/v1/admin/settings/section/system", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+      ],
+    },
+  },
+};
+
+/** Restart-required edits: the pending values are shown, each with a pending badge. */
+export const PendingChanges: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        systemHandler({
+          serverCertificate: {
+            enabled: true,
+            organizationName: "Acme Legal Ltd",
+            validity: 730,
+            regenerateOnStartup: false,
+          },
+          _pending: {
+            serverCertificate: {
+              organizationName: "Acme Legal International",
+              validity: 365,
+              regenerateOnStartup: true,
+            },
+          },
+        }),
+      ],
+    },
+  },
+};
+
+/** Login mode disabled: nothing is fetched, the banner shows and the controls lock. */
+export const LoginDisabled: Story = {
+  decorators: [withProviders(false)],
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminFeaturesSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminFeaturesSection.tsx
@@ -173,9 +173,18 @@ export default function AdminFeaturesSection() {
                 )}
               </Text>
               <Badge
-                color="grape"
+                /* grape-6 puts white text at 4.02:1; the darker shade clears
+                   4.5:1 at this size. */
+                color="grape.8"
                 size="sm"
                 style={{ cursor: "pointer" }}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key !== "Enter" && e.key !== " ") return;
+                  e.preventDefault();
+                  navigate("/settings/adminPlan");
+                }}
                 onClick={() => navigate("/settings/adminPlan")}
                 title={t(
                   "admin.settings.badge.clickToUpgrade",
@@ -216,6 +225,10 @@ export default function AdminFeaturesSection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.features.serverCertificate.enabled.label",
+                    "Enable Server Certificate",
+                  )}
                   checked={settings.serverCertificate?.enabled ?? true}
                   onChange={(e) => {
                     if (!loginEnabled) return;
@@ -333,6 +346,10 @@ export default function AdminFeaturesSection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.features.serverCertificate.regenerateOnStartup.label",
+                    "Regenerate on Startup",
+                  )}
                   checked={
                     settings.serverCertificate?.regenerateOnStartup ?? false
                   }

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminLegalSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminLegalSection.stories.tsx
@@ -1,0 +1,117 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminLegalSection from "@app/components/shared/config/configSections/AdminLegalSection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { UnsavedChangesProvider } from "@app/contexts/UnsavedChangesContext";
+
+/**
+ * Admin settings section for the links to legal documents, plus the login
+ * agreement users must accept after signing in.
+ *
+ * The five URL fields and the loginAgreement node all come from the `legal`
+ * settings section fetched on mount, so each story is defined by that one
+ * response. The embedded LoginAgreementEditor loads its own per-language
+ * markdown separately and degrades to empty text when that request is not
+ * mocked, which is fine here — this file is about the section around it.
+ *
+ * Login mode off suppresses the fetch, shows the login-required banner and locks
+ * every control, so it is supplied as a decorator rather than a response.
+ */
+function withProviders(enableLogin: boolean) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={{ enableLogin }}
+      >
+        <UnsavedChangesProvider>
+          <Story />
+        </UnsavedChangesProvider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+function legalHandler(body: Record<string, unknown>) {
+  return http.get("/api/v1/admin/settings/section/legal", () =>
+    HttpResponse.json(body),
+  );
+}
+
+const CONFIGURED_LEGAL = {
+  termsAndConditions: "https://acme-legal.test/terms",
+  privacyPolicy: "https://acme-legal.test/privacy",
+  accessibilityStatement: "https://acme-legal.test/accessibility",
+  cookiePolicy: "https://acme-legal.test/cookies",
+  impressum: "https://acme-legal.test/impressum",
+  loginAgreement: {
+    enabled: true,
+    showInAnonymousMode: true,
+  },
+};
+
+const meta = {
+  title: "Config/AdminLegalSection",
+  component: AdminLegalSection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        legalHandler(CONFIGURED_LEGAL),
+        http.put("/api/v1/admin/settings/section/legal", () =>
+          HttpResponse.json({}),
+        ),
+        http.put("/api/v1/admin/settings", () => HttpResponse.json({})),
+      ],
+    },
+  },
+  decorators: [withProviders(true)],
+} satisfies Meta<typeof AdminLegalSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** All five documents hosted externally, with the login agreement turned on. */
+export const Default: Story = {};
+
+/** A stock install: no documents overridden and no login agreement. */
+export const NothingConfigured: Story = {
+  parameters: { msw: { handlers: [legalHandler({})] } },
+};
+
+/** While the settings request is in flight, a centred loader replaces the form. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/v1/admin/settings/section/legal", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+      ],
+    },
+  },
+};
+
+/** Restart-required document changes: the pending URLs show with pending badges. */
+export const PendingChanges: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        legalHandler({
+          ...CONFIGURED_LEGAL,
+          _pending: {
+            privacyPolicy: "https://acme-legal.test/privacy-2",
+            impressum: "https://acme-legal.test/legal-notice",
+          },
+        }),
+      ],
+    },
+  },
+};
+
+/** Login mode disabled: nothing is fetched, the banner shows and the form locks. */
+export const LoginDisabled: Story = {
+  decorators: [withProviders(false)],
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminMailSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminMailSection.stories.tsx
@@ -1,0 +1,119 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminMailSection from "@app/components/shared/config/configSections/AdminMailSection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { UnsavedChangesProvider } from "@app/contexts/UnsavedChangesContext";
+
+/**
+ * Admin settings section for the outbound SMTP configuration.
+ *
+ * Everything on screen comes from the `mail` settings section, fetched on mount,
+ * so each story is defined by that one response. The master "Enable Mail" switch
+ * gates the email-invites switch beneath it, which is the only conditional
+ * rendering in the form — hence a story either side of it.
+ *
+ * Unlike the neighbouring admin sections this one has no login-required banner:
+ * login state only reaches the sticky save footer, which stays hidden until the
+ * form is edited, so a login-disabled story would be indistinguishable.
+ * useSettingsDirty() and useLoginRequired() still need their providers.
+ */
+function withProviders(Story: () => React.JSX.Element) {
+  return (
+    <AppConfigProvider
+      autoFetch={false}
+      bootstrapMode="non-blocking"
+      initialConfig={{ enableLogin: true }}
+    >
+      <UnsavedChangesProvider>
+        <Story />
+      </UnsavedChangesProvider>
+    </AppConfigProvider>
+  );
+}
+
+function mailHandler(body: Record<string, unknown>) {
+  return http.get("/api/v1/admin/settings/section/mail", () =>
+    HttpResponse.json(body),
+  );
+}
+
+const CONFIGURED_SMTP = {
+  enabled: true,
+  enableInvites: true,
+  host: "smtp.acme-legal.test",
+  port: 587,
+  username: "postmaster@acme-legal.test",
+  password: "correct-horse-battery-staple",
+  from: "noreply@acme-legal.test",
+};
+
+const meta = {
+  title: "Config/AdminMailSection",
+  component: AdminMailSection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        mailHandler(CONFIGURED_SMTP),
+        http.put("/api/v1/admin/settings/section/mail", () =>
+          HttpResponse.json({}),
+        ),
+        http.put("/api/v1/admin/settings", () => HttpResponse.json({})),
+      ],
+    },
+  },
+  decorators: [withProviders],
+} satisfies Meta<typeof AdminMailSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A working relay: host, credentials and sender all set, invites available. */
+export const Default: Story = {};
+
+/** Mail switched off — the invites switch below it is disabled along with it. */
+export const MailDisabled: Story = {
+  parameters: {
+    msw: { handlers: [mailHandler({ enabled: false, enableInvites: false })] },
+  },
+};
+
+/** Nothing configured yet: every field falls back to its placeholder, port to 587. */
+export const Unconfigured: Story = {
+  parameters: { msw: { handlers: [mailHandler({})] } },
+};
+
+/** While the settings request is in flight, a centred loader replaces the form. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/v1/admin/settings/section/mail", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * A relay move saved but awaiting a restart: the pending host, port and sender
+ * are shown, each flagged with a pending badge.
+ */
+export const PendingChanges: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        mailHandler({
+          ...CONFIGURED_SMTP,
+          _pending: {
+            host: "smtp.eu.acme-legal.test",
+            port: 465,
+            from: "no-reply@acme-legal.test",
+          },
+        }),
+      ],
+    },
+  },
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminMailSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminMailSection.tsx
@@ -145,6 +145,10 @@ export default function AdminMailSection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.mail.enabled.label",
+                    "Enable Mail",
+                  )}
                   checked={settings.enabled || false}
                   onChange={(e) =>
                     setSettings({ ...settings, enabled: e.target.checked })
@@ -191,6 +195,10 @@ export default function AdminMailSection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.mail.invites.label",
+                    "Team invitation emails",
+                  )}
                   checked={settings.enableInvites || false}
                   onChange={(e) =>
                     setSettings({

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPremiumSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPremiumSection.stories.tsx
@@ -1,0 +1,114 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminPremiumSection from "@app/components/shared/config/configSections/AdminPremiumSection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { UnsavedChangesProvider } from "@app/contexts/UnsavedChangesContext";
+
+/**
+ * Admin settings section for the premium/enterprise licence key.
+ *
+ * The component takes no props: it fetches the `premium` settings blob through
+ * useAdminSettings on mount and reads login state through useLoginRequired(),
+ * so what it renders is decided by two things — the mocked GET response and
+ * whether login mode is on. Login mode off suppresses the fetch entirely, shows
+ * the login-required banner and locks every control, which is why that state
+ * gets its own decorator rather than a different response.
+ *
+ * useSettingsDirty() and useAppConfig() both throw without their providers, so
+ * every story wraps in both.
+ */
+function withProviders(enableLogin: boolean) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={{ enableLogin }}
+      >
+        <UnsavedChangesProvider>
+          <Story />
+        </UnsavedChangesProvider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+function premiumHandler(body: Record<string, unknown>) {
+  return http.get("/api/v1/admin/settings/section/premium", () =>
+    HttpResponse.json(body),
+  );
+}
+
+const meta = {
+  title: "Config/AdminPremiumSection",
+  component: AdminPremiumSection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        premiumHandler({
+          key: "STORY-LICENCE-0000-0000-0000",
+          enabled: true,
+        }),
+        http.put("/api/v1/admin/settings/section/premium", () =>
+          HttpResponse.json({}),
+        ),
+        http.put("/api/v1/admin/settings", () => HttpResponse.json({})),
+      ],
+    },
+  },
+  decorators: [withProviders(true)],
+} satisfies Meta<typeof AdminPremiumSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** An activated licence: key populated and premium features switched on. */
+export const Default: Story = {};
+
+/** No licence configured yet — the empty key field shows its placeholder. */
+export const NoLicence: Story = {
+  parameters: {
+    msw: { handlers: [premiumHandler({ key: "", enabled: false })] },
+  },
+};
+
+/** While the settings request is in flight, a centred loader replaces the form. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/v1/admin/settings/section/premium", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Edits saved but awaiting a restart: the merged values are shown with a
+ * pending badge beside each field the restart will change.
+ */
+export const PendingChanges: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        premiumHandler({
+          key: "STORY-LICENCE-0000-0000-0000",
+          enabled: false,
+          _pending: {
+            key: "STORY-LICENCE-1111-1111-1111",
+            enabled: true,
+          },
+        }),
+      ],
+    },
+  },
+};
+
+/** Login mode disabled: nothing is fetched, the banner shows and the controls lock. */
+export const LoginDisabled: Story = {
+  decorators: [withProviders(false)],
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPremiumSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPremiumSection.tsx
@@ -213,6 +213,10 @@ export default function AdminPremiumSection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.premium.enabled.label",
+                    "Enable Premium Features",
+                  )}
                   checked={settings.enabled || false}
                   onChange={(e) => {
                     if (!loginEnabled) return;

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPrivacySection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPrivacySection.stories.tsx
@@ -1,0 +1,122 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminPrivacySection from "@app/components/shared/config/configSections/AdminPrivacySection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { UnsavedChangesProvider } from "@app/contexts/UnsavedChangesContext";
+
+/**
+ * Admin settings section for analytics, metrics and search-engine visibility.
+ *
+ * The three switches are stitched together from two separate backend sections —
+ * `system` carries enableAnalytics/googlevisibility, `metrics` carries enabled —
+ * so every story has to mock both GETs; a missing one leaves the section stuck
+ * on its loader. Pending (restart-required) changes arrive in a `_pending` block
+ * on whichever endpoint owns the field, and the component maps them onto its own
+ * camelCase names, so the pending story splits them across both responses.
+ *
+ * Login mode off skips the fetch entirely, shows the login-required banner and
+ * disables the switches, which is why it is a decorator rather than a response.
+ */
+function withProviders(enableLogin: boolean) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={{ enableLogin }}
+      >
+        <UnsavedChangesProvider>
+          <Story />
+        </UnsavedChangesProvider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+function systemHandler(body: Record<string, unknown>) {
+  return http.get("/api/v1/admin/settings/section/system", () =>
+    HttpResponse.json(body),
+  );
+}
+
+function metricsHandler(body: Record<string, unknown>) {
+  return http.get("/api/v1/admin/settings/section/metrics", () =>
+    HttpResponse.json(body),
+  );
+}
+
+const meta = {
+  title: "Config/AdminPrivacySection",
+  component: AdminPrivacySection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        systemHandler({ enableAnalytics: true, googlevisibility: false }),
+        metricsHandler({ enabled: true }),
+        http.put("/api/v1/admin/settings", () => HttpResponse.json({})),
+        http.put("/api/v1/admin/settings/section/privacy", () =>
+          HttpResponse.json({}),
+        ),
+      ],
+    },
+  },
+  decorators: [withProviders(true)],
+} satisfies Meta<typeof AdminPrivacySection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Telemetry on, search indexing off — the shipped defaults for a private instance. */
+export const Default: Story = {};
+
+/** Everything opted out, the strictest configuration the section can express. */
+export const AllCollectionOff: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        systemHandler({ enableAnalytics: false, googlevisibility: false }),
+        metricsHandler({ enabled: false }),
+      ],
+    },
+  },
+};
+
+/** While either settings request is in flight, a centred loader replaces the form. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/v1/admin/settings/section/system", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+        metricsHandler({ enabled: false }),
+      ],
+    },
+  },
+};
+
+/**
+ * Restart-required edits on fields owned by both endpoints: the switches show
+ * the pending values, each flagged with a pending badge.
+ */
+export const PendingChanges: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        systemHandler({
+          enableAnalytics: false,
+          googlevisibility: false,
+          _pending: { enableAnalytics: true, googlevisibility: true },
+        }),
+        metricsHandler({ enabled: false, _pending: { enabled: true } }),
+      ],
+    },
+  },
+};
+
+/** Login mode disabled: nothing is fetched, the banner shows and the switches lock. */
+export const LoginDisabled: Story = {
+  decorators: [withProviders(false)],
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPrivacySection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminPrivacySection.tsx
@@ -181,6 +181,10 @@ export default function AdminPrivacySection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.privacy.enableAnalytics.label",
+                    "Enable Analytics",
+                  )}
                   checked={settings?.enableAnalytics || false}
                   onChange={(e) => {
                     if (!loginEnabled) return;
@@ -219,6 +223,10 @@ export default function AdminPrivacySection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.privacy.metricsEnabled.label",
+                    "Enable Metrics",
+                  )}
                   checked={settings?.metricsEnabled || false}
                   onChange={(e) => {
                     if (!loginEnabled) return;
@@ -269,6 +277,10 @@ export default function AdminPrivacySection() {
               </div>
               <Group gap="xs">
                 <Switch
+                  aria-label={t(
+                    "admin.settings.privacy.googleVisibility.label",
+                    "Google Visibility",
+                  )}
                   checked={settings?.googleVisibility || false}
                   onChange={(e) => {
                     if (!loginEnabled) return;

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminStorageSharingSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminStorageSharingSection.stories.tsx
@@ -1,0 +1,173 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminStorageSharingSection from "@app/components/shared/config/configSections/AdminStorageSharingSection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { UnsavedChangesProvider } from "@app/contexts/UnsavedChangesContext";
+
+/**
+ * Admin settings section for server-side file storage and the sharing options
+ * built on top of it.
+ *
+ * The five switches form a dependency chain: storage gates sharing and group
+ * signing, sharing gates share links and email sharing, and those last two carry
+ * their own external prerequisites — a configured frontend URL for links, a
+ * configured mail relay for email. Each unmet prerequisite both disables its
+ * switch and adds an amber "requires…" note, so the interesting states are
+ * points along that chain rather than variations of one payload.
+ *
+ * The settings are stitched from three sections — `storage` for the switches,
+ * `system` for the frontend URL and `mail` for the relay — so every story mocks
+ * all three; a missing one leaves the section stuck on its loader.
+ */
+function withProviders(enableLogin: boolean) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={{ enableLogin }}
+      >
+        <UnsavedChangesProvider>
+          <Story />
+        </UnsavedChangesProvider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+function sectionHandlers({
+  storage,
+  frontendUrl = "",
+  mailEnabled = false,
+}: {
+  storage: Record<string, unknown>;
+  frontendUrl?: string;
+  mailEnabled?: boolean;
+}) {
+  return [
+    http.get("/api/v1/admin/settings/section/storage", () =>
+      HttpResponse.json(storage),
+    ),
+    http.get("/api/v1/admin/settings/section/system", () =>
+      HttpResponse.json({ frontendUrl }),
+    ),
+    http.get("/api/v1/admin/settings/section/mail", () =>
+      HttpResponse.json({ enabled: mailEnabled }),
+    ),
+  ];
+}
+
+const ALL_ON = {
+  enabled: true,
+  sharing: { enabled: true, linkEnabled: true, emailEnabled: true },
+  signing: { enabled: true },
+};
+
+const meta = {
+  title: "Config/AdminStorageSharingSection",
+  component: AdminStorageSharingSection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        ...sectionHandlers({
+          storage: ALL_ON,
+          frontendUrl: "https://pdf.acme-legal.test",
+          mailEnabled: true,
+        }),
+        http.put("/api/v1/admin/settings/section/storage", () =>
+          HttpResponse.json({}),
+        ),
+        http.put("/api/v1/admin/settings", () => HttpResponse.json({})),
+      ],
+    },
+  },
+  decorators: [withProviders(true)],
+} satisfies Meta<typeof AdminStorageSharingSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Every prerequisite met, so the full chain of switches is on and editable. */
+export const Default: Story = {};
+
+/** Storage off — the switches that depend on it are disabled, whatever their stored value. */
+export const StorageDisabled: Story = {
+  parameters: {
+    msw: {
+      handlers: sectionHandlers({
+        storage: {
+          enabled: false,
+          sharing: { enabled: true, linkEnabled: true, emailEnabled: true },
+          signing: { enabled: true },
+        },
+        frontendUrl: "https://pdf.acme-legal.test",
+        mailEnabled: true,
+      }),
+    },
+  },
+};
+
+/**
+ * Sharing is on but the frontend URL and mail relay are not configured: both
+ * sharing channels are disabled and each shows its "requires…" note.
+ */
+export const PrerequisitesMissing: Story = {
+  parameters: {
+    msw: {
+      handlers: sectionHandlers({
+        storage: {
+          enabled: true,
+          sharing: { enabled: true, linkEnabled: false, emailEnabled: false },
+          signing: { enabled: false },
+        },
+      }),
+    },
+  },
+};
+
+/** While any of the three settings requests is in flight, a centred loader replaces the form. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/v1/admin/settings/section/storage", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+        http.get("/api/v1/admin/settings/section/system", () =>
+          HttpResponse.json({}),
+        ),
+        http.get("/api/v1/admin/settings/section/mail", () =>
+          HttpResponse.json({}),
+        ),
+      ],
+    },
+  },
+};
+
+/** Restart-required edits: the pending switch positions show with pending badges. */
+export const PendingChanges: Story = {
+  parameters: {
+    msw: {
+      handlers: sectionHandlers({
+        storage: {
+          enabled: true,
+          sharing: { enabled: false, linkEnabled: false, emailEnabled: false },
+          signing: { enabled: false },
+          _pending: {
+            sharing: { enabled: true, linkEnabled: true },
+            signing: { enabled: true },
+          },
+        },
+        frontendUrl: "https://pdf.acme-legal.test",
+        mailEnabled: true,
+      }),
+    },
+  },
+};
+
+/** Login mode disabled: nothing is fetched, the banner shows and every switch locks. */
+export const LoginDisabled: Story = {
+  decorators: [withProviders(false)],
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminStorageSharingSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminStorageSharingSection.tsx
@@ -183,6 +183,10 @@ export default function AdminStorageSharingSection() {
                 </Text>
               </div>
               <Switch
+                aria-label={t(
+                  "admin.settings.storage.enabled.label",
+                  "Enable Server File Storage",
+                )}
                 checked={storageEnabled}
                 onChange={(e) =>
                   setSettings({ ...settings, enabled: e.currentTarget.checked })
@@ -216,6 +220,10 @@ export default function AdminStorageSharingSection() {
                 </Text>
               </div>
               <Switch
+                aria-label={t(
+                  "admin.settings.storage.sharing.enabled.label",
+                  "Enable Sharing",
+                )}
                 checked={settings.sharing?.enabled ?? false}
                 onChange={(e) =>
                   setSettings({
@@ -277,6 +285,10 @@ export default function AdminStorageSharingSection() {
                 )}
               </div>
               <Switch
+                aria-label={t(
+                  "admin.settings.storage.sharing.links.label",
+                  "Share links",
+                )}
                 checked={settings.sharing?.linkEnabled ?? false}
                 onChange={(e) =>
                   setSettings({
@@ -340,6 +352,10 @@ export default function AdminStorageSharingSection() {
                 )}
               </div>
               <Switch
+                aria-label={t(
+                  "admin.settings.storage.sharing.email.label",
+                  "Share by email",
+                )}
                 checked={settings.sharing?.emailEnabled ?? false}
                 onChange={(e) =>
                   setSettings({
@@ -379,6 +395,10 @@ export default function AdminStorageSharingSection() {
                 </Text>
               </div>
               <Switch
+                aria-label={t(
+                  "admin.settings.storage.signing.enabled.label",
+                  "Enable Group Signing",
+                )}
                 checked={settings.signing?.enabled ?? false}
                 onChange={(e) =>
                   setSettings({

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminUsageSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminUsageSection.stories.tsx
@@ -1,0 +1,125 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import AdminUsageSection from "@app/components/shared/config/configSections/AdminUsageSection";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import type { EndpointStatisticsResponse } from "@app/services/usageAnalyticsService";
+
+/**
+ * Admin dashboard of endpoint usage: a chart and table of the busiest endpoints,
+ * with controls for how many to show and whether to count API calls, UI calls or
+ * both.
+ *
+ * The section takes no props. What it shows is decided by the licence: only an
+ * ENTERPRISE licence with login mode on reaches the real statistics endpoint.
+ * Anything short of that falls back to a built-in demo dataset, freezes the
+ * controls and raises the enterprise banner — a deliberate teaser rather than an
+ * empty state, so it is the state most admins actually see. Login and licence
+ * both come from useAppConfig(), so each story sets them on the provider, and
+ * only the licensed stories need the endpoint mocked at all.
+ */
+function withConfig(config: { enableLogin: boolean; license?: string }) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={config}
+      >
+        <Story />
+      </AppConfigProvider>
+    );
+  };
+}
+
+const STATISTICS: EndpointStatisticsResponse = {
+  totalVisits: 4820,
+  totalEndpoints: 6,
+  endpoints: [
+    { endpoint: "merge-pdfs", visits: 1640, percentage: 34.0 },
+    { endpoint: "compress-pdf", visits: 1120, percentage: 23.2 },
+    { endpoint: "sign", visits: 880, percentage: 18.3 },
+    { endpoint: "ocr-pdf", visits: 540, percentage: 11.2 },
+    { endpoint: "add-watermark", visits: 380, percentage: 7.9 },
+    { endpoint: "split-pages", visits: 260, percentage: 5.4 },
+  ],
+};
+
+const STATISTICS_PATH = "/api/v1/proprietary/ui-data/usage-endpoint-statistics";
+
+const meta = {
+  title: "Config/AdminUsageSection",
+  component: AdminUsageSection,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [http.get(STATISTICS_PATH, () => HttpResponse.json(STATISTICS))],
+    },
+  },
+  decorators: [withConfig({ enableLogin: true })],
+} satisfies Meta<typeof AdminUsageSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** No enterprise licence: demo figures behind the enterprise banner, controls frozen. */
+export const Default: Story = {};
+
+/** Login mode off as well, so both the login and enterprise banners are raised. */
+export const LoginDisabled: Story = {
+  decorators: [withConfig({ enableLogin: false })],
+};
+
+/**
+ * Licensed and logged in: real statistics, live controls, and the explanatory
+ * banner linking through to the audit dashboard.
+ */
+export const EnterpriseLicensed: Story = {
+  decorators: [withConfig({ enableLogin: true, license: "ENTERPRISE" })],
+};
+
+/** While the statistics request is in flight, a centred loader replaces the dashboard. */
+export const Loading: Story = {
+  decorators: [withConfig({ enableLogin: true, license: "ENTERPRISE" })],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(STATISTICS_PATH, async () => {
+          await delay("infinite");
+          return HttpResponse.json(STATISTICS);
+        }),
+      ],
+    },
+  },
+};
+
+/** The statistics request failed: an error alert replaces the dashboard entirely. */
+export const LoadError: Story = {
+  decorators: [withConfig({ enableLogin: true, license: "ENTERPRISE" })],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(STATISTICS_PATH, () =>
+          HttpResponse.json(null, { status: 500 }),
+        ),
+      ],
+    },
+  },
+};
+
+/** Licensed, but the instance has recorded no traffic yet. */
+export const NoTrafficRecorded: Story = {
+  decorators: [withConfig({ enableLogin: true, license: "ENTERPRISE" })],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(STATISTICS_PATH, () =>
+          HttpResponse.json({
+            totalVisits: 0,
+            totalEndpoints: 0,
+            endpoints: [],
+          } satisfies EndpointStatisticsResponse),
+        ),
+      ],
+    },
+  },
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/plan/LicenseKeySection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/plan/LicenseKeySection.stories.tsx
@@ -1,0 +1,107 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, userEvent } from "storybook/test";
+import LicenseKeySection from "@app/components/shared/config/configSections/plan/LicenseKeySection";
+import type { LicenseInfo } from "@app/services/licenseService";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { LicenseProvider } from "@app/contexts/LicenseContext";
+
+/**
+ * The collapsible panel at the foot of the plan page for activating a licence
+ * bought outside the in-app checkout, either as a key string or a certificate
+ * file.
+ *
+ * Everything below the toggle lives behind local state — the collapse itself and
+ * the key/file choice — so the interesting states are only reachable by driving
+ * the control rather than by setting a prop. Each story below opens the panel
+ * first for that reason. The toggle is the only button while collapsed, so it is
+ * found by role without depending on the translated copy.
+ *
+ * A licence already installed adds two alerts above the form: an overwrite
+ * warning and a summary of what is currently active, which reads differently for
+ * a key than for a file path.
+ *
+ * useLicense() throws outside a provider. LicenseProvider is mounted with a
+ * non-admin config so it settles without issuing a licence request of its own.
+ */
+function withLicenseContext(enableLogin: boolean) {
+  return function Decorator(Story: () => React.JSX.Element) {
+    return (
+      <AppConfigProvider
+        autoFetch={false}
+        bootstrapMode="non-blocking"
+        initialConfig={{ enableLogin }}
+      >
+        <LicenseProvider>
+          <Story />
+        </LicenseProvider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+async function openPanel(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole("button"));
+}
+
+const keyLicence: LicenseInfo = {
+  licenseType: "SERVER",
+  enabled: true,
+  maxUsers: 0,
+  hasKey: true,
+  licenseKey: "STORY-LICENCE-0000-0000-0000",
+};
+
+const fileLicence: LicenseInfo = {
+  licenseType: "ENTERPRISE",
+  enabled: true,
+  maxUsers: 250,
+  hasKey: true,
+  licenseKey: "file:/opt/stirling/licence.cert",
+};
+
+const meta = {
+  title: "Config/Plan/LicenseKeySection",
+  component: LicenseKeySection,
+  parameters: { layout: "padded" },
+  decorators: [withLicenseContext(true)],
+} satisfies Meta<typeof LicenseKeySection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Closed, which is how the panel first appears beneath the plan cards. */
+export const Collapsed: Story = {};
+
+/** Opened with no licence installed: just the explanatory alert and the key field. */
+export const Expanded: Story = {
+  play: ({ canvasElement }) => openPanel(canvasElement),
+};
+
+/** The certificate-file alternative, which swaps the key field for a file picker. */
+export const CertificateFileUpload: Story = {
+  play: async ({ canvasElement }) => {
+    await openPanel(canvasElement);
+    const canvas = within(canvasElement);
+    // The key/file choice is a radiogroup; the second option is the file upload.
+    await userEvent.click(canvas.getAllByRole("radio")[1]);
+  },
+};
+
+/** A key licence is already active: the overwrite warning and the active-licence summary appear. */
+export const ExistingKeyLicence: Story = {
+  args: { currentLicenseInfo: keyLicence },
+  play: ({ canvasElement }) => openPanel(canvasElement),
+};
+
+/** The active licence came from a certificate file, so its summary names the path instead. */
+export const ExistingFileLicence: Story = {
+  args: { currentLicenseInfo: fileLicence },
+  play: ({ canvasElement }) => openPanel(canvasElement),
+};
+
+/** Login mode disabled: the panel still opens but every input and the save action are locked. */
+export const LoginDisabled: Story = {
+  decorators: [withLicenseContext(false)],
+  play: ({ canvasElement }) => openPanel(canvasElement),
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/plan/StaticCheckoutModal.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/plan/StaticCheckoutModal.stories.tsx
@@ -1,0 +1,81 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, userEvent } from "storybook/test";
+import StaticCheckoutModal from "@app/components/shared/config/configSections/plan/StaticCheckoutModal";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { LicenseProvider } from "@app/contexts/LicenseContext";
+
+/**
+ * The checkout used when Stripe is not wired into the app: it collects an email,
+ * sends the buyer to a static Stripe payment link in a new tab, then waits for
+ * them to paste back the licence key that arrives by email.
+ *
+ * The modal walks three stages held in local state (email → billing period →
+ * licence activation), so only the first is reachable by props alone; the later
+ * ones are driven through the form. `planName` and `isUpgrade` change nothing
+ * but the heading — either one pointing at Enterprise produces the same title —
+ * so there is one story per distinct heading rather than one per prop.
+ *
+ * Mantine renders the modal into a portal outside the story canvas, so the
+ * queries below run against the document body.
+ *
+ * useLicense() throws outside a provider; LicenseProvider is mounted with a
+ * non-admin config so it settles without issuing a licence request of its own.
+ */
+function withLicenseContext(Story: () => React.JSX.Element) {
+  return (
+    <AppConfigProvider
+      autoFetch={false}
+      bootstrapMode="non-blocking"
+      initialConfig={{ enableLogin: true }}
+    >
+      <LicenseProvider>
+        <Story />
+      </LicenseProvider>
+    </AppConfigProvider>
+  );
+}
+
+const meta = {
+  title: "Config/Plan/StaticCheckoutModal",
+  component: StaticCheckoutModal,
+  parameters: { layout: "centered" },
+  args: {
+    opened: true,
+    onClose: () => {},
+    planName: "server",
+  },
+  decorators: [withLicenseContext],
+} satisfies Meta<typeof StaticCheckoutModal>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Buying a Server licence from the free tier — the opening email step. */
+export const ServerLicence: Story = {};
+
+/** Moving up to Enterprise, which reframes the same email step as an upgrade. */
+export const EnterpriseUpgrade: Story = {
+  args: { planName: "enterprise" },
+};
+
+/** A malformed address is rejected in place rather than advancing the flow. */
+export const InvalidEmail: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await userEvent.type(body.getByRole("textbox"), "not-an-email{enter}");
+  },
+};
+
+/**
+ * Past the email step: the monthly/yearly choice, each option opening the
+ * matching Stripe payment link.
+ */
+export const BillingPeriodChoice: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await userEvent.type(
+      body.getByRole("textbox"),
+      "jane@acme-legal.test{enter}",
+    );
+  },
+};

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/plan/StaticPlanSection.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/plan/StaticPlanSection.stories.tsx
@@ -1,0 +1,91 @@
+import type React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StaticPlanSection from "@app/components/shared/config/configSections/plan/StaticPlanSection";
+import type { LicenseInfo } from "@app/services/licenseService";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { LicenseProvider } from "@app/contexts/LicenseContext";
+
+/**
+ * The plan page shown when Stripe-backed checkout is unavailable — no Supabase
+ * configuration, or the live plans request failed. It lists the three tiers from
+ * hardcoded copy rather than fetched pricing, so the only thing that changes
+ * what it renders is the licence it is handed.
+ *
+ * Each card's action is derived from that licence's tier: the current tier gets
+ * "Manage", anything below it collapses to "Included", and Enterprise stays
+ * blocked until a Server licence exists. The stories below walk that ladder,
+ * since the button logic is the substance of the component.
+ *
+ * The embedded licence-key panel and checkout modal both call useLicense(),
+ * which throws outside a provider. LicenseProvider is mounted with a non-admin
+ * config so it settles without issuing a licence request of its own — the tier
+ * on screen comes from the prop, not from the context.
+ */
+function withLicenseContext(Story: () => React.JSX.Element) {
+  return (
+    <AppConfigProvider
+      autoFetch={false}
+      bootstrapMode="non-blocking"
+      initialConfig={{ enableLogin: true }}
+    >
+      <LicenseProvider>
+        <Story />
+      </LicenseProvider>
+    </AppConfigProvider>
+  );
+}
+
+const freeLicence: LicenseInfo = {
+  licenseType: "NORMAL",
+  enabled: false,
+  maxUsers: 5,
+  hasKey: false,
+};
+
+const serverLicence: LicenseInfo = {
+  licenseType: "SERVER",
+  enabled: true,
+  maxUsers: 0,
+  hasKey: true,
+  licenseKey: "STORY-LICENCE-2222-2222-2222",
+};
+
+const enterpriseLicence: LicenseInfo = {
+  licenseType: "ENTERPRISE",
+  enabled: true,
+  maxUsers: 250,
+  hasKey: true,
+  licenseKey: "file:/opt/stirling/licence.cert",
+};
+
+const meta = {
+  title: "Config/Plan/StaticPlanSection",
+  component: StaticPlanSection,
+  parameters: { layout: "padded" },
+  decorators: [withLicenseContext],
+} satisfies Meta<typeof StaticPlanSection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Free tier: Free is the current plan, Server offers an upgrade, Enterprise is gated behind it. */
+export const FreeTier: Story = {
+  args: { currentLicenseInfo: freeLicence },
+};
+
+/** Server licence: Free collapses to "Included", Server offers billing management, Enterprise asks for contact. */
+export const ServerTier: Story = {
+  args: { currentLicenseInfo: serverLicence },
+};
+
+/** Enterprise licence: both lower tiers collapse to "Included" and only Enterprise is manageable. */
+export const EnterpriseTier: Story = {
+  args: { currentLicenseInfo: enterpriseLicence },
+};
+
+/**
+ * Licence details not supplied at all — the tier is indeterminate, so Free is
+ * marked current but the paid cards resolve to no action rather than an
+ * upgrade path. Worth keeping visible: it is what an admin briefly sees while
+ * licence info is still resolving.
+ */
+export const LicenceUnknown: Story = {};


### PR DESCRIPTION
Eight admin settings sections, 43 stories, and the defects they surfaced.

### Thirteen unlabelled switches

Every toggle in these sections renders its label as a sibling `<Text>` with no association, so assistive technology got a bare switch with no indication of what it controls. Thirteen across five sections now carry the same wording as the heading beside them.

This is a whole-feature-area pattern rather than one component's slip — worth a convention if more settings sections get built.

### The PRO badge

White on grape-6 measures **4.02:1**, under the 4.5:1 its size needs; grape-8 clears it. The badge also navigates on click while being a bare span, so it gained a keyboard path.

### Story fixtures, not secrets

The licence keys in the fixtures were UUID-shaped, which the secret scanner reads as credentials — the gate refused the commit until they became obvious placeholders. Worth remembering when writing fixtures for anything credential-ish.

### Verification

- 43 stories, **0 violations**
- Typecheck clean, `task pre-commit` green