### PR TITLE
test(portal,fileManager,viewer): three batches and five contrast fixes

### DIFF
--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -8633,6 +8633,7 @@ title = "Rotate Settings Overview"
 
 [ruler]
 clearAll = "Clear all"
+deleteMeasurement = "Delete measurement"
 hideAllLabels = "Hide all labels"
 hideSmallLabels = "Hide small labels"
 physicalValues = "Physical"

--- a/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
@@ -45,6 +45,7 @@ export function OpacityControl({
             min={10}
             max={100}
             label={(val) => `${val}%`}
+            thumbLabel={t("annotation.opacity", "Opacity")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
@@ -75,6 +75,7 @@ export function PropertiesPopover({
           min={8}
           max={32}
           label={(val) => `${val}pt`}
+          thumbLabel={t("annotation.fontSize", "Font size")}
         />
       </div>
 
@@ -86,6 +87,7 @@ export function PropertiesPopover({
         <Slider
           value={Math.round((obj?.opacity ?? 1) * 100)}
           onChange={(val) => onUpdate({ opacity: val / 100 })}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -144,6 +146,7 @@ export function PropertiesPopover({
               fillOpacity: newOpacity,
             });
           }}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -169,6 +172,7 @@ export function PropertiesPopover({
               min={0}
               max={12}
               label={(val) => `${val}pt`}
+              thumbLabel={t("annotation.strokeWidth", "Stroke")}
             />
           </div>
           <Button

--- a/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
@@ -49,6 +49,7 @@ export function WidthControl({
             min={min}
             max={max}
             label={(val) => `${val}pt`}
+            thumbLabel={t("annotation.width", "Width")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/fileManager/EmptyFilesState.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/EmptyFilesState.stories.tsx
@@ -1,0 +1,65 @@
+/**
+ * What the file manager shows before anything has been added. The copy and
+ * icons come from the file-action hooks, which desktop builds override — these
+ * stories render the web wording.
+ *
+ * Only one context field is read (the upload click handler), so the fixture
+ * supplies that alone rather than the whole provider.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import EmptyFilesState from "@app/components/fileManager/EmptyFilesState";
+import {
+  FileManagerContext,
+  type FileManagerContextValue,
+} from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof EmptyFilesState> = {
+  title: "FileManager/EmptyFilesState",
+  component: EmptyFilesState,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    // The wordmark resolves its logo variant through PreferencesContext, which
+    // the Storybook preview does not mount, so this story supplies it.
+    (Story) => (
+      <PreferencesProvider>
+        <FileManagerContext.Provider
+          value={
+            { onLocalFileClick: () => {} } as unknown as FileManagerContextValue
+          }
+        >
+          <div style={{ height: "32rem" }}>
+            <Story />
+          </div>
+        </FileManagerContext.Provider>
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof EmptyFilesState>;
+
+export const Default: Story = {};
+
+/** The panel centres itself, so a short container crops rather than reflows. */
+export const ShortContainer: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: "18rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Narrow widths are the mobile case — the upload actions stack. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * The scrolling list that fills the file manager. Which branch it renders is
+ * decided entirely by context — the active source, whether files are loading,
+ * and whether any survive the search filter — so the stories drive it through
+ * the provider rather than through props.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileListArea from "@app/components/fileManager/FileListArea";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+import type { FileId } from "@app/types/file";
+
+const FILES = [
+  makeStub("f1", "quarterly-report.pdf"),
+  makeStub("f2", "signed-contract.pdf", { size: 840_000 }),
+  makeStub("f3", "scan-2026-03-14.pdf", { size: 12_600_000 }),
+  makeStub("f4", "minutes.pdf", { size: 96_000 }),
+];
+
+const meta: Meta<typeof FileListArea> = {
+  title: "FileManager/FileListArea",
+  component: FileListArea,
+  parameters: { layout: "padded" },
+  args: { scrollAreaHeight: "26rem" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FileListArea>;
+
+export const Default: Story = {
+  decorators: [withFileManager({ recentFiles: FILES })],
+};
+
+/** No files at all — the list gives way to the empty state. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};
+
+export const Loading: Story = {
+  decorators: [withFileManager({ recentFiles: FILES, isLoading: true })],
+};
+
+/** Files already open in the editor are marked as active in the list. */
+export const WithActiveFile: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: ["f2" as FileId],
+    }),
+  ],
+};
+
+/** Enough rows to scroll, which is the normal state for a working library. */
+export const ManyFiles: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: Array.from({ length: 24 }, (_, i) =>
+        makeStub(`many-${i}`, `document-${String(i + 1).padStart(3, "0")}.pdf`),
+      ),
+    }),
+  ],
+};
+
+/** A short frame proves the list scrolls inside its own box, not the page. */
+export const ShortFrame: Story = {
+  args: { scrollAreaHeight: "12rem" },
+  decorators: [withFileManager({ recentFiles: FILES })],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListItem.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListItem.tsx
@@ -213,6 +213,9 @@ const FileListItem: React.FC<FileListItemProps> = ({
               <Checkbox
                 checked={isSelected}
                 onChange={() => {}} // Handled by parent onClick
+                aria-label={t("fileManager.selectFile", "Select {{name}}", {
+                  name: file.name,
+                })}
                 size="sm"
                 pl="sm"
                 pr="xs"
@@ -261,12 +264,9 @@ const FileListItem: React.FC<FileListItemProps> = ({
                     : t("storageShare.roleViewer", "Viewer")}
                 </Badge>
               ) : isLocalOnly ? (
-                <Badge
-                  size="xs"
-                  variant="default"
-                  c="dimmed"
-                  style={{ opacity: 0.75 }}
-                >
+                // No extra opacity: at this size the muted colour is already at
+                // the edge of 4.5:1, and fading it drops below.
+                <Badge size="xs" variant="default" c="dimmed">
                   {t("fileManager.localOnly", "Local only")}
                 </Badge>
               ) : uploadEnabled && isOutOfSync ? (

--- a/frontend/editor/src/core/components/fileManager/SearchInput.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/SearchInput.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * The file manager's search box. It reads the term and the change handler from
+ * FileManagerContext rather than taking props, so the stories mount it against
+ * a two-field slice of that context instead of the whole provider chain.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SearchInput from "@app/components/fileManager/SearchInput";
+import {
+  FileManagerContext,
+  type FileManagerContextValue,
+} from "@app/contexts/FileManagerContext";
+
+/**
+ * SearchInput reads exactly two fields. Supplying only those keeps the fixture
+ * honest about what the component depends on; the cast is what makes a partial
+ * value acceptable in place of the full context.
+ */
+function withSearch(
+  searchTerm: string,
+  onSearchChange: (term: string) => void = () => {},
+) {
+  return (children: React.ReactNode) => (
+    <FileManagerContext.Provider
+      value={
+        { searchTerm, onSearchChange } as unknown as FileManagerContextValue
+      }
+    >
+      {children}
+    </FileManagerContext.Provider>
+  );
+}
+
+const meta: Meta<typeof SearchInput> = {
+  title: "FileManager/SearchInput",
+  component: SearchInput,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchInput>;
+
+export const Empty: Story = {
+  render: () => withSearch("")(<SearchInput />),
+};
+
+export const WithTerm: Story = {
+  render: () => withSearch("invoice")(<SearchInput />),
+};
+
+/** Long terms are not truncated by the component — the field scrolls instead. */
+export const LongTerm: Story = {
+  render: () =>
+    withSearch("quarterly-report-2026-final-revised-approved")(<SearchInput />),
+};
+
+/** The container controls width, so the box stretches to whatever it is given. */
+export const Narrow: Story = {
+  render: () => (
+    <div style={{ width: 220 }}>{withSearch("draft")(<SearchInput />)}</div>
+  ),
+};
+
+/** Typing is driven by the context handler, so state lives outside the field. */
+export const Interactive: Story = {
+  render: function Interactive() {
+    const [term, setTerm] = useState("");
+    return withSearch(term, setTerm)(<SearchInput />);
+  },
+};

--- a/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
@@ -1,0 +1,98 @@
+/**
+ * Shared fixtures for the file manager stories.
+ *
+ * These components sit deep in a provider chain — FileManagerContext needs
+ * FileContext for useFileActions/useFileManagement, list rows additionally read
+ * AppConfig — and none of it is part of the shared preview decorators. Rather
+ * than each story rebuilding that tree, they mount the real providers here over
+ * static data, so what a story exercises is the component and not a stub.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FileManagerProvider } from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+/** A grey rectangle, so thumbnail lookups short-circuit instead of reading
+ *  file bytes out of IndexedDB. */
+const THUMBNAIL =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160'%3E%3Crect width='120' height='160' fill='%23e9ecef'/%3E%3C/svg%3E";
+
+/** Fixed so stories render identically on every run. */
+const LAST_MODIFIED = Date.parse("2026-03-14T09:30:00Z");
+
+export function makeStub(
+  id: string,
+  name: string,
+  overrides: Partial<StirlingFileStub> = {},
+): StirlingFileStub {
+  return {
+    id: id as FileId,
+    name,
+    type: "application/pdf",
+    size: 2_400_000,
+    lastModified: LAST_MODIFIED,
+    isLeaf: true,
+    originalFileId: id,
+    versionNumber: 1,
+    thumbnailUrl: THUMBNAIL,
+    ...overrides,
+  };
+}
+
+export const mockFile = makeStub("story-file-1", "quarterly-report.pdf");
+
+/** Storage off keeps the row's upload and share affordances out of the way;
+ *  stories that want them pass their own config. */
+const BASE_CONFIG = {
+  storageEnabled: false,
+  storageSharingEnabled: false,
+  storageShareLinksEnabled: false,
+  frontendUrl: "https://stirling.example",
+};
+
+interface FixtureOptions {
+  recentFiles?: StirlingFileStub[];
+  activeFileIds?: FileId[];
+  isLoading?: boolean;
+  config?: Partial<typeof BASE_CONFIG>;
+}
+
+export function withFileManager({
+  recentFiles = [mockFile],
+  activeFileIds = [],
+  isLoading = false,
+  config,
+}: FixtureOptions = {}) {
+  return (Story: () => ReactElement) => (
+    <AppConfigProvider
+      initialConfig={{ ...BASE_CONFIG, ...config } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      {/* The empty state's wordmark resolves a logo variant through
+          PreferencesContext, which the preview does not mount. */}
+      <PreferencesProvider>
+        <FileContextProvider>
+          <FileManagerProvider
+            recentFiles={recentFiles}
+            onRecentFilesSelected={() => {}}
+            onNewFilesSelect={() => {}}
+            onClose={() => {}}
+            isFileSupported={() => true}
+            isOpen
+            onFileRemove={() => {}}
+            modalHeight="600px"
+            refreshRecentFiles={async () => {}}
+            isLoading={isLoading}
+            activeFileIds={activeFileIds}
+          >
+            <Story />
+          </FileManagerProvider>
+        </FileContextProvider>
+      </PreferencesProvider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
@@ -334,6 +334,7 @@ export function PdfViewerToolbar({
             max={500}
             step={5}
             onChange={(val) => zoomActions.setZoomLevel?.(val / 100)}
+            thumbLabel={t("viewer.zoomLevel", "Zoom level")}
             size="xs"
             styles={{
               root: { minWidth: "6rem", width: "6rem", flexShrink: 0 },

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
@@ -192,6 +192,9 @@ export function PdfViewerToolbar({
 
       {/* Page Input */}
       <NumberInput
+        /* Only the page count sits beside it, as plain text — the field itself
+           carries no name without this. */
+        aria-label={t("viewer.pageNumber", "Page number")}
         value={pageInput}
         onChange={(value) => {
           const page = Number(value);

--- a/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.stories.tsx
@@ -1,0 +1,151 @@
+/**
+ * The measurement overlay that sits above a rendered page. Everything here is
+ * SVG drawn in screen coordinates: the layer is normally mounted inside the
+ * viewer's own <svg>, so these stories supply that wrapper themselves and place
+ * measurements at fixed points rather than deriving them from a real page.
+ *
+ * The label layout is the interesting behaviour — labels are hidden, shown, or
+ * expanded depending on zoom, crowding, and which measurement is hovered — so
+ * each visibility mode gets a story rather than a control.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  RulerMeasurementLayer,
+  type RulerRenderedMeasurement,
+} from "@app/components/viewer/RulerMeasurementLayer";
+import type { MeasureScale } from "@app/utils/measurementTypes";
+
+const SCALE: MeasureScale = { factor: 0.05, ratio: 100, unit: "m" };
+
+function rendered(
+  id: string,
+  startS: { x: number; y: number },
+  endS: { x: number; y: number },
+  measureScale: MeasureScale | null = null,
+): RulerRenderedMeasurement {
+  const distPts = Math.hypot(endS.x - startS.x, endS.y - startS.y);
+  return {
+    // Screen and page coordinates coincide here: the stories render at zoom 1
+    // against a single page, so no projection is involved.
+    measurement: {
+      id,
+      start: { ...startS, pageIndex: 0 },
+      end: { ...endS, pageIndex: 0 },
+    },
+    startS,
+    endS,
+    distPts,
+    measureScale,
+  };
+}
+
+const MEASUREMENTS = [
+  rendered("a", { x: 80, y: 90 }, { x: 320, y: 90 }),
+  rendered("b", { x: 120, y: 150 }, { x: 300, y: 260 }),
+  rendered("c", { x: 360, y: 120 }, { x: 480, y: 300 }),
+];
+
+/** Close enough together that the crowding rules start dropping idle labels. */
+const CROWDED = [
+  rendered("a", { x: 60, y: 80 }, { x: 150, y: 80 }),
+  rendered("b", { x: 60, y: 110 }, { x: 150, y: 110 }),
+  rendered("c", { x: 60, y: 140 }, { x: 150, y: 140 }),
+  rendered("d", { x: 60, y: 170 }, { x: 150, y: 170 }),
+  rendered("e", { x: 170, y: 80 }, { x: 260, y: 80 }),
+  rendered("f", { x: 170, y: 110 }, { x: 260, y: 110 }),
+];
+
+const noop = () => {};
+
+const meta: Meta<typeof RulerMeasurementLayer> = {
+  title: "Viewer/RulerMeasurementLayer",
+  component: RulerMeasurementLayer,
+  parameters: { layout: "fullscreen" },
+  args: {
+    measurements: MEASUREMENTS,
+    zoom: 1,
+    selectedId: null,
+    hoveredId: null,
+    labelVisibilityMode: "hideSmall",
+    isInteractionPassthroughActive: false,
+    onSelect: noop,
+    onDelete: noop,
+    onHoverChange: noop,
+    onClearAll: noop,
+    onCycleLabelVisibilityMode: noop,
+  },
+  render: (args) => (
+    <div style={{ background: "var(--c-surface-sunken)", padding: "1rem" }}>
+      {/* Coordinates are fixed but the canvas is not, so the viewBox scales the
+          page rather than letting a narrow frame scroll it. */}
+      <svg
+        viewBox="0 0 560 360"
+        width="100%"
+        style={{
+          display: "block",
+          background: "var(--c-surface-raised)",
+          borderRadius: 4,
+        }}
+      >
+        <RulerMeasurementLayer {...args} />
+      </svg>
+    </div>
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof RulerMeasurementLayer>;
+
+export const Default: Story = {};
+
+/** Nothing measured yet: the toolbar controls are not drawn at all. */
+export const Empty: Story = { args: { measurements: [] } };
+
+export const Selected: Story = { args: { selectedId: "b" } };
+
+/** Hovering expands the label to its multi-line form. */
+export const Hovered: Story = { args: { hoveredId: "a" } };
+
+/** With a scale applied the label gains the converted real-world distance. */
+export const Scaled: Story = {
+  args: {
+    measurements: MEASUREMENTS.map((m) => ({ ...m, measureScale: SCALE })),
+    hoveredId: "a",
+  },
+};
+
+export const LabelsShowAll: Story = { args: { labelVisibilityMode: "showAll" } };
+
+export const LabelsHidden: Story = { args: { labelVisibilityMode: "hideAll" } };
+
+/** hideSmall drops idle labels that would collide; showAll forces them back. */
+export const CrowdedHideSmall: Story = { args: { measurements: CROWDED } };
+
+export const CrowdedShowAll: Story = {
+  args: { measurements: CROWDED, labelVisibilityMode: "showAll" },
+};
+
+/** Mid-draw: the first point is placed and the line follows the cursor. */
+export const DrawingInProgress: Story = {
+  args: {
+    measurements: [],
+    firstPoint: { x: 120, y: 120 },
+    cursor: { x: 380, y: 240 },
+    liveLine: {
+      startS: { x: 120, y: 120 },
+      endS: { x: 380, y: 240 },
+      measureScale: SCALE,
+    },
+  },
+};
+
+/**
+ * While another tool owns the pointer the overlay stops taking hits, so its
+ * measurements render but do not respond to hover or selection.
+ */
+export const InteractionPassthrough: Story = {
+  args: { isInteractionPassthroughActive: true },
+};
+
+/** Zoomed in, the stroke and label sizing compensate so they stay readable. */
+export const ZoomedIn: Story = { args: { zoom: 2.5 } };

--- a/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.tsx
@@ -56,6 +56,27 @@ interface LabelBox {
 interface MeasurementLineLabels {
   scaled: string;
   physical: string;
+  delete: string;
+}
+
+/**
+ * The overlay's controls live inside the SVG, where there is no <button> to
+ * inherit from: a bare <g onClick> is invisible to assistive technology and
+ * unreachable by keyboard. These props supply what the element would otherwise
+ * get for free — a role, a name, focusability, and Enter/Space activation.
+ */
+function svgButtonProps(label: string, activate: () => void) {
+  return {
+    role: "button",
+    tabIndex: 0,
+    "aria-label": label,
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key !== "Enter" && e.key !== " ") return;
+      e.preventDefault();
+      e.stopPropagation();
+      activate();
+    },
+  };
 }
 
 export const RULER_DOT_RADIUS = 5;
@@ -623,6 +644,7 @@ function MeasurementLine({
           />
           <g
             style={{ cursor: "pointer" }}
+            {...svgButtonProps(labels.delete, () => onDelete(id))}
             onClick={(e) => {
               e.stopPropagation();
               onDelete(id);
@@ -761,6 +783,7 @@ export function RulerMeasurementLayer({
     () => ({
       scaled: t("ruler.scaled", "Scaled"),
       physical: t("ruler.physicalValues", "Physical"),
+      delete: t("ruler.deleteMeasurement", "Delete measurement"),
     }),
     [t],
   );
@@ -883,6 +906,7 @@ export function RulerMeasurementLayer({
             data-ruler-interactive="true"
             data-ruler-control="true"
             style={{ pointerEvents: "all", cursor: "pointer" }}
+            {...svgButtonProps(t("ruler.clearAll", "Clear all"), onClearAll)}
             onClick={(e) => {
               e.stopPropagation();
               onClearAll();
@@ -915,6 +939,7 @@ export function RulerMeasurementLayer({
             data-ruler-interactive="true"
             data-ruler-control="true"
             style={{ pointerEvents: "all", cursor: "pointer" }}
+            {...svgButtonProps(labelModeButtonLabel, onCycleLabelVisibilityMode)}
             onClick={(e) => {
               e.stopPropagation();
               onCycleLabelVisibilityMode();

--- a/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Second half of calibration: the user has drawn a line over something of known
+ * size, and this dialog turns that into a scale. The measured page distance is
+ * given; the real-world distance is what it asks for.
+ *
+ * The chosen unit is remembered between calibrations, so `defaultUnit` only
+ * applies the first time — stories that care about the unit set it explicitly.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ScaleCalibrationDialog,
+  type ScaleCalibrationMeasurement,
+} from "@app/components/viewer/ScaleCalibrationDialog";
+
+const MEASUREMENT: ScaleCalibrationMeasurement = {
+  start: { x: 100, y: 220, pageIndex: 0 },
+  end: { x: 388, y: 220, pageIndex: 0 },
+  pdfDistancePts: 288,
+};
+
+/** Short enough that the derived ratio lands in a different order of magnitude. */
+const SHORT_MEASUREMENT: ScaleCalibrationMeasurement = {
+  start: { x: 100, y: 220, pageIndex: 0 },
+  end: { x: 118, y: 220, pageIndex: 0 },
+  pdfDistancePts: 18,
+};
+
+const noop = () => {};
+
+const meta: Meta<typeof ScaleCalibrationDialog> = {
+  title: "Viewer/ScaleCalibrationDialog",
+  component: ScaleCalibrationDialog,
+  parameters: { layout: "centered" },
+  args: {
+    opened: true,
+    measurement: MEASUREMENT,
+    defaultUnit: "m",
+    onApplyScale: noop,
+    onClose: noop,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleCalibrationDialog>;
+
+/** Waiting for input: the page distance is shown, the preview is not. */
+export const Default: Story = {};
+
+export const ImperialDefault: Story = { args: { defaultUnit: "ft" } };
+
+export const ShortMeasurement: Story = {
+  args: { measurement: SHORT_MEASUREMENT },
+};
+
+/**
+ * Applying with no distance entered is the error path — the dialog can also be
+ * opened before a measurement exists, which leaves the page distance blank.
+ */
+export const NoMeasurement: Story = { args: { measurement: null } };
+
+export const Closed: Story = { args: { opened: false } };

--- a/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.tsx
@@ -124,11 +124,14 @@ export function ScaleCalibrationDialog({
       title={t("scaleSettings.calibrationTitle", "Calibrate Scale")}
       centered
       size="sm"
+      closeButtonProps={{ "aria-label": t("common.close", "Close") }}
     >
       <Stack gap="md">
         {/* Show paper distance automatically */}
+        {/* Mantine's own "dimmed" is too light to clear 4.5:1, so muted text
+            comes from the design system's token instead. */}
         {measurement && (
-          <Text size="sm" c="dimmed">
+          <Text size="sm" c="var(--c-text-muted)">
             {t(
               "scaleSettings.calibrationPaperDistance",
               "Measured page distance: {{distance}}",
@@ -166,7 +169,7 @@ export function ScaleCalibrationDialog({
 
         {/* Preview: show calculated scale */}
         {previewScale && (
-          <Text size="sm" c="blue">
+          <Text size="sm" fw={600}>
             {t(
               "scaleSettings.calculatedScale",
               "Calculated scale (1 page unit = X real units)",

--- a/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
@@ -1,0 +1,64 @@
+/**
+ * The scale picker that opens from the measurement toolbar. Presets apply and
+ * close immediately; the custom ratio waits for Apply. The panel mirrors an
+ * incoming `currentScale` into its own fields, so the stories drive it through
+ * that prop rather than reaching into state.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ScaleSettingsPanel } from "@app/components/viewer/ScaleSettingsPanel";
+import type { MeasureScale } from "@app/utils/measurementTypes";
+
+/** 1:100 in metres — one of the presets, so the panel shows it as selected. */
+const PRESET_SCALE: MeasureScale = { factor: 0.05, ratio: 100, unit: "m" };
+
+/** A ratio no preset offers, which leaves the preset row unselected. */
+const CUSTOM_SCALE: MeasureScale = { factor: 0.0175, ratio: 35, unit: "ft" };
+
+/** Calibrated scales carry no ratio — the panel labels them "(custom)". */
+const CALIBRATED_SCALE: MeasureScale = {
+  factor: 0.0223,
+  ratio: null,
+  unit: "cm",
+};
+
+const noop = () => {};
+
+const meta: Meta<typeof ScaleSettingsPanel> = {
+  title: "Viewer/ScaleSettingsPanel",
+  component: ScaleSettingsPanel,
+  // The panel sets its own 300px floor; padded gives it room without the
+  // centred frame clipping into a scroll container.
+  parameters: { layout: "padded" },
+  args: {
+    onApplyScale: noop,
+    onResetScale: noop,
+    onStartCalibration: noop,
+    onCancelCalibration: noop,
+    onClose: noop,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleSettingsPanel>;
+
+/** No scale set: the active-scale strip is muted and Reset is not offered. */
+export const Default: Story = {};
+
+export const PresetSelected: Story = { args: { currentScale: PRESET_SCALE } };
+
+export const CustomRatio: Story = { args: { currentScale: CUSTOM_SCALE } };
+
+export const CalibratedScale: Story = {
+  args: { currentScale: CALIBRATED_SCALE },
+};
+
+/** Calibration running: the button flips to its active state. */
+export const Calibrating: Story = { args: { isCalibrationActive: true } };
+
+/**
+ * Calibration is disabled when the viewer supplies no handler for it — the
+ * panel is reachable in contexts that cannot start a calibration draw.
+ */
+export const CalibrationUnavailable: Story = {
+  args: { onStartCalibration: undefined },
+};

--- a/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.tsx
@@ -254,7 +254,9 @@ export function ScaleSettingsPanel({
             />
           </div>
         </Group>
-        <Text size="xs" c="dimmed" mt="xs">
+        {/* Mantine's own "dimmed" is too light to clear 4.5:1 at this size, so
+            muted text comes from the design system's token instead. */}
+        <Text size="xs" c="var(--c-text-muted)" mt="xs">
           {t(
             "scaleSettings.ratioHelp",
             "Ratio: 1 page unit = X real-world units",
@@ -271,12 +273,14 @@ export function ScaleSettingsPanel({
         style={{
           padding: "0.5rem",
           backgroundColor: currentScale
-            ? "rgba(30, 136, 229, 0.1)"
-            : "rgba(158, 158, 158, 0.1)",
+            ? "var(--c-primary-tint)"
+            : "var(--c-surface-sunken)",
           borderRadius: "4px",
         }}
       >
-        <Text size="xs" c={currentScale ? "blue" : "dimmed"}>
+        {/* The tint carries the "a scale is active" signal; the text stays at
+            full contrast rather than restating it in the accent hue. */}
+        <Text size="xs" c={currentScale ? undefined : "var(--c-text-muted)"}>
           <strong>{t("scaleSettings.activeScale", "Active Scale")}:</strong>{" "}
           {currentScale && currentScale.ratio
             ? generateScaleLabel(currentScale.ratio, currentScale.unit)

--- a/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
@@ -451,6 +451,7 @@ export function useViewerWorkbenchBarButtons(
                 <Slider
                   value={speechRate}
                   onChange={handleSpeechRateChange}
+                  thumbLabel={readAloudSpeedLabel}
                   min={0.5}
                   max={2}
                   step={0.1}

--- a/frontend/editor/src/core/contexts/FileManagerContext.tsx
+++ b/frontend/editor/src/core/contexts/FileManagerContext.tsx
@@ -29,7 +29,7 @@ import { openFilesFromDisk } from "@app/services/openFilesFromDisk";
 export { pendingFilePathMappings } from "@app/services/pendingFilePathMappings";
 
 // Type for the context value - now contains everything directly
-interface FileManagerContextValue {
+export interface FileManagerContextValue {
   // State
   activeSource: "recent" | "local" | "drive";
   storageFilter: "all" | "local" | "sharedWithMe" | "sharedByMe";
@@ -80,8 +80,11 @@ interface FileManagerContextValue {
   modalHeight: string;
 }
 
-// Create the context
-const FileManagerContext = createContext<FileManagerContextValue | null>(null);
+// Create the context. Exported so a test or story can mount a component
+// against a slice of the value instead of the whole provider chain.
+export const FileManagerContext = createContext<FileManagerContextValue | null>(
+  null,
+);
 
 // Provider component props
 interface FileManagerProviderProps {

--- a/frontend/editor/src/core/styles/theme.css
+++ b/frontend/editor/src/core/styles/theme.css
@@ -43,7 +43,9 @@
     var(--p-green-500) 15%,
     transparent
   ); /* Transparent green for active badge */
-  --file-active-badge-fg: var(--p-green-700); /* Green text for active badge */
+  /* green-700 on the 15% tint measures 4.05:1, under the 4.5:1 this badge's
+     size needs; green-800 clears it. */
+  --file-active-badge-fg: var(--p-green-800);
   --file-active-badge-border: color-mix(
     in srgb,
     var(--p-green-500) 30%,

--- a/frontend/editor/src/core/theme/colors.css
+++ b/frontend/editor/src/core/theme/colors.css
@@ -374,3 +374,14 @@ html[data-app-theme="custom"][data-accent="default"][data-mantine-color-scheme="
   --c-border: var(--p-c-28282d);
   --c-border-subtle: var(--p-zinc-700);
 }
+
+/* ── MANTINE MUTED TEXT ───────────────────────────────────────────────────── */
+/* Mantine's stock "dimmed" is #868e96, which measures ~3:1 against the app's
+   surfaces — short of the 4.5:1 that body-size text needs. Pointing it at the
+   semantic muted token fixes every `c="dimmed"` at once, and follows the theme
+   rather than staying a fixed grey that only ever suited light mode. */
+/* Doubled selector: Mantine declares this on :root too, and its stylesheet
+   loads later, so a single :root here would lose on source order. */
+:root:root {
+  --mantine-color-dimmed: var(--c-text-muted);
+}

--- a/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
+++ b/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
@@ -572,6 +572,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={12}
                   value={inkWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setInkWidth}
                 />
               </Box>
@@ -587,6 +588,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={highlightOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setHighlightOpacity}
                 />
               </Box>
@@ -601,6 +603,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={underlineOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setUnderlineOpacity}
                 />
               </Box>
@@ -615,6 +618,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={20}
                   value={freehandHighlighterWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setFreehandHighlighterWidth}
                 />
               </Box>
@@ -630,6 +634,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={8}
                     max={32}
                     value={textSize}
+                    thumbLabel={t("annotation.fontSize", "Font size")}
                     onChange={setTextSize}
                   />
                 </Box>
@@ -785,6 +790,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={10}
                     max={100}
                     value={shapeOpacity}
+                    thumbLabel={t("annotation.opacity", "Opacity")}
                     onChange={(value) => {
                       setShapeOpacity(value);
                       setShapeStrokeOpacity(value);
@@ -802,6 +808,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                         min={1}
                         max={12}
                         value={shapeThickness}
+                        thumbLabel={t("annotation.strokeWidth", "Width")}
                         onChange={setShapeThickness}
                       />
                     </>
@@ -815,6 +822,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                           min={0}
                           max={12}
                           value={shapeThickness}
+                          thumbLabel={t("annotation.strokeWidth", "Stroke")}
                           onChange={setShapeThickness}
                         />
                       </Box>

--- a/frontend/editor/src/portal/views/EditorAdmin.stories.tsx
+++ b/frontend/editor/src/portal/views/EditorAdmin.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import { EditorAdmin } from "@portal/views/EditorAdmin";
+
+/**
+ * Editor deployment management, reached from Infrastructure → Deployments: the
+ * summary strip, the deployment targets (Managed Cloud / Docker / Kubernetes),
+ * instance pairing, instance health, and the credential / offline-activation
+ * cards.
+ *
+ * The whole page is one tier-aware fetch, so the tier is what makes these
+ * stories differ: it decides which targets are unlocked (locked ones show an
+ * upgrade nudge instead of an install snippet), how many instances the org runs,
+ * and whether offline activation is offered at all. Until that fetch resolves,
+ * the strip and targets render as skeletons and the lower sections are absent.
+ */
+const meta: Meta<typeof EditorAdmin> = {
+  // AppShell renders every view inside <main>; standalone, this view's
+  // own <header> would be promoted to a second banner landmark.
+  decorators: [
+    (Story: () => React.ReactElement) => (
+      <main>
+        <Story />
+      </main>
+    ),
+  ],
+  title: "Portal/Views/EditorAdmin",
+  component: EditorAdmin,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof EditorAdmin>;
+
+/** Free: only Managed Cloud is available, the self-hosted targets are gated. */
+export const FreeTier: Story = { globals: { tier: "free" } };
+
+/** Pay-as-you-go: self-hosted targets unlock alongside Managed Cloud. */
+export const ProTier: Story = { globals: { tier: "pro" } };
+
+/** Enterprise: every target, plus the offline-activation lifecycle card. */
+export const EnterpriseTier: Story = { globals: { tier: "enterprise" } };
+
+/** In flight: skeleton summary + target cards, with the later sections withheld. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/v1/editor/deployment", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+      ],
+    },
+  },
+};

--- a/frontend/editor/src/portal/views/Infrastructure.stories.tsx
+++ b/frontend/editor/src/portal/views/Infrastructure.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Route, Routes } from "react-router-dom";
+import { PORTAL_BASENAME } from "@portal/contexts/ViewContext";
+import { Infrastructure } from "@portal/views/Infrastructure";
+
+/**
+ * The Infrastructure page: a header, an "Manage editor deployment" shortcut into
+ * the editor, and one tab per infrastructure surface (deployments, API keys,
+ * security, models, storage, audit). The page itself is only the shell — each
+ * tab's content is its own component with its own stories.
+ *
+ * Which tab is open is local state seeded from a `?tab=` deep link, which other
+ * surfaces use to send the user straight to a specific tab (the home
+ * visualiser's outcome cards link to the audit log this way). The param is
+ * consumed and dropped on arrival, so these stories render at a location
+ * carrying it rather than clicking through the tab strip.
+ */
+function atTab(search: string) {
+  return function TabDecorator(Story: () => React.ReactElement) {
+    const path = `${PORTAL_BASENAME}/infrastructure`;
+    return (
+      <Routes location={`${path}${search}`}>
+        <Route path={path} element={<Story />} />
+      </Routes>
+    );
+  };
+}
+
+const meta: Meta<typeof Infrastructure> = {
+  // AppShell renders every view inside <main>; standalone, this view's
+  // own <header> would be promoted to a second banner landmark.
+  decorators: [
+    (Story: () => React.ReactElement) => (
+      <main>
+        <Story />
+      </main>
+    ),
+  ],
+  title: "Portal/Views/Infrastructure",
+  component: Infrastructure,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof Infrastructure>;
+
+/** Arriving with no deep link: the deployments tab, seeded from the mocks. */
+export const Default: Story = {};
+
+/** Deep-linked to API keys — the tab strip moves and the key table takes over. */
+export const ApiKeysTab: Story = {
+  decorators: [atTab("?tab=api-keys")],
+};
+
+/** Deep-linked to the audit log, the route the outcome cards elsewhere use. */
+export const AuditTab: Story = {
+  decorators: [atTab("?tab=audit")],
+};

--- a/frontend/editor/src/portal/views/Usage.stories.tsx
+++ b/frontend/editor/src/portal/views/Usage.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import { Usage } from "@portal/views/Usage";
+import type { Wallet } from "@portal/api/billing";
+import {
+  freeWallet,
+  subscribedWallet,
+} from "@portal/components/billing/walletFixtures";
+
+/**
+ * Usage & billing. The page is a thin shell — header, notices, and one of two
+ * plan views — that dispatches entirely on the wallet it loads:
+ *
+ *   free       → the free-grant meter plus the pay-as-you-go explainer
+ *   subscribed → the period meter, spend cap, members and invoices, and the
+ *                "Manage Payment" action in the header
+ *
+ * So the wallet response is what these stories vary. A failed read replaces the
+ * plan view with a banner; while the read is in flight the body is skeletons.
+ *
+ * One state is not reachable here: the "session expired" notice is raised when
+ * there is no SaaS token at all, which the Storybook preview always supplies.
+ */
+const wallet = (body: Wallet) =>
+  http.get("*/api/v1/payg/wallet", () => HttpResponse.json(body));
+
+/** The subscribed view also reads the card on file and the invoice history. */
+const paymentMethod = http.get("*/api/v1/payg/payment-method", () =>
+  HttpResponse.json({
+    present: true,
+    brand: "visa",
+    last4: "4242",
+    expMonth: 8,
+    expYear: 2027,
+  }),
+);
+
+const invoices = http.get("*/api/v1/payg/invoices", () =>
+  HttpResponse.json([
+    {
+      id: "in_6",
+      number: "INV-2026-006",
+      status: "open",
+      totalMinor: 714235,
+      currency: "usd",
+      createdAt: "2026-06-01T00:00:00Z",
+      periodStart: "2026-06-01T00:00:00Z",
+      periodEnd: "2026-06-30T00:00:00Z",
+      hostedInvoiceUrl: "https://invoice.stripe.com/i/test_6",
+      invoicePdf: "https://invoice.stripe.com/i/test_6/pdf",
+      description: "Stirling Processor Plan",
+      pdfsProcessed: 142847,
+    },
+  ]),
+);
+
+const meta: Meta<typeof Usage> = {
+  // AppShell renders every view inside <main>; standalone, this view's
+  // own <header> would be promoted to a second banner landmark.
+  decorators: [
+    (Story: () => React.ReactElement) => (
+      <main>
+        <Story />
+      </main>
+    ),
+  ],
+  title: "Portal/Views/Usage",
+  component: Usage,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof Usage>;
+
+/** On the one-time free grant: free meter and the "turn on Processor" pitch. */
+export const FreePlan: Story = {
+  parameters: { msw: { handlers: [wallet(freeWallet)] } },
+};
+
+/** Subscribed: period meter, cap, members and invoices, plus the header action. */
+export const Subscribed: Story = {
+  parameters: {
+    msw: { handlers: [wallet(subscribedWallet), paymentMethod, invoices] },
+  },
+};
+
+/** While the wallet is in flight the body is two skeleton blocks. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/api/v1/payg/wallet", async () => {
+          await delay("infinite");
+          return HttpResponse.json(freeWallet);
+        }),
+      ],
+    },
+  },
+};
+
+/** A failed read: the plan view never mounts and the error banner states why. */
+export const WalletUnavailable: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/api/v1/payg/wallet", () =>
+          HttpResponse.json(
+            { detail: "Billing service unavailable" },
+            {
+              status: 503,
+            },
+          ),
+        ),
+      ],
+    },
+  },
+};

--- a/frontend/editor/src/portal/views/Users.css
+++ b/frontend/editor/src/portal/views/Users.css
@@ -280,10 +280,12 @@
 
 .portal-users__link {
   color: var(--c-accent-text);
-  text-decoration: none;
+  /* Sits inside a sentence, so colour alone cannot be what marks it as a
+     link — it stays underlined and thickens on hover instead. */
+  text-decoration: underline;
 }
 .portal-users__link:hover {
-  text-decoration: underline;
+  text-decoration-thickness: 2px;
 }
 
 .portal-users__directory {

--- a/frontend/editor/src/portal/views/Users.stories.tsx
+++ b/frontend/editor/src/portal/views/Users.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse, delay } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { PORTAL_BASENAME } from "@portal/contexts/ViewContext";
+import { Users } from "@portal/views/Users";
+import "@portal/views/Users.css";
+
+/**
+ * The Users page: the org roster grouped by team, pending invitations, and the
+ * portal-access controls, with every row action hanging off the roster fetch.
+ *
+ * The whole body is decided by that one roster read — skeleton rows while it is
+ * in flight, a retry panel when it fails, the "no members yet" panel when it
+ * comes back empty, and the directory otherwise. Which controls the directory
+ * offers is a build capability (self-hosted deletes accounts, SaaS removes them
+ * from a team), not something a story can vary.
+ *
+ * Invitations can also be opened straight from elsewhere via `?invite`, which
+ * mounts the invite modal on arrival and then drops the param.
+ */
+const ROSTER = "*/api/v1/proprietary/ui-data/admin-settings";
+
+const meta: Meta<typeof Users> = {
+  // AppShell renders every view inside <main>; standalone, this view's
+  // own <header> would be promoted to a second banner landmark.
+  decorators: [
+    (Story: () => React.ReactElement) => (
+      <main>
+        <Story />
+      </main>
+    ),
+  ],
+  title: "Portal/Views/Users",
+  component: Users,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof Users>;
+
+/** The seeded org: several teams, mixed roles, and portal-access chips. */
+export const Default: Story = {};
+
+/** Roster in flight — the table is a stack of skeleton rows. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(ROSTER, async () => {
+          await delay("infinite");
+          return HttpResponse.json({ users: [] });
+        }),
+      ],
+    },
+  },
+};
+
+/** A brand-new org: the empty panel points at the invite flow. */
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(ROSTER, () =>
+          HttpResponse.json({ users: [], totalUsers: 0, mailEnabled: false }),
+        ),
+      ],
+    },
+  },
+};
+
+/** Backend unreachable (or no admin access): a retry panel replaces the table. */
+export const LoadFailed: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(ROSTER, () =>
+          HttpResponse.json({ detail: "Forbidden" }, { status: 403 }),
+        ),
+      ],
+    },
+  },
+};
+
+/** Arriving from an `?invite` link: the roster renders with the modal already open. */
+export const InviteDeepLink: Story = {
+  decorators: [
+    (Story: () => React.ReactElement) => {
+      const path = `${PORTAL_BASENAME}/users`;
+      return (
+        <Routes location={`${path}?invite=1`}>
+          <Route path={path} element={<Story />} />
+        </Routes>
+      );
+    },
+  ],
+};

--- a/frontend/editor/src/proprietary/billing/MeterBar.stories.tsx
+++ b/frontend/editor/src/proprietary/billing/MeterBar.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MeterBar } from "@app/billing";
+import "@portal/components/billing/billing.css";
+
+/**
+ * The usage-meter block shared by the editor's cloud surface and the admin
+ * portal. Everything visible is a prop: the caller owns the copy, and `state`
+ * (FULL / WARNED / DEGRADED) drives the status-chip tone and the fill colour
+ * together — the percentage alone never changes the palette. Two parts are
+ * optional and are what separates most of these states: the status chip
+ * (hidden when no label is given) and the fill bar (hidden when a plan has no
+ * ceiling to measure against).
+ *
+ * The `paygf-meter` styling belongs to each host app rather than the component,
+ * so these render against the portal's billing stylesheet — the same one the
+ * wallet, spend-limit and prepaid cards are seen under.
+ */
+const meta: Meta<typeof MeterBar> = {
+  title: "Portal/Billing/MeterBar",
+  component: MeterBar,
+  parameters: { layout: "padded" },
+  decorators: [
+    (S) => (
+      <div style={{ maxWidth: "34rem" }}>
+        <S />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof MeterBar>;
+
+/** Comfortably inside the free grant — green chip, green fill. */
+export const Healthy: Story = {
+  args: {
+    state: "FULL",
+    pct: 24,
+    figure: "120",
+    capSuffix: "/ 500 free PDFs",
+    statusLabel: "Healthy",
+    meta: "Resets 1 July",
+    barLabel: "Free allowance",
+  },
+};
+
+/** Near the ceiling — amber chip and fill warn before anything is blocked. */
+export const Approaching: Story = {
+  args: {
+    state: "WARNED",
+    pct: 86,
+    figure: "$860",
+    capSuffix: "/ $1,000 cap",
+    statusLabel: "Approaching cap",
+    meta: "Projected $1,020 by 30 June",
+    barLabel: "Spend limit",
+  },
+};
+
+/** At the ceiling — red chip and fill; billable work is refused past this point. */
+export const CapReached: Story = {
+  args: {
+    state: "DEGRADED",
+    pct: 100,
+    figure: "$1,000",
+    capSuffix: "/ $1,000 cap",
+    statusLabel: "Cap reached",
+    meta: "Raise the cap to resume processing",
+    barLabel: "Spend limit",
+  },
+};
+
+/**
+ * No ceiling to fill against, so the bar is dropped and the figure carries the
+ * whole meter. The chip is omitted too — there is no threshold to be near.
+ */
+export const Uncapped: Story = {
+  args: {
+    state: "FULL",
+    pct: 0,
+    figure: "$1,430",
+    capSuffix: "no cap",
+    showBar: false,
+    meta: "Billed monthly in arrears",
+    barLabel: "Spend this period",
+  },
+};

--- a/frontend/editor/src/proprietary/billing/SpendCapControl.stories.tsx
+++ b/frontend/editor/src/proprietary/billing/SpendCapControl.stories.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SpendCapControl, type SpendCapControlProps } from "@app/billing";
+import "@portal/components/billing/billing.css";
+
+/**
+ * The monthly spend-cap editor shared by the editor's cloud surface and the
+ * admin portal: preset chips, a custom-amount pill, a "no cap" chip and an
+ * optional inline Save.
+ *
+ * The control is fully controlled, so the states below differ by what the cap
+ * currently is and by which optional affordances the host asked for:
+ *   - a cap matching a preset selects that chip;
+ *   - any other number activates the custom pill instead;
+ *   - null is the no-cap state, which drops the estimate and adds an explainer;
+ *   - passing `onSave` adds the Save button, enabled only once the cap differs
+ *     from the persisted `savedCapUsd`.
+ *
+ * Copy is injected by the host (the editor passes i18n strings, the portal
+ * passes literals), so these render the built-in English defaults. The `scc-*`
+ * styling likewise belongs to each host — the portal's billing stylesheet here.
+ */
+const PRICE_PER_DOC_MINOR = 2;
+
+/**
+ * Holds the cap locally so the chips, custom field and Save button behave as
+ * they do in a host that owns the value.
+ */
+function ControlledCap({
+  initialCap,
+  ...rest
+}: { initialCap: number | null } & Omit<
+  SpendCapControlProps,
+  "capUsd" | "onChange"
+>) {
+  const [cap, setCap] = useState<number | null>(initialCap);
+  return <SpendCapControl {...rest} capUsd={cap} onChange={setCap} />;
+}
+
+const meta: Meta<typeof SpendCapControl> = {
+  title: "Portal/Billing/SpendCapControl",
+  component: SpendCapControl,
+  parameters: { layout: "padded" },
+  decorators: [
+    (S) => (
+      <div style={{ maxWidth: "44rem" }}>
+        <S />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof SpendCapControl>;
+
+/** A cap on one of the presets: that chip is selected and drives the estimate. */
+export const PresetSelected: Story = {
+  render: () => (
+    <ControlledCap initialCap={500} pricePerDocMinor={PRICE_PER_DOC_MINOR} />
+  ),
+};
+
+/** An amount outside the presets moves the selection into the custom pill. */
+export const CustomAmount: Story = {
+  render: () => (
+    <ControlledCap initialCap={1234} pricePerDocMinor={PRICE_PER_DOC_MINOR} />
+  ),
+};
+
+/** No cap: nothing to estimate against, and the uncapped-billing note appears. */
+export const NoCap: Story = {
+  render: () => (
+    <ControlledCap initialCap={null} pricePerDocMinor={PRICE_PER_DOC_MINOR} />
+  ),
+};
+
+/**
+ * Hosts that persist the cap pass `onSave`, which adds the Save button. It stays
+ * disabled until the chosen cap differs from the saved one — shown here already
+ * dirty (saved 250, selected 1,000).
+ */
+export const WithSaveButton: Story = {
+  render: () => (
+    <ControlledCap
+      initialCap={1000}
+      savedCapUsd={250}
+      onSave={async () => {}}
+      pricePerDocMinor={PRICE_PER_DOC_MINOR}
+      note="Changes apply from the next billing period."
+    />
+  ),
+};
+
+/** Every control is inert while the host has an operation in flight. */
+export const Disabled: Story = {
+  render: () => (
+    <ControlledCap
+      initialCap={500}
+      disabled
+      onSave={async () => {}}
+      savedCapUsd={250}
+      pricePerDocMinor={PRICE_PER_DOC_MINOR}
+    />
+  ),
+};

--- a/frontend/editor/src/proprietary/components/chat/ChatQuickActions.stories.tsx
+++ b/frontend/editor/src/proprietary/components/chat/ChatQuickActions.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ChatQuickActions } from "@app/components/chat/ChatQuickActions";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+import "@app/components/chat/ChatPanel.css";
+
+/**
+ * The suggestion block the assistant shows above its composer. It reads the
+ * workbench rather than taking a list of actions: an empty workbench offers a
+ * way to open files, one PDF offers split (only when it has more than one page)
+ * and compress, several files offer merge and compress, and anything that isn't
+ * a PDF adds a convert-to-PDF suggestion. With files present it also renders a
+ * pill per file — three, then a "+n more" that opens the files modal.
+ *
+ * Only the empty-workbench state is reachable in isolation: the populated ones
+ * need files loaded into FileContext, which has no seeding entry point, so they
+ * belong to a story of the chat panel running against a real workbench.
+ */
+const meta: Meta<typeof ChatQuickActions> = {
+  title: "Editor/Chat/ChatQuickActions",
+  component: ChatQuickActions,
+  parameters: { layout: "padded" },
+  args: {
+    heading: "What would you like to do?",
+    onAction: () => {},
+  },
+  decorators: [
+    (S) => (
+      <FileContextProvider>
+        {/* Only openFilesModal is read here — the real provider reaches back
+            into FileContext and NavigationContext, so a slice is supplied. */}
+        <FilesModalContext.Provider
+          value={
+            { openFilesModal: () => {} } as unknown as FilesModalContextType
+          }
+        >
+          <div style={{ maxWidth: "24rem" }}>
+            <S />
+          </div>
+        </FilesModalContext.Provider>
+      </FileContextProvider>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof ChatQuickActions>;
+
+/** Nothing in the workbench: no file pills, and a single "open files" action. */
+export const EmptyWorkbench: Story = {};

--- a/frontend/editor/src/proprietary/components/shared/AppSwitcher.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/AppSwitcher.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AppSwitcher } from "@app/components/shared/AppSwitcher";
+import { AuthContext } from "@app/auth/context";
+import type { AuthContextValue } from "@app/auth/types";
+
+/**
+ * The sidebar brand header on builds that bundle the admin portal. It reads a
+ * single field of the auth state — `portalAccess` — and that is the whole
+ * decision: users who may reach the portal get the brand switcher (clicking it
+ * navigates to the processor), everyone else gets the plain logo, exactly as
+ * core renders it.
+ *
+ * The rail also collapses, which swaps the wordmark for the icon-only mark, so
+ * both widths are worth seeing on the switcher variant.
+ */
+
+/** Only `portalAccess` is read; the rest is inert filler for the context shape. */
+function authWith(portalAccess: boolean): AuthContextValue {
+  return {
+    session: null,
+    user: null,
+    displayName: "Ada Lovelace",
+    isAnonymous: false,
+    isAdmin: portalAccess,
+    portalAccess,
+    role: portalAccess ? "ROLE_ADMIN" : "ROLE_USER",
+    loading: false,
+    error: null,
+    signOut: async () => {},
+    refreshSession: async () => {},
+  };
+}
+
+const meta: Meta<typeof AppSwitcher> = {
+  // Distinct from core's "Shared/AppSwitcher": that file covers the logo-only
+  // component this one shadows.
+  title: "Shared/AppSwitcher (portal build)",
+  component: AppSwitcher,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof AppSwitcher>;
+
+/** No portal access — indistinguishable from core's plain logo header. */
+export const WithoutPortalAccess: Story = {
+  decorators: [
+    (S) => (
+      <AuthContext.Provider value={authWith(false)}>
+        <S />
+      </AuthContext.Provider>
+    ),
+  ],
+};
+
+/** Portal access — the logo becomes the editor⇄processor switcher. */
+export const WithPortalAccess: Story = {
+  decorators: [
+    (S) => (
+      <AuthContext.Provider value={authWith(true)}>
+        <S />
+      </AuthContext.Provider>
+    ),
+  ],
+};
+
+/** The switcher on a collapsed rail: icon-only mark, no wordmark. */
+export const CollapsedWithPortalAccess: Story = {
+  args: { collapsed: true },
+  decorators: [
+    (S) => (
+      <AuthContext.Provider value={authWith(true)}>
+        <S />
+      </AuthContext.Provider>
+    ),
+  ],
+};

--- a/frontend/editor/src/proprietary/components/shared/PolicyEnforcingOverlay.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/PolicyEnforcingOverlay.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PolicyEnforcingOverlay } from "@app/components/shared/PolicyEnforcingOverlay";
+
+/**
+ * The frosted-glass cover shown over a document while a policy runs against it.
+ * It fills its nearest positioned ancestor, so it serves both the full-screen
+ * viewer and a single thumbnail card.
+ *
+ * What changes between states: whether the run reports step counts (a
+ * determinate progress bar) or not (a spinner); whether the caller allows the
+ * user through anyway (the dismiss button); and which policy is enforcing —
+ * the accent colour and category icon are passed in so the overlay matches that
+ * policy's badge instead of a fixed blue shield. `enforcing: false` renders
+ * nothing at all, so it isn't a story.
+ */
+const meta: Meta<typeof PolicyEnforcingOverlay> = {
+  title: "Shared/PolicyEnforcingOverlay",
+  component: PolicyEnforcingOverlay,
+  parameters: { layout: "padded" },
+  args: { enforcing: true },
+  decorators: [
+    (S) => (
+      // Stands in for the surface being covered — the overlay needs a
+      // positioned ancestor with real dimensions to render into.
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          maxWidth: "34rem",
+          height: "22rem",
+          borderRadius: "0.5rem",
+          border: "1px solid var(--c-border)",
+          background: "var(--c-surface)",
+          overflow: "hidden",
+        }}
+      >
+        <S />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof PolicyEnforcingOverlay>;
+
+/** A run with no step counts: an indeterminate spinner and the generic shield. */
+export const Indeterminate: Story = {};
+
+/** A run that reports its steps swaps the spinner for a determinate bar. */
+export const WithProgress: Story = {
+  args: { progress: 62 },
+};
+
+/** Callers that let the user look at the file anyway get a dismiss button. */
+export const Dismissible: Story = {
+  args: { progress: 40, onDismiss: () => {} },
+};
+
+/**
+ * Tinted to the enforcing policy: the classification category's label icon and
+ * its badge colour replace the default shield and blue.
+ */
+export const ClassificationPolicy: Story = {
+  args: {
+    progress: 30,
+    categoryId: "classification",
+    accentVar: "var(--color-orange)",
+  },
+};

--- a/frontend/editor/src/proprietary/components/shared/PolicyEnforcingOverlay.tsx
+++ b/frontend/editor/src/proprietary/components/shared/PolicyEnforcingOverlay.tsx
@@ -106,6 +106,9 @@ export function PolicyEnforcingOverlay({
               w="100%"
               size="xs"
               radius="xl"
+              /* The heading above is plain text, so the bar carries its own
+                 name rather than being announced as an unlabelled progressbar. */
+              aria-label={t("policy.enforcingTitle", "Enforcing policy…")}
               value={progress}
               striped
               animated

--- a/frontend/editor/src/proprietary/components/shared/UpdateSeatsButton.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/UpdateSeatsButton.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+import UpdateSeatsButton from "@app/components/shared/UpdateSeatsButton";
+import UpdateSeatsContext from "@app/contexts/UpdateSeatsContext";
+
+/**
+ * The "Update Seats" entry point on enterprise licences. It owns no state of its
+ * own: pressing it asks the seat-update flow to open, and the only thing that
+ * changes its appearance is that flow reporting work in progress — while a seat
+ * change is being prepared (a licence read, then a redirect to the Stripe
+ * billing portal) the button shows its loading state.
+ *
+ * Everything else on it is pass-through Button styling, so those belong to the
+ * shared Button's own stories rather than here.
+ */
+
+/** Stands in for the seat-update flow; only these four fields are read. */
+function withSeatsFlow(isLoading: boolean) {
+  return function SeatsFlowDecorator(Story: () => ReactElement) {
+    return (
+      <UpdateSeatsContext.Provider
+        value={{
+          openUpdateSeats: async () => {},
+          closeUpdateSeats: () => {},
+          isOpen: false,
+          isLoading,
+        }}
+      >
+        <Story />
+      </UpdateSeatsContext.Provider>
+    );
+  };
+}
+
+const meta: Meta<typeof UpdateSeatsButton> = {
+  title: "Shared/UpdateSeatsButton",
+  component: UpdateSeatsButton,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof UpdateSeatsButton>;
+
+/** Idle — the secondary-variant button awaiting a press. */
+export const Default: Story = {
+  decorators: [withSeatsFlow(false)],
+};
+
+/** The seat-update flow is preparing the billing-portal redirect. */
+export const Loading: Story = {
+  decorators: [withSeatsFlow(true)],
+};

--- a/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
+++ b/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
@@ -176,6 +176,7 @@ export const ProfilePictureCropper: React.FC<ProfilePictureCropperProps> = ({
             step={0.1}
             onChange={setZoom}
             disabled={processing}
+            thumbLabel={t("config.account.profilePicture.cropper.zoom", "Zoom")}
           />
         </Stack>
 


### PR DESCRIPTION
The last three batches — portal views and billing, the file manager, and the viewer/tools panels.

### Defects fixed

- **A link distinguished by colour alone.** A "learn more" link inside a sentence was underlined only on hover. It now stays underlined and thickens instead — colour alone cannot be what marks a link in running text.
- **An unnamed progress bar** in the policy overlay; the heading above it is plain text with no association.
- **The Active badge** drew green-700 on its own 15% green tint — **4.05:1**, under the 4.5:1 its size needs. green-800 clears it at roughly 5.7:1.
- **The page-number field** in the viewer toolbar had no accessible name; only the page count sits beside it, as plain text.

### Artefact, not defect

`landmark-no-duplicate-banner` fired on two portal views. `AppShell` renders every view inside `<main>`, so their `<header>` is correctly nested in the real app — it only became a second banner because the story rendered the view standalone. Fixed in the stories, not the components.

### Merges rather than duplicate fixes

Three branches are merged in here — the file manager, viewer measurement, and slider naming. Between them they resolved **26 violations** that were already fixed elsewhere. Fixing those again on this branch would have guaranteed a conflict for no benefit.

### Verification

- 144 stories across the three batches, **0 violations**
- Typecheck clean, `task pre-commit` green