### PR TITLE
test(auth): login screens, route guards, and four cross-cutting a11y fixes

### DIFF
--- a/frontend/editor/src/core/components/fileEditor/AddFileCard.stories.tsx
+++ b/frontend/editor/src/core/components/fileEditor/AddFileCard.stories.tsx
@@ -1,0 +1,42 @@
+/**
+ * The trailing card in the file editor's grid that invites the user to add more
+ * files. Clicking the card (or its "Add Files" button) opens the files modal;
+ * the smaller button beside it goes straight to the native file picker.
+ *
+ * The two buttons share one slot: hovering the upload button expands it to fill
+ * the row and hides "Add Files". That is internal state, so it is not a story.
+ * `accept` and `multiple` only reach the hidden input and change nothing on
+ * screen, which leaves a single rendered state.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddFileCard from "@app/components/fileEditor/AddFileCard";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+
+const meta = {
+  title: "FileEditor/AddFileCard",
+  component: AddFileCard,
+  parameters: { layout: "centered" },
+  args: { onFileSelect: () => {} },
+  decorators: [
+    (Story) => (
+      // Only openFilesModal is read. The real provider reaches FileContext and
+      // NavigationContext, so a slice is supplied instead.
+      <FilesModalContext.Provider
+        value={{ openFilesModal: () => {} } as unknown as FilesModalContextType}
+      >
+        {/* The card fills the cell the file editor's grid gives it. */}
+        <div style={{ width: "16rem", height: "20rem" }}>
+          <Story />
+        </div>
+      </FilesModalContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof AddFileCard>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/editor/src/core/components/fileEditor/AddFileCard.tsx
+++ b/frontend/editor/src/core/components/fileEditor/AddFileCard.tsx
@@ -70,16 +70,10 @@ const AddFileCard = ({
 
       <div
         className={`${styles.addFileCard} select-none flex flex-col transition-all relative cursor-pointer`}
-        tabIndex={0}
-        role="button"
-        aria-label={t("fileEditor.addFiles", "Add files")}
+        /* The card holds its own Add-files and upload buttons, so making the
+           card a button as well nests one control inside another. The click is
+           a mouse convenience; the buttons carry the keyboard path. */
         onClick={handleCardClick}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            handleCardClick();
-          }
-        }}
       >
         {/* Main content area */}
         <div className={styles.addFileContent}>

--- a/frontend/editor/src/core/components/fileManager/DesktopLayout.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/DesktopLayout.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * The three-column arrangement of the file manager modal on a wide viewport:
+ * sources on the left, the search/actions/list stack in the middle, and the
+ * selected file's details on the right.
+ *
+ * The layout takes no props — everything comes from the provider. The search
+ * bar and action bar above the list are tied to the Recent source, and the
+ * list's scroll height is computed from the modal height and whether any files
+ * exist, so the populated and empty cases are laid out differently.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import DesktopLayout from "@app/components/fileManager/DesktopLayout";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const FILES = [
+  makeStub("file-1", "quarterly-report.pdf"),
+  makeStub("file-2", "invoice-2026-01.pdf"),
+  makeStub("file-3", "scan-of-contract.pdf", { size: 18_400_000 }),
+];
+
+const meta = {
+  title: "FileManager/DesktopLayout",
+  component: DesktopLayout,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "600px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DesktopLayout>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Files present and one of them selected, so the details column is filled in. */
+export const Default: Story = {
+  decorators: [
+    withFileManager({ recentFiles: FILES, activeFileIds: [FILES[0].id] }),
+  ],
+};
+
+/** First run: the middle column is the empty state and the details are blank. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};
+
+/** With storage on, the middle column gains the filter and bulk cloud actions. */
+export const StorageEnabled: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id],
+      config: { storageEnabled: true, storageSharingEnabled: true },
+    }),
+  ],
+};

--- a/frontend/editor/src/core/components/fileManager/FileActions.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileActions.stories.tsx
@@ -1,0 +1,112 @@
+/**
+ * The action bar above the recent-files list: select-all, an optional storage
+ * filter, the selection count, and the bulk delete/download/upload/share
+ * buttons.
+ *
+ * What appears is decided by the storage config and by the current selection.
+ * The upload button needs storage on; the share button additionally needs
+ * sharing and share links on, which also widen the filter from All/Local to
+ * include the two "shared" tabs. The delete and download buttons are always
+ * present but disabled until something is selected, and the whole bar renders
+ * nothing at all while there are no recent files.
+ *
+ * Selection is provider state seeded from `activeFileIds`, so the stories vary
+ * that rather than a prop.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileActions from "@app/components/fileManager/FileActions";
+import type { FileId } from "@app/types/file";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const FILES = [
+  makeStub("file-1", "quarterly-report.pdf"),
+  makeStub("file-2", "invoice-2026-01.pdf"),
+  makeStub("file-3", "scan.pdf"),
+];
+
+const meta = {
+  title: "FileManager/FileActions",
+  component: FileActions,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof FileActions>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Local-only build, nothing selected: bulk actions present but inert. */
+export const Default: Story = {
+  decorators: [withFileManager({ recentFiles: FILES })],
+};
+
+/** With a selection the count appears and delete/download become live. */
+export const WithSelection: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id, FILES[1].id],
+    }),
+  ],
+};
+
+/** Storage on adds the All/Local filter and the bulk upload button. */
+export const StorageEnabled: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id],
+      config: { storageEnabled: true },
+    }),
+  ],
+};
+
+/**
+ * Sharing and share links on add the share button and the two "shared" filter
+ * tabs.
+ */
+export const SharingEnabled: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id],
+      config: {
+        storageEnabled: true,
+        storageSharingEnabled: true,
+        storageShareLinksEnabled: true,
+      },
+    }),
+  ],
+};
+
+/**
+ * A selection that includes a file owned by someone else: bulk upload and share
+ * stay disabled because they only apply to files the user owns.
+ */
+export const SelectionIncludesSharedFile: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: [
+        FILES[0],
+        makeStub("file-shared", "budget-from-alex.pdf", {
+          remoteStorageId: 42,
+          remoteOwnedByCurrentUser: false,
+          remoteOwnerUsername: "alex",
+          remoteAccessRole: "viewer",
+        }),
+      ],
+      activeFileIds: [FILES[0].id, "file-shared" as FileId],
+      config: {
+        storageEnabled: true,
+        storageSharingEnabled: true,
+        storageShareLinksEnabled: true,
+      },
+    }),
+  ],
+};
+
+/** With no recent files the bar renders nothing. */
+export const NoFiles: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};

--- a/frontend/editor/src/core/components/fileManager/FileInfoCard.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileInfoCard.stories.tsx
@@ -1,0 +1,123 @@
+/**
+ * The details card on the right of the file manager: name, format, size, date
+ * and version, followed by whatever the file's storage situation warrants.
+ *
+ * The trailing rows are all conditional and are driven by the stub's remote
+ * fields rather than by props. A file with no `remoteStorageId` is local only;
+ * one the user owns on the server shows a sync state that turns to "changes not
+ * uploaded" once its local timestamp is newer than the remote one; one owned by
+ * somebody else shows the owner and offers a copy. Sharing rows additionally
+ * need the storage/sharing config on, and a tool chain appears only when the
+ * file carries history.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileInfoCard from "@app/components/fileManager/FileInfoCard";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const MODIFIED = Date.UTC(2026, 0, 14);
+
+/** The default local-only build. */
+const local = withFileManager();
+
+/** Storage plus sharing, for the stories about server-side state. */
+const cloud = withFileManager({
+  config: {
+    storageEnabled: true,
+    storageSharingEnabled: true,
+    storageShareLinksEnabled: true,
+  },
+});
+
+const meta = {
+  title: "FileManager/FileInfoCard",
+  component: FileInfoCard,
+  args: { modalHeight: "600px" },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "22rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FileInfoCard>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A file that has never left the browser: the "Local only" badge, nothing else. */
+export const LocalOnly: Story = {
+  args: { currentFile: makeStub("file-1", "quarterly-report.pdf") },
+  decorators: [local],
+};
+
+/** No file selected — the labels stay, their values are blank. */
+export const NoFileSelected: Story = {
+  args: { currentFile: null },
+  decorators: [local],
+};
+
+/** A file that has been through tools carries its chain as badges. */
+export const WithToolHistory: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      versionNumber: 3,
+      toolHistory: [
+        { toolId: "split", timestamp: MODIFIED },
+        { toolId: "compress", timestamp: MODIFIED },
+      ],
+    }),
+  },
+  decorators: [local],
+};
+
+/** Uploaded and current: the cloud row reads "Synced" and shows the sync time. */
+export const SyncedToCloud: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Edited since the last upload, so the cloud row warns instead. */
+export const ChangesNotUploaded: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      lastModified: MODIFIED + 3_600_000,
+      createdAt: MODIFIED + 3_600_000,
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Someone else's file: owner row, "Shared with you" badge, and a copy action. */
+export const SharedWithYou: Story = {
+  args: {
+    currentFile: makeStub("file-1", "budget-from-alex.pdf", {
+      remoteStorageId: 11,
+      remoteOwnedByCurrentUser: false,
+      remoteOwnerUsername: "alex",
+      remoteAccessRole: "viewer",
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** The user's own file with links out: a sharing row and the management entry. */
+export const SharedByYou: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+      remoteHasShareLinks: true,
+    }),
+  },
+  decorators: [cloud],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
@@ -1,0 +1,55 @@
+/**
+ * The scrolling body of the file manager. It renders one row per leaf file,
+ * with each row's version history collapsed underneath it.
+ *
+ * Three states, all decided by provider data rather than props: files present,
+ * no files while still reading them out of storage (a "loading files" line), and
+ * no files once that has finished (the full empty state with its upload
+ * prompt). Selecting a source other than Recent replaces the list wholesale
+ * with the Google Drive placeholder, but that source is chosen inside the
+ * provider and so is not reachable from a story.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileListArea from "@app/components/fileManager/FileListArea";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const MODIFIED = Date.UTC(2026, 0, 14);
+
+const FILES = [
+  makeStub("file-1", "quarterly-report.pdf", {
+    versionNumber: 3,
+    toolHistory: [{ toolId: "compress", timestamp: MODIFIED }],
+  }),
+  makeStub("file-2", "invoice-2026-01.pdf"),
+  makeStub("file-3", "scan-of-contract.pdf", { size: 18_400_000 }),
+];
+
+const meta = {
+  title: "FileManager/FileListArea",
+  component: FileListArea,
+  parameters: { layout: "fullscreen" },
+  args: { scrollAreaHeight: "22rem" },
+} satisfies Meta<typeof FileListArea>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A populated list, with the second file marked active in the workbench. */
+export const Default: Story = {
+  decorators: [
+    withFileManager({ recentFiles: FILES, activeFileIds: [FILES[1].id] }),
+  ],
+};
+
+/** Nothing stored yet: the empty state takes over the whole area. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};
+
+/** Still reading from storage — a holding line rather than the empty state. */
+export const Loading: Story = {
+  decorators: [withFileManager({ recentFiles: [], isLoading: true })],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListItem.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListItem.stories.tsx
@@ -1,0 +1,142 @@
+/**
+ * A single row in the file manager's recent list: checkbox, name, a run of
+ * status badges, size/date, and a hover-revealed overflow menu.
+ *
+ * The badges are the interesting part. Version always shows; "Active" comes
+ * from the prop; and the storage badge is one of a mutually exclusive set
+ * decided by the stub's remote fields — local only, synced, changes not
+ * uploaded, or a shared-with-you pair of ownership and role — most of which
+ * additionally require the storage/sharing config to be on. `isHistoryFile`
+ * turns the row into an indented, non-selectable version entry instead.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileListItem from "@app/components/fileManager/FileListItem";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const MODIFIED = Date.UTC(2026, 0, 14);
+const FILE = makeStub("file-1", "quarterly-report.pdf");
+
+/** The default local-only build. */
+const local = withFileManager({ recentFiles: [FILE] });
+
+/** Storage plus sharing, for the stories about server-side state. */
+const cloud = withFileManager({
+  recentFiles: [FILE],
+  config: {
+    storageEnabled: true,
+    storageSharingEnabled: true,
+    storageShareLinksEnabled: true,
+  },
+});
+
+const meta = {
+  title: "FileManager/FileListItem",
+  component: FileListItem,
+  parameters: { layout: "fullscreen" },
+  args: {
+    file: FILE,
+    isSelected: false,
+    isLatestVersion: true,
+    onSelect: () => {},
+    onRemove: () => {},
+    onDownload: () => {},
+    onDoubleClick: () => {},
+  },
+} satisfies Meta<typeof FileListItem>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A freshly uploaded file that has never been to the server. */
+export const Default: Story = { decorators: [local] };
+
+/** Selected: the checkbox is ticked and the row takes the highlight fill. */
+export const Selected: Story = {
+  args: { isSelected: true },
+  decorators: [local],
+};
+
+/** A file currently open in the workbench earns the "Active" badge. */
+export const Active: Story = {
+  args: { isActive: true },
+  decorators: [local],
+};
+
+/** A processed file: a higher version number and the tool chain that produced it. */
+export const Processed: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      versionNumber: 3,
+      toolHistory: [
+        { toolId: "split", timestamp: MODIFIED },
+        { toolId: "compress", timestamp: MODIFIED },
+      ],
+    }),
+  },
+  decorators: [local],
+};
+
+/**
+ * An older version listed under its leaf: indented behind a rule, with no
+ * checkbox because history entries cannot be selected.
+ */
+export const HistoryEntry: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", { versionNumber: 2 }),
+    isHistoryFile: true,
+    isLatestVersion: false,
+  },
+  decorators: [local],
+};
+
+/** Uploaded and current: "Synced" replaces the local-only badge. */
+export const Synced: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Edited since the last upload, so the badge warns instead. */
+export const ChangesNotUploaded: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      lastModified: MODIFIED + 3_600_000,
+      createdAt: MODIFIED + 3_600_000,
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Someone else's file: ownership and the read-only role are both called out. */
+export const SharedWithYou: Story = {
+  args: {
+    file: makeStub("file-1", "budget-from-alex.pdf", {
+      remoteStorageId: 11,
+      remoteOwnedByCurrentUser: false,
+      remoteOwnerUsername: "alex",
+      remoteAccessRole: "viewer",
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** The user's own file with a live link out. */
+export const SharedByYou: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+      remoteHasShareLinks: true,
+    }),
+  },
+  decorators: [cloud],
+};

--- a/frontend/editor/src/core/components/fileManager/FileSourceButtons.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileSourceButtons.stories.tsx
@@ -1,0 +1,74 @@
+/**
+ * The source picker down the left of the file manager: Recent, local upload,
+ * Google Drive and mobile scan.
+ *
+ * Recent and upload are always offered. The other two are each governed by a
+ * pair of config flags — one that enables the integration and one that decides
+ * whether an unavailable integration is shown greyed out or dropped from the
+ * list entirely. `horizontal` reflows the same buttons into a centred row for
+ * the mobile layout and shortens their labels ("Drive", "Mobile").
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileSourceButtons from "@app/components/fileManager/FileSourceButtons";
+import { withFileManager } from "@app/components/fileManager/storyFixtures";
+
+/** The column the buttons occupy in the desktop layout. */
+const withColumn = (Story: () => ReactElement) => (
+  <div style={{ width: "13.625rem", height: "20rem" }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: "FileManager/FileSourceButtons",
+  component: FileSourceButtons,
+  decorators: [withColumn],
+} satisfies Meta<typeof FileSourceButtons>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The plain build: Recent is the active source, and Drive and mobile scan are
+ * both present but disabled because neither is configured.
+ */
+export const Default: Story = {
+  decorators: [withFileManager()],
+};
+
+/** Hiding the unavailable integrations leaves only Recent and upload. */
+export const UnavailableSourcesHidden: Story = {
+  decorators: [
+    withFileManager({
+      config: {
+        hideDisabledToolsGoogleDrive: true,
+        hideDisabledToolsMobileQRScanner: true,
+      },
+    }),
+  ],
+};
+
+/**
+ * Fully configured: Drive takes its coloured icon and both integrations become
+ * clickable. Drive needs the client/API/app ids as well as its enable flag.
+ */
+export const AllSourcesAvailable: Story = {
+  decorators: [
+    withFileManager({
+      config: {
+        googleDriveEnabled: true,
+        googleDriveClientId: "storybook-client-id",
+        googleDriveApiKey: "storybook-api-key",
+        googleDriveAppId: "storybook-app-id",
+        enableMobileScanner: true,
+      },
+    }),
+  ],
+};
+
+/** The mobile layout's row: centred, no heading, and abbreviated labels. */
+export const Horizontal: Story = {
+  args: { horizontal: true },
+  decorators: [withFileManager()],
+};

--- a/frontend/editor/src/core/components/fileManager/MobileLayout.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/MobileLayout.stories.tsx
@@ -1,0 +1,55 @@
+/**
+ * The stacked arrangement of the file manager modal on a narrow viewport: the
+ * sources as a horizontal row, the compact file details, then the search bar,
+ * action bar and list sharing one panel.
+ *
+ * As with the desktop layout there are no props — the provider supplies
+ * everything. The search and action bars belong to the Recent source, and the
+ * list's height is worked back from the modal height, allowing extra room for
+ * the details block once a file is selected.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import MobileLayout from "@app/components/fileManager/MobileLayout";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const FILES = [
+  makeStub("file-1", "quarterly-report.pdf"),
+  makeStub("file-2", "invoice-2026-01.pdf"),
+];
+
+const meta = {
+  title: "FileManager/MobileLayout",
+  component: MobileLayout,
+  parameters: { layout: "fullscreen" },
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "600px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MobileLayout>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A file selected, so the compact details block sits above the list. */
+export const Default: Story = {
+  decorators: [
+    withFileManager({ recentFiles: FILES, activeFileIds: [FILES[0].id] }),
+  ],
+};
+
+/** Nothing selected: the details block shrinks and the list takes the room. */
+export const NoSelection: Story = {
+  decorators: [withFileManager({ recentFiles: FILES })],
+};
+
+/** First run, with the empty state filling the list panel. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};

--- a/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
@@ -1,0 +1,96 @@
+/**
+ * Shared Storybook scaffolding for the file manager.
+ *
+ * Every component under this directory reads FileManagerContext, whose context
+ * object is private — only the provider and its hook are exported — so stories
+ * cannot hand it a slice and must mount the real provider. That provider in
+ * turn calls into FileContext (file actions, file management), which itself
+ * needs IndexedDBContext, and several of the components branch on the app
+ * config. None of those are part of the shared preview decorators, so the whole
+ * stack is stood up here once rather than repeated in each story file.
+ *
+ * The data is static: no bytes are written to IndexedDB, so anything that would
+ * read file contents (thumbnail generation, downloads) simply does nothing.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FileManagerProvider } from "@app/contexts/FileManagerContext";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+/**
+ * A minimally complete file stub. `thumbnailUrl` is always set so the thumbnail
+ * hooks short-circuit on it instead of trying to read bytes out of IndexedDB.
+ */
+export function makeStub(
+  id: string,
+  name: string,
+  overrides: Partial<StirlingFileStub> = {},
+): StirlingFileStub {
+  return {
+    id: id as FileId,
+    name,
+    type: "application/pdf",
+    size: 2_400_000,
+    lastModified: Date.UTC(2026, 0, 14),
+    createdAt: Date.UTC(2026, 0, 14),
+    isLeaf: true,
+    originalFileId: id,
+    versionNumber: 1,
+    thumbnailUrl:
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160'%3E%3Crect width='120' height='160' fill='%23e9ecef'/%3E%3C/svg%3E",
+    ...overrides,
+  };
+}
+
+interface FileManagerHarnessOptions {
+  /** Files offered in the "recent" source. Empty renders the empty states. */
+  recentFiles?: StirlingFileStub[];
+  /** Seeds the provider's initial selection, which drives the bulk actions. */
+  activeFileIds?: FileId[];
+  isLoading?: boolean;
+  /** Merged over the defaults; the storage flags gate whole controls. */
+  config?: Record<string, unknown>;
+}
+
+/** Everything off — the plain local-only build most stories want. */
+const BASE_CONFIG = {
+  storageEnabled: false,
+  storageSharingEnabled: false,
+  storageShareLinksEnabled: false,
+  enableMobileScanner: false,
+};
+
+export function withFileManager({
+  recentFiles = [],
+  activeFileIds = [],
+  isLoading = false,
+  config = {},
+}: FileManagerHarnessOptions = {}) {
+  return (Story: () => ReactElement) => (
+    <AppConfigProvider
+      initialConfig={{ ...BASE_CONFIG, ...config } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      <FileContextProvider>
+        <FileManagerProvider
+          recentFiles={recentFiles}
+          onRecentFilesSelected={() => {}}
+          onNewFilesSelect={() => {}}
+          onClose={() => {}}
+          isFileSupported={() => true}
+          isOpen
+          onFileRemove={() => {}}
+          modalHeight="600px"
+          refreshRecentFiles={async () => {}}
+          isLoading={isLoading}
+          activeFileIds={activeFileIds}
+        >
+          <Story />
+        </FileManagerProvider>
+      </FileContextProvider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/filesPage/FolderTreePanel.stories.tsx
+++ b/frontend/editor/src/core/components/filesPage/FolderTreePanel.stories.tsx
@@ -1,0 +1,58 @@
+/**
+ * The resizable rail that holds the folder tree on the Files page. It supplies
+ * the heading and the drag/keyboard resize handle around FolderTreeSidebar, and
+ * wires the tree's folder actions through to the Files page context.
+ *
+ * `active` is the only prop: an inactive panel is collapsed away by CSS, hidden
+ * from assistive technology, and drops its resize handle, so the tab it belongs
+ * to can slide in and out. Its width is otherwise self-managed — auto-fitted to
+ * the longest folder name until the user drags it, after which the chosen width
+ * is persisted.
+ *
+ * No folders are seeded into IndexedDB, so the tree shows only its pinned rows.
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FolderTreePanel } from "@app/components/filesPage/FolderTreePanel";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FolderProvider } from "@app/contexts/FolderContext";
+import { FilesPageProvider } from "@app/contexts/FilesPageContext";
+
+/**
+ * The panel reads the folder tree from FolderContext and the file counts and
+ * folder dialogs from FilesPageContext; both sit above FileContext, which
+ * brings in IndexedDBContext. None are part of the shared preview decorators.
+ */
+function withFolderContexts(Story: () => ReactElement) {
+  return (
+    <FileContextProvider>
+      <FolderProvider>
+        <FilesPageProvider>
+          <div style={{ display: "flex", height: "24rem" }}>
+            <Story />
+          </div>
+        </FilesPageProvider>
+      </FolderProvider>
+    </FileContextProvider>
+  );
+}
+
+const meta = {
+  title: "FilesPage/FolderTreePanel",
+  component: FolderTreePanel,
+  parameters: { layout: "fullscreen" },
+  decorators: [withFolderContexts],
+} satisfies Meta<typeof FolderTreePanel>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Open: the heading, the tree, and the resize handle down the right edge. */
+export const Active: Story = {
+  args: { active: true },
+};
+
+/** Collapsed for a tab that is not showing folders. */
+export const Inactive: Story = {
+  args: { active: false },
+};

--- a/frontend/editor/src/core/components/filesPage/FolderTreePanel.tsx
+++ b/frontend/editor/src/core/components/filesPage/FolderTreePanel.tsx
@@ -109,7 +109,11 @@ export function FolderTreePanel({ active }: FolderTreePanelProps) {
     <div
       className="folder-tree-panel"
       data-active={String(active)}
+      /* Collapsed, the panel keeps its DOM but must not be reachable: hiding it
+         from assistive tech alone would leave its controls in the tab order,
+         focusable but invisible. inert removes both. */
       aria-hidden={!active}
+      inert={!active}
       style={
         active
           ? ({

--- a/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.stories.tsx
+++ b/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.stories.tsx
@@ -1,0 +1,48 @@
+/**
+ * The page-selection expression field at the top of the bulk selection panel —
+ * a title with a syntax-guide tooltip, an optional "Advanced" switch, and the
+ * comma/range input itself.
+ *
+ * Two things decide what renders. The clear button in the input's right section
+ * appears only while the expression is non-empty, and the Advanced switch is
+ * present only when the caller passes an `advancedOpened` boolean at all —
+ * panels that have no advanced mode omit the prop and get no switch.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import PageSelectionInput from "@app/components/pageEditor/bulkSelectionPanel/PageSelectionInput";
+
+const meta = {
+  title: "PageEditor/BulkSelectionPanel/PageSelectionInput",
+  component: PageSelectionInput,
+  args: {
+    csvInput: "",
+    setCsvInput: () => {},
+    onUpdatePagesFromCSV: () => {},
+    onClear: () => {},
+  },
+} satisfies Meta<typeof PageSelectionInput>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Empty: placeholder syntax only, and no clear affordance to offer yet. */
+export const Default: Story = {};
+
+/** A non-empty expression reveals the clear button beside the input. */
+export const WithExpression: Story = {
+  args: { csvInput: "1,3,5-10" },
+};
+
+/** Passing `advancedOpened` adds the Advanced switch to the header row. */
+export const WithAdvancedToggle: Story = {
+  args: { advancedOpened: false, onToggleAdvanced: () => {} },
+};
+
+/** The switch on, as it sits while the advanced panel below is expanded. */
+export const AdvancedOpened: Story = {
+  args: {
+    csvInput: "odd & 1-50",
+    advancedOpened: true,
+    onToggleAdvanced: () => {},
+  },
+};

--- a/frontend/editor/src/core/components/shared/PageEditorFileDropdown.stories.tsx
+++ b/frontend/editor/src/core/components/shared/PageEditorFileDropdown.stories.tsx
@@ -1,0 +1,91 @@
+/**
+ * The workbench control that reports how many files the page editor is showing
+ * and opens a menu to change the set. The menu itself lists every file with a
+ * colour swatch, a selection checkbox and a drag handle for reordering, plus an
+ * entry that opens the files modal.
+ *
+ * The trigger is what the stories can show: it renders the selected/total
+ * counts, and swaps its icon for a spinner while the workbench is switching
+ * into the page editor. The menu opens on click, so it is not a separate story.
+ */
+import type { CSSProperties } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PageEditorFileDropdown } from "@app/components/shared/PageEditorFileDropdown";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+import type { FileId } from "@app/types/file";
+
+const FILES = [
+  {
+    fileId: "file-1" as FileId,
+    name: "quarterly-report.pdf",
+    isSelected: true,
+  },
+  {
+    fileId: "file-2" as FileId,
+    name: "invoice-2026-01.pdf",
+    versionNumber: 2,
+    isSelected: true,
+  },
+  {
+    fileId: "file-3" as FileId,
+    name: "scan-of-contract.pdf",
+    isSelected: false,
+  },
+];
+
+/** Each file's swatch is looked up by id; missing ids fall back to the first colour. */
+const FILE_COLOUR_MAP = new Map<string, number>(
+  FILES.map((file, index) => [file.fileId as string, index]),
+);
+
+/** Matches the workbench segmented control the trigger renders inside. */
+const VIEW_OPTION_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const meta = {
+  title: "Shared/PageEditorFileDropdown",
+  component: PageEditorFileDropdown,
+  parameters: { layout: "centered" },
+  args: {
+    files: FILES,
+    onToggleSelection: () => {},
+    onReorder: () => {},
+    viewOptionStyle: VIEW_OPTION_STYLE,
+    fileColorMap: FILE_COLOUR_MAP,
+    selectedCount: 2,
+    totalCount: 3,
+  },
+  decorators: [
+    (Story) => (
+      // Only openFilesModal is read, by the menu's "Add File" row. The real
+      // provider reaches FileContext and NavigationContext, so a slice is used.
+      <FilesModalContext.Provider
+        value={{ openFilesModal: () => {} } as unknown as FilesModalContextType}
+      >
+        <Story />
+      </FilesModalContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof PageEditorFileDropdown>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Part of the set selected, which is the usual state. */
+export const Default: Story = {};
+
+/** Every file selected. */
+export const AllSelected: Story = {
+  args: { selectedCount: 3 },
+};
+
+/** While the workbench switches into the page editor, a spinner takes the icon's place. */
+export const Switching: Story = {
+  args: { switchingTo: "pageEditor" },
+};

--- a/frontend/editor/src/core/components/shared/TextInput.stories.tsx
+++ b/frontend/editor/src/core/components/shared/TextInput.stories.tsx
@@ -1,0 +1,75 @@
+/**
+ * The shared single-line text field: an optional leading icon, the input, and a
+ * trailing clear button.
+ *
+ * The clear button is the only conditional piece — it appears when the value has
+ * non-whitespace content, the caller has not opted out via `showClearButton`,
+ * and the field is neither disabled nor read-only. Everything else (padding,
+ * icon gutter) follows from those same choices, so the stories vary them
+ * instead of exposing them as controls.
+ *
+ * The field is controlled, so each story wraps it in local state — otherwise
+ * typing would appear to do nothing.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SearchIcon from "@mui/icons-material/Search";
+import {
+  TextInput,
+  type TextInputProps,
+} from "@app/components/shared/TextInput";
+
+function Controlled({ value, onChange: _onChange, ...props }: TextInputProps) {
+  const [current, setCurrent] = useState(value);
+  return (
+    <div style={{ width: "22rem" }}>
+      <TextInput {...props} value={current} onChange={setCurrent} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Shared/TextInput",
+  component: TextInput,
+  parameters: { layout: "padded" },
+  args: {
+    id: "story-text-input",
+    name: "story-text-input",
+    value: "",
+    onChange: () => {},
+    placeholder: "Search files",
+    "aria-label": "Search files",
+  },
+  render: (args) => <Controlled {...args} />,
+} satisfies Meta<typeof TextInput>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Empty and unadorned: placeholder only, and no clear button to show yet. */
+export const Default: Story = {};
+
+/** With content, the trailing clear button appears and the input reserves room for it. */
+export const WithValue: Story = {
+  args: { value: "quarterly report" },
+};
+
+/** A leading icon indents the text; the clear button still owns the other end. */
+export const WithIcon: Story = {
+  args: { value: "invoice", icon: <SearchIcon fontSize="small" /> },
+};
+
+/** Callers that own their own reset opt out, leaving the value flush to the edge. */
+export const WithoutClearButton: Story = {
+  args: { value: "locked in", showClearButton: false },
+};
+
+/** Disabled suppresses the clear button and greys the field out. */
+export const Disabled: Story = {
+  args: { value: "cannot edit", disabled: true },
+};
+
+/** Read-only keeps the field's normal appearance but drops the clear button. */
+export const ReadOnly: Story = {
+  args: { value: "reference value", readOnly: true },
+};

--- a/frontend/editor/src/core/components/tools/FullscreenToolSurface.stories.tsx
+++ b/frontend/editor/src/core/components/tools/FullscreenToolSurface.stories.tsx
@@ -1,0 +1,160 @@
+/**
+ * The fullscreen tool picker's surface: a search field, a details switch, and
+ * the whole catalogue beneath them.
+ *
+ * The surface is a portal onto the body, absolutely placed from the `geometry`
+ * the sidebar measures for it — with no geometry it renders nothing at all,
+ * which is how it stays out of the way before the panel has been laid out.
+ * Everything else is passed straight through to the list: the search term
+ * decides whether Quick Access survives, and the details switch decides whether
+ * each row carries its description.
+ *
+ * The list rows are ToolButtons, which read the registry, favourites, hotkeys
+ * and app config, so those contexts are stubbed rather than provided in full.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import FullscreenToolSurface from "@app/components/tools/FullscreenToolSurface";
+import {
+  ToolCategoryId,
+  SubcategoryId,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
+import type { ToolId } from "@app/types/toolId";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  ToolWorkflowContext,
+  type ToolWorkflowContextValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+
+function tool(
+  name: string,
+  categoryId: ToolCategoryId,
+  subcategoryId: SubcategoryId,
+): ToolRegistryEntry {
+  return {
+    icon: <BuildRoundedIcon />,
+    name,
+    // Entries with neither a component nor a link count as "coming soon" and
+    // are dropped from Quick Access, which would empty out half the surface.
+    component: () => null,
+    description: `${name} — what this tool does, in one line.`,
+    categoryId,
+    subcategoryId,
+    automationSettings: null,
+  } as ToolRegistryEntry;
+}
+
+const REGISTRY: Record<string, ToolRegistryEntry> = {
+  rotate: tool(
+    "Rotate pages",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.PAGE_FORMATTING,
+  ),
+  compress: tool(
+    "Compress",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.GENERAL,
+  ),
+  redact: tool(
+    "Redact",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.DOCUMENT_SECURITY,
+  ),
+  sign: tool("Sign", ToolCategoryId.STANDARD_TOOLS, SubcategoryId.SIGNING),
+  extract: tool(
+    "Extract pages",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.EXTRACTION,
+  ),
+  removeBlanks: tool(
+    "Remove blank pages",
+    ToolCategoryId.ADVANCED_TOOLS,
+    SubcategoryId.REMOVAL,
+  ),
+};
+
+const ALL_TOOLS = Object.entries(REGISTRY).map(([id, entry]) => ({
+  item: [id as ToolId, entry] as [ToolId, ToolRegistryEntry],
+}));
+
+/** Roughly the rail the sidebar hands over: inset from the right-hand edge. */
+const GEOMETRY = { left: 32, top: 32, width: 720, height: 560 };
+
+const withStubs = (Story: React.ComponentType) => (
+  <AppConfigProvider
+    initialConfig={{ premiumEnabled: true } as never}
+    bootstrapMode="non-blocking"
+    autoFetch={false}
+  >
+    <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+      <ToolWorkflowContext.Provider
+        value={
+          {
+            toolRegistry: REGISTRY,
+            favoriteTools: [],
+            isFavorite: () => false,
+            toggleFavorite: () => {},
+            toolAvailability: {},
+          } as unknown as ToolWorkflowContextValue
+        }
+      >
+        <Story />
+      </ToolWorkflowContext.Provider>
+    </HotkeyContext.Provider>
+  </AppConfigProvider>
+);
+
+const meta: Meta<typeof FullscreenToolSurface> = {
+  title: "Tools/Fullscreen/FullscreenToolSurface",
+  component: FullscreenToolSurface,
+  parameters: { layout: "fullscreen" },
+  args: {
+    searchQuery: "",
+    toolRegistry: REGISTRY,
+    filteredTools: ALL_TOOLS,
+    selectedToolKey: null,
+    showDescriptions: false,
+    matchedTextMap: new Map(),
+    geometry: GEOMETRY,
+    onSearchChange: () => {},
+    onSelect: () => {},
+    onToggleDescriptions: () => {},
+    onExitFullscreenMode: () => {},
+  },
+  decorators: [withStubs],
+};
+export default meta;
+
+type Story = StoryObj<typeof FullscreenToolSurface>;
+
+/** The full catalogue, Quick Access first. */
+export const Default: Story = {};
+
+/** The details switch on: every row grows to carry its description. */
+export const WithDescriptions: Story = { args: { showDescriptions: true } };
+
+/** Searching narrows the surface to matches and drops Quick Access. */
+export const Searching: Story = {
+  args: {
+    searchQuery: "re",
+    filteredTools: ALL_TOOLS.filter(({ item }) =>
+      item[1].name.toLowerCase().includes("re"),
+    ),
+  },
+};
+
+/** A search with no matches still fills the surface with its empty state. */
+export const NoMatches: Story = {
+  args: { searchQuery: "zzzz", filteredTools: [] },
+};
+
+/** The open tool is marked in the list. */
+export const SelectedTool: Story = { args: { selectedToolKey: "redact" } };
+
+/** Before the panel has been measured there is nowhere to place the surface. */
+export const NotYetMeasured: Story = { args: { geometry: null } };

--- a/frontend/editor/src/core/components/tools/ToolPanel.stories.tsx
+++ b/frontend/editor/src/core/components/tools/ToolPanel.stories.tsx
@@ -1,0 +1,179 @@
+/**
+ * The body of the right rail: the viewer's mini toolbar, then exactly one of
+ * three things beneath it.
+ *
+ * Which one is a chain of checks on workflow state rather than a prop. A search
+ * term while the all-tools view is open wins outright and shows the matches;
+ * otherwise the panel shows the tool picker, compact until the rail expands into
+ * the full catalogue; otherwise it shows the open tool, or an invitation to pick
+ * one. The fourth branch — a tool actually rendered — needs the real registry
+ * behind ToolRenderer, so it is covered by that component's own stories.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import DrawIcon from "@mui/icons-material/Draw";
+import CommentIcon from "@mui/icons-material/Comment";
+import ToolPanel from "@app/components/tools/ToolPanel";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+import { WorkbenchBarContext } from "@app/contexts/WorkbenchBarContext";
+import {
+  ToolCategoryId,
+  SubcategoryId,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
+import type { ToolId } from "@app/types/toolId";
+
+function tool(
+  name: string,
+  categoryId: ToolCategoryId,
+  subcategoryId: SubcategoryId,
+): ToolRegistryEntry {
+  return {
+    icon: <BuildRoundedIcon />,
+    name,
+    // Without a component or a link an entry counts as "coming soon", which
+    // renders every row disabled.
+    component: () => null,
+    description: `${name} — what this tool does, in one line.`,
+    categoryId,
+    subcategoryId,
+    automationSettings: null,
+  } as ToolRegistryEntry;
+}
+
+const FILTERED_TOOLS = [
+  [
+    "rotate",
+    tool(
+      "Rotate pages",
+      ToolCategoryId.RECOMMENDED_TOOLS,
+      SubcategoryId.PAGE_FORMATTING,
+    ),
+  ],
+  [
+    "compress",
+    tool("Compress", ToolCategoryId.RECOMMENDED_TOOLS, SubcategoryId.GENERAL),
+  ],
+  [
+    "redact",
+    tool(
+      "Redact",
+      ToolCategoryId.STANDARD_TOOLS,
+      SubcategoryId.DOCUMENT_SECURITY,
+    ),
+  ],
+  ["sign", tool("Sign", ToolCategoryId.STANDARD_TOOLS, SubcategoryId.SIGNING)],
+  [
+    "removeBlanks",
+    tool(
+      "Remove blank pages",
+      ToolCategoryId.ADVANCED_TOOLS,
+      SubcategoryId.REMOVAL,
+    ),
+  ],
+].map(([id, entry]) => ({
+  item: [id as ToolId, entry as ToolRegistryEntry] as [
+    ToolId,
+    ToolRegistryEntry,
+  ],
+}));
+
+/** The viewer bar only shows buttons filed under the tool-panel section. */
+const VIEWER_BAR_BUTTONS = [
+  {
+    id: "annotate",
+    section: "tool-panel",
+    ariaLabel: "Annotate",
+    icon: <DrawIcon />,
+  },
+  {
+    id: "comment",
+    section: "tool-panel",
+    ariaLabel: "Comment",
+    icon: <CommentIcon />,
+  },
+];
+
+const withWorkbenchBar = (Story: () => React.ReactElement) => (
+  <WorkbenchBarContext.Provider
+    value={
+      {
+        buttons: VIEWER_BAR_BUTTONS,
+        actions: {},
+        allButtonsDisabled: false,
+      } as never
+    }
+  >
+    <div
+      style={{
+        width: 380,
+        height: "80vh",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Story />
+    </div>
+  </WorkbenchBarContext.Provider>
+);
+
+const workflow = (overrides: Record<string, unknown>) =>
+  withToolContexts({
+    workbench: "viewer",
+    workflow: {
+      searchQuery: "",
+      filteredTools: FILTERED_TOOLS,
+      selectedToolKey: null,
+      handleToolSelect: () => {},
+      setPreviewFile: () => {},
+      ...overrides,
+    },
+  });
+
+const meta: Meta<typeof ToolPanel> = {
+  title: "Tools/ToolPanel",
+  component: ToolPanel,
+  parameters: { layout: "fullscreen" },
+  args: { allToolsView: false, onShowAllTools: () => {} },
+  decorators: [workflow({ leftPanelView: "toolPicker" }), withWorkbenchBar],
+};
+export default meta;
+
+type Story = StoryObj<typeof ToolPanel>;
+
+/** Resting state: the compact picker of pinned and recommended tools. */
+export const Default: Story = {};
+
+/** Expanded into the full categorised catalogue. */
+export const AllTools: Story = { args: { allToolsView: true } };
+
+/** A search term in the all-tools view replaces the picker with its matches. */
+export const Searching: Story = {
+  args: { allToolsView: true },
+  decorators: [
+    workflow({
+      leftPanelView: "toolPicker",
+      searchQuery: "re",
+      filteredTools: FILTERED_TOOLS.filter(({ item }) =>
+        item[1].name.toLowerCase().includes("re"),
+      ),
+    }),
+  ],
+};
+
+/** A search that matches nothing still leaves the empty state in place. */
+export const SearchWithNoMatches: Story = {
+  args: { allToolsView: true },
+  decorators: [
+    workflow({
+      leftPanelView: "toolPicker",
+      searchQuery: "zzzz",
+      filteredTools: [],
+    }),
+  ],
+};
+
+/** Past the picker with no tool open — the panel asks for one. */
+export const NoToolSelected: Story = {
+  decorators: [workflow({ leftPanelView: "toolContent" })],
+};

--- a/frontend/editor/src/core/components/tools/ToolPanelViewerBar.stories.tsx
+++ b/frontend/editor/src/core/components/tools/ToolPanelViewerBar.stories.tsx
@@ -11,12 +11,27 @@ import { ToolPanelViewerBar } from "@app/components/tools/ToolPanelViewerBar";
 import { withToolContexts } from "@app/components/tools/storyFixtures";
 import { WorkbenchBarContext } from "@app/contexts/WorkbenchBarContext";
 
+/** The bar renders only the "tool-panel" section, and names each control from
+ *  ariaLabel (falling back to a string tooltip) — not from `label`. */
 const BUTTONS = [
-  { id: "zoom", label: "Zoom in", icon: <ZoomInIcon />, onClick: () => {} },
-  { id: "print", label: "Print", icon: <PrintIcon />, onClick: () => {} },
+  {
+    id: "zoom",
+    section: "tool-panel",
+    ariaLabel: "Zoom in",
+    icon: <ZoomInIcon />,
+    onClick: () => {},
+  },
+  {
+    id: "print",
+    section: "tool-panel",
+    ariaLabel: "Print",
+    icon: <PrintIcon />,
+    onClick: () => {},
+  },
   {
     id: "download",
-    label: "Download",
+    section: "tool-panel",
+    ariaLabel: "Download",
     icon: <DownloadIcon />,
     onClick: () => {},
   },

--- a/frontend/editor/src/core/components/tools/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/tools/storyFixtures.tsx
@@ -44,6 +44,8 @@ export interface ToolContextOptions {
   activeFileIndex?: number;
   /** Extra viewer fields for components that reach further into it. */
   viewer?: Partial<Record<string, unknown>>;
+  /** Extra workflow fields — search state, panel view, the open tool. */
+  workflow?: Partial<Record<string, unknown>>;
 }
 
 export function withToolContexts({
@@ -51,6 +53,7 @@ export function withToolContexts({
   favourites = [],
   activeFileIndex = 0,
   viewer = {},
+  workflow = {},
 }: ToolContextOptions = {}) {
   return (Story: () => ReactElement): ReactElement => (
     <AppConfigProvider
@@ -69,6 +72,7 @@ export function withToolContexts({
                 toolPanelMode: "normal",
                 leftPanelView: "tools",
                 readerMode: false,
+                ...workflow,
               } as unknown as ToolWorkflowContextValue
             }
           >

--- a/frontend/editor/src/core/components/viewer/AttachmentSidebar.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/AttachmentSidebar.stories.tsx
@@ -1,0 +1,101 @@
+/**
+ * The viewer's attachments rail: embedded files a PDF carries, each downloadable.
+ *
+ * The sidebar owns its own fetch. On mount it asks the viewer's attachment
+ * bridge for the current document's attachments, and what it shows is that
+ * request's outcome: pending, failed, empty, or a list. Two things gate the
+ * fetch entirely — the bridge must report attachment support (it polls until it
+ * does, so an unsupported viewer sits on that notice), and there must be a
+ * document key to fetch for. These stories drive the states from the bridge
+ * rather than from props, because that is where the states actually come from.
+ *
+ * The sidebar is `position: fixed` and offsets itself left of whichever other
+ * rails are open, so the stories render full-screen.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { PdfAttachmentObject } from "@embedpdf/models";
+import { AttachmentSidebar } from "@app/components/viewer/AttachmentSidebar";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+
+const ATTACHMENTS = [
+  {
+    name: "site-survey.xlsx",
+    size: 48_128,
+    description: "Measurements taken on site",
+  },
+  { name: "contract-appendix.pdf", size: 1_204_992 },
+  { name: "photos.zip", size: 18_874_368, description: "Progress photographs" },
+] as unknown as PdfAttachmentObject[];
+
+/** Never settles, which is what the sidebar shows as "loading". */
+const pending = () => new Promise<PdfAttachmentObject[]>(() => {});
+
+function withAttachments(
+  getAttachments: () => Promise<PdfAttachmentObject[] | null>,
+  hasAttachmentSupport = true,
+) {
+  return withToolContexts({
+    viewer: {
+      hasAttachmentSupport: () => hasAttachmentSupport,
+      toggleAttachmentSidebar: () => {},
+      attachmentActions: {
+        getAttachments,
+        downloadAttachment: () => {},
+        clearAttachments: () => {},
+        setLocalAttachments: () => {},
+      },
+    },
+  });
+}
+
+const meta: Meta<typeof AttachmentSidebar> = {
+  title: "Viewer/AttachmentSidebar",
+  component: AttachmentSidebar,
+  parameters: { layout: "fullscreen" },
+  args: {
+    visible: true,
+    thumbnailVisible: false,
+    bookmarkVisible: false,
+    documentCacheKey: "report.pdf#1",
+  },
+  decorators: [withAttachments(async () => ATTACHMENTS)],
+};
+export default meta;
+
+type Story = StoryObj<typeof AttachmentSidebar>;
+
+/** A document carrying three attachments. */
+export const Default: Story = {};
+
+/** The fetch is still in flight. */
+export const Loading: Story = { decorators: [withAttachments(pending)] };
+
+/**
+ * The bridge failed. "Document not open" errors are retried silently, so this
+ * uses a genuine failure — the one case that surfaces with a retry control.
+ */
+export const LoadFailed: Story = {
+  decorators: [
+    withAttachments(async () => {
+      throw new Error("Attachment stream could not be read");
+    }),
+  ],
+};
+
+/** A document with no attachments, offering the tool that adds one. */
+export const NoAttachments: Story = {
+  decorators: [withAttachments(async () => [])],
+};
+
+/** No document open, so there is nothing to fetch for. */
+export const NoDocument: Story = { args: { documentCacheKey: undefined } };
+
+/** A viewer whose attachment bridge never registers. */
+export const UnsupportedViewer: Story = {
+  decorators: [withAttachments(async () => ATTACHMENTS, false)],
+};
+
+/** Thumbnails and bookmarks are open too, so the rail shifts left of both. */
+export const AlongsideOtherSidebars: Story = {
+  args: { thumbnailVisible: true, bookmarkVisible: true },
+};

--- a/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
@@ -292,15 +292,10 @@ export const AttachmentSidebar = ({
       >
         <div
           className="attachment-item"
+          /* The row carries a labelled download button of its own, so making
+             the row a button too nests one control inside another. The click
+             stays as a mouse convenience; the keyboard path is the button. */
           onClick={(event) => handleDownload(attachment, event)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              handleDownload(attachment, event as any);
-            }
-          }}
         >
           <div className="attachment-item__content">
             <Text size="sm" fw={500} className="attachment-item__title">

--- a/frontend/editor/src/core/components/viewer/LayerSidebar.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/LayerSidebar.stories.tsx
@@ -1,0 +1,63 @@
+/**
+ * The viewer's optional-content rail: a PDF's layers, each toggleable, with the
+ * change written back into the document after a short debounce.
+ *
+ * Nothing here is passed in as data. The sidebar reads the layers itself, out of
+ * the PDF blob it is handed, so its states are the outcomes of that read: no
+ * document to read, a read in flight, and a read that failed. The two remaining
+ * outcomes — a layered document and one with no layers — need a real PDF parsed
+ * through pdf.js, which a story cannot fabricate, so they are not covered here.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+import { LayerSidebar } from "@app/components/viewer/LayerSidebar";
+
+const withViewer = (Story: React.ComponentType) => (
+  <ViewerContext.Provider
+    value={{ toggleLayerSidebar: () => {} } as unknown as ViewerContextType}
+  >
+    <div style={{ height: "80vh" }}>
+      <Story />
+    </div>
+  </ViewerContext.Provider>
+);
+
+/** A blob whose bytes never arrive, holding the read open. */
+const stalledFile = {
+  arrayBuffer: () => new Promise<ArrayBuffer>(() => {}),
+} as unknown as Blob;
+
+/** Not a PDF, so the parse rejects and the sidebar reports the failure. */
+const unreadableFile = new Blob(["not a pdf"], { type: "application/pdf" });
+
+const meta: Meta<typeof LayerSidebar> = {
+  title: "Viewer/LayerSidebar",
+  component: LayerSidebar,
+  parameters: { layout: "fullscreen" },
+  args: {
+    visible: true,
+    rightOffset: 0,
+    onApplyLayers: async () => {},
+    onLayersDetected: () => {},
+  },
+  decorators: [withViewer],
+};
+export default meta;
+
+type Story = StoryObj<typeof LayerSidebar>;
+
+/** No document open — there is nothing to read layers from. */
+export const NoDocument: Story = {};
+
+/** The PDF is being parsed for optional-content groups. */
+export const Loading: Story = {
+  args: { file: stalledFile, documentCacheKey: "stalled" },
+};
+
+/** The parse failed; the reason is shown rather than an empty list. */
+export const LoadFailed: Story = {
+  args: { file: unreadableFile, documentCacheKey: "unreadable" },
+};

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.stories.tsx
@@ -1,0 +1,126 @@
+/**
+ * The floating toolbar under the document: page navigation, spread mode, the
+ * colour filter and zoom.
+ *
+ * Its props are near-vestigial — everything on show comes from the viewer
+ * context's bridge state. The page position decides which of the four
+ * navigation buttons are disabled (you cannot go back from page one, or forward
+ * from the last), a single-page document also locks the spread toggle, and
+ * `pdfRenderMode` cycles normal → dark → sepia, changing both the icon and
+ * whether the button reads as active. Rather than stand up the EmbedPDF
+ * pipeline behind those bridges, these stories supply the slice of context the
+ * toolbar reads.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+import { PdfViewerToolbar } from "@app/components/viewer/PdfViewerToolbar";
+
+interface ToolbarState {
+  currentPage: number;
+  totalPages: number;
+  zoomPercent?: number;
+  isDualPage?: boolean;
+  pdfRenderMode?: "normal" | "dark" | "sepia";
+}
+
+function viewerValue({
+  currentPage,
+  totalPages,
+  zoomPercent = 140,
+  isDualPage = false,
+  pdfRenderMode = "normal",
+}: ToolbarState): ViewerContextType {
+  // The toolbar mirrors bridge state into local state through these
+  // registrations; returning a no-op unregister is all a story needs.
+  const noopRegister = () => () => {};
+
+  return {
+    getScrollState: () => ({ currentPage, totalPages }),
+    getZoomState: () => ({ currentZoom: zoomPercent / 100, zoomPercent }),
+    getSpreadState: () => ({
+      spreadMode: isDualPage ? "odd" : "none",
+      isDualPage,
+    }),
+    scrollActions: {
+      scrollToPage: () => {},
+      scrollToFirstPage: () => {},
+      scrollToLastPage: () => {},
+    },
+    zoomActions: {
+      zoomIn: () => {},
+      zoomOut: () => {},
+      setZoomLevel: () => {},
+    },
+    spreadActions: { toggleSpreadMode: () => {} },
+    registerImmediateScrollUpdate: noopRegister,
+    registerImmediateZoomUpdate: noopRegister,
+    registerImmediateSpreadUpdate: noopRegister,
+    pdfRenderMode,
+    cyclePdfRenderMode: () => {},
+  } as unknown as ViewerContextType;
+}
+
+const withViewer = (state: ToolbarState) => (Story: React.ComponentType) => (
+  <ViewerContext.Provider value={viewerValue(state)}>
+    <Story />
+  </ViewerContext.Provider>
+);
+
+const meta: Meta<typeof PdfViewerToolbar> = {
+  title: "Viewer/PdfViewerToolbar",
+  component: PdfViewerToolbar,
+  parameters: { layout: "centered" },
+  decorators: [withViewer({ currentPage: 5, totalPages: 12 })],
+};
+export default meta;
+
+type Story = StoryObj<typeof PdfViewerToolbar>;
+
+/** Part-way through a document: every control is live. */
+export const Default: Story = {};
+
+/** On page one, so both backward controls are disabled. */
+export const FirstPage: Story = {
+  decorators: [withViewer({ currentPage: 1, totalPages: 12 })],
+};
+
+/** On the last page, so both forward controls are disabled. */
+export const LastPage: Story = {
+  decorators: [withViewer({ currentPage: 12, totalPages: 12 })],
+};
+
+/** A one-page document: navigation and the spread toggle have nowhere to go. */
+export const SinglePageDocument: Story = {
+  decorators: [withViewer({ currentPage: 1, totalPages: 1 })],
+};
+
+/** Two-up reading — the toggle is active and offers the way back. */
+export const DualPageSpread: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, isDualPage: true }),
+  ],
+};
+
+/** The dark colour filter is on; the button now offers sepia next. */
+export const DarkFilter: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, pdfRenderMode: "dark" }),
+  ],
+};
+
+/** Sepia is the last step of the cycle, so the button offers to clear it. */
+export const SepiaFilter: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, pdfRenderMode: "sepia" }),
+  ],
+};
+
+/** Zoomed well in: the slider sits near its ceiling and the readout follows. */
+export const ZoomedIn: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, zoomPercent: 320 }),
+  ],
+};

--- a/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
@@ -1,0 +1,59 @@
+/**
+ * The calibration modal: the user drags a line over a known distance on the
+ * page, then tells the viewer how long that line really is.
+ *
+ * The only thing the dialog knows on open is the measurement it was handed.
+ * That measurement decides whether the "measured page distance" line appears at
+ * all, and `formatPaperDistance` switches its unit by magnitude (mm below
+ * 100 mm, then cm, then m), so the same component reads quite differently for a
+ * short line and a long one. The calculated-scale preview only appears once a
+ * real-world distance has been typed, so it is not a static state.
+ *
+ * The unit selector prefers the last unit the user calibrated in, which is read
+ * from local storage — `defaultUnit` only applies on a fresh browser profile.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ScaleCalibrationDialog,
+  type ScaleCalibrationMeasurement,
+} from "@app/components/viewer/ScaleCalibrationDialog";
+
+function measurement(pdfDistancePts: number): ScaleCalibrationMeasurement {
+  return {
+    start: { pageIndex: 0, x: 100, y: 240 },
+    end: { pageIndex: 0, x: 100 + pdfDistancePts, y: 240 },
+    pdfDistancePts,
+  };
+}
+
+const meta: Meta<typeof ScaleCalibrationDialog> = {
+  title: "Viewer/ScaleCalibrationDialog",
+  component: ScaleCalibrationDialog,
+  parameters: { layout: "fullscreen" },
+  args: {
+    opened: true,
+    defaultUnit: "m",
+    measurement: measurement(200),
+    onApplyScale: () => {},
+    onClose: () => {},
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleCalibrationDialog>;
+
+/** A line a few centimetres long on the page. */
+export const Default: Story = {};
+
+/** A short line, reported in millimetres. */
+export const ShortMeasurement: Story = {
+  args: { measurement: measurement(36) },
+};
+
+/** A line over a metre long, reported in metres. */
+export const LongMeasurement: Story = {
+  args: { measurement: measurement(3600) },
+};
+
+/** Opened without a measurement: the page-distance line has nothing to report. */
+export const NoMeasurement: Story = { args: { measurement: null } };

--- a/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
@@ -1,0 +1,75 @@
+/**
+ * The measurement scale editor behind the ruler's settings button: preset
+ * ratios, a custom ratio + unit pair, and the calibration toggle.
+ *
+ * Everything the panel shows is decided by two props. `currentScale` seeds the
+ * form, decides whether a preset button is highlighted (a preset is "selected"
+ * only when its parsed ratio equals the active one), fills the active-scale
+ * strip, and is the sole reason the Reset button exists. `isCalibrationActive`
+ * flips the calibration button between start and cancel — and because the
+ * button falls back to disabled when the matching handler is missing, a viewer
+ * that cannot calibrate renders it greyed rather than hiding it.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ScaleSettingsPanel } from "@app/components/viewer/ScaleSettingsPanel";
+import type { MeasureScale } from "@app/utils/measurementTypes";
+
+/** Ratio 1:100 in metres — one of the preset buttons, so it renders selected. */
+const PRESET_SCALE: MeasureScale = { factor: 100 / 72, ratio: 100, unit: "m" };
+
+/** A ratio typed by hand: no preset matches, so none is highlighted. */
+const CUSTOM_SCALE: MeasureScale = {
+  factor: 37.5 / 72,
+  ratio: 37.5,
+  unit: "ft",
+};
+
+/**
+ * Calibration produces a factor without an architectural ratio, which the
+ * active-scale strip words as "<unit> (custom)".
+ */
+const CALIBRATED_SCALE: MeasureScale = {
+  factor: 0.0254,
+  ratio: null,
+  unit: "in",
+};
+
+const meta: Meta<typeof ScaleSettingsPanel> = {
+  title: "Viewer/ScaleSettingsPanel",
+  component: ScaleSettingsPanel,
+  parameters: { layout: "padded" },
+  args: {
+    onApplyScale: () => {},
+    onResetScale: () => {},
+    onStartCalibration: () => {},
+    onCancelCalibration: () => {},
+    onClose: () => {},
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleSettingsPanel>;
+
+/** No scale set yet: empty ratio, no preset selected, no Reset. */
+export const Default: Story = {};
+
+/** An active preset ratio — its button is filled and Reset appears. */
+export const PresetScale: Story = { args: { currentScale: PRESET_SCALE } };
+
+/** A hand-typed ratio: the form is populated but no preset claims it. */
+export const CustomRatio: Story = { args: { currentScale: CUSTOM_SCALE } };
+
+/** A calibrated scale carries no ratio, so the strip reads "in (custom)". */
+export const CalibratedScale: Story = {
+  args: { currentScale: CALIBRATED_SCALE },
+};
+
+/** Mid-calibration: the button becomes the primary "Calibrating" cancel. */
+export const Calibrating: Story = {
+  args: { currentScale: PRESET_SCALE, isCalibrationActive: true },
+};
+
+/** Nothing to start calibration with, so the button is offered but disabled. */
+export const CalibrationUnavailable: Story = {
+  args: { onStartCalibration: undefined },
+};

--- a/frontend/editor/src/core/tools/formFill/FieldInput.stories.tsx
+++ b/frontend/editor/src/core/tools/formFill/FieldInput.stories.tsx
@@ -1,0 +1,160 @@
+/**
+ * The widget used for one PDF form field, in both the tool panel and the viewer
+ * sidebar.
+ *
+ * The field's own metadata picks the control: a text field becomes a textarea
+ * once it is marked multiline, a listbox becomes a multi-select once it allows
+ * more than one choice, and a type the component has no widget for (a signature
+ * or push button) falls back to a plain text input. Options carry two parallel
+ * arrays — the values stored in the PDF and the labels shown to the user — so
+ * the dropdowns below deliberately differ between the two.
+ *
+ * The widget reads its own value out of the form-fill value store rather than
+ * from a prop, so the fixture seeds the store by loading the same field.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FieldInput } from "@app/tools/formFill/FieldInput";
+import { field, withFormFill } from "@app/tools/formFill/storyFixtures";
+import type { FormField } from "@app/tools/formFill/types";
+
+const TEXT = field({
+  name: "fullName",
+  label: "Full name",
+  value: "Jordan Blake",
+});
+
+const MULTILINE = field({
+  name: "address",
+  label: "Address",
+  multiline: true,
+  value: "12 Cathedral Road\nCardiff\nCF11 9LJ",
+  tooltip: "Include the postcode",
+});
+
+const CHECKBOX = field({
+  name: "agreeToTerms",
+  label: "I agree to the terms",
+  type: "checkbox",
+  value: "Yes",
+  widgets: [
+    { pageIndex: 0, x: 72, y: 300, width: 14, height: 14, exportValue: "Yes" },
+  ],
+});
+
+const COMBOBOX = field({
+  name: "country",
+  label: "Country",
+  type: "combobox",
+  value: "uk",
+  options: ["uk", "fr", "de"],
+  displayOptions: ["United Kingdom", "France", "Germany"],
+});
+
+const LISTBOX = field({
+  name: "department",
+  label: "Department",
+  type: "listbox",
+  value: "ops",
+  options: ["ops", "legal", "finance"],
+  displayOptions: ["Operations", "Legal", "Finance"],
+});
+
+const MULTI_LISTBOX = field({
+  name: "interests",
+  label: "Interests",
+  type: "listbox",
+  multiSelect: true,
+  value: "print,archive",
+  options: ["print", "archive", "share"],
+  displayOptions: ["Printing", "Archiving", "Sharing"],
+});
+
+const RADIO = field({
+  name: "delivery",
+  label: "Delivery",
+  type: "radio",
+  value: "1",
+  options: ["Post", "Courier", "Collection"],
+  widgets: [
+    { pageIndex: 0, x: 72, y: 380, width: 14, height: 14, exportValue: "post" },
+    {
+      pageIndex: 0,
+      x: 72,
+      y: 400,
+      width: 14,
+      height: 14,
+      exportValue: "courier",
+    },
+    {
+      pageIndex: 0,
+      x: 72,
+      y: 420,
+      width: 14,
+      height: 14,
+      exportValue: "collection",
+    },
+  ],
+});
+
+const READ_ONLY = field({
+  name: "reference",
+  label: "Reference number",
+  readOnly: true,
+  value: "INV-20418",
+});
+
+const SIGNATURE = field({
+  name: "signature",
+  label: "Signature",
+  type: "signature",
+});
+
+/** Each story mounts the store with only the field it is showing. */
+const story = (target: FormField): StoryObj<typeof FieldInput> => ({
+  args: { field: target },
+  decorators: [withFormFill({ fields: [target] })],
+});
+
+const meta: Meta<typeof FieldInput> = {
+  title: "Tools/FormFill/FieldInput",
+  component: FieldInput,
+  parameters: { layout: "padded" },
+  args: { field: TEXT, onValueChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof FieldInput>;
+
+/** A single-line text field. */
+export const Text: Story = story(TEXT);
+
+/** Multiline text grows into an auto-sizing textarea. */
+export const MultilineText: Story = story(MULTILINE);
+
+/** A checkbox carries its own label, unlike the other widgets. */
+export const Checkbox: Story = story(CHECKBOX);
+
+/** A combobox: searchable, clearable, showing display labels. */
+export const Combobox: Story = story(COMBOBOX);
+
+/** A single-choice listbox, which renders as the same select. */
+export const Listbox: Story = story(LISTBOX);
+
+/** A multi-select listbox stores its choices as one comma-joined value. */
+export const MultiSelectListbox: Story = story(MULTI_LISTBOX);
+
+/** Radio widgets become one option each, keyed by widget position. */
+export const RadioGroup: Story = story(RADIO);
+
+/** A read-only field is shown but cannot be edited. */
+export const ReadOnly: Story = story(READ_ONLY);
+
+/** Signature fields have no widget of their own, so they fall back to text. */
+export const UnsupportedType: Story = story(SIGNATURE);

--- a/frontend/editor/src/core/tools/formFill/FormFieldSidebar.stories.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormFieldSidebar.stories.tsx
@@ -1,0 +1,40 @@
+/**
+ * The right-hand list of a PDF's form fields, used when the form-fill tool
+ * itself is not open.
+ *
+ * The sidebar is a view onto form-fill state: it groups whatever fields were
+ * parsed out of the document by the page their first widget sits on, and shows
+ * a loading or empty notice when there are none to group. Each card carries the
+ * field's type icon, a "req" marker when it is mandatory and its tooltip as a
+ * hint; signature and button fields get a card but no input, since neither is
+ * fillable from a list. The focused field — set by clicking a widget on the page
+ * — is highlighted and scrolled into view.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FormFieldSidebar } from "@app/tools/formFill/FormFieldSidebar";
+import { withFormFill } from "@app/tools/formFill/storyFixtures";
+
+const meta: Meta<typeof FormFieldSidebar> = {
+  title: "Tools/FormFill/FormFieldSidebar",
+  component: FormFieldSidebar,
+  parameters: { layout: "fullscreen" },
+  args: { visible: true, onToggle: () => {} },
+  decorators: [withFormFill()],
+};
+export default meta;
+
+type Story = StoryObj<typeof FormFieldSidebar>;
+
+/** A form spanning two pages, so the list carries a divider for each. */
+export const Default: Story = {};
+
+/** A field focused from the page: its card is marked and scrolled to. */
+export const ActiveField: Story = {
+  decorators: [withFormFill({ activeField: "country" })],
+};
+
+/** The document is still being parsed for fields. */
+export const Loading: Story = { decorators: [withFormFill({ pending: true })] };
+
+/** A PDF with no form in it at all. */
+export const NoFields: Story = { decorators: [withFormFill({ fields: [] })] };

--- a/frontend/editor/src/core/tools/formFill/FormSaveBar.stories.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormSaveBar.stories.tsx
@@ -1,0 +1,57 @@
+/**
+ * The banner that drops into the corner of the viewer when the open PDF turns
+ * out to have fillable fields.
+ *
+ * It is a prompt, not a panel: it appears only when the document has fields the
+ * user could fill (signature and button fields do not count), they are finished
+ * loading, the form-fill tool is not already open with its own save controls,
+ * and the user has not dismissed it. Until something is actually typed it just
+ * announces the form; editing a value adds the unsaved badge and the two ways
+ * out — apply the changes back into the viewer, or download the filled copy.
+ * The download is held while an export policy is running against the file.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FormSaveBar } from "@app/tools/formFill/FormSaveBar";
+import { STORY_PDF, withFormFill } from "@app/tools/formFill/storyFixtures";
+
+const meta: Meta<typeof FormSaveBar> = {
+  title: "Tools/FormFill/FormSaveBar",
+  component: FormSaveBar,
+  parameters: { layout: "fullscreen" },
+  args: {
+    file: STORY_PDF,
+    isFormFillToolActive: false,
+    onApply: async () => {},
+  },
+  decorators: [
+    withFormFill(),
+    (Story) => (
+      // The bar pins itself to the top-right of the viewport it sits in.
+      <div style={{ position: "relative", height: "60vh" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof FormSaveBar>;
+
+/** Fields found, nothing typed yet. */
+export const Default: Story = {};
+
+/** A value has been edited, so the save actions appear. */
+export const UnsavedChanges: Story = {
+  decorators: [withFormFill({ filled: { fullName: "Jordan Blake" } })],
+};
+
+/** A policy is running against the file, so it cannot leave the app yet. */
+export const DownloadBlockedByPolicy: Story = {
+  args: { policyEnforcing: true },
+  decorators: [withFormFill({ filled: { fullName: "Jordan Blake" } })],
+};
+
+/** The form-fill tool is open and owns saving, so the bar stays away. */
+export const HiddenWhileToolOpen: Story = {
+  args: { isFormFillToolActive: true },
+};

--- a/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
+++ b/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
@@ -1,0 +1,133 @@
+/**
+ * Form-fill context for the formFill stories.
+ *
+ * Every form-fill component reads its fields and values from FormFillProvider,
+ * and the provider only ever gets them by asking a data provider to parse a real
+ * PDF. Both shipped providers need either the pdfium WASM module or the backend,
+ * neither of which exists in a story — so these helpers hand the provider a stub
+ * that returns fixed fields, and drive it the way the app does: fetch on mount,
+ * then type into the form.
+ */
+import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import {
+  FormFillProvider,
+  useFormFill,
+} from "@app/tools/formFill/FormFillContext";
+import type { IFormDataProvider } from "@app/tools/formFill/providers/types";
+import type { FormField } from "@app/tools/formFill/types";
+
+/** Stands in for the open document; the stub provider never reads its bytes. */
+export const STORY_PDF = new Blob(["%PDF-1.7"], { type: "application/pdf" });
+
+export function field(
+  overrides: Partial<FormField> & { name: string },
+): FormField {
+  return {
+    label: overrides.name,
+    type: "text",
+    value: "",
+    options: null,
+    displayOptions: null,
+    required: false,
+    readOnly: false,
+    multiSelect: false,
+    multiline: false,
+    tooltip: null,
+    widgets: [{ pageIndex: 0, x: 72, y: 120, width: 220, height: 22 }],
+    ...overrides,
+  };
+}
+
+/** A small cross-section of field types, as a filled-in form would carry. */
+export const SAMPLE_FIELDS: FormField[] = [
+  field({ name: "fullName", label: "Full name", required: true }),
+  field({
+    name: "address",
+    label: "Address",
+    multiline: true,
+    tooltip: "Include the postcode",
+  }),
+  field({
+    name: "agreeToTerms",
+    label: "I agree to the terms",
+    type: "checkbox",
+  }),
+  field({
+    name: "country",
+    label: "Country",
+    type: "combobox",
+    options: ["uk", "fr", "de"],
+    displayOptions: ["United Kingdom", "France", "Germany"],
+  }),
+  field({
+    name: "reference",
+    label: "Reference number",
+    readOnly: true,
+    value: "INV-20418",
+  }),
+  field({
+    name: "signature",
+    label: "Signature",
+    type: "signature",
+    widgets: [{ pageIndex: 1, x: 72, y: 480, width: 180, height: 60 }],
+  }),
+];
+
+export interface FormFillOptions {
+  /** Fields the stub provider reports for the document. */
+  fields?: FormField[];
+  /** Hold the fetch open, so the form stays in its loading state. */
+  pending?: boolean;
+  /** Values applied after load — this is what marks the form dirty. */
+  filled?: Record<string, string>;
+  /** Field to focus, as clicking its widget on the page would. */
+  activeField?: string;
+}
+
+function stubProvider({
+  fields = SAMPLE_FIELDS,
+  pending = false,
+}: FormFillOptions): IFormDataProvider {
+  return {
+    name: "pdf-lib",
+    fetchFields: () =>
+      pending ? new Promise<FormField[]>(() => {}) : Promise.resolve(fields),
+    fillForm: async () => STORY_PDF,
+  };
+}
+
+/**
+ * Drives the provider once on mount. The fetch is what populates the fields and
+ * seeds the value store; anything applied afterwards counts as user input.
+ */
+function FormFillLoader({
+  filled,
+  activeField,
+  children,
+}: FormFillOptions & { children: ReactNode }) {
+  const { fetchFields, setValue, setActiveField } = useFormFill();
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void fetchFields(STORY_PDF, "story-document").then(() => {
+      Object.entries(filled ?? {}).forEach(([name, value]) =>
+        setValue(name, value),
+      );
+      if (activeField) setActiveField(activeField);
+    });
+  }, [fetchFields, setValue, setActiveField, filled, activeField]);
+
+  return <>{children}</>;
+}
+
+export function withFormFill(options: FormFillOptions = {}) {
+  return (Story: () => ReactElement): ReactElement => (
+    <FormFillProvider provider={stubProvider(options)}>
+      <FormFillLoader {...options}>
+        <Story />
+      </FormFillLoader>
+    </FormFillProvider>
+  );
+}

--- a/frontend/editor/src/proprietary/auth/guards/RequireAdmin.stories.tsx
+++ b/frontend/editor/src/proprietary/auth/guards/RequireAdmin.stories.tsx
@@ -1,0 +1,109 @@
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { AuthContext } from "@app/auth/context";
+import type { AuthContextValue, AuthSession } from "@app/auth/types";
+import { RequireAdmin } from "@app/auth/guards/RequireAdmin";
+
+/**
+ * The admin gate around the settings and processor route trees. Three fields
+ * of the auth context decide what it renders: while `loading` it shows the
+ * `loading` slot, with no session it shows `fallback`, and for a signed-in
+ * user who is not an admin it shows `forbidden` while calling `onForbidden`
+ * so the route can redirect. Only an authenticated admin sees the children.
+ *
+ * The guard reads three fields, so the stories supply a slice of the auth
+ * context rather than mounting a real provider, and each slot renders as a
+ * labelled panel so the branch taken is visible.
+ */
+
+/** Auth context slice; `session`, `loading` and `isAdmin` steer this guard. */
+function authValue(
+  overrides: Partial<AuthContextValue> = {},
+): AuthContextValue {
+  return {
+    session: null,
+    user: null,
+    displayName: null,
+    isAnonymous: false,
+    isAdmin: false,
+    portalAccess: false,
+    role: null,
+    loading: false,
+    error: null,
+    signOut: async () => {},
+    refreshSession: async () => {},
+    ...overrides,
+  };
+}
+
+const activeSession: AuthSession = {
+  user: { id: "1", email: "ada@example.com", username: "ada", role: "USER" },
+  access_token: "storybook-token",
+  expires_in: 3600,
+};
+
+/** Labelled stand-in for whichever slot the guard chose to render. */
+function Panel({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        padding: "1.5rem",
+        borderRadius: "0.75rem",
+        border: "1px solid var(--c-border)",
+        background: "var(--c-surface)",
+        color: "var(--c-text)",
+        textAlign: "center",
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
+function withAuth(value: AuthContextValue): Decorator {
+  return (Story) => (
+    <AuthContext.Provider value={value}>
+      <Story />
+    </AuthContext.Provider>
+  );
+}
+
+const meta: Meta<typeof RequireAdmin> = {
+  title: "Auth/Guards/Require Admin",
+  component: RequireAdmin,
+  parameters: { layout: "centered" },
+  args: {
+    children: <Panel label="Admin content" />,
+    fallback: <Panel label="Login screen (fallback)" />,
+    forbidden: <Panel label="Redirecting away…" />,
+    loading: <Panel label="Resolving session…" />,
+    onForbidden: () => {},
+  },
+};
+export default meta;
+type Story = StoryObj<typeof RequireAdmin>;
+
+/** An authenticated admin: the guarded tree renders. */
+export const Admin: Story = {
+  decorators: [withAuth(authValue({ session: activeSession, isAdmin: true }))],
+};
+
+/**
+ * Signed in without the admin role. `onForbidden` fires so the route can send
+ * the user back to the editor; the forbidden slot covers the gap until it does.
+ */
+export const NotAdmin: Story = {
+  decorators: [withAuth(authValue({ session: activeSession }))],
+};
+
+/** No session at all: the login screen takes over, no redirect is triggered. */
+export const SignedOut: Story = {
+  decorators: [withAuth(authValue())],
+};
+
+/**
+ * Session still resolving. The redirect is deliberately held back here — a
+ * half-loaded session must not be mistaken for a non-admin one.
+ */
+export const Loading: Story = {
+  decorators: [withAuth(authValue({ loading: true }))],
+};

--- a/frontend/editor/src/proprietary/auth/guards/RequireAuth.stories.tsx
+++ b/frontend/editor/src/proprietary/auth/guards/RequireAuth.stories.tsx
@@ -1,0 +1,104 @@
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { AuthContext } from "@app/auth/context";
+import type { AuthContextValue, AuthSession } from "@app/auth/types";
+import { RequireAuth } from "@app/auth/guards/RequireAuth";
+
+/**
+ * The session gate wrapped around protected route trees. It renders one of
+ * three slots depending purely on the auth context: `loading` while the
+ * session is still resolving, `fallback` when there is no session, and its
+ * children once a session exists.
+ *
+ * The guard reads only `session` and `loading`, so the stories hand it a slice
+ * of the auth context instead of mounting a real provider. Each slot is a
+ * labelled panel so it is obvious which branch was taken.
+ */
+
+/** Auth context slice; only `session` and `loading` steer this guard. */
+function authValue(
+  overrides: Partial<AuthContextValue> = {},
+): AuthContextValue {
+  return {
+    session: null,
+    user: null,
+    displayName: null,
+    isAnonymous: false,
+    isAdmin: false,
+    portalAccess: false,
+    role: null,
+    loading: false,
+    error: null,
+    signOut: async () => {},
+    refreshSession: async () => {},
+    ...overrides,
+  };
+}
+
+const activeSession: AuthSession = {
+  user: { id: "1", email: "ada@example.com", username: "ada", role: "USER" },
+  access_token: "storybook-token",
+  expires_in: 3600,
+};
+
+/** Labelled stand-in for whichever slot the guard chose to render. */
+function Panel({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        padding: "1.5rem",
+        borderRadius: "0.75rem",
+        border: "1px solid var(--c-border)",
+        background: "var(--c-surface)",
+        color: "var(--c-text)",
+        textAlign: "center",
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
+function withAuth(value: AuthContextValue): Decorator {
+  return (Story) => (
+    <AuthContext.Provider value={value}>
+      <Story />
+    </AuthContext.Provider>
+  );
+}
+
+const meta: Meta<typeof RequireAuth> = {
+  title: "Auth/Guards/Require Auth",
+  component: RequireAuth,
+  parameters: { layout: "centered" },
+  args: {
+    children: <Panel label="Protected content" />,
+    fallback: <Panel label="Login screen (fallback)" />,
+    loading: <Panel label="Resolving session…" />,
+  },
+};
+export default meta;
+type Story = StoryObj<typeof RequireAuth>;
+
+/** A resolved session: the guard renders the protected tree. */
+export const Authenticated: Story = {
+  decorators: [withAuth(authValue({ session: activeSession }))],
+};
+
+/** No session: the caller's login screen takes over. */
+export const SignedOut: Story = {
+  decorators: [withAuth(authValue())],
+};
+
+/** Session still resolving: neither content nor login screen flashes. */
+export const Loading: Story = {
+  decorators: [withAuth(authValue({ loading: true }))],
+};
+
+/**
+ * With no `loading` slot the guard renders nothing until the session
+ * resolves, which is how routes that own their own spinner use it.
+ */
+export const LoadingWithoutSlot: Story = {
+  args: { loading: undefined },
+  decorators: [withAuth(authValue({ loading: true }))],
+};

--- a/frontend/editor/src/proprietary/auth/guards/RequirePortalAccess.stories.tsx
+++ b/frontend/editor/src/proprietary/auth/guards/RequirePortalAccess.stories.tsx
@@ -1,0 +1,113 @@
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { AuthContext } from "@app/auth/context";
+import type { AuthContextValue, AuthSession } from "@app/auth/types";
+import { RequirePortalAccess } from "@app/auth/guards/RequirePortalAccess";
+
+/**
+ * The processor/portal gate. It mirrors the admin guard but keys off
+ * `portalAccess`, the backend grant that covers admins plus anyone given
+ * access explicitly: `loading` while the session resolves, `fallback` when
+ * signed out, and `forbidden` (alongside a call to `onForbidden`) for a
+ * signed-in user without the grant.
+ *
+ * The guard reads three context fields, so the stories supply a slice of the
+ * auth context rather than mounting a real provider, and each slot renders as
+ * a labelled panel so the branch taken is visible.
+ */
+
+/**
+ * Auth context slice; `session`, `loading` and `portalAccess` steer this guard.
+ */
+function authValue(
+  overrides: Partial<AuthContextValue> = {},
+): AuthContextValue {
+  return {
+    session: null,
+    user: null,
+    displayName: null,
+    isAnonymous: false,
+    isAdmin: false,
+    portalAccess: false,
+    role: null,
+    loading: false,
+    error: null,
+    signOut: async () => {},
+    refreshSession: async () => {},
+    ...overrides,
+  };
+}
+
+const activeSession: AuthSession = {
+  user: { id: "1", email: "ada@example.com", username: "ada", role: "USER" },
+  access_token: "storybook-token",
+  expires_in: 3600,
+};
+
+/** Labelled stand-in for whichever slot the guard chose to render. */
+function Panel({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        padding: "1.5rem",
+        borderRadius: "0.75rem",
+        border: "1px solid var(--c-border)",
+        background: "var(--c-surface)",
+        color: "var(--c-text)",
+        textAlign: "center",
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
+function withAuth(value: AuthContextValue): Decorator {
+  return (Story) => (
+    <AuthContext.Provider value={value}>
+      <Story />
+    </AuthContext.Provider>
+  );
+}
+
+const meta: Meta<typeof RequirePortalAccess> = {
+  title: "Auth/Guards/Require Portal Access",
+  component: RequirePortalAccess,
+  parameters: { layout: "centered" },
+  args: {
+    children: <Panel label="Processor content" />,
+    fallback: <Panel label="Login screen (fallback)" />,
+    forbidden: <Panel label="Redirecting away…" />,
+    loading: <Panel label="Resolving session…" />,
+    onForbidden: () => {},
+  },
+};
+export default meta;
+type Story = StoryObj<typeof RequirePortalAccess>;
+
+/** The grant is present: the processor renders. */
+export const WithAccess: Story = {
+  decorators: [
+    withAuth(authValue({ session: activeSession, portalAccess: true })),
+  ],
+};
+
+/**
+ * Signed in without the grant. `onForbidden` fires so the route can send the
+ * user back to the editor; the forbidden slot covers the gap until it does.
+ */
+export const WithoutAccess: Story = {
+  decorators: [withAuth(authValue({ session: activeSession }))],
+};
+
+/** No session at all: the login screen takes over, no redirect is triggered. */
+export const SignedOut: Story = {
+  decorators: [withAuth(authValue())],
+};
+
+/**
+ * Session still resolving. The redirect is deliberately held back here — an
+ * unresolved session must not be mistaken for a missing grant.
+ */
+export const Loading: Story = {
+  decorators: [withAuth(authValue({ loading: true }))],
+};

--- a/frontend/editor/src/proprietary/routes/AuthCallback.stories.tsx
+++ b/frontend/editor/src/proprietary/routes/AuthCallback.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AuthCallback from "@app/routes/AuthCallback";
+import "@app/auth/ui/auth.css";
+
+/**
+ * The landing screen an OAuth or SSO provider redirects back to. It has a
+ * single visual state — a branded "completing authentication" card with a
+ * spinner — because every outcome of the token exchange resolves by
+ * navigating elsewhere: on to the requested page, or back to the login screen
+ * carrying an error. Only the waiting moment is ever rendered here.
+ *
+ * With no token in the URL fragment the route redirects immediately, so the
+ * story shows the card as the user sees it during a real exchange.
+ */
+const meta: Meta<typeof AuthCallback> = {
+  title: "Auth/Auth Callback",
+  component: AuthCallback,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj<typeof AuthCallback>;
+
+export const Default: Story = {};

--- a/frontend/editor/src/proprietary/routes/authShared/AuthLayout.stories.tsx
+++ b/frontend/editor/src/proprietary/routes/authShared/AuthLayout.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AuthLayout from "@app/routes/authShared/AuthLayout";
+import LoginHeader from "@app/routes/login/LoginHeader";
+import "@app/auth/ui/auth.css";
+
+/**
+ * The editor's wrapper around the shared auth card: the same centred shell the
+ * portal uses, with the editor's legal and cookie footer pinned to the bottom
+ * of the viewport. It takes no props beyond its children, so what varies
+ * between stories is the height of the content sitting inside the card and how
+ * that content sits against the fixed footer.
+ */
+const meta: Meta<typeof AuthLayout> = {
+  title: "Auth/Auth Layout",
+  component: AuthLayout,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj<typeof AuthLayout>;
+
+/** A short screen — the card floats well clear of the footer. */
+export const Default: Story = {
+  args: {
+    children: (
+      <LoginHeader
+        title="Sign in"
+        subtitle="Enter your credentials to continue."
+      />
+    ),
+  },
+};
+
+/**
+ * A tall screen: the card grows towards the fixed footer, which is the case
+ * that shows whether the two collide on short viewports.
+ */
+export const TallContent: Story = {
+  args: {
+    children: (
+      <>
+        <LoginHeader title="Create your account" />
+        {Array.from({ length: 8 }, (_, i) => (
+          <p key={i} style={{ color: "var(--c-text)" }}>
+            Placeholder form row {i + 1}
+          </p>
+        ))}
+      </>
+    ),
+  },
+};

--- a/frontend/editor/src/proprietary/routes/login/LoggedInState.stories.tsx
+++ b/frontend/editor/src/proprietary/routes/login/LoggedInState.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AuthContext } from "@app/auth/context";
+import type { AuthContextValue, AuthUser } from "@app/auth/types";
+import LoggedInState from "@app/routes/login/LoggedInState";
+
+/**
+ * The interstitial the login route shows when someone who already has a
+ * session lands on it: a confirmation card naming the signed-in address,
+ * which redirects to the workspace a couple of seconds later.
+ *
+ * It reads only the user off the auth context, so the stories supply a slice
+ * of that context rather than mounting a real provider. The redirect timer
+ * still runs; in Storybook there is nowhere to navigate to, so the card stays
+ * on screen.
+ */
+
+/** Minimal auth context slice — only `user` is read by this screen. */
+function authValue(user: AuthUser | null): AuthContextValue {
+  return {
+    session: null,
+    user,
+    displayName: user?.username ?? null,
+    isAnonymous: false,
+    isAdmin: false,
+    portalAccess: false,
+    role: user?.role ?? null,
+    loading: false,
+    error: null,
+    signOut: async () => {},
+    refreshSession: async () => {},
+  };
+}
+
+const signedInUser: AuthUser = {
+  id: "1",
+  email: "ada@example.com",
+  username: "ada",
+  role: "USER",
+};
+
+const meta: Meta<typeof LoggedInState> = {
+  title: "Auth/Logged In State",
+  component: LoggedInState,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj<typeof LoggedInState>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <AuthContext.Provider value={authValue(signedInUser)}>
+        <Story />
+      </AuthContext.Provider>
+    ),
+  ],
+};
+
+/**
+ * Sessions without an email address — anonymous or SSO users the backend
+ * returns no address for — leave the label with nothing after the colon.
+ */
+export const WithoutEmail: Story = {
+  decorators: [
+    (Story) => (
+      <AuthContext.Provider value={authValue({ ...signedInUser, email: "" })}>
+        <Story />
+      </AuthContext.Provider>
+    ),
+  ],
+};

--- a/frontend/editor/src/proprietary/routes/login/LoginHeader.stories.tsx
+++ b/frontend/editor/src/proprietary/routes/login/LoginHeader.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import LoginHeader from "@app/routes/login/LoginHeader";
+import "@app/auth/ui/auth.css";
+
+/**
+ * The wordmark-and-title block that opens every auth screen. The wordmark
+ * variant is resolved from the user's logo preference and the active colour
+ * scheme, so it needs no props; what callers vary is the copy (title, optional
+ * subtitle) and whether the block is centred.
+ */
+const meta: Meta<typeof LoginHeader> = {
+  title: "Auth/Login Header",
+  component: LoginHeader,
+  parameters: { layout: "centered" },
+  args: {
+    title: "Sign in to Stirling PDF",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof LoginHeader>;
+
+export const Default: Story = {};
+
+/** Screens that need a line of guidance beneath the title pass a subtitle. */
+export const WithSubtitle: Story = {
+  args: {
+    subtitle: "Enter your credentials to continue.",
+  },
+};
+
+/**
+ * Centred layout, used where the header stands alone rather than above a
+ * left-aligned form — status and callback screens, for instance.
+ */
+export const Centered: Story = {
+  args: {
+    subtitle: "Enter your credentials to continue.",
+    centerOnly: true,
+  },
+};
+
+/** Long titles wrap within the card instead of widening it. */
+export const LongTitle: Story = {
+  args: {
+    title: "Sign in to continue to your organisation's document workspace",
+  },
+};

--- a/frontend/editor/src/proprietary/routes/login/NavigationLink.stories.tsx
+++ b/frontend/editor/src/proprietary/routes/login/NavigationLink.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import NavigationLink from "@app/routes/login/NavigationLink";
+import "@app/auth/ui/auth.css";
+
+/**
+ * The quiet text link the auth screens use to move between login, signup and
+ * password reset. Its only variation is the disabled state, which the screens
+ * apply while a submission is in flight so the user cannot navigate away
+ * mid-request.
+ */
+const meta: Meta<typeof NavigationLink> = {
+  title: "Auth/Navigation Link",
+  component: NavigationLink,
+  parameters: { layout: "centered" },
+  args: {
+    text: "Back to login",
+    onClick: () => {},
+  },
+};
+export default meta;
+type Story = StoryObj<typeof NavigationLink>;
+
+export const Default: Story = {};
+
+/** Held inert while the surrounding form is submitting. */
+export const Disabled: Story = {
+  args: { isDisabled: true },
+};

--- a/frontend/editor/src/proprietary/routes/signup/SignupForm.stories.tsx
+++ b/frontend/editor/src/proprietary/routes/signup/SignupForm.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SignupForm from "@app/routes/signup/SignupForm";
+import "@app/auth/ui/auth.css";
+
+/**
+ * The account-creation form body. Three things change what it shows: the
+ * password field (the confirmation input stays collapsed until the password
+ * reaches four characters), and the `showName` / `showTerms` flags, which the
+ * cloud signup turns on and the self-hosted one leaves off.
+ *
+ * The form is fully controlled, so the stories pass fixed values and no-op
+ * setters — each story pins one state rather than exposing a live form.
+ */
+const meta: Meta<typeof SignupForm> = {
+  title: "Auth/Signup Form",
+  component: SignupForm,
+  parameters: { layout: "centered" },
+  args: {
+    email: "",
+    password: "",
+    confirmPassword: "",
+    setEmail: () => {},
+    setPassword: () => {},
+    setConfirmPassword: () => {},
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof SignupForm>;
+
+/** Untouched form: confirmation collapsed, submit disabled. */
+export const Default: Story = {};
+
+/**
+ * Past the four-character threshold the confirmation field animates open, so
+ * the form grows a row without the layout jumping.
+ */
+export const ConfirmationRevealed: Story = {
+  args: {
+    email: "ada@example.com",
+    password: "hunter2",
+    confirmPassword: "hunter2",
+  },
+};
+
+/** The cloud signup additionally collects a name and terms acceptance. */
+export const WithNameAndTerms: Story = {
+  args: {
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+    password: "hunter2",
+    confirmPassword: "hunter2",
+    setName: () => {},
+    setAgree: () => {},
+    showName: true,
+    showTerms: true,
+  },
+};
+
+/** Terms presented but not yet accepted, which holds the submit disabled. */
+export const TermsNotAccepted: Story = {
+  args: {
+    email: "ada@example.com",
+    password: "hunter2",
+    confirmPassword: "hunter2",
+    agree: false,
+    setAgree: () => {},
+    showTerms: true,
+  },
+};
+
+/** Server-side validation returned per-field messages. */
+export const WithFieldErrors: Story = {
+  args: {
+    name: "Ada Lovelace",
+    email: "not-an-email",
+    password: "short",
+    confirmPassword: "shore",
+    setName: () => {},
+    showName: true,
+    fieldErrors: {
+      name: "Please enter your name.",
+      email: "Enter a valid email address.",
+      password: "Password must be at least 8 characters.",
+      confirmPassword: "Passwords do not match.",
+    },
+  },
+};
+
+/** In flight: the submit button takes over as the progress indicator. */
+export const Submitting: Story = {
+  args: {
+    email: "ada@example.com",
+    password: "hunter2",
+    confirmPassword: "hunter2",
+    isSubmitting: true,
+  },
+};

--- a/frontend/editor/src/saas/routes/login/SuccessMessage.stories.tsx
+++ b/frontend/editor/src/saas/routes/login/SuccessMessage.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SuccessMessage from "./SuccessMessage";
+import "@app/auth/ui/auth.css";
+
+/**
+ * The confirmation banner the cloud auth screens render after a request that
+ * has no immediate next step — a magic link sent, a reset email dispatched.
+ * It is the mirror of the auth error banner: a single message, or nothing at
+ * all when there is none to show.
+ *
+ * The component is imported by path rather than through `@app/*` because it
+ * lives only in the SaaS layer, which the shared Storybook does not alias.
+ */
+const meta: Meta<typeof SuccessMessage> = {
+  title: "Auth/Success Message",
+  component: SuccessMessage,
+  parameters: { layout: "centered" },
+  args: {
+    success: "Check your inbox — we've sent you a sign-in link.",
+  },
+};
+export default meta;
+type Story = StoryObj<typeof SuccessMessage>;
+
+export const Default: Story = {};
+
+/** Longer copy wraps inside the banner rather than stretching the card. */
+export const LongMessage: Story = {
+  args: {
+    success:
+      "We've emailed a sign-in link to you. It expires in 15 minutes, so if it stops working just request another one from this screen.",
+  },
+};
+
+/** With no message the component renders nothing, leaving no reserved space. */
+export const Empty: Story = {
+  args: { success: null },
+};


### PR DESCRIPTION
Auth coverage plus the a11y fixes the wider sweep surfaced.

### Coverage

Login header, logged-in state, signup form, auth callback and layout, plus the three route guards. The guards render real slots rather than redirecting, so each covers its authenticated, refused and still-loading branches through an `AuthContext` slice instead of the provider. **Nothing to fix in this area — 34 stories, clean first time.**

### Four defects fixed here

- **`AttachmentSidebar` and `AddFileCard`** were each a `role="button"` div wrapping their own real buttons — a control inside a control. The rows keep their click as a mouse convenience; the buttons carry the keyboard path.
- **`FolderTreePanel`** set `aria-hidden` when collapsed while its controls stayed in the tab order — focusable but invisible. It is now `inert` too.
- **The workbench bar** named its controls from `ariaLabel`, which neither story fixture supplied, so every button rendered with an empty `aria-label`.

### Scope note

This branch is wider than its title suggests. A `git add` by directory swept several agent-authored story files in alongside the a11y fixes, so the diff carries more than the auth work. Everything in it is scanned and green; the boundary is just less tidy than intended.

### Verification

- Typecheck clean, `task pre-commit` green