### PR TITLE
feat(storybook): make every layer storyable, and fix the shared a11y primitives

### DIFF
--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -210,6 +210,16 @@ tasks:
       #   task frontend:storybook:test -- Button
       - npx vitest run --config .storybook/vitest.config.ts {{.CLI_ARGS}}
 
+  storybook:coverage:
+    desc: "Which rendered surfaces have a story, and what each gap would need"
+    summary: |
+      Reports coverage by import rather than by adjacent file, and classifies
+      every gap by the work a story needs — props, a context slice, MSW
+      handlers or router state. Pass --todo to list every gap, or
+      --area <path> to scope it.
+    cmds:
+      - node editor/scripts/storybook-coverage.mjs {{.CLI_ARGS}}
+
   storybook:a11y:
     desc: "a11y regression gate over every story, light and dark: fail only on NEW axe violations"
     deps: [prepare, storybook:browser]

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import type { StorybookConfig } from "@storybook/react-vite";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -10,6 +11,45 @@ import tsconfigPaths from "vite-tsconfig-paths";
  * the portal layer at editor/src/portal/). MDX docs pages live in
  * editor/src/portal/docs/.
  */
+
+/** Layer search order for @app/*, mirroring each flavour's vite tsconfig. */
+const FLAVOUR_LAYERS: Record<string, string[]> = {
+  desktop: ["desktop", "cloud", "proprietary", "core"],
+  saas: ["saas", "cloud", "proprietary", "core"],
+  cloud: ["cloud", "proprietary", "core"],
+  prototypes: ["prototypes", "proprietary", "core"],
+};
+
+const SUFFIXES = ["", ".tsx", ".ts", "/index.tsx", "/index.ts"];
+
+function flavourAppAlias() {
+  return {
+    name: "storybook-app-alias-by-flavour",
+    // Ahead of vite-tsconfig-paths, which would otherwise answer first with the
+    // proprietary order.
+    enforce: "pre" as const,
+    resolveId(source: string, importer: string | undefined) {
+      if (!importer || !source.startsWith("@app/")) return null;
+      const layer = importer
+        .split("\\")
+        .join("/")
+        .match(/\/editor\/src\/(desktop|saas|cloud|prototypes)\//)?.[1];
+      if (!layer) return null;
+      const rest = source.slice("@app/".length);
+      for (const candidate of FLAVOUR_LAYERS[layer]) {
+        for (const suffix of SUFFIXES) {
+          const full = resolve(
+            __dirname,
+            `../editor/src/${candidate}/${rest}${suffix}`,
+          );
+          if (existsSync(full) && statSync(full).isFile()) return full;
+        }
+      }
+      return null;
+    },
+  };
+}
+
 const config: StorybookConfig = {
   stories: [
     "../editor/src/portal/**/*.mdx",
@@ -53,6 +93,12 @@ const config: StorybookConfig = {
     // shared Storybook can host editor components without duplicating the alias
     // map here.
     config.plugins = config.plugins ?? [];
+    // Stories under desktop/, saas/, cloud/ and prototypes/ import @app/* too,
+    // but each of those builds resolves it against its own layer first — an
+    // order the single tsconfig below cannot express. Resolving by the
+    // importer's layer lets those stories load without changing what @app/*
+    // means for core, proprietary or portal stories, which never match here.
+    config.plugins.push(flavourAppAlias());
     config.plugins.push(
       tsconfigPaths({
         projects: [

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -18,6 +18,8 @@ import { TierProvider, type Tier } from "@portal/contexts/TierContext";
 import { LinkProvider, type LinkState } from "@portal/contexts/LinkContext";
 import { ThemeProvider, useTheme } from "@portal/contexts/ThemeContext";
 import { UIProvider } from "@portal/contexts/UIContext";
+import { PreferencesProvider } from "@core/contexts/PreferencesContext";
+import { SidebarProvider } from "@core/contexts/SidebarContext";
 import { SuiProvider } from "@portal/theme/SuiProvider";
 import { MantineProvider } from "@mantine/core";
 import {
@@ -269,17 +271,25 @@ const withProviders: Decorator = (Story, context) => {
                   from useLink() (matches App.tsx's nesting). */}
               <LinkProvider key={linkState} initialState={linkState}>
                 <TierKey tier={tier}>
-                  <UIProvider>
-                    <Suspense fallback={null}>
-                      {isPortalStory ? (
-                        <div className="portal-scope">
-                          <Story />
-                        </div>
-                      ) : (
-                        <Story />
-                      )}
-                    </Suspense>
-                  </UIProvider>
+                  {/* Tooltip reads the user's logo preference and the sidebar
+                      geometry it positions against. It is used by ~100
+                      components, so without these a story that renders one
+                      throws. The real app always has both mounted. */}
+                  <PreferencesProvider>
+                    <SidebarProvider>
+                      <UIProvider>
+                        <Suspense fallback={null}>
+                          {isPortalStory ? (
+                            <div className="portal-scope">
+                              <Story />
+                            </div>
+                          ) : (
+                            <Story />
+                          )}
+                        </Suspense>
+                      </UIProvider>
+                    </SidebarProvider>
+                  </PreferencesProvider>
                 </TierKey>
               </LinkProvider>
             </StoryTheme>

--- a/frontend/.storybook/tsconfig.json
+++ b/frontend/.storybook/tsconfig.json
@@ -5,7 +5,16 @@
   // The per-layer typecheck projects also cover story files, but each resolves
   // @app/* its own way - not the way the single Storybook build renders them.
   "extends": "../editor/tsconfig.proprietary.vite.json",
-  "exclude": [],
+  // Stories in the flavour layers import @app/* expecting their own layer's
+  // resolution (cloud -> proprietary -> core, and so on), which a single alias
+  // map cannot express. Each is already typechecked by its own layer project;
+  // checking them again here would only assert the wrong resolution.
+  "exclude": [
+    "../editor/src/cloud/**/*.stories.*",
+    "../editor/src/desktop/**/*.stories.*",
+    "../editor/src/saas/**/*.stories.*",
+    "../editor/src/prototypes/**/*.stories.*"
+  ],
   "include": [
     "./**/*",
     "../editor/src/global.d.ts",

--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -11239,6 +11239,7 @@ unknownFile = "Unknown file"
 view = "View"
 zoom = "Zoom"
 zoomIn = "Zoom In"
+zoomLevel = "Zoom level"
 zoomOut = "Zoom Out"
 
 [viewer.attachments]

--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -11367,6 +11367,7 @@ unknownFile = "Unknown file"
 view = "View"
 zoom = "Zoom"
 zoomIn = "Zoom In"
+zoomLevel = "Zoom level"
 zoomOut = "Zoom Out"
 
 [viewer.attachments]

--- a/frontend/editor/scripts/storybook-coverage.mjs
+++ b/frontend/editor/scripts/storybook-coverage.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// Storybook coverage report — which rendered surfaces have a story, and what
+// stands between the ones that don't and having one. Modes:
+//
+//   node storybook-coverage.mjs           summary by area (report only)
+//   node storybook-coverage.mjs --todo    every uncovered surface, with the
+//                                         work each needs
+//   node storybook-coverage.mjs --area core/components/tools
+//
+// Coverage is counted by *import*, not by an adjacent .stories.tsx: several
+// components are covered by a shared story file (MantineForms covers Select,
+// MultiSelect, NumberInput and ColorInput between them), and counting siblings
+// reports those as gaps and invites duplicate stories.
+//
+// Each uncovered surface is classified by what a story would have to supply:
+//
+//   props      no context to supply. Note this means "no provider needed", not
+//              "cheap" — a props-only component can still be expensive to
+//              story if its props are heavy (ButtonAppearanceOverlay wants
+//              real PDF bytes; AppConfigModalLazy lazy-loads the whole
+//              settings tree). Read the props before assuming it is quick.
+//   context    it (or something it renders) reads a React context. The cheap
+//              fix is usually to export the context and hand the story the
+//              slice the component actually touches, rather than mounting the
+//              provider and whatever chain sits behind it.
+//   data       it fetches, so the story needs MSW handlers
+//   router     it reads router state
+//
+// Not counted as surfaces at all: providers, contexts, gates, routers, test
+// helpers, and modules that return a config object rather than markup.
+//
+// Known blocker — four flavours cannot be storied as things stand.
+//
+// Storybook resolves @app/* through editor/tsconfig.proprietary.vite.json,
+// which maps it to src/proprietary/* then src/core/* and excludes src/desktop.
+// A file in another flavour that imports an @app/* asset living only in its own
+// tree therefore fails to resolve, and the story file does not load at all:
+//
+//   desktop      80 of 152 @app/ imports unresolvable
+//   saas         54 of 232
+//   cloud        28 of  77
+//   prototypes    4 of  40
+//   portal-saas   0 of   7   (fine)
+//
+// That accounts for the 0% areas below — it is a build-config gap, not
+// neglect. Closing it means either per-flavour alias projects in
+// .storybook/main.ts or hoisting the shared assets, and it is a decision with
+// blast radius across every existing story, so it is deliberately not made
+// here.
+//
+// Run from frontend/.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const SRC = resolve(process.cwd(), "editor/src");
+const args = process.argv.slice(2);
+const wantTodo = args.includes("--todo");
+const areaFilter = args.includes("--area")
+  ? args[args.indexOf("--area") + 1]
+  : null;
+
+/* ── file walk ────────────────────────────────────────────────────────────── */
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.name.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+const all = walk(SRC);
+const rel = (f) => relative(SRC, f).split("\\").join("/");
+const storyFiles = all.filter((f) => f.endsWith(".stories.tsx"));
+const sources = all.filter(
+  (f) => !f.endsWith(".stories.tsx") && !f.endsWith(".test.tsx"),
+);
+
+/* ── what the stories already reach ───────────────────────────────────────── */
+
+const importedNames = new Set();
+const importedPaths = new Set();
+for (const f of storyFiles) {
+  const src = readFileSync(f, "utf8");
+  for (const m of src.matchAll(
+    /import\s+(?:type\s+)?(?:\{([^}]*)\}|(\w+))\s*(?:,\s*\{([^}]*)\})?\s*from\s+["']([^"']+)/g,
+  )) {
+    for (const group of [m[1], m[3]]) {
+      if (!group) continue;
+      for (const name of group.split(","))
+        importedNames.add(
+          name.trim().split(" as ")[0].replace("type ", "").trim(),
+        );
+    }
+    if (m[2]) importedNames.add(m[2]);
+    importedPaths.add(m[4]);
+  }
+}
+
+/* ── classification ───────────────────────────────────────────────────────── */
+
+// Bridge: the viewer's *APIBridge components register an API into context and
+// render null — wiring, like the rest of these.
+const INFRA_NAME =
+  /(Provider|Providers|Context|Gate|Boundary|Mount|Router|Guard|Bridge)\.tsx$/;
+const INFRA_DIR = /\/(contexts|test|tests|mocks|hooks|types|utils|api|data)\//;
+const RENDERS = /return\s*\(?\s*<|=>\s*\(?\s*</;
+// A module whose exported function returns a config object, not markup.
+const CONFIG_FACTORY = /:\s*(SlideConfig|ToolFlowConfig|\w+Config)\s*\{/;
+const DATA = /\buse(Query|Mutation|SWR|InfiniteQuery)\b|\bfetch\w*\(/;
+const ROUTER = /\buse(Navigate|Params|Location|SearchParams)\b/;
+const CONTEXT = /\buse[A-Z]\w*\(/g;
+// Hooks that are plainly not context reads.
+const LOCAL_HOOK =
+  /^use(State|Effect|Memo|Callback|Ref|Id|Reducer|Context|Translation|LayoutEffect|ImperativeHandle|Transition|DeferredValue|SyncExternalStore|Debounced\w*|Media\w*|Disclosure|Form)$/;
+// Contexts .storybook/preview.tsx already mounts for every story. A component
+// that reads only these needs no fixture work, so it counts as props-level.
+const HARNESS_PROVIDED =
+  /^use(Preferences|SidebarContext|Tier|Link|UI|Theme|QueryClient|Navigate|Location|Params|SearchParams)$/;
+
+const byPath = new Map(sources.map((f) => [rel(f), f]));
+
+function localImports(src, fromRel) {
+  const out = [];
+  for (const m of src.matchAll(
+    /from\s+["'](@app\/|@core\/|\.\.?\/)([^"']+)/g,
+  )) {
+    const spec = m[1] + m[2];
+    const guess = spec.replace(/^@app\//, "core/").replace(/^@core\//, "core/");
+    for (const cand of [`${guess}.tsx`, `${guess}/index.tsx`]) {
+      if (byPath.has(cand)) out.push(cand);
+    }
+    void fromRel;
+  }
+  return out;
+}
+
+/** Does this file, or anything it renders, read a context? Depth-limited. */
+function needsContext(relPath, seen = new Set(), depth = 0) {
+  if (depth > 3 || seen.has(relPath)) return false;
+  seen.add(relPath);
+  const file = byPath.get(relPath);
+  if (!file) return false;
+  const src = readFileSync(file, "utf8");
+  for (const m of src.matchAll(CONTEXT)) {
+    const name = m[0].slice(0, -1);
+    if (!LOCAL_HOOK.test(name) && !HARNESS_PROVIDED.test(name)) return true;
+  }
+  return localImports(src, relPath).some((child) =>
+    needsContext(child, seen, depth + 1),
+  );
+}
+
+const rows = [];
+for (const file of sources) {
+  const r = rel(file);
+  const base = r.split("/").pop();
+  if (!/^[A-Z]/.test(base)) continue;
+  const src = readFileSync(file, "utf8");
+  if (!RENDERS.test(src)) continue;
+  if (INFRA_NAME.test(base) || INFRA_DIR.test("/" + r)) continue;
+  if (CONFIG_FACTORY.test(src)) continue;
+
+  const stem = base.replace(".tsx", "");
+  const tail = r.replace(".tsx", "");
+  const covered =
+    importedNames.has(stem) ||
+    [...importedPaths].some((p) => p.endsWith(tail) || p.endsWith("/" + stem));
+
+  let needs = "props";
+  if (DATA.test(src)) needs = "data";
+  else if (ROUTER.test(src)) needs = "router";
+  else if (needsContext(r)) needs = "context";
+
+  const parts = r.split("/");
+  rows.push({
+    area: parts.slice(0, Math.min(3, parts.length - 1)).join("/"),
+    file: r,
+    covered,
+    needs,
+    loc: src.split("\n").length,
+  });
+}
+
+/* ── report ───────────────────────────────────────────────────────────────── */
+
+const shown = areaFilter
+  ? rows.filter((r) => r.file.startsWith(areaFilter))
+  : rows;
+const todo = shown.filter((r) => !r.covered);
+
+if (wantTodo || areaFilter) {
+  const order = { props: 0, context: 1, router: 2, data: 3 };
+  for (const r of todo.sort(
+    (a, b) => order[a.needs] - order[b.needs] || a.loc - b.loc,
+  )) {
+    console.log(
+      `  ${r.needs.padEnd(8)} ${String(r.loc).padStart(5)} loc  ${r.file}`,
+    );
+  }
+  console.log("");
+}
+
+const areas = new Map();
+for (const r of shown) {
+  const a = areas.get(r.area) ?? { total: 0, covered: 0 };
+  a.total += 1;
+  if (r.covered) a.covered += 1;
+  areas.set(r.area, a);
+}
+
+console.log(
+  `${"area".padEnd(38)}${"total".padStart(6)}${"covered".padStart(9)}${"%".padStart(6)}`,
+);
+for (const [area, a] of [...areas].sort(
+  (x, y) => y[1].total - y[1].covered - (x[1].total - x[1].covered),
+)) {
+  if (a.total === a.covered) continue;
+  const pct = Math.round((100 * a.covered) / a.total);
+  console.log(
+    `${area.padEnd(38)}${String(a.total).padStart(6)}${String(a.covered).padStart(9)}${String(pct).padStart(5)}%`,
+  );
+}
+
+const covered = shown.filter((r) => r.covered).length;
+const byNeed = todo.reduce(
+  (acc, r) => ((acc[r.needs] = (acc[r.needs] ?? 0) + 1), acc),
+  {},
+);
+console.log(
+  `\nsurfaces ${shown.length}   covered ${covered} (${Math.round((100 * covered) / shown.length)}%)   remaining ${todo.length}`,
+);
+console.log(
+  `remaining by what a story needs: ` +
+    Object.entries(byNeed)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, v]) => `${k} ${v}`)
+      .join("   "),
+);

--- a/frontend/editor/src/cloud/components/UsageLimitModalHost.stories.tsx
+++ b/frontend/editor/src/cloud/components/UsageLimitModalHost.stories.tsx
@@ -1,0 +1,98 @@
+/**
+ * The always-mounted host for the two usage-limit warnings. It takes no props
+ * and shows nothing of its own: which modal appears is decided by whichever
+ * imperative opener the app calls, so each story calls one on mount. The
+ * server-side run paths reach these same two modals through a third event,
+ * picking between them on the caller's subscription state, so they add no
+ * appearance of their own.
+ *
+ * Each modal holds itself back until the wallet resolves and then reads its
+ * headline and meter from it — hence the mocked wallet behind every story.
+ *
+ * Mantine renders the modals into a portal outside the story canvas.
+ */
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
+import UsageLimitModalHost from "@app/components/UsageLimitModalHost";
+import {
+  openFreeLimitModal,
+  openSpendCapModal,
+} from "@app/components/usageLimitModals";
+import type { Wallet } from "@app/billing";
+
+/** A team that has just spent the last of its one-time free grant. */
+const EXHAUSTED_FREE_WALLET: Wallet = {
+  teamId: 42,
+  status: "free",
+  role: "leader",
+  billingPeriodStart: "2025-03-01",
+  billingPeriodEnd: "2025-03-31",
+  billableUsed: 500,
+  billableLimit: 500,
+  freeAllowance: 500,
+  freeRemaining: 0,
+  pricePerDocMinor: 2,
+  bundleRatePerCreditMinor: null,
+  currency: "usd",
+  estimatedBillMinor: 0,
+  capUsd: null,
+  noCap: false,
+  stripeSubscriptionId: null,
+  spendUnitsThisPeriod: 500,
+  categoryBreakdown: { api: 120, ai: 240, automation: 140 },
+  categoryDocs: { api: 120, ai: 240, automation: 140 },
+  docsProcessedThisPeriod: 500,
+  uniquePdfsThisPeriod: 480,
+  sizeMultiplierPdfsThisPeriod: 12,
+  billingMode: "payg",
+  prepaidUnitsRemaining: 0,
+  prepaidUnitsTotal: 0,
+  prepaidExpiresAt: null,
+  members: [],
+  recent: [],
+};
+
+/** A subscribed team whose spend has run into its own monthly ceiling. */
+const CAPPED_WALLET: Wallet = {
+  ...EXHAUSTED_FREE_WALLET,
+  status: "subscribed",
+  billableLimit: null,
+  estimatedBillMinor: 5000,
+  capUsd: 50,
+  stripeSubscriptionId: "sub_storybook",
+};
+
+function walletHandler(wallet: Wallet) {
+  return [http.get("*/api/v1/payg/wallet", () => HttpResponse.json(wallet))];
+}
+
+/** Stands in for the app code that hits a limit and calls an opener. */
+function Trigger({ open }: { open: () => void }) {
+  useEffect(() => {
+    const id = window.setTimeout(open, 0);
+    return () => window.clearTimeout(id);
+  }, [open]);
+  return <UsageLimitModalHost />;
+}
+
+const meta: Meta<typeof UsageLimitModalHost> = {
+  title: "Cloud/UsageLimitModalHost",
+  component: UsageLimitModalHost,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof UsageLimitModalHost>;
+
+/** The free grant is spent, so the upgrade invitation appears. */
+export const FreeLimitReached: Story = {
+  parameters: { msw: { handlers: walletHandler(EXHAUSTED_FREE_WALLET) } },
+  render: () => <Trigger open={openFreeLimitModal} />,
+};
+
+/** A subscribed team at its monthly ceiling, invited to raise it instead. */
+export const SpendCapReached: Story = {
+  parameters: { msw: { handlers: walletHandler(CAPPED_WALLET) } },
+  render: () => <Trigger open={openSpendCapModal} />,
+};

--- a/frontend/editor/src/cloud/components/shared/config/configSections/UpgradeModal.stories.tsx
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/UpgradeModal.stories.tsx
@@ -1,0 +1,44 @@
+/**
+ * The upgrade-to-Processor flow. Three panels share one frame — set a monthly
+ * ceiling, pay, then a short confirmation — and the step is held in local state.
+ * Only the first is reachable here: the second mints a Stripe Checkout session
+ * through the platform billing seam and the third sits behind it, so neither
+ * can be posed from props.
+ *
+ * On that first panel the per-document rate is what changes the rendering: it
+ * drives the live estimate of how many paid PDFs a ceiling buys. The `currency`
+ * and `freeLimit` props are only read by the later panels, so they get no
+ * stories of their own.
+ *
+ * The modal portals to the document body, escaping the story canvas, and covers
+ * the viewport the way it covers the settings page it opens over.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import UpgradeModal from "@app/components/shared/config/configSections/UpgradeModal";
+
+const meta: Meta<typeof UpgradeModal> = {
+  title: "Cloud/UpgradeModal",
+  component: UpgradeModal,
+  parameters: { layout: "fullscreen" },
+  args: {
+    open: true,
+    teamId: 42,
+    onClose: () => {},
+    onComplete: () => {},
+    currency: "USD",
+    freeLimit: 500,
+    pricePerDocMinor: 2,
+    rateCurrency: "usd",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof UpgradeModal>;
+
+/** Choosing a ceiling, with the document estimate derived from the known rate. */
+export const SetCap: Story = {};
+
+/** No rate resolved for the team yet, so the ceiling stands without an estimate. */
+export const WithoutRate: Story = {
+  args: { pricePerDocMinor: null, rateCurrency: null },
+};

--- a/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
@@ -45,6 +45,7 @@ export function OpacityControl({
             min={10}
             max={100}
             label={(val) => `${val}%`}
+            thumbLabel={t("annotation.opacity", "Opacity")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
@@ -75,6 +75,7 @@ export function PropertiesPopover({
           min={8}
           max={32}
           label={(val) => `${val}pt`}
+          thumbLabel={t("annotation.fontSize", "Font size")}
         />
       </div>
 
@@ -86,6 +87,7 @@ export function PropertiesPopover({
         <Slider
           value={Math.round((obj?.opacity ?? 1) * 100)}
           onChange={(val) => onUpdate({ opacity: val / 100 })}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -144,6 +146,7 @@ export function PropertiesPopover({
               fillOpacity: newOpacity,
             });
           }}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -169,6 +172,7 @@ export function PropertiesPopover({
               min={0}
               max={12}
               label={(val) => `${val}pt`}
+              thumbLabel={t("annotation.strokeWidth", "Stroke")}
             />
           </div>
           <Button

--- a/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
@@ -49,6 +49,7 @@ export function WidthControl({
             min={min}
             max={max}
             label={(val) => `${val}pt`}
+            thumbLabel={t("annotation.width", "Width")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/fileManager/FileHistoryGroup.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileHistoryGroup.stories.tsx
@@ -1,0 +1,74 @@
+/**
+ * The older versions listed beneath a file in the file manager: a count heading
+ * and one indented, non-selectable row per superseded version, newest first.
+ *
+ * The group draws nothing at all unless it is expanded AND at least one history
+ * entry survives the filter that drops the leaf file itself — so an expanded
+ * group whose only entry is the leaf renders exactly like a collapsed one, and
+ * is not given a story of its own.
+ *
+ * The rows are FileListItem, which reads FileManagerContext and AppConfig, so
+ * the shared file-manager fixture stands those up.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileHistoryGroup from "@app/components/fileManager/FileHistoryGroup";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const LEAF = makeStub("report-v4", "quarterly-report.pdf", {
+  versionNumber: 4,
+  originalFileId: "report",
+});
+
+/** Deliberately out of order: the group sorts by version number itself. */
+const HISTORY = [
+  makeStub("report-v2", "quarterly-report.pdf", {
+    versionNumber: 2,
+    originalFileId: "report",
+    isLeaf: false,
+  }),
+  LEAF,
+  makeStub("report-v3", "quarterly-report.pdf", {
+    versionNumber: 3,
+    originalFileId: "report",
+    isLeaf: false,
+  }),
+  makeStub("report-v1", "quarterly-report.pdf", {
+    versionNumber: 1,
+    originalFileId: "report",
+    isLeaf: false,
+  }),
+];
+
+const meta = {
+  title: "FileManager/FileHistoryGroup",
+  component: FileHistoryGroup,
+  parameters: { layout: "fullscreen" },
+  args: {
+    leafFile: LEAF,
+    historyFiles: HISTORY,
+    isExpanded: true,
+    onDownloadSingle: () => {},
+    onFileDoubleClick: () => {},
+    onHistoryFileRemove: () => {},
+  },
+  decorators: [withFileManager({ recentFiles: HISTORY })],
+} satisfies Meta<typeof FileHistoryGroup>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Three superseded versions under the current one, newest first. */
+export const Default: Story = {};
+
+/** A file processed once: a single earlier version to fall back to. */
+export const SingleEarlierVersion: Story = {
+  args: { historyFiles: [LEAF, HISTORY[0]] },
+};
+
+/** Collapsed, which is how the group sits until the row's menu opens it. */
+export const Collapsed: Story = {
+  args: { isExpanded: false },
+};

--- a/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
@@ -1,0 +1,98 @@
+/**
+ * Shared fixtures for the file manager stories.
+ *
+ * These components sit deep in a provider chain — FileManagerContext needs
+ * FileContext for useFileActions/useFileManagement, list rows additionally read
+ * AppConfig — and none of it is part of the shared preview decorators. Rather
+ * than each story rebuilding that tree, they mount the real providers here over
+ * static data, so what a story exercises is the component and not a stub.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FileManagerProvider } from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+/** A grey rectangle, so thumbnail lookups short-circuit instead of reading
+ *  file bytes out of IndexedDB. */
+const THUMBNAIL =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160'%3E%3Crect width='120' height='160' fill='%23e9ecef'/%3E%3C/svg%3E";
+
+/** Fixed so stories render identically on every run. */
+const LAST_MODIFIED = Date.parse("2026-03-14T09:30:00Z");
+
+export function makeStub(
+  id: string,
+  name: string,
+  overrides: Partial<StirlingFileStub> = {},
+): StirlingFileStub {
+  return {
+    id: id as FileId,
+    name,
+    type: "application/pdf",
+    size: 2_400_000,
+    lastModified: LAST_MODIFIED,
+    isLeaf: true,
+    originalFileId: id,
+    versionNumber: 1,
+    thumbnailUrl: THUMBNAIL,
+    ...overrides,
+  };
+}
+
+export const mockFile = makeStub("story-file-1", "quarterly-report.pdf");
+
+/** Storage off keeps the row's upload and share affordances out of the way;
+ *  stories that want them pass their own config. */
+const BASE_CONFIG = {
+  storageEnabled: false,
+  storageSharingEnabled: false,
+  storageShareLinksEnabled: false,
+  frontendUrl: "https://stirling.example",
+};
+
+interface FixtureOptions {
+  recentFiles?: StirlingFileStub[];
+  activeFileIds?: FileId[];
+  isLoading?: boolean;
+  config?: Partial<typeof BASE_CONFIG>;
+}
+
+export function withFileManager({
+  recentFiles = [mockFile],
+  activeFileIds = [],
+  isLoading = false,
+  config,
+}: FixtureOptions = {}) {
+  return (Story: () => ReactElement) => (
+    <AppConfigProvider
+      initialConfig={{ ...BASE_CONFIG, ...config } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      {/* The empty state's wordmark resolves a logo variant through
+          PreferencesContext, which the preview does not mount. */}
+      <PreferencesProvider>
+        <FileContextProvider>
+          <FileManagerProvider
+            recentFiles={recentFiles}
+            onRecentFilesSelected={() => {}}
+            onNewFilesSelect={() => {}}
+            onClose={() => {}}
+            isFileSupported={() => true}
+            isOpen
+            onFileRemove={() => {}}
+            modalHeight="600px"
+            refreshRecentFiles={async () => {}}
+            isLoading={isLoading}
+            activeFileIds={activeFileIds}
+          >
+            <Story />
+          </FileManagerProvider>
+        </FileContextProvider>
+      </PreferencesProvider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
@@ -57,7 +57,9 @@ interface FixtureOptions {
   recentFiles?: StirlingFileStub[];
   activeFileIds?: FileId[];
   isLoading?: boolean;
-  config?: Partial<typeof BASE_CONFIG>;
+  /** Any AppConfig field, not just the few defaulted below — stories reach for
+   *  Drive and tool-visibility flags too. */
+  config?: Record<string, unknown>;
 }
 
 export function withFileManager({

--- a/frontend/editor/src/core/components/tools/addAttachments/AddAttachmentsSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addAttachments/AddAttachmentsSettings.stories.tsx
@@ -1,0 +1,82 @@
+/**
+ * The attachment picker shared by the Add Attachments tool panel and its
+ * automation step: a file chooser, the list of files queued for embedding, and
+ * the PDF/A-3b conversion option.
+ *
+ * Everything on show comes from the `parameters` prop. An empty attachment list
+ * hides the list section and leaves the chooser reading "Choose files…"; once
+ * files are queued the chooser invites more and each file gets a row with its
+ * size and a remove button. `disabled` greys the whole control set, which is
+ * how the panel looks while an operation is running.
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddAttachmentsSettings from "@app/components/tools/addAttachments/AddAttachmentsSettings";
+
+/** Byte-exact so the reported size is the same on every render. */
+function attachment(name: string, kilobytes: number): File {
+  return new File([new Uint8Array(kilobytes * 1024)], name, {
+    type: "application/octet-stream",
+  });
+}
+
+const FILES = [
+  attachment("invoice-2026-Q1.csv", 18),
+  attachment("terms-and-conditions.docx", 246),
+];
+
+/** The tool panel is a narrow column; the filename clamp depends on it. */
+const inPanel = (Story: () => ReactElement) => (
+  <div style={{ maxWidth: 340 }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: "Tools/AddAttachments/AddAttachmentsSettings",
+  component: AddAttachmentsSettings,
+  decorators: [inPanel],
+  args: {
+    parameters: { attachments: [], convertToPdfA3b: false },
+    onParameterChange: () => {},
+  },
+} satisfies Meta<typeof AddAttachmentsSettings>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Nothing chosen yet: just the chooser and the conversion option. */
+export const Default: Story = {};
+
+/** Two files queued, each with its size and a remove button. */
+export const WithAttachments: Story = {
+  args: { parameters: { attachments: FILES, convertToPdfA3b: false } },
+};
+
+/** Archival output requested, which routes the job through Ghostscript. */
+export const ConvertToPdfA3b: Story = {
+  args: { parameters: { attachments: FILES, convertToPdfA3b: true } },
+};
+
+/** A name too long for one line wraps to two and then clips. */
+export const LongFileName: Story = {
+  args: {
+    parameters: {
+      attachments: [
+        attachment(
+          "2026-quarterly-financial-statement-consolidated-final-approved.xlsx",
+          512,
+        ),
+      ],
+      convertToPdfA3b: false,
+    },
+  },
+};
+
+/** Locked while the operation runs: nothing can be added or removed. */
+export const Disabled: Story = {
+  args: {
+    parameters: { attachments: FILES, convertToPdfA3b: false },
+    disabled: true,
+  },
+};

--- a/frontend/editor/src/core/components/tools/automate/AutomationEntry.stories.tsx
+++ b/frontend/editor/src/core/components/tools/automate/AutomationEntry.stories.tsx
@@ -1,0 +1,90 @@
+/**
+ * A single row in the Automate list — a saved workflow, a suggested one, or the
+ * entry that starts a new one.
+ *
+ * A `title` names the row outright; without one the row spells out its tool
+ * chain instead, with an arrow between each step. Those step labels come from
+ * the tool registry when it is passed and from the translation bundle
+ * otherwise, so a registry is only worth passing for an operation the bundle
+ * has no name for — it changes the wording, never the shape, and so gets no
+ * story of its own. `keepIconColor` holds the badge in the accent colour, which
+ * is how the "create new" row sets itself apart from the saved ones.
+ *
+ * The overflow menu is present whenever `showMenu` is set but stays faded out
+ * until the row is hovered or the menu is open, so the story that covers it
+ * hovers the row first.
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, userEvent } from "storybook/test";
+import AddIcon from "@mui/icons-material/Add";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import AutomationEntry from "@app/components/tools/automate/AutomationEntry";
+
+/** The Automate panel is a narrow column and the row fills it. */
+const inPanel = (Story: () => ReactElement) => (
+  <div style={{ maxWidth: 340 }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: "Tools/Automate/AutomationEntry",
+  component: AutomationEntry,
+  decorators: [inPanel],
+  args: {
+    operations: ["compress", "flatten"],
+    onClick: () => {},
+  },
+} satisfies Meta<typeof AutomationEntry>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A suggested workflow, which names itself by its chain of tools. */
+export const Default: Story = {};
+
+/** A saved workflow: its own name, with the chain kept for the tooltip. */
+export const NamedAutomation: Story = {
+  args: {
+    title: "Monthly board pack",
+    description: "Shrinks the pack and locks the forms before it goes out.",
+    badgeIcon: AutoAwesomeIcon,
+    operations: ["compress", "flatten", "addPassword"],
+  },
+};
+
+/**
+ * The row that starts a new workflow: accented badge, no chain to describe, and
+ * so no tooltip either.
+ */
+export const CreateNewEntry: Story = {
+  args: {
+    title: "Create new automation",
+    badgeIcon: AddIcon,
+    keepIconColor: true,
+    operations: [],
+    onImport: () => {},
+    showMenu: true,
+  },
+};
+
+/** Hovered, which fades in the overflow menu the row keeps its actions behind. */
+export const MenuRevealedOnHover: Story = {
+  args: {
+    title: "Nightly redaction pass",
+    badgeIcon: AutoAwesomeIcon,
+    operations: ["redact", "sanitize"],
+    showMenu: true,
+    onEdit: () => {},
+    onDelete: () => {},
+    onExportAutomation: () => {},
+    onExportFolderScan: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.hover(
+      canvas.getByRole("button", { name: "Nightly redaction pass" }),
+    );
+  },
+};

--- a/frontend/editor/src/core/components/tools/changeMetadata/ChangeMetadataSingleStep.stories.tsx
+++ b/frontend/editor/src/core/components/tools/changeMetadata/ChangeMetadataSingleStep.stories.tsx
@@ -1,0 +1,67 @@
+/**
+ * The whole Change Metadata form on one panel: delete-all, the standard fields,
+ * the document dates and the advanced options, in that order.
+ *
+ * Two things decide what is editable. "Delete all metadata" makes every field
+ * below it pointless, so ticking it locks the other three sections while
+ * leaving their values on screen. The panel is also disabled wholesale by its
+ * host — while the tool is running, or while metadata is still being read off
+ * the selected file — and that locks the delete-all switch too.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import ChangeMetadataSingleStep from "@app/components/tools/changeMetadata/ChangeMetadataSingleStep";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+import {
+  defaultParameters,
+  type ChangeMetadataParameters,
+} from "@app/hooks/tools/changeMetadata/useChangeMetadataParameters";
+import { TrappedStatus } from "@app/types/metadata";
+
+/** A document whose metadata has already been read in, so every field is populated. */
+const populated: ChangeMetadataParameters = {
+  ...defaultParameters,
+  title: "Q3 Supplier Agreement",
+  author: "A. Okonkwo",
+  subject: "Logistics framework terms",
+  keywords: "logistics, framework, 2026",
+  creator: "Stirling PDF",
+  producer: "Stirling PDF",
+  creationDate: new Date("2026-01-15T09:30:00Z"),
+  modificationDate: new Date("2026-03-02T14:05:00Z"),
+  trapped: TrappedStatus.FALSE,
+  customMetadata: [
+    { id: "custom1", key: "Department", value: "Procurement" },
+    { id: "custom2", key: "Retention", value: "7 years" },
+  ],
+};
+
+const meta = {
+  title: "Tools/ChangeMetadata/ChangeMetadataSingleStep",
+  component: ChangeMetadataSingleStep,
+  parameters: { layout: "padded" },
+  // The panel reads the view-scoped file list to pre-fill itself; with no files
+  // loaded nothing is extracted and the form stands on the parameters given.
+  decorators: [withToolContexts()],
+  args: {
+    parameters: defaultParameters,
+    onParameterChange: () => {},
+  },
+} satisfies Meta<typeof ChangeMetadataSingleStep>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A fresh panel with nothing read in yet — every field empty and editable. */
+export const Default: Story = {};
+
+export const Populated: Story = { args: { parameters: populated } };
+
+/** Delete-all ticked: the values stay visible but the sections below are locked. */
+export const DeleteAll: Story = {
+  args: { parameters: { ...populated, deleteAll: true } },
+};
+
+/** Locked by the host, so even the delete-all switch is out of reach. */
+export const Disabled: Story = {
+  args: { parameters: populated, disabled: true },
+};

--- a/frontend/editor/src/core/components/tools/pdfTextEditor/FontStatusPanel.stories.tsx
+++ b/frontend/editor/src/core/components/tools/pdfTextEditor/FontStatusPanel.stories.tsx
@@ -1,0 +1,118 @@
+/**
+ * The font report in the text editor: how faithfully each font in the document
+ * can be reproduced when it is exported again.
+ *
+ * The panel derives everything from the document it is given. Each font is
+ * graded — a standard PDF font or a fully embedded one is perfect, an embedded
+ * subset warns that newly typed characters may be missing, and a font that is
+ * neither embedded nor available to the backend is missing — and the headline
+ * colour, message and summary badges follow from the worst grade present.
+ * Passing a `pageIndex` narrows the report to the fonts that page actually
+ * uses and retitles it accordingly. A document with no fonts renders nothing,
+ * which is why every story below supplies some.
+ *
+ * The "fallback" summary badge has no story: the analysis never assigns that
+ * grade, so nothing can produce it.
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FontStatusPanel from "@app/components/tools/pdfTextEditor/FontStatusPanel";
+import type {
+  PdfJsonDocument,
+  PdfJsonFont,
+} from "@app/tools/pdfTextEditor/pdfTextEditorTypes";
+
+/** One of the standard 14: always present in a reader, so always perfect. */
+const HELVETICA: PdfJsonFont = {
+  id: "F1",
+  baseName: "Helvetica",
+  subtype: "Type1",
+  encoding: "WinAnsiEncoding",
+  embedded: false,
+};
+
+/** Embedded whole, so even edited text exports exactly. */
+const INTER: PdfJsonFont = {
+  id: "F2",
+  baseName: "Inter-Regular",
+  subtype: "TrueType",
+  encoding: "WinAnsiEncoding",
+  embedded: true,
+  webProgramFormat: "woff2",
+};
+
+/** Embedded, but only the glyphs the document already uses. */
+const INTER_SUBSET: PdfJsonFont = {
+  id: "F3",
+  baseName: "ABCDEE+Inter-Bold",
+  subtype: "TrueType",
+  encoding: "WinAnsiEncoding",
+  embedded: true,
+  webProgramFormat: "woff2",
+};
+
+/** Neither embedded nor held by the backend, so export substitutes it. */
+const BARLOW: PdfJsonFont = {
+  id: "F4",
+  baseName: "Barlow-Medium",
+  subtype: "TrueType",
+  encoding: "MacRomanEncoding",
+  embedded: false,
+};
+
+function doc(fonts: PdfJsonFont[]): PdfJsonDocument {
+  return { fonts, pages: [] };
+}
+
+/** Only Helvetica is used on the first page; Inter appears elsewhere. */
+const PAGED_DOCUMENT: PdfJsonDocument = {
+  fonts: [HELVETICA, INTER],
+  pages: [
+    {
+      pageNumber: 1,
+      textElements: [{ text: "Quarterly summary", fontId: "F1" }],
+    },
+    {
+      pageNumber: 2,
+      textElements: [{ text: "Appendix", fontId: "F2" }],
+    },
+  ],
+};
+
+/** The report sits in the editor's side column. */
+const inPanel = (Story: () => ReactElement) => (
+  <div style={{ maxWidth: 340 }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: "Tools/PdfTextEditor/FontStatusPanel",
+  component: FontStatusPanel,
+  decorators: [inPanel],
+  args: {
+    document: doc([HELVETICA, INTER]),
+    onCollapsedChange: () => {},
+  },
+} satisfies Meta<typeof FontStatusPanel>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Every font reproduces exactly, so the panel is green and reassuring. */
+export const AllFontsPerfect: Story = {};
+
+/** A subset and an unembedded font drop the headline to a warning. */
+export const WithWarnings: Story = {
+  args: { document: doc([HELVETICA, INTER_SUBSET, BARLOW]) },
+};
+
+/** Scoped to one page, which reports only the fonts that page draws with. */
+export const CurrentPageOnly: Story = {
+  args: { document: PAGED_DOCUMENT, pageIndex: 0 },
+};
+
+/** Collapsed to its header, dimmed, with the detail folded away. */
+export const Collapsed: Story = {
+  args: { document: doc([HELVETICA, INTER_SUBSET, BARLOW]), isCollapsed: true },
+};

--- a/frontend/editor/src/core/components/tools/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/tools/storyFixtures.tsx
@@ -1,0 +1,127 @@
+/**
+ * Shared context slices for the tool-panel stories.
+ *
+ * These components sit under providers that reach most of the app — the tool
+ * workflow stands up the registry and navigation, the workbench bar derives its
+ * buttons from the whole workbench. Each component here reads only a handful of
+ * fields, so the slices below supply those instead. What a story mounts is then
+ * an honest record of what its component actually depends on.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import {
+  NavigationStateContext,
+  type NavigationContextStateValue,
+} from "@app/contexts/NavigationContext";
+import {
+  ToolWorkflowContext,
+  ToolWorkflowDataContext,
+  ToolWorkflowActionsContext,
+  type ToolWorkflowContextValue,
+  type ToolWorkflowDataValue,
+  type ToolWorkflowActionsValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+
+export interface ToolContextOptions {
+  /** Which workbench is active; several components render only in one. */
+  workbench?: string;
+  /** Favourited tool ids, for anything drawing a star. */
+  favourites?: string[];
+  /** Index the viewer is showing, for scope-aware copy. */
+  activeFileIndex?: number;
+  /** Extra viewer fields for components that reach further into it. */
+  viewer?: Partial<Record<string, unknown>>;
+  /** Extra workflow fields — search state, panel view, the open tool. */
+  workflow?: Partial<Record<string, unknown>>;
+}
+
+export function withToolContexts({
+  workbench = "viewer",
+  favourites = [],
+  activeFileIndex = 0,
+  viewer = {},
+  workflow = {},
+}: ToolContextOptions = {}) {
+  return (Story: () => ReactElement): ReactElement => (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled: true } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <NavigationStateContext.Provider
+          value={{ workbench } as unknown as NavigationContextStateValue}
+        >
+          <ToolWorkflowContext.Provider
+            value={
+              {
+                getSelectedTool: () => null,
+                toolPanelMode: "normal",
+                leftPanelView: "tools",
+                readerMode: false,
+                ...workflow,
+              } as unknown as ToolWorkflowContextValue
+            }
+          >
+            <ToolWorkflowDataContext.Provider
+              value={
+                {
+                  isFavorite: (id: string) => favourites.includes(id),
+                  toolAvailability: {},
+                  toolRegistry: {},
+                  favoriteTools: favourites,
+                } as unknown as ToolWorkflowDataValue
+              }
+            >
+              <ToolWorkflowActionsContext.Provider
+                value={
+                  {
+                    toggleFavorite: () => {},
+                    handleToolSelect: () => {},
+                  } as unknown as ToolWorkflowActionsValue
+                }
+              >
+                <ViewerContext.Provider
+                  value={
+                    {
+                      activeFileIndex,
+                      ...viewer,
+                    } as unknown as ViewerContextType
+                  }
+                >
+                  <FilesModalContext.Provider
+                    value={
+                      {
+                        openFilesModal: () => {},
+                        onFileUpload: () => {},
+                      } as unknown as FilesModalContextType
+                    }
+                  >
+                    {/* Real FileContext: the file list drives scope-aware copy,
+                        and it stands up standalone with no files. */}
+                    <FileContextProvider>
+                      <Story />
+                    </FileContextProvider>
+                  </FilesModalContext.Provider>
+                </ViewerContext.Provider>
+              </ToolWorkflowActionsContext.Provider>
+            </ToolWorkflowDataContext.Provider>
+          </ToolWorkflowContext.Provider>
+        </NavigationStateContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
@@ -334,6 +334,7 @@ export function PdfViewerToolbar({
             max={500}
             step={5}
             onChange={(val) => zoomActions.setZoomLevel?.(val / 100)}
+            thumbLabel={t("viewer.zoomLevel", "Zoom level")}
             size="xs"
             styles={{
               root: { minWidth: "6rem", width: "6rem", flexShrink: 0 },

--- a/frontend/editor/src/core/components/viewer/RulerScaleSettingsButton.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerScaleSettingsButton.stories.tsx
@@ -1,0 +1,36 @@
+/**
+ * The cog on the ruler toolbar that opens the measurement scale settings.
+ *
+ * At rest the button is all there is to see: the scale panel lives inside a
+ * popover and the label inside a tooltip, both of which only appear once the
+ * user interacts. So the current scale, the calibration state and the apply /
+ * reset handlers change nothing about the resting render — the only prop that
+ * does is `disabled`, which is how the toolbar reflects a document that cannot
+ * be measured yet.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RulerScaleSettingsButton } from "@app/components/viewer/RulerScaleSettingsButton";
+
+const meta = {
+  title: "Viewer/RulerScaleSettingsButton",
+  component: RulerScaleSettingsButton,
+  args: {
+    label: "Scale settings",
+    tooltipPosition: "right",
+    currentScale: { factor: 1 / 72, ratio: null, unit: "in" },
+    onApplyScale: () => {},
+    onResetScale: () => {},
+    onStartCalibration: () => {},
+    onCancelCalibration: () => {},
+  },
+} satisfies Meta<typeof RulerScaleSettingsButton>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** No measurable document loaded, so the cog is inert. */
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
@@ -451,6 +451,7 @@ export function useViewerWorkbenchBarButtons(
                 <Slider
                   value={speechRate}
                   onChange={handleSpeechRateChange}
+                  thumbLabel={readAloudSpeedLabel}
                   min={0.5}
                   max={2}
                   step={0.1}

--- a/frontend/editor/src/core/contexts/FileManagerContext.tsx
+++ b/frontend/editor/src/core/contexts/FileManagerContext.tsx
@@ -29,7 +29,7 @@ import { openFilesFromDisk } from "@app/services/openFilesFromDisk";
 export { pendingFilePathMappings } from "@app/services/pendingFilePathMappings";
 
 // Type for the context value - now contains everything directly
-interface FileManagerContextValue {
+export interface FileManagerContextValue {
   // State
   activeSource: "recent" | "local" | "drive";
   storageFilter: "all" | "local" | "sharedWithMe" | "sharedByMe";
@@ -80,8 +80,11 @@ interface FileManagerContextValue {
   modalHeight: string;
 }
 
-// Create the context
-const FileManagerContext = createContext<FileManagerContextValue | null>(null);
+// Create the context. Exported so a test or story can mount a component
+// against a slice of the value instead of the whole provider chain.
+export const FileManagerContext = createContext<FileManagerContextValue | null>(
+  null,
+);
 
 // Provider component props
 interface FileManagerProviderProps {

--- a/frontend/editor/src/core/contexts/FilesModalContext.tsx
+++ b/frontend/editor/src/core/contexts/FilesModalContext.tsx
@@ -43,8 +43,9 @@ export interface FilesModalContextType {
 
 // Exported so a test or story can mount a component against a slice of the
 // value: the provider itself pulls in FileContext and NavigationContext.
-export const FilesModalContext =
-  createContext<FilesModalContextType | null>(null);
+export const FilesModalContext = createContext<FilesModalContextType | null>(
+  null,
+);
 
 export const FilesModalProvider: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/frontend/editor/src/core/contexts/FilesModalContext.tsx
+++ b/frontend/editor/src/core/contexts/FilesModalContext.tsx
@@ -26,7 +26,7 @@ import {
   readResponseHeader,
 } from "@app/services/shareBundleUtils";
 
-interface FilesModalContextType {
+export interface FilesModalContextType {
   isFilesModalOpen: boolean;
   openFilesModal: (options?: {
     insertAfterPage?: number;
@@ -41,7 +41,10 @@ interface FilesModalContextType {
   setOnModalClose: (callback: () => void) => void;
 }
 
-const FilesModalContext = createContext<FilesModalContextType | null>(null);
+// Exported so a test or story can mount a component against a slice of the
+// value: the provider itself pulls in FileContext and NavigationContext.
+export const FilesModalContext =
+  createContext<FilesModalContextType | null>(null);
 
 export const FilesModalProvider: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/frontend/editor/src/core/contexts/HotkeyContext.tsx
+++ b/frontend/editor/src/core/contexts/HotkeyContext.tsx
@@ -22,7 +22,7 @@ import { ToolCategoryId, ToolRegistryEntry } from "@app/data/toolsTaxonomy";
 
 type Bindings = Partial<Record<ToolId, HotkeyBinding>>;
 
-interface HotkeyContextValue {
+export interface HotkeyContextValue {
   hotkeys: Bindings;
   defaults: Bindings;
   isMac: boolean;
@@ -38,7 +38,12 @@ interface HotkeyContextValue {
   getDisplayParts: (binding: HotkeyBinding | null | undefined) => string[];
 }
 
-const HotkeyContext = createContext<HotkeyContextValue | undefined>(undefined);
+// Exported so a component that only reads a slice of this (HotkeyDisplay wants
+// getDisplayParts) can be mounted without HotkeyProvider, which pulls in the
+// whole tool-workflow chain behind it.
+export const HotkeyContext = createContext<HotkeyContextValue | undefined>(
+  undefined,
+);
 
 const STORAGE_KEY = "stirlingpdf.hotkeys";
 

--- a/frontend/editor/src/core/contexts/NavigationContext.tsx
+++ b/frontend/editor/src/core/contexts/NavigationContext.tsx
@@ -128,8 +128,11 @@ export interface NavigationContextActionsValue {
   actions: NavigationContextActions;
 }
 
-// Create contexts
-const NavigationStateContext = createContext<
+// Create contexts. The state context is exported so a test or story can mount a
+// component against a slice of it: the provider itself reaches the tool
+// registry, which is far more than a component reading one navigation field
+// needs standing up.
+export const NavigationStateContext = createContext<
   NavigationContextStateValue | undefined
 >(undefined);
 const NavigationActionsContext = createContext<

--- a/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
+++ b/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
@@ -58,7 +58,7 @@ export interface CustomWorkbenchViewInstance extends CustomWorkbenchViewRegistra
   data: any;
 }
 
-interface ToolWorkflowContextValue extends ToolWorkflowState {
+export interface ToolWorkflowContextValue extends ToolWorkflowState {
   // Tool management (from hook)
   selectedToolKey: ToolId | null;
   selectedTool: ToolRegistryEntry | null;
@@ -116,7 +116,10 @@ const __GLOBAL_CONTEXT_KEY__ = "__ToolWorkflowContext__";
 const existingContext = (globalThis as any)[__GLOBAL_CONTEXT_KEY__] as
   | React.Context<ToolWorkflowContextValue | undefined>
   | undefined;
-const ToolWorkflowContext =
+// Exported so a test or story can mount a component against a slice of the
+// value. The provider itself stands up the whole tool registry and navigation
+// chain, which is far more than a component reading a few fields needs.
+export const ToolWorkflowContext =
   existingContext ??
   createContext<ToolWorkflowContextValue | undefined>(undefined);
 if (!existingContext) {
@@ -156,10 +159,14 @@ export interface ToolWorkflowDataValue {
   isFavorite: (toolId: ToolId) => boolean;
 }
 
-const ToolWorkflowActionsContext = createContext<
+// Exported alongside ToolWorkflowContext so a story can supply the callbacks a
+// component reaches for without standing up the provider.
+export const ToolWorkflowActionsContext = createContext<
   ToolWorkflowActionsValue | undefined
 >(undefined);
-const ToolWorkflowDataContext = createContext<
+// Exported alongside the other two so a story can supply the registry and
+// favourites a component reads without standing up the provider.
+export const ToolWorkflowDataContext = createContext<
   ToolWorkflowDataValue | undefined
 >(undefined);
 

--- a/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
+++ b/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
@@ -23,9 +23,9 @@ interface WorkbenchBarContextValue {
 
 // Exported so a story can supply the bar's buttons without the provider,
 // which derives them from the whole workbench.
-export const WorkbenchBarContext = createContext<WorkbenchBarContextValue | undefined>(
-  undefined,
-);
+export const WorkbenchBarContext = createContext<
+  WorkbenchBarContextValue | undefined
+>(undefined);
 
 export function WorkbenchBarProvider({
   children,

--- a/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
+++ b/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
@@ -21,7 +21,9 @@ interface WorkbenchBarContextValue {
   clear: () => void;
 }
 
-const WorkbenchBarContext = createContext<WorkbenchBarContextValue | undefined>(
+// Exported so a story can supply the bar's buttons without the provider,
+// which derives them from the whole workbench.
+export const WorkbenchBarContext = createContext<WorkbenchBarContextValue | undefined>(
   undefined,
 );
 

--- a/frontend/editor/src/core/theme/colors.css
+++ b/frontend/editor/src/core/theme/colors.css
@@ -417,3 +417,14 @@ html[data-app-theme="custom"][data-accent="default"][data-mantine-color-scheme="
   --c-border: var(--p-c-28282d);
   --c-border-subtle: var(--p-zinc-700);
 }
+
+/* ── MANTINE MUTED TEXT ───────────────────────────────────────────────────── */
+/* Mantine's stock "dimmed" is #868e96, which measures ~3:1 against the app's
+   surfaces — short of the 4.5:1 that body-size text needs. Pointing it at the
+   semantic muted token fixes every `c="dimmed"` at once, and follows the theme
+   rather than staying a fixed grey that only ever suited light mode. */
+/* Doubled selector: Mantine declares this on :root too, and its stylesheet
+   loads later, so a single :root here would lose on source order. */
+:root:root {
+  --mantine-color-dimmed: var(--c-text-muted);
+}

--- a/frontend/editor/src/core/tools/annotate/AnnotationPanel.stories.tsx
+++ b/frontend/editor/src/core/tools/annotate/AnnotationPanel.stories.tsx
@@ -1,0 +1,162 @@
+/**
+ * The Annotate tool panel: the select-and-edit button, undo/redo and the
+ * overflow action beside it, then the annotation tools grouped by kind, and the
+ * save button at the foot.
+ *
+ * Which tool is active decides the highlighting across those groups, and it is
+ * also the only thing that reveals the settings card — that card is rendered
+ * for the stamp tool alone, where it carries the image uploader and, once an
+ * image is chosen, its preview. The viewer's annotation visibility switch
+ * disables every tool at once, undo and redo follow the history the viewer
+ * reports, and the save button waits on whether there is anything to apply.
+ *
+ * The colour picker and the clear-all confirmation are both modals opened from
+ * within, so neither is reachable by setting a prop.
+ *
+ * The panel closes with the suggested-tools strip, which reads the tool
+ * workflow and navigation contexts; the shared tool fixture supplies them.
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AnnotationPanel } from "@app/tools/annotate/AnnotationPanel";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+import type { ViewerContextType } from "@app/contexts/ViewerContext";
+
+/** A one-inch red square, so the stamp preview has something stable to show. */
+const STAMP_IMAGE =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='72' height='72'%3E%3Crect width='72' height='72' fill='%23cc0000'/%3E%3C/svg%3E";
+
+const styleState = {
+  inkColor: "#0066cc",
+  inkWidth: 3,
+  highlightColor: "#ffd43b",
+  highlightOpacity: 40,
+  freehandHighlighterWidth: 10,
+  underlineColor: "#0066cc",
+  underlineOpacity: 100,
+  strikeoutColor: "#cc0000",
+  strikeoutOpacity: 100,
+  squigglyColor: "#009900",
+  squigglyOpacity: 100,
+  textColor: "#000000",
+  textSize: 14,
+  textAlignment: "left" as const,
+  textBackgroundColor: "#ffffff",
+  noteBackgroundColor: "#fff3bf",
+  shapeStrokeColor: "#0066cc",
+  shapeFillColor: "#e7f5ff",
+  shapeOpacity: 100,
+  shapeStrokeOpacity: 100,
+  shapeFillOpacity: 100,
+  shapeThickness: 2,
+};
+
+const styleActions = {
+  setInkColor: () => {},
+  setInkWidth: () => {},
+  setHighlightColor: () => {},
+  setHighlightOpacity: () => {},
+  setFreehandHighlighterWidth: () => {},
+  setUnderlineColor: () => {},
+  setUnderlineOpacity: () => {},
+  setStrikeoutColor: () => {},
+  setStrikeoutOpacity: () => {},
+  setSquigglyColor: () => {},
+  setSquigglyOpacity: () => {},
+  setTextColor: () => {},
+  setTextSize: () => {},
+  setTextAlignment: () => {},
+  setTextBackgroundColor: () => {},
+  setNoteBackgroundColor: () => {},
+  setShapeStrokeColor: () => {},
+  setShapeFillColor: () => {},
+  setShapeOpacity: () => {},
+  setShapeStrokeOpacity: () => {},
+  setShapeFillOpacity: () => {},
+  setShapeThickness: () => {},
+};
+
+/** Annotations hidden in the viewer, which locks the whole palette. */
+const HIDDEN_VIEWER = {
+  isAnnotationsVisible: false,
+  setAnnotationMode: () => {},
+} as unknown as ViewerContextType;
+
+/** The tool panel column. */
+const inPanel = (Story: () => ReactElement) => (
+  <div style={{ maxWidth: 380 }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: "Tools/Annotate/AnnotationPanel",
+  component: AnnotationPanel,
+  decorators: [inPanel, withToolContexts()],
+  args: {
+    activeTool: "select",
+    activateAnnotationTool: () => {},
+    styleState,
+    styleActions,
+    getActiveColor: () => "#0066cc",
+    buildToolOptions: () => ({}),
+    deriveToolFromAnnotation: () => undefined,
+    selectedAnn: null,
+    selectedTextDraft: "",
+    setSelectedTextDraft: () => {},
+    selectedFontSize: 14,
+    setSelectedFontSize: () => {},
+    annotationApiRef: { current: null },
+    signatureApiRef: { current: null },
+    viewerContext: null,
+    setPlacementMode: () => {},
+    setSignatureConfig: () => {},
+    computeStampDisplaySize: () => ({ width: 144, height: 144 }),
+    setStampImageData: () => {},
+    stampImageSize: null,
+    setStampImageSize: () => {},
+    setPlacementPreviewSize: () => {},
+    undo: () => {},
+    redo: () => {},
+    historyAvailability: { canUndo: false, canRedo: false },
+    onClearDocumentAnnotations: () => true,
+    onApplyChanges: () => {},
+    applyDisabled: false,
+  },
+} satisfies Meta<typeof AnnotationPanel>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** The resting state: select-and-edit, nothing drawn yet, nothing to undo. */
+export const Default: Story = {};
+
+/** A markup tool taken up, which moves the emphasis into its group. */
+export const HighlightSelected: Story = {
+  args: { activeTool: "highlight" },
+};
+
+/** The stamp tool, the one tool that brings its own settings card. */
+export const StampSelected: Story = {
+  args: { activeTool: "stamp" },
+};
+
+/** An image chosen for the stamp, shown back before it is placed. */
+export const StampWithImage: Story = {
+  args: { activeTool: "stamp", stampImageData: STAMP_IMAGE },
+};
+
+/** Annotations hidden in the viewer: every tool is out of reach. */
+export const AnnotationsHidden: Story = {
+  args: { viewerContext: HIDDEN_VIEWER, activeTool: "ink" },
+};
+
+/** Edits behind and ahead, so both history controls are live. */
+export const HistoryAvailable: Story = {
+  args: { historyAvailability: { canUndo: true, canRedo: true } },
+};
+
+/** Nothing changed since the last save, so there is nothing to apply. */
+export const NothingToSave: Story = {
+  args: { applyDisabled: true },
+};

--- a/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
+++ b/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
@@ -572,6 +572,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={12}
                   value={inkWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setInkWidth}
                 />
               </Box>
@@ -587,6 +588,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={highlightOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setHighlightOpacity}
                 />
               </Box>
@@ -601,6 +603,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={underlineOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setUnderlineOpacity}
                 />
               </Box>
@@ -615,6 +618,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={20}
                   value={freehandHighlighterWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setFreehandHighlighterWidth}
                 />
               </Box>
@@ -630,6 +634,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={8}
                     max={32}
                     value={textSize}
+                    thumbLabel={t("annotation.fontSize", "Font size")}
                     onChange={setTextSize}
                   />
                 </Box>
@@ -785,6 +790,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={10}
                     max={100}
                     value={shapeOpacity}
+                    thumbLabel={t("annotation.opacity", "Opacity")}
                     onChange={(value) => {
                       setShapeOpacity(value);
                       setShapeStrokeOpacity(value);
@@ -802,6 +808,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                         min={1}
                         max={12}
                         value={shapeThickness}
+                        thumbLabel={t("annotation.strokeWidth", "Width")}
                         onChange={setShapeThickness}
                       />
                     </>
@@ -815,6 +822,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                           min={0}
                           max={12}
                           value={shapeThickness}
+                          thumbLabel={t("annotation.strokeWidth", "Stroke")}
                           onChange={setShapeThickness}
                         />
                       </Box>

--- a/frontend/editor/src/core/tools/formFill/ButtonAppearanceOverlay.stories.tsx
+++ b/frontend/editor/src/core/tools/formFill/ButtonAppearanceOverlay.stories.tsx
@@ -1,0 +1,28 @@
+/**
+ * The layer that paints a PDF's push-button widgets over a rendered page.
+ *
+ * What it shows is decided entirely by the appearances PDFium renders out of
+ * the document bytes: it draws one canvas per button found on `pageIndex` and
+ * returns nothing when there are none. With no source — the state it is mounted
+ * in until the viewer has a document — there is nothing to resolve, so the
+ * layer is empty. Page dimensions only scale bitmaps that already exist, so
+ * varying them cannot produce a second state here.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ButtonAppearanceOverlay } from "@app/tools/formFill/ButtonAppearanceOverlay";
+
+const meta = {
+  title: "Tools/FormFill/ButtonAppearanceOverlay",
+  component: ButtonAppearanceOverlay,
+  args: {
+    pageIndex: 0,
+    pdfSource: null,
+    pageWidth: 612,
+    pageHeight: 792,
+  },
+} satisfies Meta<typeof ButtonAppearanceOverlay>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
+++ b/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
@@ -1,0 +1,133 @@
+/**
+ * Form-fill context for the formFill stories.
+ *
+ * Every form-fill component reads its fields and values from FormFillProvider,
+ * and the provider only ever gets them by asking a data provider to parse a real
+ * PDF. Both shipped providers need either the pdfium WASM module or the backend,
+ * neither of which exists in a story — so these helpers hand the provider a stub
+ * that returns fixed fields, and drive it the way the app does: fetch on mount,
+ * then type into the form.
+ */
+import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import {
+  FormFillProvider,
+  useFormFill,
+} from "@app/tools/formFill/FormFillContext";
+import type { IFormDataProvider } from "@app/tools/formFill/providers/types";
+import type { FormField } from "@app/tools/formFill/types";
+
+/** Stands in for the open document; the stub provider never reads its bytes. */
+export const STORY_PDF = new Blob(["%PDF-1.7"], { type: "application/pdf" });
+
+export function field(
+  overrides: Partial<FormField> & { name: string },
+): FormField {
+  return {
+    label: overrides.name,
+    type: "text",
+    value: "",
+    options: null,
+    displayOptions: null,
+    required: false,
+    readOnly: false,
+    multiSelect: false,
+    multiline: false,
+    tooltip: null,
+    widgets: [{ pageIndex: 0, x: 72, y: 120, width: 220, height: 22 }],
+    ...overrides,
+  };
+}
+
+/** A small cross-section of field types, as a filled-in form would carry. */
+export const SAMPLE_FIELDS: FormField[] = [
+  field({ name: "fullName", label: "Full name", required: true }),
+  field({
+    name: "address",
+    label: "Address",
+    multiline: true,
+    tooltip: "Include the postcode",
+  }),
+  field({
+    name: "agreeToTerms",
+    label: "I agree to the terms",
+    type: "checkbox",
+  }),
+  field({
+    name: "country",
+    label: "Country",
+    type: "combobox",
+    options: ["uk", "fr", "de"],
+    displayOptions: ["United Kingdom", "France", "Germany"],
+  }),
+  field({
+    name: "reference",
+    label: "Reference number",
+    readOnly: true,
+    value: "INV-20418",
+  }),
+  field({
+    name: "signature",
+    label: "Signature",
+    type: "signature",
+    widgets: [{ pageIndex: 1, x: 72, y: 480, width: 180, height: 60 }],
+  }),
+];
+
+export interface FormFillOptions {
+  /** Fields the stub provider reports for the document. */
+  fields?: FormField[];
+  /** Hold the fetch open, so the form stays in its loading state. */
+  pending?: boolean;
+  /** Values applied after load — this is what marks the form dirty. */
+  filled?: Record<string, string>;
+  /** Field to focus, as clicking its widget on the page would. */
+  activeField?: string;
+}
+
+function stubProvider({
+  fields = SAMPLE_FIELDS,
+  pending = false,
+}: FormFillOptions): IFormDataProvider {
+  return {
+    name: "pdf-lib",
+    fetchFields: () =>
+      pending ? new Promise<FormField[]>(() => {}) : Promise.resolve(fields),
+    fillForm: async () => STORY_PDF,
+  };
+}
+
+/**
+ * Drives the provider once on mount. The fetch is what populates the fields and
+ * seeds the value store; anything applied afterwards counts as user input.
+ */
+function FormFillLoader({
+  filled,
+  activeField,
+  children,
+}: FormFillOptions & { children: ReactNode }) {
+  const { fetchFields, setValue, setActiveField } = useFormFill();
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void fetchFields(STORY_PDF, "story-document").then(() => {
+      Object.entries(filled ?? {}).forEach(([name, value]) =>
+        setValue(name, value),
+      );
+      if (activeField) setActiveField(activeField);
+    });
+  }, [fetchFields, setValue, setActiveField, filled, activeField]);
+
+  return <>{children}</>;
+}
+
+export function withFormFill(options: FormFillOptions = {}) {
+  return (Story: () => ReactElement): ReactElement => (
+    <FormFillProvider provider={stubProvider(options)}>
+      <FormFillLoader {...options}>
+        <Story />
+      </FormFillLoader>
+    </FormFillProvider>
+  );
+}

--- a/frontend/editor/src/desktop/components/DesktopOnboardingModal.stories.tsx
+++ b/frontend/editor/src/desktop/components/DesktopOnboardingModal.stories.tsx
@@ -1,0 +1,37 @@
+/**
+ * First-launch onboarding for the desktop app. Two slides share one frame: a
+ * welcome panel, then a sign-in panel that hands over to the setup wizard. Which
+ * one shows is held in local state and advanced by the user, and the hero
+ * artwork, icon and dismiss behaviour all follow it.
+ *
+ * The modal shows itself only until the user has been through it once, which it
+ * records in web storage; the stories clear that record so it opens.
+ *
+ * Mantine renders the modal into a portal outside the story canvas.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, userEvent } from "storybook/test";
+import { DesktopOnboardingModal } from "@app/components/DesktopOnboardingModal";
+
+const meta: Meta<typeof DesktopOnboardingModal> = {
+  title: "Desktop/OnboardingModal",
+  component: DesktopOnboardingModal,
+  parameters: { layout: "fullscreen" },
+  beforeEach: async () => {
+    localStorage.removeItem("stirling-desktop-onboarding-seen");
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DesktopOnboardingModal>;
+
+/** The opening slide, as it appears on a first launch. */
+export const Welcome: Story = {};
+
+/** The second slide, where the setup wizard takes over the body. */
+export const SignIn: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await userEvent.click(body.getByRole("button", { name: /^Next/ }));
+  },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/DesktopAuthLayout.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/DesktopAuthLayout.stories.tsx
@@ -1,0 +1,41 @@
+/**
+ * The frame every desktop setup-wizard screen sits in. It contributes the
+ * branding and centring; the screen itself is passed as children.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DesktopAuthLayout } from "@app/components/SetupWizard/DesktopAuthLayout";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof DesktopAuthLayout> = {
+  title: "Desktop/SetupWizard/DesktopAuthLayout",
+  component: DesktopAuthLayout,
+  parameters: { layout: "fullscreen" },
+  // The shell's wordmark resolves a logo variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DesktopAuthLayout>;
+
+export const Default: Story = {
+  args: { children: <p>Sign-in form goes here.</p> },
+};
+
+/** Taller content, where the frame has to scroll rather than clip. */
+export const TallContent: Story = {
+  args: {
+    children: (
+      <div style={{ display: "grid", gap: "1rem" }}>
+        {Array.from({ length: 12 }, (_, i) => (
+          <p key={i}>Setup step detail line {i + 1}</p>
+        ))}
+      </div>
+    ),
+  },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLink.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLink.stories.tsx
@@ -1,0 +1,21 @@
+/**
+ * The escape hatch at the bottom of the desktop sign-in screen, for people
+ * connecting to their own server rather than a Stirling account.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SelfHostedLink } from "@app/components/SetupWizard/SelfHostedLink";
+
+const meta: Meta<typeof SelfHostedLink> = {
+  title: "Desktop/SetupWizard/SelfHostedLink",
+  component: SelfHostedLink,
+  parameters: { layout: "centered" },
+  args: { onClick: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof SelfHostedLink>;
+
+export const Default: Story = {};
+
+/** Disabled while the wizard is mid-request. */
+export const Disabled: Story = { args: { disabled: true } };

--- a/frontend/editor/src/desktop/components/SetupWizard/ServerSelection.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/ServerSelection.stories.tsx
@@ -1,0 +1,44 @@
+/**
+ * The server-URL form itself. Two things decide what it shows: the `loading`
+ * flag the wizard passes down while it finishes connecting, and whether a
+ * previous session left a server address in web storage, which adds a shortcut
+ * back to it.
+ *
+ * The form's own error and "login not enabled" panels are raised by testing the
+ * address against a live server, so they are not reachable from props alone.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ServerSelection } from "@app/components/SetupWizard/ServerSelection";
+
+const LAST_SERVER_KEY = "server_url";
+
+const meta: Meta<typeof ServerSelection> = {
+  title: "Desktop/SetupWizard/ServerSelection",
+  component: ServerSelection,
+  parameters: { layout: "padded" },
+  // Start from no remembered server so a story only shows the shortcut when it
+  // asks for it.
+  beforeEach: async () => {
+    localStorage.removeItem(LAST_SERVER_KEY);
+  },
+  args: {
+    onSelect: () => {},
+    loading: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ServerSelection>;
+
+/** Nothing remembered, so the address has to be typed in full. */
+export const Default: Story = {};
+
+/** A previous session's server, offered as a one-click shortcut. */
+export const WithLastUsedServer: Story = {
+  beforeEach: async () => {
+    localStorage.setItem(LAST_SERVER_KEY, "https://pdf.example.internal");
+  },
+};
+
+/** The wizard is still connecting, which locks the field and the button. */
+export const Connecting: Story = { args: { loading: true } };

--- a/frontend/editor/src/desktop/components/SetupWizard/ServerSelectionScreen.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/ServerSelectionScreen.stories.tsx
@@ -1,0 +1,48 @@
+/**
+ * The wizard step that points the desktop app at a self-hosted server: a
+ * heading, the banner for whatever the last attempt reported, and the URL form
+ * beneath it. The screen owns none of that — the wizard hands it the error text
+ * and tells it when a connection is being established.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ServerSelectionScreen } from "@app/components/SetupWizard/ServerSelectionScreen";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof ServerSelectionScreen> = {
+  title: "Desktop/SetupWizard/ServerSelectionScreen",
+  component: ServerSelectionScreen,
+  parameters: { layout: "padded" },
+  // The heading's logo resolves a variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+  // The form offers a shortcut back to the server last reached, remembered in
+  // web storage. Clearing it keeps the stories independent of whatever the
+  // browser happens to be carrying.
+  beforeEach: async () => {
+    localStorage.removeItem("server_url");
+  },
+  args: {
+    onSelect: () => {},
+    loading: false,
+    error: null,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ServerSelectionScreen>;
+
+/** A first connection, with nothing yet entered. */
+export const Default: Story = {};
+
+/** The wizard rejected the last attempt, which adds the banner above the form. */
+export const WithError: Story = {
+  args: { error: "Could not reach that server. Check the address and retry." },
+};
+
+/** The wizard is establishing the connection, so the form is held disabled. */
+export const Connecting: Story = { args: { loading: true } };

--- a/frontend/editor/src/desktop/components/SignInModal.stories.tsx
+++ b/frontend/editor/src/desktop/components/SignInModal.stories.tsx
@@ -1,0 +1,37 @@
+/**
+ * The desktop sign-in dialog. It takes no props and stays unmounted until
+ * something elsewhere in the app asks for sign-in over a window event, at which
+ * point it hosts the setup wizard in a modal frame. The `locked` flag that the
+ * request may carry only governs whether the dialog can be dismissed, so it
+ * produces no second appearance.
+ *
+ * The story fires that request on mount, which is the only way to see the
+ * dialog at all. Mantine renders it into a portal outside the story canvas.
+ */
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SignInModal } from "@app/components/SignInModal";
+import { OPEN_SIGN_IN_EVENT } from "@app/constants/signInEvents";
+
+/** Stands in for whatever part of the app asked the user to sign in. */
+function Trigger() {
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      window.dispatchEvent(new CustomEvent(OPEN_SIGN_IN_EVENT));
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, []);
+  return <SignInModal />;
+}
+
+const meta: Meta<typeof SignInModal> = {
+  title: "Desktop/SignInModal",
+  component: SignInModal,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SignInModal>;
+
+/** Answering a sign-in request, opened on the wizard's first step. */
+export const Opened: Story = { render: () => <Trigger /> };

--- a/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.stories.tsx
+++ b/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.stories.tsx
@@ -1,0 +1,46 @@
+/**
+ * The save-state dot on a desktop file thumbnail. Three states, decided from
+ * the file stub rather than a prop: never written to disk, written but with
+ * unsaved edits, and clean.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FileEditorStatusDot } from "@app/components/fileEditor/FileEditorStatusDot";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+function stub(overrides: Partial<StirlingFileStub>): StirlingFileStub {
+  return {
+    id: "story-file" as FileId,
+    name: "report.pdf",
+    type: "application/pdf",
+    size: 120_000,
+    lastModified: Date.parse("2026-03-14T09:30:00Z"),
+    isLeaf: true,
+    originalFileId: "story-file",
+    versionNumber: 1,
+    ...overrides,
+  } as StirlingFileStub;
+}
+
+const meta: Meta<typeof FileEditorStatusDot> = {
+  title: "Desktop/FileEditorStatusDot",
+  component: FileEditorStatusDot,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FileEditorStatusDot>;
+
+/** Held in memory only — nothing has been written to disk yet. */
+export const NotSaved: Story = {
+  args: { file: stub({ localFilePath: undefined }) },
+};
+
+/** On disk, but edited since. */
+export const UnsavedChanges: Story = {
+  args: { file: stub({ localFilePath: "/tmp/report.pdf", isDirty: true }) },
+};
+
+export const Saved: Story = {
+  args: { file: stub({ localFilePath: "/tmp/report.pdf", isDirty: false }) },
+};

--- a/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.tsx
+++ b/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.tsx
@@ -25,9 +25,12 @@ export function FileEditorStatusDot({ file }: FileEditorStatusDotProps) {
   return (
     <div className={styles.thumbBadgesRight}>
       <Tooltip label={label}>
+        {/* A bare span cannot carry aria-label; without a role the save state
+            is conveyed by colour alone and announced as nothing at all. */}
         <span
           className={styles.statusDot}
           style={{ backgroundColor: color }}
+          role="img"
           aria-label={label}
         />
       </Tooltip>

--- a/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.stories.tsx
+++ b/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * A div dressed as a disabled button. Mantine's `disabled` kills pointer events
+ * outright, which also kills the tooltip explaining *why* the control is
+ * unavailable — so this renders the disabled look by hand and keeps hover.
+ *
+ * Desktop-layer stories resolve `@app/*` against desktop → cloud → proprietary
+ * → core, matching the desktop build rather than the editor's order.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DisabledButtonWithTooltip } from "@app/components/shared/DisabledButtonWithTooltip";
+
+const meta: Meta<typeof DisabledButtonWithTooltip> = {
+  title: "Desktop/DisabledButtonWithTooltip",
+  component: DisabledButtonWithTooltip,
+  parameters: { layout: "padded" },
+  args: {
+    tooltip: "Sign in to use this tool",
+    children: "Convert to PDF/A",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DisabledButtonWithTooltip>;
+
+/** The tooltip only appears on hover, so the resting state is what is captured. */
+export const Default: Story = {};
+
+export const LongLabel: Story = {
+  args: { children: "Convert this document to an archival PDF/A-3b file" },
+};
+
+/** A long reason wraps inside the tooltip rather than widening it. */
+export const LongTooltip: Story = {
+  args: {
+    tooltip:
+      "This tool needs a desktop licence and an active connection to the cloud backend.",
+  },
+};
+
+/** In a narrow column the control still fills its container. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 200 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.tsx
+++ b/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.tsx
@@ -20,25 +20,39 @@ export function DisabledButtonWithTooltip({
   className,
   style,
 }: DisabledButtonWithTooltipProps) {
-  const [hovered, setHovered] = React.useState(false);
+  const [shown, setShown] = React.useState(false);
+  const tooltipId = React.useId();
   return (
     <div
       className="relative w-full"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={() => setShown(true)}
+      onMouseLeave={() => setShown(false)}
     >
+      {/* The point of this control is to look disabled while still explaining
+          why. That explanation has to reach a keyboard as well as a pointer, so
+          the element stays focusable and announces itself as a disabled button
+          described by its own tooltip. */}
       <div
         className={`locked-button${className ? ` ${className}` : ""}`}
         style={style}
+        role="button"
+        aria-disabled="true"
+        aria-describedby={tooltipId}
+        tabIndex={0}
+        onFocus={() => setShown(true)}
+        onBlur={() => setShown(false)}
       >
         {children}
       </div>
-      {hovered && (
-        <div className="locked-button-tooltip">
-          {tooltip}
-          <div className="locked-button-tooltip-arrow" />
-        </div>
-      )}
+      <div
+        id={tooltipId}
+        role="tooltip"
+        className="locked-button-tooltip"
+        style={shown ? undefined : { display: "none" }}
+      >
+        {tooltip}
+        <div className="locked-button-tooltip-arrow" />
+      </div>
     </div>
   );
 }

--- a/frontend/editor/src/desktop/components/tools/toolPicker/ToolPickerFooterExtensions.stories.tsx
+++ b/frontend/editor/src/desktop/components/tools/toolPicker/ToolPickerFooterExtensions.stories.tsx
@@ -1,0 +1,32 @@
+/**
+ * The strip that sits under the desktop tool list inviting the user to sign in.
+ * It exists for local (offline) mode only and renders nothing in the SaaS and
+ * self-hosted modes, so it has a single appearance.
+ *
+ * The mode is answered by the desktop shell rather than by a prop; with no
+ * shell to answer, the connection service settles on local — precisely the mode
+ * this footer belongs to.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ToolPickerFooterExtensions } from "@app/components/tools/toolPicker/ToolPickerFooterExtensions";
+
+const meta: Meta<typeof ToolPickerFooterExtensions> = {
+  title: "Desktop/ToolPicker/FooterExtensions",
+  component: ToolPickerFooterExtensions,
+  parameters: { layout: "padded" },
+  // The real footer spans the tool panel, where the message has to wrap around
+  // a button that never shrinks.
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof ToolPickerFooterExtensions>;
+
+/** Offline, with the cloud tools still behind a sign-in. */
+export const LocalMode: Story = {};

--- a/frontend/editor/src/portal/components/PortalSettingsHost.stories.tsx
+++ b/frontend/editor/src/portal/components/PortalSettingsHost.stories.tsx
@@ -1,0 +1,59 @@
+/**
+ * Mounts the editor's settings modal inside the portal, supplying the contexts
+ * the settings tree needs because the portal lives outside the editor's own
+ * provider stack.
+ *
+ * It takes no props: the portal's UI state decides everything. Until settings
+ * have been opened once it renders nothing — providers included — so that case
+ * is not a story; each story below opens it on mount instead. The section it
+ * lands on is the only thing that varies, and the host appends one of its own:
+ * the admin "Account link" section, which the editor's registry does not carry.
+ */
+import { useEffect, useRef } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PortalSettingsHost } from "@portal/components/PortalSettingsHost";
+import { useUI } from "@portal/contexts/UIContext";
+
+/**
+ * Opens settings once on mount. The portal has no other way in from a story —
+ * the host reads the open state off the real UI context rather than a prop.
+ */
+function OpenOnMount({ section }: { section?: string }) {
+  const { openSettings } = useUI();
+  const opened = useRef(false);
+  useEffect(() => {
+    if (opened.current) return;
+    opened.current = true;
+    openSettings(section);
+  }, [openSettings, section]);
+  return null;
+}
+
+const meta: Meta<typeof PortalSettingsHost> = {
+  title: "Portal/PortalSettingsHost",
+  component: PortalSettingsHost,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof PortalSettingsHost>;
+
+/** Opened with no section asked for, so the modal picks its own default. */
+export const Opened: Story = {
+  render: () => (
+    <>
+      <OpenOnMount />
+      <PortalSettingsHost />
+    </>
+  ),
+};
+
+/** Opened straight onto the portal's own section, under an Admin group. */
+export const AtAccountLink: Story = {
+  render: () => (
+    <>
+      <OpenOnMount section="account-link" />
+      <PortalSettingsHost />
+    </>
+  ),
+};

--- a/frontend/editor/src/portal/components/procurement/ProcurementBanner.stories.tsx
+++ b/frontend/editor/src/portal/components/procurement/ProcurementBanner.stories.tsx
@@ -1,0 +1,88 @@
+/**
+ * The deal-status hero as Home actually mounts it: bound to the shared
+ * procurement controller rather than to loose props.
+ *
+ * The controller decides three things here. Its snapshot is the deal being
+ * shown — no snapshot and the hero does not render at all, so that is not a
+ * state to look at. Its `busy` flag puts the primary action into its loading
+ * form while a request is in flight. And `isLinked` gates scheduling a call,
+ * since booking runs through the linked account, so an unlinked org loses that
+ * icon action.
+ *
+ * The wrapper's own decision is where the primary action leads: an exploring
+ * deal has no journey to open yet, so its action starts trial setup instead of
+ * expanding the flow.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ControlledDealStatusHero } from "@portal/components/procurement/ProcurementBanner";
+import type { ProcurementController } from "@portal/components/procurement/useProcurement";
+import type { ProcurementSnapshot } from "@portal/api/procurement";
+
+const snapshot: ProcurementSnapshot = {
+  dealId: 1,
+  stage: "trial",
+  deployment: "cloud",
+  seats: 250,
+  trialStartedAt: "2026-06-25T00:00:00Z",
+  trialEndsAt: "2026-07-09T00:00:00Z",
+  trialExtensionsUsed: 0,
+  licensed: false,
+  licenseKey: null,
+  businessName: "Northwind Logistics",
+  contactName: null,
+  contactEmail: null,
+  agreementSignedVersion: null,
+  latestQuote: null,
+};
+
+/** Only the fields the hero and its wiring read; the rest of the controller is unused here. */
+function controller(
+  overrides: Partial<ProcurementController> = {},
+): ProcurementController {
+  return {
+    data: snapshot,
+    stage: snapshot.stage,
+    busy: false,
+    isLinked: true,
+    setOpen: () => {},
+    setExtra: () => {},
+    onStartTrial: () => {},
+    onAcceptQuote: async () => {},
+    ...overrides,
+  } as unknown as ProcurementController;
+}
+
+const meta: Meta<typeof ControlledDealStatusHero> = {
+  title: "Portal/Procurement/ControlledDealStatusHero",
+  component: ControlledDealStatusHero,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ControlledDealStatusHero>;
+
+/** A trial under way on a linked org — every icon action available. */
+export const ActiveTrial: Story = { args: { controller: controller() } };
+
+/**
+ * Interest recorded but no trial started: the deal sits on the trial rung with
+ * setting the trial up as its ask.
+ */
+export const Exploring: Story = {
+  args: {
+    controller: controller({
+      data: { ...snapshot, stage: "exploring", trialEndsAt: null },
+      stage: "exploring",
+    }),
+  },
+};
+
+/** A request in flight — the primary action shows its loading state. */
+export const Busy: Story = {
+  args: { controller: controller({ busy: true }) },
+};
+
+/** No linked account, so there is no email to prefill and scheduling drops out. */
+export const Unlinked: Story = {
+  args: { controller: controller({ isLinked: false }) },
+};

--- a/frontend/editor/src/proprietary/auth/ui/AuthShell.tsx
+++ b/frontend/editor/src/proprietary/auth/ui/AuthShell.tsx
@@ -15,7 +15,11 @@ export interface AuthShellProps {
 export function AuthShell({ children, footer }: AuthShellProps) {
   return (
     <div className={styles.authContainer}>
-      <div className={styles.authCard}>
+      {/* The card caps at 96vh and hides its scrollbar, so on a short viewport
+          it scrolls with nothing to grab. Focusable so a keyboard can scroll
+          it; the group role keeps it announced as one region rather than an
+          unlabelled interactive element. */}
+      <div className={styles.authCard} tabIndex={0} role="group">
         <div className={styles.authContent}>{children}</div>
       </div>
       {footer && (

--- a/frontend/editor/src/proprietary/components/shared/config/LoginLandingSetting.stories.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/LoginLandingSetting.stories.tsx
@@ -1,0 +1,51 @@
+/**
+ * The processor-user preference for where to land after signing in.
+ *
+ * Whether it appears at all is decided before anything is drawn: the build must
+ * have the role-based landing switched on and ship the processor routes, and
+ * the signed-in account must be one that defaults to the processor. Any of
+ * those failing renders nothing, so the hidden case is not a story — the
+ * mocked `/auth/me` and `/team/my` pair below is what makes the eligible case
+ * reachable. `/team/my` answering 404 is the self-hosted shape, where
+ * `portalAccess` alone decides.
+ *
+ * Once shown there is one control, whose selected segment reflects the stored
+ * preference (Processor by default).
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
+import { LoginLandingSetting } from "@app/components/shared/config/LoginLandingSetting";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof LoginLandingSetting> = {
+  title: "Config/LoginLandingSetting",
+  component: LoginLandingSetting,
+  parameters: {
+    layout: "padded",
+    msw: {
+      handlers: [
+        http.get("/api/v1/auth/me", () =>
+          HttpResponse.json({
+            user: { role: "ROLE_ADMIN", portalAccess: true },
+          }),
+        ),
+        http.get(
+          "/api/v1/team/my",
+          () => new HttpResponse(null, { status: 404 }),
+        ),
+      ],
+    },
+  },
+  decorators: [
+    (S) => (
+      <PreferencesProvider>
+        <S />
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof LoginLandingSetting>;
+
+export const Default: Story = {};

--- a/frontend/editor/src/proprietary/components/viewer/PolicyEnforcementOverlay.stories.tsx
+++ b/frontend/editor/src/proprietary/components/viewer/PolicyEnforcementOverlay.stories.tsx
@@ -1,0 +1,102 @@
+/**
+ * Covers the viewer while a policy is still running against the open document.
+ *
+ * It is handed the whole run list and picks the first run that is still working
+ * — queued, running, waiting for input, or sitting in a retry backoff. With no
+ * such run it renders nothing, so settled runs are not a state worth showing.
+ * Two things then decide what appears: whether that run reports step counts
+ * (a determinate bar rather than a spinner), and which policy category is
+ * enforcing, since the accent colour and icon follow that policy's badge.
+ *
+ * Dismissing collapses the cover to a corner badge so the document can be read
+ * while the run finishes; the badge is internal state, reached by clicking.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, userEvent } from "storybook/test";
+import { PolicyEnforcementOverlay } from "@app/components/viewer/PolicyEnforcementOverlay";
+import type { PolicyRunRecord } from "@app/components/policies/policyRunStore";
+
+function run(overrides: Partial<PolicyRunRecord> = {}): PolicyRunRecord {
+  return {
+    runId: "run-1",
+    categoryId: "security",
+    fileId: "file-1",
+    fileName: "contract.pdf",
+    fileSize: 248_000,
+    target: "saas",
+    status: "RUNNING",
+    outputs: [],
+    error: null,
+    startedAt: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof PolicyEnforcementOverlay> = {
+  title: "Viewer/PolicyEnforcementOverlay",
+  component: PolicyEnforcementOverlay,
+  parameters: { layout: "padded" },
+  decorators: [
+    (S) => (
+      // Stands in for the document surface being covered: the overlay and the
+      // collapsed badge both position themselves against the nearest
+      // positioned ancestor, so they need one with real dimensions.
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          maxWidth: "34rem",
+          height: "22rem",
+          borderRadius: "0.5rem",
+          border: "1px solid var(--c-border)",
+          background: "var(--c-surface)",
+          overflow: "hidden",
+        }}
+      >
+        <S />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof PolicyEnforcementOverlay>;
+
+/** A run under way with no step counts yet: an indeterminate spinner. */
+export const Enforcing: Story = { args: { runs: [run()] } };
+
+/** Once the run reports its steps, the spinner becomes a determinate bar. */
+export const WithProgress: Story = {
+  args: { runs: [run({ currentStep: 3, stepCount: 5 })] },
+};
+
+/**
+ * A different policy category retints the whole cover — retention's red accent
+ * and its own icon in place of the security shield.
+ */
+export const RetentionPolicy: Story = {
+  args: {
+    runs: [
+      run({
+        categoryId: "retention",
+        runId: "run-2",
+        currentStep: 1,
+        stepCount: 4,
+      }),
+    ],
+  },
+};
+
+/**
+ * Dismissed while the run continues: the cover collapses to a corner badge,
+ * inset from the corner itself so it never swallows the close button there.
+ */
+export const Dismissed: Story = {
+  args: { runs: [run({ currentStep: 2, stepCount: 4 })] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Dismiss overlay" }),
+    );
+  },
+};

--- a/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.stories.tsx
+++ b/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.stories.tsx
@@ -1,0 +1,46 @@
+/**
+ * The square-crop step between choosing a profile picture and uploading it.
+ * What it shows is decided by the file handed to it: with one, the picture sits
+ * under a draggable crop frame with a zoom slider; without one, the frame is
+ * empty. Its remaining states — the "processing" button and the error banner —
+ * belong to a crop already in progress and cannot be posed from props.
+ *
+ * Mantine renders the modal into a portal outside the story canvas.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ProfilePictureCropper } from "@app/components/shared/config/ProfilePictureCropper";
+
+/**
+ * A landscape picture, so the square frame has something to crop away on both
+ * sides. Drawn rather than fetched to keep every render identical.
+ */
+const SAMPLE_PICTURE = `<svg xmlns="http://www.w3.org/2000/svg" width="480" height="320">
+  <rect width="480" height="320" fill="#1f3a5f"/> <!-- theme-allow-color sample photo, not themed UI -->
+  <circle cx="240" cy="130" r="70" fill="#f2d0a4"/> <!-- theme-allow-color -->
+  <path d="M240 215c-80 0-130 45-130 105h260c0-60-50-105-130-105z" fill="#e07a5f"/> <!-- theme-allow-color -->
+</svg>`;
+
+const samplePicture = new File([SAMPLE_PICTURE], "portrait.svg", {
+  type: "image/svg+xml",
+});
+
+const meta: Meta<typeof ProfilePictureCropper> = {
+  title: "SaaS/Config/ProfilePictureCropper",
+  component: ProfilePictureCropper,
+  parameters: { layout: "fullscreen" },
+  args: {
+    opened: true,
+    file: samplePicture,
+    onClose: () => {},
+    onCropComplete: () => {},
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ProfilePictureCropper>;
+
+/** The usual case: a chosen picture, framed and ready to adjust. */
+export const WithPicture: Story = {};
+
+/** No picture to work on, which leaves the frame blank but the controls live. */
+export const WithoutPicture: Story = { args: { file: null } };

--- a/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
+++ b/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
@@ -176,6 +176,7 @@ export const ProfilePictureCropper: React.FC<ProfilePictureCropperProps> = ({
             step={0.1}
             onChange={setZoom}
             disabled={processing}
+            thumbLabel={t("config.account.profilePicture.cropper.zoom", "Zoom")}
           />
         </Stack>
 

--- a/frontend/editor/src/saas/routes/login/MagicLinkForm.stories.tsx
+++ b/frontend/editor/src/saas/routes/login/MagicLinkForm.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Magic-link sign-in on the SaaS login screen. Collapsed it is a single link;
+ * expanded it becomes an email field and a send button, so the two states are
+ * really two different components sharing a prop.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import MagicLinkForm from "@app/routes/login/MagicLinkForm";
+
+const meta: Meta<typeof MagicLinkForm> = {
+  title: "SaaS/Login/MagicLinkForm",
+  component: MagicLinkForm,
+  parameters: { layout: "padded" },
+  args: {
+    showMagicLink: false,
+    magicLinkEmail: "",
+    setMagicLinkEmail: () => {},
+    setShowMagicLink: () => {},
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MagicLinkForm>;
+
+/** Collapsed — just the link that opens the form. */
+export const Collapsed: Story = {};
+
+export const Expanded: Story = { args: { showMagicLink: true } };
+
+export const WithEmail: Story = {
+  args: { showMagicLink: true, magicLinkEmail: "a.whitfield@example.com" },
+};
+
+/** Sending, which disables the field and the button together. */
+export const Submitting: Story = {
+  args: {
+    showMagicLink: true,
+    magicLinkEmail: "a.whitfield@example.com",
+    isSubmitting: true,
+  },
+};
+
+/** Typing for real, so the field and its clear/submit states track input. */
+export const Interactive: Story = {
+  render: function Interactive() {
+    const [open, setOpen] = useState(true);
+    const [email, setEmail] = useState("");
+    return (
+      <MagicLinkForm
+        showMagicLink={open}
+        magicLinkEmail={email}
+        setMagicLinkEmail={setEmail}
+        setShowMagicLink={setOpen}
+        onSubmit={() => {}}
+        isSubmitting={false}
+      />
+    );
+  },
+};


### PR DESCRIPTION
The trunk for the Storybook coverage work. Everything a story needs to render, plus the a11y fixes that many components inherit — deliberately one PR, because splitting it makes every coverage PR downstream red until all the pieces land.

## Harness

- **`@app/*` resolves per layer**, so `desktop`, `saas`, `cloud` and `prototypes` can host a story at all. Previously they could not — **62 surfaces** were unreachable. Imports from `core`, `proprietary` and `portal` never match the new resolver, so nothing about existing stories changes.
- **The preview mounts the providers** roughly a hundred components reach for through `Tooltip`.
- **Six contexts exported** so a story can supply the few fields a component reads instead of standing up a provider that reaches half the app.
- **Three shared fixtures**, and a coverage tool that counts surfaces by import.

## Shared a11y fixes

| Fix | Measured | After |
|---|---|---|
| Mantine `dimmed` → semantic muted token | ~3.0:1 | clears 4.5:1 both themes |
| Danger accent fill under white text | 3.76:1 | 4.85:1 |
| 17 unnamed slider thumbs | announced unnamed | named |

The dimmed change alone affects **654 call sites**; measured across the 140 story files whose components use it, stories with violations went **311 → 151**.

## Not fixed here, deliberately

The same rule sets danger *text* to red-500 (3.49:1 on light). **No single fixed red clears 4.5:1 as text in both themes** — red-600 passes on light and fails on dark, red-500 the reverse. That needs a theme-aware token and a design decision, not a swap.

## Review order

The four coverage PRs branch off this one and are **mutually independent** — no file appears in more than one. Land this, then they can go in any order or in parallel.