### PR TITLE
test(core): Storybook coverage for the editor surfaces

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import type { StorybookConfig } from "@storybook/react-vite";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -10,6 +11,45 @@ import tsconfigPaths from "vite-tsconfig-paths";
  * the portal layer at editor/src/portal/). MDX docs pages live in
  * editor/src/portal/docs/.
  */
+
+/** Layer search order for @app/*, mirroring each flavour's vite tsconfig. */
+const FLAVOUR_LAYERS: Record<string, string[]> = {
+  desktop: ["desktop", "cloud", "proprietary", "core"],
+  saas: ["saas", "cloud", "proprietary", "core"],
+  cloud: ["cloud", "proprietary", "core"],
+  prototypes: ["prototypes", "proprietary", "core"],
+};
+
+const SUFFIXES = ["", ".tsx", ".ts", "/index.tsx", "/index.ts"];
+
+function flavourAppAlias() {
+  return {
+    name: "storybook-app-alias-by-flavour",
+    // Ahead of vite-tsconfig-paths, which would otherwise answer first with the
+    // proprietary order.
+    enforce: "pre" as const,
+    resolveId(source: string, importer: string | undefined) {
+      if (!importer || !source.startsWith("@app/")) return null;
+      const layer = importer
+        .split("\\")
+        .join("/")
+        .match(/\/editor\/src\/(desktop|saas|cloud|prototypes)\//)?.[1];
+      if (!layer) return null;
+      const rest = source.slice("@app/".length);
+      for (const candidate of FLAVOUR_LAYERS[layer]) {
+        for (const suffix of SUFFIXES) {
+          const full = resolve(
+            __dirname,
+            `../editor/src/${candidate}/${rest}${suffix}`,
+          );
+          if (existsSync(full) && statSync(full).isFile()) return full;
+        }
+      }
+      return null;
+    },
+  };
+}
+
 const config: StorybookConfig = {
   stories: [
     "../editor/src/portal/**/*.mdx",
@@ -53,6 +93,12 @@ const config: StorybookConfig = {
     // shared Storybook can host editor components without duplicating the alias
     // map here.
     config.plugins = config.plugins ?? [];
+    // Stories under desktop/, saas/, cloud/ and prototypes/ import @app/* too,
+    // but each of those builds resolves it against its own layer first — an
+    // order the single tsconfig below cannot express. Resolving by the
+    // importer's layer lets those stories load without changing what @app/*
+    // means for core, proprietary or portal stories, which never match here.
+    config.plugins.push(flavourAppAlias());
     config.plugins.push(
       tsconfigPaths({
         projects: [

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -18,7 +18,14 @@ import { TierProvider, type Tier } from "@portal/contexts/TierContext";
 import { LinkProvider, type LinkState } from "@portal/contexts/LinkContext";
 import { ThemeProvider, useTheme } from "@portal/contexts/ThemeContext";
 import { UIProvider } from "@portal/contexts/UIContext";
+import { PreferencesProvider } from "@core/contexts/PreferencesContext";
+import { SidebarProvider } from "@core/contexts/SidebarContext";
 import { SuiProvider } from "@portal/theme/SuiProvider";
+import { MantineProvider } from "@mantine/core";
+import {
+  mantineTheme as editorMantineTheme,
+  editorCssVariablesResolver,
+} from "@core/theme/mantineTheme";
 import { handlers } from "@portal/mocks/handlers";
 import { configureSupabase } from "@proprietary/auth/supabase/supabaseClient";
 import i18next from "i18next";
@@ -29,6 +36,11 @@ import { rtlLanguages, supportedLanguages } from "@core/i18n/languages";
 import "@mantine/core/styles.css";
 import "@core/tokens/tokens.css";
 import "@core/theme/index.css";
+// The editor's Mantine theme resolves its palette through the --color-* vocab
+// defined here. The app picks this up via styles/tailwind.css; Storybook has no
+// tailwind entry, so without it every var(--color-*) in the theme is undefined
+// and Mantine silently falls back to its stock palette.
+import "@core/styles/theme.css";
 import "@core/tokens/base.css";
 
 // Storybook-only: bundle every shipped locale's TOML at build time via a ?raw
@@ -190,6 +202,37 @@ const withLocale: Decorator = (Story, context) => {
   return <Story />;
 };
 
+/**
+ * Applies the Mantine theme the story's component actually runs under in the
+ * app: PortalApp wraps the Processor in SuiProvider, while the editor wraps
+ * everything else in its own ThemeProvider. Getting this wrong is not just
+ * cosmetic — the two themes carry different neutral ramps, so rendering an
+ * editor component under the Processor's theme drops it onto Mantine's stock
+ * greys and reports contrast failures the app doesn't have.
+ */
+function StoryTheme({
+  isPortalStory,
+  colorScheme,
+  children,
+}: {
+  isPortalStory: boolean;
+  colorScheme: "light" | "dark";
+  children: React.ReactNode;
+}) {
+  if (isPortalStory) {
+    return <SuiProvider colorScheme={colorScheme}>{children}</SuiProvider>;
+  }
+  return (
+    <MantineProvider
+      theme={editorMantineTheme}
+      cssVariablesResolver={editorCssVariablesResolver}
+      forceColorScheme={colorScheme}
+    >
+      {children}
+    </MantineProvider>
+  );
+}
+
 const withProviders: Decorator = (Story, context) => {
   const tier = (context.globals.tier as Tier) ?? "pro";
   const linkState =
@@ -201,25 +244,36 @@ const withProviders: Decorator = (Story, context) => {
   // anything that isn't "dark" as light — matching the addon's own
   // `selected || defaultTheme` fallback where defaultTheme is light.
   const colorScheme = context.globals.theme === "dark" ? "dark" : "light";
+  // Storybook titles are the routing key here: the Processor's stories are all
+  // filed under "Portal/".
+  const isPortalStory = (context.title ?? "").startsWith("Portal/");
   return (
     <MemoryRouter initialEntries={["/"]}>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <SchemeSetup scheme={colorScheme} />
           <ThemeBridge theme={colorScheme}>
-            <SuiProvider colorScheme={colorScheme}>
+            <StoryTheme isPortalStory={isPortalStory} colorScheme={colorScheme}>
               {/* LinkProvider must wrap TierProvider: TierContext derives its tier
                   from useLink() (matches App.tsx's nesting). */}
               <LinkProvider key={linkState} initialState={linkState}>
                 <TierKey tier={tier}>
-                  <UIProvider>
-                    <Suspense fallback={null}>
-                      <Story />
-                    </Suspense>
-                  </UIProvider>
+                  {/* Tooltip reads the user's logo preference and the sidebar
+                      geometry it positions against. It is used by ~100
+                      components, so without these a story that renders one
+                      throws. The real app always has both mounted. */}
+                  <PreferencesProvider>
+                    <SidebarProvider>
+                      <UIProvider>
+                        <Suspense fallback={null}>
+                          <Story />
+                        </Suspense>
+                      </UIProvider>
+                    </SidebarProvider>
+                  </PreferencesProvider>
                 </TierKey>
               </LinkProvider>
-            </SuiProvider>
+            </StoryTheme>
           </ThemeBridge>
         </ThemeProvider>
       </QueryClientProvider>
@@ -246,6 +300,14 @@ const preview: Preview = {
       // any violation. Context is left at the addon default (the document root)
       // so it resolves under both the Storybook UI and the Vitest browser mount.
       test: "error",
+      context: {
+        // Nodes carrying this attribute render a facsimile of the user's own
+        // document — their stamp text, their watermark, in the colour and
+        // opacity they chose. WCAG contrast governs the interface, not the
+        // content authored through it, and the controls that set those values
+        // are checked normally.
+        exclude: ["[data-user-content-preview]"],
+      },
     },
   },
   globalTypes: {

--- a/frontend/editor/scripts/storybook-coverage.mjs
+++ b/frontend/editor/scripts/storybook-coverage.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// Storybook coverage report — which rendered surfaces have a story, and what
+// stands between the ones that don't and having one. Modes:
+//
+//   node storybook-coverage.mjs           summary by area (report only)
+//   node storybook-coverage.mjs --todo    every uncovered surface, with the
+//                                         work each needs
+//   node storybook-coverage.mjs --area core/components/tools
+//
+// Coverage is counted by *import*, not by an adjacent .stories.tsx: several
+// components are covered by a shared story file (MantineForms covers Select,
+// MultiSelect, NumberInput and ColorInput between them), and counting siblings
+// reports those as gaps and invites duplicate stories.
+//
+// Each uncovered surface is classified by what a story would have to supply:
+//
+//   props      no context to supply. Note this means "no provider needed", not
+//              "cheap" — a props-only component can still be expensive to
+//              story if its props are heavy (ButtonAppearanceOverlay wants
+//              real PDF bytes; AppConfigModalLazy lazy-loads the whole
+//              settings tree). Read the props before assuming it is quick.
+//   context    it (or something it renders) reads a React context. The cheap
+//              fix is usually to export the context and hand the story the
+//              slice the component actually touches, rather than mounting the
+//              provider and whatever chain sits behind it.
+//   data       it fetches, so the story needs MSW handlers
+//   router     it reads router state
+//
+// Not counted as surfaces at all: providers, contexts, gates, routers, test
+// helpers, and modules that return a config object rather than markup.
+//
+// Known blocker — four flavours cannot be storied as things stand.
+//
+// Storybook resolves @app/* through editor/tsconfig.proprietary.vite.json,
+// which maps it to src/proprietary/* then src/core/* and excludes src/desktop.
+// A file in another flavour that imports an @app/* asset living only in its own
+// tree therefore fails to resolve, and the story file does not load at all:
+//
+//   desktop      80 of 152 @app/ imports unresolvable
+//   saas         54 of 232
+//   cloud        28 of  77
+//   prototypes    4 of  40
+//   portal-saas   0 of   7   (fine)
+//
+// That accounts for the 0% areas below — it is a build-config gap, not
+// neglect. Closing it means either per-flavour alias projects in
+// .storybook/main.ts or hoisting the shared assets, and it is a decision with
+// blast radius across every existing story, so it is deliberately not made
+// here.
+//
+// Run from frontend/.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const SRC = resolve(process.cwd(), "editor/src");
+const args = process.argv.slice(2);
+const wantTodo = args.includes("--todo");
+const areaFilter = args.includes("--area")
+  ? args[args.indexOf("--area") + 1]
+  : null;
+
+/* ── file walk ────────────────────────────────────────────────────────────── */
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.name.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+const all = walk(SRC);
+const rel = (f) => relative(SRC, f).split("\\").join("/");
+const storyFiles = all.filter((f) => f.endsWith(".stories.tsx"));
+const sources = all.filter(
+  (f) => !f.endsWith(".stories.tsx") && !f.endsWith(".test.tsx"),
+);
+
+/* ── what the stories already reach ───────────────────────────────────────── */
+
+const importedNames = new Set();
+const importedPaths = new Set();
+for (const f of storyFiles) {
+  const src = readFileSync(f, "utf8");
+  for (const m of src.matchAll(
+    /import\s+(?:type\s+)?(?:\{([^}]*)\}|(\w+))\s*(?:,\s*\{([^}]*)\})?\s*from\s+["']([^"']+)/g,
+  )) {
+    for (const group of [m[1], m[3]]) {
+      if (!group) continue;
+      for (const name of group.split(","))
+        importedNames.add(
+          name.trim().split(" as ")[0].replace("type ", "").trim(),
+        );
+    }
+    if (m[2]) importedNames.add(m[2]);
+    importedPaths.add(m[4]);
+  }
+}
+
+/* ── classification ───────────────────────────────────────────────────────── */
+
+// Bridge: the viewer's *APIBridge components register an API into context and
+// render null — wiring, like the rest of these.
+const INFRA_NAME =
+  /(Provider|Providers|Context|Gate|Boundary|Mount|Router|Guard|Bridge)\.tsx$/;
+const INFRA_DIR = /\/(contexts|test|tests|mocks|hooks|types|utils|api|data)\//;
+const RENDERS = /return\s*\(?\s*<|=>\s*\(?\s*</;
+// A module whose exported function returns a config object, not markup.
+const CONFIG_FACTORY = /:\s*(SlideConfig|ToolFlowConfig|\w+Config)\s*\{/;
+const DATA = /\buse(Query|Mutation|SWR|InfiniteQuery)\b|\bfetch\w*\(/;
+const ROUTER = /\buse(Navigate|Params|Location|SearchParams)\b/;
+const CONTEXT = /\buse[A-Z]\w*\(/g;
+// Hooks that are plainly not context reads.
+const LOCAL_HOOK =
+  /^use(State|Effect|Memo|Callback|Ref|Id|Reducer|Context|Translation|LayoutEffect|ImperativeHandle|Transition|DeferredValue|SyncExternalStore|Debounced\w*|Media\w*|Disclosure|Form)$/;
+// Contexts .storybook/preview.tsx already mounts for every story. A component
+// that reads only these needs no fixture work, so it counts as props-level.
+const HARNESS_PROVIDED =
+  /^use(Preferences|SidebarContext|Tier|Link|UI|Theme|QueryClient|Navigate|Location|Params|SearchParams)$/;
+
+const byPath = new Map(sources.map((f) => [rel(f), f]));
+
+function localImports(src, fromRel) {
+  const out = [];
+  for (const m of src.matchAll(
+    /from\s+["'](@app\/|@core\/|\.\.?\/)([^"']+)/g,
+  )) {
+    const spec = m[1] + m[2];
+    const guess = spec.replace(/^@app\//, "core/").replace(/^@core\//, "core/");
+    for (const cand of [`${guess}.tsx`, `${guess}/index.tsx`]) {
+      if (byPath.has(cand)) out.push(cand);
+    }
+    void fromRel;
+  }
+  return out;
+}
+
+/** Does this file, or anything it renders, read a context? Depth-limited. */
+function needsContext(relPath, seen = new Set(), depth = 0) {
+  if (depth > 3 || seen.has(relPath)) return false;
+  seen.add(relPath);
+  const file = byPath.get(relPath);
+  if (!file) return false;
+  const src = readFileSync(file, "utf8");
+  for (const m of src.matchAll(CONTEXT)) {
+    const name = m[0].slice(0, -1);
+    if (!LOCAL_HOOK.test(name) && !HARNESS_PROVIDED.test(name)) return true;
+  }
+  return localImports(src, relPath).some((child) =>
+    needsContext(child, seen, depth + 1),
+  );
+}
+
+const rows = [];
+for (const file of sources) {
+  const r = rel(file);
+  const base = r.split("/").pop();
+  if (!/^[A-Z]/.test(base)) continue;
+  const src = readFileSync(file, "utf8");
+  if (!RENDERS.test(src)) continue;
+  if (INFRA_NAME.test(base) || INFRA_DIR.test("/" + r)) continue;
+  if (CONFIG_FACTORY.test(src)) continue;
+
+  const stem = base.replace(".tsx", "");
+  const tail = r.replace(".tsx", "");
+  const covered =
+    importedNames.has(stem) ||
+    [...importedPaths].some((p) => p.endsWith(tail) || p.endsWith("/" + stem));
+
+  let needs = "props";
+  if (DATA.test(src)) needs = "data";
+  else if (ROUTER.test(src)) needs = "router";
+  else if (needsContext(r)) needs = "context";
+
+  const parts = r.split("/");
+  rows.push({
+    area: parts.slice(0, Math.min(3, parts.length - 1)).join("/"),
+    file: r,
+    covered,
+    needs,
+    loc: src.split("\n").length,
+  });
+}
+
+/* ── report ───────────────────────────────────────────────────────────────── */
+
+const shown = areaFilter
+  ? rows.filter((r) => r.file.startsWith(areaFilter))
+  : rows;
+const todo = shown.filter((r) => !r.covered);
+
+if (wantTodo || areaFilter) {
+  const order = { props: 0, context: 1, router: 2, data: 3 };
+  for (const r of todo.sort(
+    (a, b) => order[a.needs] - order[b.needs] || a.loc - b.loc,
+  )) {
+    console.log(
+      `  ${r.needs.padEnd(8)} ${String(r.loc).padStart(5)} loc  ${r.file}`,
+    );
+  }
+  console.log("");
+}
+
+const areas = new Map();
+for (const r of shown) {
+  const a = areas.get(r.area) ?? { total: 0, covered: 0 };
+  a.total += 1;
+  if (r.covered) a.covered += 1;
+  areas.set(r.area, a);
+}
+
+console.log(
+  `${"area".padEnd(38)}${"total".padStart(6)}${"covered".padStart(9)}${"%".padStart(6)}`,
+);
+for (const [area, a] of [...areas].sort(
+  (x, y) => y[1].total - y[1].covered - (x[1].total - x[1].covered),
+)) {
+  if (a.total === a.covered) continue;
+  const pct = Math.round((100 * a.covered) / a.total);
+  console.log(
+    `${area.padEnd(38)}${String(a.total).padStart(6)}${String(a.covered).padStart(9)}${String(pct).padStart(5)}%`,
+  );
+}
+
+const covered = shown.filter((r) => r.covered).length;
+const byNeed = todo.reduce(
+  (acc, r) => ((acc[r.needs] = (acc[r.needs] ?? 0) + 1), acc),
+  {},
+);
+console.log(
+  `\nsurfaces ${shown.length}   covered ${covered} (${Math.round((100 * covered) / shown.length)}%)   remaining ${todo.length}`,
+);
+console.log(
+  `remaining by what a story needs: ` +
+    Object.entries(byNeed)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, v]) => `${k} ${v}`)
+      .join("   "),
+);

--- a/frontend/editor/src/core/components/StorageStatsCard.tsx
+++ b/frontend/editor/src/core/components/StorageStatsCard.tsx
@@ -39,6 +39,7 @@ const StorageStatsCard: React.FC<StorageStatsCardProps> = ({
           </Text>
           {storageStats.quota && (
             <Progress
+              aria-label={t("fileManager.storageUsed", "Storage used")}
               value={storageUsagePercent}
               color={
                 storageUsagePercent > 80

--- a/frontend/editor/src/core/components/annotation/shared/ColorPicker.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/ColorPicker.tsx
@@ -51,6 +51,13 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({
           format="hex"
           value={selectedColor}
           onChange={onColorChange}
+          // The saturation area and hue bar are role="slider" divs; these are
+          // their only accessible names.
+          saturationLabel={t(
+            "colorPicker.saturation",
+            "Saturation and brightness",
+          )}
+          hueLabel={t("colorPicker.hue", "Hue")}
           swatches={[
             "#000000",
             "#0066cc",
@@ -73,6 +80,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({
               max={100}
               value={opacity}
               onChange={onOpacityChange}
+              thumbLabel={resolvedOpacityLabel}
               marks={[
                 { value: 25, label: "25%" },
                 { value: 50, label: "50%" },

--- a/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
@@ -45,6 +45,7 @@ export function OpacityControl({
             min={10}
             max={100}
             label={(val) => `${val}%`}
+            thumbLabel={t("annotation.opacity", "Opacity")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
@@ -75,6 +75,7 @@ export function PropertiesPopover({
           min={8}
           max={32}
           label={(val) => `${val}pt`}
+          thumbLabel={t("annotation.fontSize", "Font size")}
         />
       </div>
 
@@ -86,6 +87,7 @@ export function PropertiesPopover({
         <Slider
           value={Math.round((obj?.opacity ?? 1) * 100)}
           onChange={(val) => onUpdate({ opacity: val / 100 })}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -144,6 +146,7 @@ export function PropertiesPopover({
               fillOpacity: newOpacity,
             });
           }}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -169,6 +172,7 @@ export function PropertiesPopover({
               min={0}
               max={12}
               label={(val) => `${val}pt`}
+              thumbLabel={t("annotation.strokeWidth", "Stroke")}
             />
           </div>
           <Button

--- a/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
@@ -49,6 +49,7 @@ export function WidthControl({
             min={min}
             max={max}
             label={(val) => `${val}pt`}
+            thumbLabel={t("annotation.width", "Width")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/fileEditor/AddFileCard.stories.tsx
+++ b/frontend/editor/src/core/components/fileEditor/AddFileCard.stories.tsx
@@ -1,0 +1,42 @@
+/**
+ * The trailing card in the file editor's grid that invites the user to add more
+ * files. Clicking the card (or its "Add Files" button) opens the files modal;
+ * the smaller button beside it goes straight to the native file picker.
+ *
+ * The two buttons share one slot: hovering the upload button expands it to fill
+ * the row and hides "Add Files". That is internal state, so it is not a story.
+ * `accept` and `multiple` only reach the hidden input and change nothing on
+ * screen, which leaves a single rendered state.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddFileCard from "@app/components/fileEditor/AddFileCard";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+
+const meta = {
+  title: "FileEditor/AddFileCard",
+  component: AddFileCard,
+  parameters: { layout: "centered" },
+  args: { onFileSelect: () => {} },
+  decorators: [
+    (Story) => (
+      // Only openFilesModal is read. The real provider reaches FileContext and
+      // NavigationContext, so a slice is supplied instead.
+      <FilesModalContext.Provider
+        value={{ openFilesModal: () => {} } as unknown as FilesModalContextType}
+      >
+        {/* The card fills the cell the file editor's grid gives it. */}
+        <div style={{ width: "16rem", height: "20rem" }}>
+          <Story />
+        </div>
+      </FilesModalContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof AddFileCard>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/editor/src/core/components/fileEditor/AddFileCard.tsx
+++ b/frontend/editor/src/core/components/fileEditor/AddFileCard.tsx
@@ -70,16 +70,10 @@ const AddFileCard = ({
 
       <div
         className={`${styles.addFileCard} select-none flex flex-col transition-all relative cursor-pointer`}
-        tabIndex={0}
-        role="button"
-        aria-label={t("fileEditor.addFiles", "Add files")}
+        /* The card holds its own Add-files and upload buttons, so making the
+           card a button as well nests one control inside another. The click is
+           a mouse convenience; the buttons carry the keyboard path. */
         onClick={handleCardClick}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            handleCardClick();
-          }
-        }}
       >
         {/* Main content area */}
         <div className={styles.addFileContent}>
@@ -161,7 +155,7 @@ const AddFileCard = ({
                 icon={icons.uploadIconName}
                 width="1.25rem"
                 height="1.25rem"
-                style={{ color: "var(--c-primary)", flexShrink: 0 }}
+                style={{ color: "var(--c-accent-text)", flexShrink: 0 }}
               />
               {isUploadHover && (
                 <span

--- a/frontend/editor/src/core/components/fileManager/CompactFileDetails.tsx
+++ b/frontend/editor/src/core/components/fileManager/CompactFileDetails.tsx
@@ -107,7 +107,7 @@ const CompactFileDetails: React.FC<CompactFileDetailsProps> = ({
             {currentFile && ` • v${currentFile.versionNumber || 1}`}
           </Text>
           {hasMultipleFiles && (
-            <Text size="xs" c="blue">
+            <Text size="xs" c="var(--c-accent-text)">
               {currentFileIndex + 1} of {selectedFiles.length}
             </Text>
           )}

--- a/frontend/editor/src/core/components/fileManager/DesktopLayout.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/DesktopLayout.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * The three-column arrangement of the file manager modal on a wide viewport:
+ * sources on the left, the search/actions/list stack in the middle, and the
+ * selected file's details on the right.
+ *
+ * The layout takes no props — everything comes from the provider. The search
+ * bar and action bar above the list are tied to the Recent source, and the
+ * list's scroll height is computed from the modal height and whether any files
+ * exist, so the populated and empty cases are laid out differently.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import DesktopLayout from "@app/components/fileManager/DesktopLayout";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const FILES = [
+  makeStub("file-1", "quarterly-report.pdf"),
+  makeStub("file-2", "invoice-2026-01.pdf"),
+  makeStub("file-3", "scan-of-contract.pdf", { size: 18_400_000 }),
+];
+
+const meta = {
+  title: "FileManager/DesktopLayout",
+  component: DesktopLayout,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "600px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DesktopLayout>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Files present and one of them selected, so the details column is filled in. */
+export const Default: Story = {
+  decorators: [
+    withFileManager({ recentFiles: FILES, activeFileIds: [FILES[0].id] }),
+  ],
+};
+
+/** First run: the middle column is the empty state and the details are blank. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};
+
+/** With storage on, the middle column gains the filter and bulk cloud actions. */
+export const StorageEnabled: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id],
+      config: { storageEnabled: true, storageSharingEnabled: true },
+    }),
+  ],
+};

--- a/frontend/editor/src/core/components/fileManager/EmptyFilesState.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/EmptyFilesState.stories.tsx
@@ -1,0 +1,65 @@
+/**
+ * What the file manager shows before anything has been added. The copy and
+ * icons come from the file-action hooks, which desktop builds override — these
+ * stories render the web wording.
+ *
+ * Only one context field is read (the upload click handler), so the fixture
+ * supplies that alone rather than the whole provider.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import EmptyFilesState from "@app/components/fileManager/EmptyFilesState";
+import {
+  FileManagerContext,
+  type FileManagerContextValue,
+} from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof EmptyFilesState> = {
+  title: "FileManager/EmptyFilesState",
+  component: EmptyFilesState,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    // The wordmark resolves its logo variant through PreferencesContext, which
+    // the Storybook preview does not mount, so this story supplies it.
+    (Story) => (
+      <PreferencesProvider>
+        <FileManagerContext.Provider
+          value={
+            { onLocalFileClick: () => {} } as unknown as FileManagerContextValue
+          }
+        >
+          <div style={{ height: "32rem" }}>
+            <Story />
+          </div>
+        </FileManagerContext.Provider>
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof EmptyFilesState>;
+
+export const Default: Story = {};
+
+/** The panel centres itself, so a short container crops rather than reflows. */
+export const ShortContainer: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: "18rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Narrow widths are the mobile case — the upload actions stack. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/frontend/editor/src/core/components/fileManager/EmptyFilesState.tsx
+++ b/frontend/editor/src/core/components/fileManager/EmptyFilesState.tsx
@@ -103,7 +103,7 @@ const EmptyFilesState: React.FC = () => {
               icon={icons.uploadIconName}
               width="1.25rem"
               height="1.25rem"
-              style={{ color: "var(--c-primary)" }}
+              style={{ color: "var(--c-accent-text)" }}
             />
             {isUploadHover && (
               <span style={{ marginLeft: ".5rem" }}>

--- a/frontend/editor/src/core/components/fileManager/FileActions.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileActions.stories.tsx
@@ -1,0 +1,112 @@
+/**
+ * The action bar above the recent-files list: select-all, an optional storage
+ * filter, the selection count, and the bulk delete/download/upload/share
+ * buttons.
+ *
+ * What appears is decided by the storage config and by the current selection.
+ * The upload button needs storage on; the share button additionally needs
+ * sharing and share links on, which also widen the filter from All/Local to
+ * include the two "shared" tabs. The delete and download buttons are always
+ * present but disabled until something is selected, and the whole bar renders
+ * nothing at all while there are no recent files.
+ *
+ * Selection is provider state seeded from `activeFileIds`, so the stories vary
+ * that rather than a prop.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileActions from "@app/components/fileManager/FileActions";
+import type { FileId } from "@app/types/file";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const FILES = [
+  makeStub("file-1", "quarterly-report.pdf"),
+  makeStub("file-2", "invoice-2026-01.pdf"),
+  makeStub("file-3", "scan.pdf"),
+];
+
+const meta = {
+  title: "FileManager/FileActions",
+  component: FileActions,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof FileActions>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Local-only build, nothing selected: bulk actions present but inert. */
+export const Default: Story = {
+  decorators: [withFileManager({ recentFiles: FILES })],
+};
+
+/** With a selection the count appears and delete/download become live. */
+export const WithSelection: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id, FILES[1].id],
+    }),
+  ],
+};
+
+/** Storage on adds the All/Local filter and the bulk upload button. */
+export const StorageEnabled: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id],
+      config: { storageEnabled: true },
+    }),
+  ],
+};
+
+/**
+ * Sharing and share links on add the share button and the two "shared" filter
+ * tabs.
+ */
+export const SharingEnabled: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: [FILES[0].id],
+      config: {
+        storageEnabled: true,
+        storageSharingEnabled: true,
+        storageShareLinksEnabled: true,
+      },
+    }),
+  ],
+};
+
+/**
+ * A selection that includes a file owned by someone else: bulk upload and share
+ * stay disabled because they only apply to files the user owns.
+ */
+export const SelectionIncludesSharedFile: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: [
+        FILES[0],
+        makeStub("file-shared", "budget-from-alex.pdf", {
+          remoteStorageId: 42,
+          remoteOwnedByCurrentUser: false,
+          remoteOwnerUsername: "alex",
+          remoteAccessRole: "viewer",
+        }),
+      ],
+      activeFileIds: [FILES[0].id, "file-shared" as FileId],
+      config: {
+        storageEnabled: true,
+        storageSharingEnabled: true,
+        storageShareLinksEnabled: true,
+      },
+    }),
+  ],
+};
+
+/** With no recent files the bar renders nothing. */
+export const NoFiles: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};

--- a/frontend/editor/src/core/components/fileManager/FileInfoCard.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileInfoCard.stories.tsx
@@ -1,0 +1,123 @@
+/**
+ * The details card on the right of the file manager: name, format, size, date
+ * and version, followed by whatever the file's storage situation warrants.
+ *
+ * The trailing rows are all conditional and are driven by the stub's remote
+ * fields rather than by props. A file with no `remoteStorageId` is local only;
+ * one the user owns on the server shows a sync state that turns to "changes not
+ * uploaded" once its local timestamp is newer than the remote one; one owned by
+ * somebody else shows the owner and offers a copy. Sharing rows additionally
+ * need the storage/sharing config on, and a tool chain appears only when the
+ * file carries history.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileInfoCard from "@app/components/fileManager/FileInfoCard";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const MODIFIED = Date.UTC(2026, 0, 14);
+
+/** The default local-only build. */
+const local = withFileManager();
+
+/** Storage plus sharing, for the stories about server-side state. */
+const cloud = withFileManager({
+  config: {
+    storageEnabled: true,
+    storageSharingEnabled: true,
+    storageShareLinksEnabled: true,
+  },
+});
+
+const meta = {
+  title: "FileManager/FileInfoCard",
+  component: FileInfoCard,
+  args: { modalHeight: "600px" },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "22rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FileInfoCard>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A file that has never left the browser: the "Local only" badge, nothing else. */
+export const LocalOnly: Story = {
+  args: { currentFile: makeStub("file-1", "quarterly-report.pdf") },
+  decorators: [local],
+};
+
+/** No file selected — the labels stay, their values are blank. */
+export const NoFileSelected: Story = {
+  args: { currentFile: null },
+  decorators: [local],
+};
+
+/** A file that has been through tools carries its chain as badges. */
+export const WithToolHistory: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      versionNumber: 3,
+      toolHistory: [
+        { toolId: "split", timestamp: MODIFIED },
+        { toolId: "compress", timestamp: MODIFIED },
+      ],
+    }),
+  },
+  decorators: [local],
+};
+
+/** Uploaded and current: the cloud row reads "Synced" and shows the sync time. */
+export const SyncedToCloud: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Edited since the last upload, so the cloud row warns instead. */
+export const ChangesNotUploaded: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      lastModified: MODIFIED + 3_600_000,
+      createdAt: MODIFIED + 3_600_000,
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Someone else's file: owner row, "Shared with you" badge, and a copy action. */
+export const SharedWithYou: Story = {
+  args: {
+    currentFile: makeStub("file-1", "budget-from-alex.pdf", {
+      remoteStorageId: 11,
+      remoteOwnedByCurrentUser: false,
+      remoteOwnerUsername: "alex",
+      remoteAccessRole: "viewer",
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** The user's own file with links out: a sharing row and the management entry. */
+export const SharedByYou: Story = {
+  args: {
+    currentFile: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+      remoteHasShareLinks: true,
+    }),
+  },
+  decorators: [cloud],
+};

--- a/frontend/editor/src/core/components/fileManager/FileInfoCard.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileInfoCard.tsx
@@ -86,19 +86,29 @@ const FileInfoCard: React.FC<FileInfoCardProps> = ({
       }}
     >
       <Box
-        bg="gray.4"
         p="sm"
         style={{
+          background: "var(--c-surface-raised)",
           borderTopLeftRadius: "var(--mantine-radius-md)",
           borderTopRightRadius: "var(--mantine-radius-md)",
           flexShrink: 0,
         }}
       >
-        <Text size="sm" fw={500} ta="center" c="white">
+        <Text size="sm" fw={500} ta="center">
           {t("fileManager.details", "File Details")}
         </Text>
       </Box>
-      <ScrollArea style={{ flex: 1, minHeight: 0 }} p="md">
+      {/* The viewport is focusable and named so keyboard users can scroll the
+          detail list once it overflows. */}
+      <ScrollArea
+        style={{ flex: 1, minHeight: 0 }}
+        p="md"
+        viewportProps={{
+          tabIndex: 0,
+          role: "group",
+          "aria-label": t("fileManager.details", "File Details"),
+        }}
+      >
         <Stack gap="sm">
           <Group justify="space-between" py="xs">
             <Text size="sm" c="dimmed">

--- a/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListArea.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * The scrolling list that fills the file manager. Which branch it renders is
+ * decided entirely by context — the active source, whether files are loading,
+ * and whether any survive the search filter — so the stories drive it through
+ * the provider rather than through props.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileListArea from "@app/components/fileManager/FileListArea";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+import type { FileId } from "@app/types/file";
+
+const FILES = [
+  makeStub("f1", "quarterly-report.pdf"),
+  makeStub("f2", "signed-contract.pdf", { size: 840_000 }),
+  makeStub("f3", "scan-2026-03-14.pdf", { size: 12_600_000 }),
+  makeStub("f4", "minutes.pdf", { size: 96_000 }),
+];
+
+const meta: Meta<typeof FileListArea> = {
+  title: "FileManager/FileListArea",
+  component: FileListArea,
+  parameters: { layout: "padded" },
+  args: { scrollAreaHeight: "26rem" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FileListArea>;
+
+export const Default: Story = {
+  decorators: [withFileManager({ recentFiles: FILES })],
+};
+
+/** No files at all — the list gives way to the empty state. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};
+
+export const Loading: Story = {
+  decorators: [withFileManager({ recentFiles: FILES, isLoading: true })],
+};
+
+/** Files already open in the editor are marked as active in the list. */
+export const WithActiveFile: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: FILES,
+      activeFileIds: ["f2" as FileId],
+    }),
+  ],
+};
+
+/** Enough rows to scroll, which is the normal state for a working library. */
+export const ManyFiles: Story = {
+  decorators: [
+    withFileManager({
+      recentFiles: Array.from({ length: 24 }, (_, i) =>
+        makeStub(`many-${i}`, `document-${String(i + 1).padStart(3, "0")}.pdf`),
+      ),
+    }),
+  ],
+};
+
+/** A short frame proves the list scrolls inside its own box, not the page. */
+export const ShortFrame: Story = {
+  args: { scrollAreaHeight: "12rem" },
+  decorators: [withFileManager({ recentFiles: FILES })],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListItem.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListItem.stories.tsx
@@ -1,0 +1,142 @@
+/**
+ * A single row in the file manager's recent list: checkbox, name, a run of
+ * status badges, size/date, and a hover-revealed overflow menu.
+ *
+ * The badges are the interesting part. Version always shows; "Active" comes
+ * from the prop; and the storage badge is one of a mutually exclusive set
+ * decided by the stub's remote fields — local only, synced, changes not
+ * uploaded, or a shared-with-you pair of ownership and role — most of which
+ * additionally require the storage/sharing config to be on. `isHistoryFile`
+ * turns the row into an indented, non-selectable version entry instead.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileListItem from "@app/components/fileManager/FileListItem";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const MODIFIED = Date.UTC(2026, 0, 14);
+const FILE = makeStub("file-1", "quarterly-report.pdf");
+
+/** The default local-only build. */
+const local = withFileManager({ recentFiles: [FILE] });
+
+/** Storage plus sharing, for the stories about server-side state. */
+const cloud = withFileManager({
+  recentFiles: [FILE],
+  config: {
+    storageEnabled: true,
+    storageSharingEnabled: true,
+    storageShareLinksEnabled: true,
+  },
+});
+
+const meta = {
+  title: "FileManager/FileListItem",
+  component: FileListItem,
+  parameters: { layout: "fullscreen" },
+  args: {
+    file: FILE,
+    isSelected: false,
+    isLatestVersion: true,
+    onSelect: () => {},
+    onRemove: () => {},
+    onDownload: () => {},
+    onDoubleClick: () => {},
+  },
+} satisfies Meta<typeof FileListItem>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A freshly uploaded file that has never been to the server. */
+export const Default: Story = { decorators: [local] };
+
+/** Selected: the checkbox is ticked and the row takes the highlight fill. */
+export const Selected: Story = {
+  args: { isSelected: true },
+  decorators: [local],
+};
+
+/** A file currently open in the workbench earns the "Active" badge. */
+export const Active: Story = {
+  args: { isActive: true },
+  decorators: [local],
+};
+
+/** A processed file: a higher version number and the tool chain that produced it. */
+export const Processed: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      versionNumber: 3,
+      toolHistory: [
+        { toolId: "split", timestamp: MODIFIED },
+        { toolId: "compress", timestamp: MODIFIED },
+      ],
+    }),
+  },
+  decorators: [local],
+};
+
+/**
+ * An older version listed under its leaf: indented behind a rule, with no
+ * checkbox because history entries cannot be selected.
+ */
+export const HistoryEntry: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", { versionNumber: 2 }),
+    isHistoryFile: true,
+    isLatestVersion: false,
+  },
+  decorators: [local],
+};
+
+/** Uploaded and current: "Synced" replaces the local-only badge. */
+export const Synced: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Edited since the last upload, so the badge warns instead. */
+export const ChangesNotUploaded: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      lastModified: MODIFIED + 3_600_000,
+      createdAt: MODIFIED + 3_600_000,
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED,
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** Someone else's file: ownership and the read-only role are both called out. */
+export const SharedWithYou: Story = {
+  args: {
+    file: makeStub("file-1", "budget-from-alex.pdf", {
+      remoteStorageId: 11,
+      remoteOwnedByCurrentUser: false,
+      remoteOwnerUsername: "alex",
+      remoteAccessRole: "viewer",
+    }),
+  },
+  decorators: [cloud],
+};
+
+/** The user's own file with a live link out. */
+export const SharedByYou: Story = {
+  args: {
+    file: makeStub("file-1", "quarterly-report.pdf", {
+      remoteStorageId: 7,
+      remoteStorageUpdatedAt: MODIFIED + 60_000,
+      remoteHasShareLinks: true,
+    }),
+  },
+  decorators: [cloud],
+};

--- a/frontend/editor/src/core/components/fileManager/FileListItem.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileListItem.tsx
@@ -213,6 +213,9 @@ const FileListItem: React.FC<FileListItemProps> = ({
               <Checkbox
                 checked={isSelected}
                 onChange={() => {}} // Handled by parent onClick
+                aria-label={t("fileManager.selectFile", "Select {{name}}", {
+                  name: file.name,
+                })}
                 size="sm"
                 pl="sm"
                 pr="xs"
@@ -261,12 +264,9 @@ const FileListItem: React.FC<FileListItemProps> = ({
                     : t("storageShare.roleViewer", "Viewer")}
                 </Badge>
               ) : isLocalOnly ? (
-                <Badge
-                  size="xs"
-                  variant="default"
-                  c="dimmed"
-                  style={{ opacity: 0.75 }}
-                >
+                // No extra opacity: at this size the muted colour is already at
+                // the edge of 4.5:1, and fading it drops below.
+                <Badge size="xs" variant="default" c="dimmed">
                   {t("fileManager.localOnly", "Local only")}
                 </Badge>
               ) : uploadEnabled && isOutOfSync ? (

--- a/frontend/editor/src/core/components/fileManager/FileSourceButtons.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/FileSourceButtons.stories.tsx
@@ -1,0 +1,74 @@
+/**
+ * The source picker down the left of the file manager: Recent, local upload,
+ * Google Drive and mobile scan.
+ *
+ * Recent and upload are always offered. The other two are each governed by a
+ * pair of config flags — one that enables the integration and one that decides
+ * whether an unavailable integration is shown greyed out or dropped from the
+ * list entirely. `horizontal` reflows the same buttons into a centred row for
+ * the mobile layout and shortens their labels ("Drive", "Mobile").
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileSourceButtons from "@app/components/fileManager/FileSourceButtons";
+import { withFileManager } from "@app/components/fileManager/storyFixtures";
+
+/** The column the buttons occupy in the desktop layout. */
+const withColumn = (Story: () => ReactElement) => (
+  <div style={{ width: "13.625rem", height: "20rem" }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: "FileManager/FileSourceButtons",
+  component: FileSourceButtons,
+  decorators: [withColumn],
+} satisfies Meta<typeof FileSourceButtons>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The plain build: Recent is the active source, and Drive and mobile scan are
+ * both present but disabled because neither is configured.
+ */
+export const Default: Story = {
+  decorators: [withFileManager()],
+};
+
+/** Hiding the unavailable integrations leaves only Recent and upload. */
+export const UnavailableSourcesHidden: Story = {
+  decorators: [
+    withFileManager({
+      config: {
+        hideDisabledToolsGoogleDrive: true,
+        hideDisabledToolsMobileQRScanner: true,
+      },
+    }),
+  ],
+};
+
+/**
+ * Fully configured: Drive takes its coloured icon and both integrations become
+ * clickable. Drive needs the client/API/app ids as well as its enable flag.
+ */
+export const AllSourcesAvailable: Story = {
+  decorators: [
+    withFileManager({
+      config: {
+        googleDriveEnabled: true,
+        googleDriveClientId: "storybook-client-id",
+        googleDriveApiKey: "storybook-api-key",
+        googleDriveAppId: "storybook-app-id",
+        enableMobileScanner: true,
+      },
+    }),
+  ],
+};
+
+/** The mobile layout's row: centred, no heading, and abbreviated labels. */
+export const Horizontal: Story = {
+  args: { horizontal: true },
+  decorators: [withFileManager()],
+};

--- a/frontend/editor/src/core/components/fileManager/MobileLayout.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/MobileLayout.stories.tsx
@@ -1,0 +1,55 @@
+/**
+ * The stacked arrangement of the file manager modal on a narrow viewport: the
+ * sources as a horizontal row, the compact file details, then the search bar,
+ * action bar and list sharing one panel.
+ *
+ * As with the desktop layout there are no props — the provider supplies
+ * everything. The search and action bars belong to the Recent source, and the
+ * list's height is worked back from the modal height, allowing extra room for
+ * the details block once a file is selected.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import MobileLayout from "@app/components/fileManager/MobileLayout";
+import {
+  makeStub,
+  withFileManager,
+} from "@app/components/fileManager/storyFixtures";
+
+const FILES = [
+  makeStub("file-1", "quarterly-report.pdf"),
+  makeStub("file-2", "invoice-2026-01.pdf"),
+];
+
+const meta = {
+  title: "FileManager/MobileLayout",
+  component: MobileLayout,
+  parameters: { layout: "fullscreen" },
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "600px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MobileLayout>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A file selected, so the compact details block sits above the list. */
+export const Default: Story = {
+  decorators: [
+    withFileManager({ recentFiles: FILES, activeFileIds: [FILES[0].id] }),
+  ],
+};
+
+/** Nothing selected: the details block shrinks and the list takes the room. */
+export const NoSelection: Story = {
+  decorators: [withFileManager({ recentFiles: FILES })],
+};
+
+/** First run, with the empty state filling the list panel. */
+export const Empty: Story = {
+  decorators: [withFileManager({ recentFiles: [] })],
+};

--- a/frontend/editor/src/core/components/fileManager/SearchInput.stories.tsx
+++ b/frontend/editor/src/core/components/fileManager/SearchInput.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * The file manager's search box. It reads the term and the change handler from
+ * FileManagerContext rather than taking props, so the stories mount it against
+ * a two-field slice of that context instead of the whole provider chain.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SearchInput from "@app/components/fileManager/SearchInput";
+import {
+  FileManagerContext,
+  type FileManagerContextValue,
+} from "@app/contexts/FileManagerContext";
+
+/**
+ * SearchInput reads exactly two fields. Supplying only those keeps the fixture
+ * honest about what the component depends on; the cast is what makes a partial
+ * value acceptable in place of the full context.
+ */
+function withSearch(
+  searchTerm: string,
+  onSearchChange: (term: string) => void = () => {},
+) {
+  return (children: React.ReactNode) => (
+    <FileManagerContext.Provider
+      value={
+        { searchTerm, onSearchChange } as unknown as FileManagerContextValue
+      }
+    >
+      {children}
+    </FileManagerContext.Provider>
+  );
+}
+
+const meta: Meta<typeof SearchInput> = {
+  title: "FileManager/SearchInput",
+  component: SearchInput,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchInput>;
+
+export const Empty: Story = {
+  render: () => withSearch("")(<SearchInput />),
+};
+
+export const WithTerm: Story = {
+  render: () => withSearch("invoice")(<SearchInput />),
+};
+
+/** Long terms are not truncated by the component — the field scrolls instead. */
+export const LongTerm: Story = {
+  render: () =>
+    withSearch("quarterly-report-2026-final-revised-approved")(<SearchInput />),
+};
+
+/** The container controls width, so the box stretches to whatever it is given. */
+export const Narrow: Story = {
+  render: () => (
+    <div style={{ width: 220 }}>{withSearch("draft")(<SearchInput />)}</div>
+  ),
+};
+
+/** Typing is driven by the context handler, so state lives outside the field. */
+export const Interactive: Story = {
+  render: function Interactive() {
+    const [term, setTerm] = useState("");
+    return withSearch(term, setTerm)(<SearchInput />);
+  },
+};

--- a/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
@@ -1,0 +1,98 @@
+/**
+ * Shared fixtures for the file manager stories.
+ *
+ * These components sit deep in a provider chain — FileManagerContext needs
+ * FileContext for useFileActions/useFileManagement, list rows additionally read
+ * AppConfig — and none of it is part of the shared preview decorators. Rather
+ * than each story rebuilding that tree, they mount the real providers here over
+ * static data, so what a story exercises is the component and not a stub.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FileManagerProvider } from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+/** A grey rectangle, so thumbnail lookups short-circuit instead of reading
+ *  file bytes out of IndexedDB. */
+const THUMBNAIL =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160'%3E%3Crect width='120' height='160' fill='%23e9ecef'/%3E%3C/svg%3E";
+
+/** Fixed so stories render identically on every run. */
+const LAST_MODIFIED = Date.parse("2026-03-14T09:30:00Z");
+
+export function makeStub(
+  id: string,
+  name: string,
+  overrides: Partial<StirlingFileStub> = {},
+): StirlingFileStub {
+  return {
+    id: id as FileId,
+    name,
+    type: "application/pdf",
+    size: 2_400_000,
+    lastModified: LAST_MODIFIED,
+    isLeaf: true,
+    originalFileId: id,
+    versionNumber: 1,
+    thumbnailUrl: THUMBNAIL,
+    ...overrides,
+  };
+}
+
+export const mockFile = makeStub("story-file-1", "quarterly-report.pdf");
+
+/** Storage off keeps the row's upload and share affordances out of the way;
+ *  stories that want them pass their own config. */
+const BASE_CONFIG = {
+  storageEnabled: false,
+  storageSharingEnabled: false,
+  storageShareLinksEnabled: false,
+  frontendUrl: "https://stirling.example",
+};
+
+interface FixtureOptions {
+  recentFiles?: StirlingFileStub[];
+  activeFileIds?: FileId[];
+  isLoading?: boolean;
+  config?: Partial<typeof BASE_CONFIG>;
+}
+
+export function withFileManager({
+  recentFiles = [mockFile],
+  activeFileIds = [],
+  isLoading = false,
+  config,
+}: FixtureOptions = {}) {
+  return (Story: () => ReactElement) => (
+    <AppConfigProvider
+      initialConfig={{ ...BASE_CONFIG, ...config } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      {/* The empty state's wordmark resolves a logo variant through
+          PreferencesContext, which the preview does not mount. */}
+      <PreferencesProvider>
+        <FileContextProvider>
+          <FileManagerProvider
+            recentFiles={recentFiles}
+            onRecentFilesSelected={() => {}}
+            onNewFilesSelect={() => {}}
+            onClose={() => {}}
+            isFileSupported={() => true}
+            isOpen
+            onFileRemove={() => {}}
+            modalHeight="600px"
+            refreshRecentFiles={async () => {}}
+            isLoading={isLoading}
+            activeFileIds={activeFileIds}
+          >
+            <Story />
+          </FileManagerProvider>
+        </FileContextProvider>
+      </PreferencesProvider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/filesPage/FileGrid.tsx
+++ b/frontend/editor/src/core/components/filesPage/FileGrid.tsx
@@ -906,35 +906,47 @@ function ListView({
 
   return (
     <div className="files-page-list" role="grid">
+      {/* Each direct child is a columnheader: a role="row" may only own cells, so
+          the sort controls and the select-all box have to sit inside one. */}
       <div className="files-page-list-row is-header" role="row">
         {onSetSelection && visibleFileIds.length > 0 ? (
-          <Checkbox
-            checked={allSelected}
-            indeterminate={someSelected}
-            onChange={() => {
-              onSetSelection(allSelected ? new Set() : new Set(visibleFileIds));
-            }}
-            aria-label={
-              allSelected
-                ? t("filesPage.deselectAll", "Clear selection")
-                : t("filesPage.selectAll", "Select all")
-            }
-          />
+          <span role="columnheader">
+            <Checkbox
+              checked={allSelected}
+              indeterminate={someSelected}
+              onChange={() => {
+                onSetSelection(
+                  allSelected ? new Set() : new Set(visibleFileIds),
+                );
+              }}
+              aria-label={
+                allSelected
+                  ? t("filesPage.deselectAll", "Clear selection")
+                  : t("filesPage.selectAll", "Select all")
+              }
+            />
+          </span>
         ) : (
           <span aria-hidden="true" />
         )}
-        <span {...headerProps("name-asc", "name-desc")}>
-          {t("filesPage.column.name", "Name")}
-          {sortIndicator("name-asc", "name-desc")}
+        <span role="columnheader">
+          <span {...headerProps("name-asc", "name-desc")}>
+            {t("filesPage.column.name", "Name")}
+            {sortIndicator("name-asc", "name-desc")}
+          </span>
         </span>
-        <span>{t("filesPage.column.type", "Type")}</span>
-        <span {...headerProps("size-asc", "size-desc")}>
-          {t("filesPage.column.size", "Size")}
-          {sortIndicator("size-asc", "size-desc")}
+        <span role="columnheader">{t("filesPage.column.type", "Type")}</span>
+        <span role="columnheader">
+          <span {...headerProps("size-asc", "size-desc")}>
+            {t("filesPage.column.size", "Size")}
+            {sortIndicator("size-asc", "size-desc")}
+          </span>
         </span>
-        <span {...headerProps("modified-asc", "modified-desc")}>
-          {t("filesPage.column.modified", "Modified")}
-          {sortIndicator("modified-asc", "modified-desc")}
+        <span role="columnheader">
+          <span {...headerProps("modified-asc", "modified-desc")}>
+            {t("filesPage.column.modified", "Modified")}
+            {sortIndicator("modified-asc", "modified-desc")}
+          </span>
         </span>
         <span aria-hidden="true" />
       </div>
@@ -1091,7 +1103,12 @@ function FolderRow({
       className={`files-page-list-row${isDropTarget ? " is-drop-target" : ""}`}
     >
       <span aria-hidden="true" />
-      <span style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+      {/* Each direct child is a gridcell: a role="row" may only own cells, so the
+          actions menu has to sit inside one. */}
+      <span
+        role="gridcell"
+        style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+      >
         <FolderThumbnail
           color={folder.color}
           size="row"
@@ -1119,61 +1136,65 @@ function FolderRow({
           )}
         </span>
       </span>
-      <span>{t("filesPage.folder", "Folder")}</span>
-      <span>
+      <span role="gridcell">{t("filesPage.folder", "Folder")}</span>
+      <span role="gridcell">
         {fileCount === 0
           ? "-"
           : t("filesPage.folderItems", "{{count}} items", { count: fileCount })}
       </span>
-      <span>{getFileDate({ lastModified: folder.updatedAt })}</span>
-      <Menu shadow="md" position="bottom-end" withinPortal>
-        <Menu.Target>
-          <ActionIcon
-            ref={kebabRef}
-            variant="tertiary"
-            size="sm"
-            onClick={(e) => e.stopPropagation()}
-            aria-label={t("filesPage.folderMenu", "Folder actions")}
-          >
-            <MoreVertIcon fontSize="small" />
-          </ActionIcon>
-        </Menu.Target>
-        <Menu.Dropdown>
-          <Menu.Item
-            leftSection={<OpenInNewIcon fontSize="small" />}
-            onClick={onOpen}
-          >
-            {t("filesPage.open", "Open")}
-          </Menu.Item>
-          <Menu.Item
-            leftSection={<DriveFileRenameOutlineIcon fontSize="small" />}
-            onClick={onRename}
-            disabled={!serverReachable}
-            title={!serverReachable ? offlineHint : undefined}
-          >
-            {t("filesPage.rename", "Rename")}
-          </Menu.Item>
-          <Menu.Divider />
-          <Menu.Label>
-            {t("filesPage.appearance.title", "Appearance")}
-          </Menu.Label>
-          <FolderAppearancePicker
-            folder={folder}
-            onChange={onChangeAppearance}
-            disabled={!serverReachable}
-          />
-          <Menu.Divider />
-          <Menu.Item
-            color="red"
-            leftSection={<DeleteIcon fontSize="small" />}
-            onClick={onDelete}
-            disabled={!serverReachable}
-            title={!serverReachable ? offlineHint : undefined}
-          >
-            {t("filesPage.deleteFolder", "Delete folder")}
-          </Menu.Item>
-        </Menu.Dropdown>
-      </Menu>
+      <span role="gridcell">
+        {getFileDate({ lastModified: folder.updatedAt })}
+      </span>
+      <span role="gridcell">
+        <Menu shadow="md" position="bottom-end" withinPortal>
+          <Menu.Target>
+            <ActionIcon
+              ref={kebabRef}
+              variant="tertiary"
+              size="sm"
+              onClick={(e) => e.stopPropagation()}
+              aria-label={t("filesPage.folderMenu", "Folder actions")}
+            >
+              <MoreVertIcon fontSize="small" />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item
+              leftSection={<OpenInNewIcon fontSize="small" />}
+              onClick={onOpen}
+            >
+              {t("filesPage.open", "Open")}
+            </Menu.Item>
+            <Menu.Item
+              leftSection={<DriveFileRenameOutlineIcon fontSize="small" />}
+              onClick={onRename}
+              disabled={!serverReachable}
+              title={!serverReachable ? offlineHint : undefined}
+            >
+              {t("filesPage.rename", "Rename")}
+            </Menu.Item>
+            <Menu.Divider />
+            <Menu.Label>
+              {t("filesPage.appearance.title", "Appearance")}
+            </Menu.Label>
+            <FolderAppearancePicker
+              folder={folder}
+              onChange={onChangeAppearance}
+              disabled={!serverReachable}
+            />
+            <Menu.Divider />
+            <Menu.Item
+              color="red"
+              leftSection={<DeleteIcon fontSize="small" />}
+              onClick={onDelete}
+              disabled={!serverReachable}
+              title={!serverReachable ? offlineHint : undefined}
+            >
+              {t("filesPage.deleteFolder", "Delete folder")}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </span>
     </div>
   );
 }
@@ -1254,35 +1275,40 @@ function FileRow({
         isInWorkspace ? " is-in-workspace" : ""
       }`}
     >
-      {/* Checkbox only shows in multi-select mode (see FileCard). When the
-          checkbox is hidden the first grid column collapses, but the row's
-          CSS grid keeps the columns aligned via the named template, so no
-          empty cell shows. */}
+      {/* Each direct child is a gridcell: a role="row" may only own cells, so the
+          checkbox and the actions menu have to sit inside one.
+
+          The checkbox only shows in multi-select mode (see FileCard). When it is
+          hidden the first grid column collapses, but the row's CSS grid keeps the
+          columns aligned via the named template, so no empty cell shows. */}
       {multiSelectActive ? (
-        <Checkbox
-          checked={isSelected}
-          onClick={(e) => {
-            // Toggle this file in/out of the selection without modifier keys.
-            e.stopPropagation();
-            onClick({
-              ...e,
-              shiftKey: false,
-              ctrlKey: true,
-              metaKey: true,
-            } as unknown as React.MouseEvent);
-          }}
-          onChange={() => {
-            /* handled by onClick */
-          }}
-          aria-label={t("filesPage.selectFile", "Select file {{name}}", {
-            name: file.name,
-          })}
-        />
+        <span role="gridcell">
+          <Checkbox
+            checked={isSelected}
+            onClick={(e) => {
+              // Toggle this file in/out of the selection without modifier keys.
+              e.stopPropagation();
+              onClick({
+                ...e,
+                shiftKey: false,
+                ctrlKey: true,
+                metaKey: true,
+              } as unknown as React.MouseEvent);
+            }}
+            onChange={() => {
+              /* handled by onClick */
+            }}
+            aria-label={t("filesPage.selectFile", "Select file {{name}}", {
+              name: file.name,
+            })}
+          />
+        </span>
       ) : (
         // Empty cell preserves grid column alignment.
         <span aria-hidden="true" />
       )}
       <span
+        role="gridcell"
         style={{
           display: "flex",
           alignItems: "center",
@@ -1342,94 +1368,96 @@ function FileRow({
           </span>
         )}
       </span>
-      <span>{ext || t("filesPage.file", "File")}</span>
-      <span>{fileSize}</span>
-      <span>{fileDate}</span>
-      <Menu shadow="md" position="bottom-end" withinPortal>
-        <Menu.Target>
-          <ActionIcon
-            ref={kebabRef}
-            variant="tertiary"
-            size="sm"
-            onClick={(e) => e.stopPropagation()}
-            aria-label={t("filesPage.fileMenu", "File actions")}
-            data-testid="file-card-actions"
-          >
-            <MoreVertIcon fontSize="small" />
-          </ActionIcon>
-        </Menu.Target>
-        <Menu.Dropdown>
-          <Menu.Item
-            leftSection={<OpenInNewIcon fontSize="small" />}
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpen();
-            }}
-          >
-            {t("filesPage.addToWorkspace", "Add to workspace")}
-          </Menu.Item>
-          <OpenInNewWindowMenuItem file={file} />
-          <Menu.Item
-            leftSection={<DriveFileMoveIcon fontSize="small" />}
-            onClick={(e) => {
-              e.stopPropagation();
-              onMove();
-            }}
-          >
-            {t("filesPage.moveTo", "Move to…")}
-          </Menu.Item>
-          {/* Per-file Save to server; shown for local-only files. When
-              storage is off it stays visible but disabled with a tooltip. */}
-          {onSaveToServer && file.remoteStorageId == null && (
-            <Tooltip
-              label={saveToServerDisabledReason}
-              disabled={!saveToServerDisabledReason}
-              withinPortal
-              position="left"
-              multiline
-              w={240}
+      <span role="gridcell">{ext || t("filesPage.file", "File")}</span>
+      <span role="gridcell">{fileSize}</span>
+      <span role="gridcell">{fileDate}</span>
+      <span role="gridcell">
+        <Menu shadow="md" position="bottom-end" withinPortal>
+          <Menu.Target>
+            <ActionIcon
+              ref={kebabRef}
+              variant="tertiary"
+              size="sm"
+              onClick={(e) => e.stopPropagation()}
+              aria-label={t("filesPage.fileMenu", "File actions")}
+              data-testid="file-card-actions"
             >
-              <Menu.Item
-                leftSection={<CloudUploadIcon fontSize="small" />}
-                disabled={Boolean(saveToServerDisabledReason)}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSaveToServer();
-                }}
-                style={
-                  saveToServerDisabledReason
-                    ? { pointerEvents: "auto" }
-                    : undefined
-                }
-              >
-                {t("filesPage.saveToServer", "Save to server")}
-              </Menu.Item>
-            </Tooltip>
-          )}
-          {onVersionHistory && (file.versionNumber ?? 1) > 1 && (
+              <MoreVertIcon fontSize="small" />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
             <Menu.Item
-              leftSection={<HistoryIcon fontSize="small" />}
+              leftSection={<OpenInNewIcon fontSize="small" />}
               onClick={(e) => {
                 e.stopPropagation();
-                onVersionHistory();
+                onOpen();
               }}
             >
-              {t("filesPage.versionHistory", "Version history")}
+              {t("filesPage.addToWorkspace", "Add to workspace")}
             </Menu.Item>
-          )}
-          <Menu.Divider />
-          <Menu.Item
-            color="red"
-            leftSection={<DeleteIcon fontSize="small" />}
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove();
-            }}
-          >
-            {t("filesPage.remove", "Delete")}
-          </Menu.Item>
-        </Menu.Dropdown>
-      </Menu>
+            <OpenInNewWindowMenuItem file={file} />
+            <Menu.Item
+              leftSection={<DriveFileMoveIcon fontSize="small" />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onMove();
+              }}
+            >
+              {t("filesPage.moveTo", "Move to…")}
+            </Menu.Item>
+            {/* Per-file Save to server; shown for local-only files. When
+              storage is off it stays visible but disabled with a tooltip. */}
+            {onSaveToServer && file.remoteStorageId == null && (
+              <Tooltip
+                label={saveToServerDisabledReason}
+                disabled={!saveToServerDisabledReason}
+                withinPortal
+                position="left"
+                multiline
+                w={240}
+              >
+                <Menu.Item
+                  leftSection={<CloudUploadIcon fontSize="small" />}
+                  disabled={Boolean(saveToServerDisabledReason)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSaveToServer();
+                  }}
+                  style={
+                    saveToServerDisabledReason
+                      ? { pointerEvents: "auto" }
+                      : undefined
+                  }
+                >
+                  {t("filesPage.saveToServer", "Save to server")}
+                </Menu.Item>
+              </Tooltip>
+            )}
+            {onVersionHistory && (file.versionNumber ?? 1) > 1 && (
+              <Menu.Item
+                leftSection={<HistoryIcon fontSize="small" />}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onVersionHistory();
+                }}
+              >
+                {t("filesPage.versionHistory", "Version history")}
+              </Menu.Item>
+            )}
+            <Menu.Divider />
+            <Menu.Item
+              color="red"
+              leftSection={<DeleteIcon fontSize="small" />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove();
+              }}
+            >
+              {t("filesPage.remove", "Delete")}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </span>
     </div>
   );
 }

--- a/frontend/editor/src/core/components/filesPage/FileOriginBadge.tsx
+++ b/frontend/editor/src/core/components/filesPage/FileOriginBadge.tsx
@@ -32,12 +32,12 @@ const styles = {
   },
   cloud: {
     background: "color-mix(in srgb, var(--c-primary) 16%, transparent)",
-    color: "var(--c-primary)",
+    color: "var(--c-accent-text)",
   },
   shared: {
     background:
       "color-mix(in srgb, var(--mantine-color-orange-6) 16%, transparent)",
-    color: "var(--mantine-color-orange-6)",
+    color: "var(--color-amber-dark)",
   },
 };
 

--- a/frontend/editor/src/core/components/filesPage/FilesPage.css
+++ b/frontend/editor/src/core/components/filesPage/FilesPage.css
@@ -339,6 +339,9 @@
 }
 
 .files-page-list-row.is-header [data-sortable="true"] {
+  /* Block so the hit area and hover tint fill the columnheader cell that wraps
+     it, rather than hugging the label text. */
+  display: block;
   cursor: pointer;
   padding: 0.2rem 0.4rem;
   margin: -0.2rem -0.4rem;
@@ -741,7 +744,7 @@
   height: 5rem;
   border-radius: 50%;
   background: color-mix(in srgb, var(--c-primary) 12%, transparent);
-  color: var(--c-primary);
+  color: var(--c-accent-text);
   margin-bottom: 0.25rem;
 }
 
@@ -980,7 +983,7 @@
 .files-page-details-version-timeline-count {
   margin-left: auto;
   font-weight: 600;
-  color: var(--c-primary);
+  color: var(--c-accent-text);
   text-transform: none;
   letter-spacing: 0;
 }
@@ -1112,7 +1115,29 @@
 .files-page-details-version-timeline-expand-btn:hover span {
   color: var(--c-text);
 }
-
+.files-page-details-version-timeline-delta {
+  font-size: 0.82rem;
+  color: var(--c-text);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+.files-page-details-version-timeline-delta.is-origin {
+  font-weight: 400;
+  color: var(--c-text-subtle);
+  font-style: italic;
+}
+.files-page-details-version-timeline-delta-plus {
+  color: var(--c-accent-text);
+  font-weight: 700;
+}
+.files-page-details-version-timeline-spacer {
+  flex: 1;
+}
 .files-page-details-version-timeline-chevron {
   color: var(--c-text-subtle);
   transition: transform 0.15s ease;
@@ -1120,7 +1145,7 @@
 
 .files-page-details-version-timeline-chevron.is-expanded {
   transform: rotate(180deg);
-  color: var(--c-primary);
+  color: var(--c-accent-text);
 }
 
 .files-page-details-version-timeline-expanded {
@@ -1185,7 +1210,7 @@
   justify-content: center;
   gap: 1rem;
   pointer-events: none;
-  color: var(--c-primary);
+  color: var(--c-accent-text);
   font-weight: 600;
   font-size: 1.1rem;
   z-index: 10;

--- a/frontend/editor/src/core/components/filesPage/FolderThumbnail.tsx
+++ b/frontend/editor/src/core/components/filesPage/FolderThumbnail.tsx
@@ -151,7 +151,10 @@ export function FolderThumbnail({
             borderRadius: "999px",
             background: "var(--c-surface, #fff)",
             border: `1px solid ${accent}`,
-            color: accent,
+            // The ring carries the folder's accent; the numeral does not.
+            // Folder colours are user-chosen and many are too light to read
+            // as text on the white pill.
+            color: "var(--c-text)",
             fontSize: "0.7rem",
             fontWeight: 700,
             display: "inline-flex",

--- a/frontend/editor/src/core/components/filesPage/FolderTreePanel.stories.tsx
+++ b/frontend/editor/src/core/components/filesPage/FolderTreePanel.stories.tsx
@@ -1,0 +1,58 @@
+/**
+ * The resizable rail that holds the folder tree on the Files page. It supplies
+ * the heading and the drag/keyboard resize handle around FolderTreeSidebar, and
+ * wires the tree's folder actions through to the Files page context.
+ *
+ * `active` is the only prop: an inactive panel is collapsed away by CSS, hidden
+ * from assistive technology, and drops its resize handle, so the tab it belongs
+ * to can slide in and out. Its width is otherwise self-managed — auto-fitted to
+ * the longest folder name until the user drags it, after which the chosen width
+ * is persisted.
+ *
+ * No folders are seeded into IndexedDB, so the tree shows only its pinned rows.
+ */
+import type { ReactElement } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FolderTreePanel } from "@app/components/filesPage/FolderTreePanel";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FolderProvider } from "@app/contexts/FolderContext";
+import { FilesPageProvider } from "@app/contexts/FilesPageContext";
+
+/**
+ * The panel reads the folder tree from FolderContext and the file counts and
+ * folder dialogs from FilesPageContext; both sit above FileContext, which
+ * brings in IndexedDBContext. None are part of the shared preview decorators.
+ */
+function withFolderContexts(Story: () => ReactElement) {
+  return (
+    <FileContextProvider>
+      <FolderProvider>
+        <FilesPageProvider>
+          <div style={{ display: "flex", height: "24rem" }}>
+            <Story />
+          </div>
+        </FilesPageProvider>
+      </FolderProvider>
+    </FileContextProvider>
+  );
+}
+
+const meta = {
+  title: "FilesPage/FolderTreePanel",
+  component: FolderTreePanel,
+  parameters: { layout: "fullscreen" },
+  decorators: [withFolderContexts],
+} satisfies Meta<typeof FolderTreePanel>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Open: the heading, the tree, and the resize handle down the right edge. */
+export const Active: Story = {
+  args: { active: true },
+};
+
+/** Collapsed for a tab that is not showing folders. */
+export const Inactive: Story = {
+  args: { active: false },
+};

--- a/frontend/editor/src/core/components/filesPage/FolderTreePanel.tsx
+++ b/frontend/editor/src/core/components/filesPage/FolderTreePanel.tsx
@@ -109,7 +109,11 @@ export function FolderTreePanel({ active }: FolderTreePanelProps) {
     <div
       className="folder-tree-panel"
       data-active={String(active)}
+      /* Collapsed, the panel keeps its DOM but must not be reachable: hiding it
+         from assistive tech alone would leave its controls in the tab order,
+         focusable but invisible. inert removes both. */
       aria-hidden={!active}
+      inert={!active}
       style={
         active
           ? ({

--- a/frontend/editor/src/core/components/hotkeys/HotkeyDisplay.stories.tsx
+++ b/frontend/editor/src/core/components/hotkeys/HotkeyDisplay.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+import { HotkeyDisplay } from "@app/components/hotkeys/HotkeyDisplay";
+import { getDisplayParts } from "@app/utils/hotkeys";
+
+/** A keyboard shortcut rendered as key caps.
+ *
+ *  HotkeyProvider pulls in the whole tool-workflow chain, but the display only
+ *  needs one function off the context — so the stories supply that slice, using
+ *  the real formatter so the caps render exactly as they do in the app. Pinned
+ *  to the non-mac glyphs to keep the stories stable across machines. */
+const withHotkeys = (Story: React.ComponentType) => (
+  <HotkeyContext.Provider
+    value={
+      {
+        getDisplayParts: (binding) => getDisplayParts(binding, false),
+      } as HotkeyContextValue
+    }
+  >
+    <Story />
+  </HotkeyContext.Provider>
+);
+
+const meta: Meta<typeof HotkeyDisplay> = {
+  title: "Hotkeys/HotkeyDisplay",
+  component: HotkeyDisplay,
+  parameters: { layout: "centered" },
+  decorators: [withHotkeys],
+};
+export default meta;
+
+type Story = StoryObj<typeof HotkeyDisplay>;
+
+/** A single key. */
+export const SingleKey: Story = { args: { binding: { code: "KeyS" } } };
+
+/** The common save shortcut. */
+export const WithModifier: Story = {
+  args: { binding: { code: "KeyS", ctrl: true } },
+};
+
+/** Several modifiers at once. */
+export const MultipleModifiers: Story = {
+  args: { binding: { code: "KeyP", ctrl: true, shift: true, alt: true } },
+};
+
+/** The macOS command modifier. */
+export const MetaModifier: Story = {
+  args: { binding: { code: "KeyK", meta: true } },
+};
+
+/** A non-letter key, which renders its own glyph rather than a letter. */
+export const ArrowKey: Story = { args: { binding: { code: "ArrowRight" } } };
+
+/** Both sizes side by side. */
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      <HotkeyDisplay binding={{ code: "KeyS", ctrl: true }} size="sm" />
+      <HotkeyDisplay binding={{ code: "KeyS", ctrl: true }} size="md" />
+    </div>
+  ),
+};
+
+/** Muted, for a shortcut shown beside a disabled action. */
+export const Muted: Story = {
+  args: { binding: { code: "KeyS", ctrl: true }, muted: true },
+};
+
+/** No binding assigned — the component renders nothing rather than an empty
+ *  cap, so an unbound action shows no stray chrome. */
+export const Unbound: Story = { args: { binding: null } };

--- a/frontend/editor/src/core/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css
+++ b/frontend/editor/src/core/components/onboarding/InitialOnboardingModal/InitialOnboardingModal.module.css
@@ -325,7 +325,7 @@
 
 .v2Badge {
   background: var(--c-primary-tint);
-  color: var(--c-accent-fg);
+  color: var(--c-accent-text);
   padding: 3px 9px;
   border-radius: 6px;
   font-size: 12px;

--- a/frontend/editor/src/core/components/onboarding/OnboardingSlideShell.stories.tsx
+++ b/frontend/editor/src/core/components/onboarding/OnboardingSlideShell.stories.tsx
@@ -77,3 +77,72 @@ export const NotDismissible: Story = {
     allowDismiss: false,
   },
 };
+
+/** The final step — the bar is fully filled and the primary action closes the
+ *  tour rather than advancing it. */
+export const LastStep: Story = {
+  args: {
+    hero: <ShellHero appIcon />,
+    slideKey: "done",
+    title: "You're all set",
+    body: "You can reopen this tour any time from the help menu.",
+    stepIndex: 4,
+    stepCount: 5,
+    buttons: [
+      { key: "back", back: true, action: "back" },
+      { key: "finish", label: "Finish", primary: true, action: "finish" },
+    ],
+    onAction: () => {},
+    onClose: () => {},
+  },
+};
+
+/** An action that is not yet available — shown rather than hidden, so the path
+ *  forward stays visible. */
+export const DisabledAction: Story = {
+  args: {
+    hero: <ShellHero>1</ShellHero>,
+    slideKey: "choose",
+    title: "Choose your install",
+    body: "Pick a platform to continue.",
+    stepIndex: 1,
+    stepCount: 4,
+    buttons: [
+      { key: "back", back: true, action: "back" },
+      {
+        key: "next",
+        label: "Download",
+        primary: true,
+        action: "next",
+        disabled: true,
+      },
+    ],
+    onAction: () => {},
+    onClose: () => {},
+  },
+};
+
+/** A body longer than the viewport must scroll inside the card rather than
+ *  pushing the actions off-screen. */
+export const LongBody: Story = {
+  args: {
+    hero: <ShellHero appIcon />,
+    slideKey: "release-notes",
+    title: "What changed in this release",
+    body: (
+      <div style={{ display: "grid", gap: "0.75rem", textAlign: "left" }}>
+        {Array.from({ length: 12 }, (_, i) => (
+          <p key={i} style={{ margin: 0 }}>
+            {i + 1}. Batch processing now runs pipelined rather than serialised,
+            so a queue finishes in roughly the time the slowest document takes.
+          </p>
+        ))}
+      </div>
+    ),
+    stepIndex: 0,
+    stepCount: 1,
+    buttons: [{ key: "ok", label: "Got it", primary: true, action: "close" }],
+    onAction: () => {},
+    onClose: () => {},
+  },
+};

--- a/frontend/editor/src/core/components/onboarding/OnboardingSlideShell.tsx
+++ b/frontend/editor/src/core/components/onboarding/OnboardingSlideShell.tsx
@@ -101,7 +101,10 @@ export default function OnboardingSlideShell({
   );
 
   return (
-    <Modal
+    // Composed rather than the plain <Modal>, because only Modal.Content lands
+    // props on the role="dialog" element — the slide draws its own title, so the
+    // dialog needs an aria-label to have an accessible name.
+    <Modal.Root
       opened={opened}
       onClose={onClose}
       closeOnClickOutside={false}
@@ -109,7 +112,6 @@ export default function OnboardingSlideShell({
       centered
       size="lg"
       radius={20}
-      withCloseButton={false}
       zIndex={Z_INDEX_OVER_FULLSCREEN_SURFACE}
       styles={{
         body: { padding: 0, maxHeight: "90vh", overflow: "hidden" },
@@ -121,106 +123,122 @@ export default function OnboardingSlideShell({
         },
       }}
     >
-      <div className={styles.card}>
-        <header className={styles.header}>
-          <div className={styles.brand}>
-            <img
-              src={stirlingMark}
-              alt=""
-              aria-hidden="true"
-              className={styles.brandLogo}
-            />
-            <span className={styles.wordmark}>Stirling</span>
-          </div>
-          <div className={styles.headerRight}>
-            {showProgress && (
-              <span className={styles.stepPill}>
-                {t("onboarding.stepOf", "Step {{current}} of {{total}}", {
-                  current: stepIndex + 1,
-                  total: stepCount,
-                })}
-              </span>
-            )}
-            {allowDismiss && (
-              <ActionIcon
-                onClick={onClose}
-                variant="tertiary"
-                accent="neutral"
-                size="md"
-                aria-label={t("common.close", "Close")}
-              >
-                <LocalIcon
-                  icon="close-rounded"
-                  width="1.1rem"
-                  height="1.1rem"
+      <Modal.Overlay />
+      <Modal.Content
+        radius={20}
+        aria-label={t("onboarding.dialogLabel", "Onboarding")}
+      >
+        <Modal.Body>
+          <div className={styles.card}>
+            <header className={styles.header}>
+              <div className={styles.brand}>
+                <img
+                  src={stirlingMark}
+                  alt=""
+                  aria-hidden="true"
+                  className={styles.brandLogo}
                 />
-              </ActionIcon>
-            )}
-          </div>
-        </header>
+                <span className={styles.wordmark}>Stirling</span>
+              </div>
+              <div className={styles.headerRight}>
+                {showProgress && (
+                  <span className={styles.stepPill}>
+                    {t("onboarding.stepOf", "Step {{current}} of {{total}}", {
+                      current: stepIndex + 1,
+                      total: stepCount,
+                    })}
+                  </span>
+                )}
+                {allowDismiss && (
+                  <ActionIcon
+                    onClick={onClose}
+                    variant="tertiary"
+                    accent="neutral"
+                    size="md"
+                    aria-label={t("common.close", "Close")}
+                  >
+                    <LocalIcon
+                      icon="close-rounded"
+                      width="1.1rem"
+                      height="1.1rem"
+                    />
+                  </ActionIcon>
+                )}
+              </div>
+            </header>
 
-        {showProgress && (
-          <div
-            className={styles.progressTrack}
-            role="progressbar"
-            aria-valuenow={stepIndex + 1}
-            aria-valuemin={1}
-            aria-valuemax={stepCount}
-          >
-            {Array.from({ length: stepCount }, (_, index) => (
-              <span
-                key={index}
-                className={`${styles.progressSeg} ${
-                  index <= stepIndex ? styles.progressSegDone : ""
-                }`}
-              />
-            ))}
-          </div>
-        )}
-
-        <div className={styles.divider} />
-
-        <div className={styles.content}>
-          <div className={styles.heroPanel}>
-            <div className={styles.heroArt} key={`hero-${slideKey}`}>
-              {hero}
-            </div>
-          </div>
-
-          <div key={`title-${slideKey}`} className={styles.titleNew}>
-            {title}
-          </div>
-
-          <div key={`body-${slideKey}`} className={styles.bodyNew}>
-            {body}
-            <style>{`.${styles.bodyNew} strong{color: var(--c-text); font-weight: 600;}`}</style>
-          </div>
-
-          <div className={styles.footer}>
-            {backButtons.length === 0 ? (
-              <div className={styles.footerEnd}>{actions}</div>
-            ) : (
-              <div className={styles.footerBetween}>
-                <div className={styles.footerGroup}>
-                  {backButtons.map((button) => (
-                    <ActionIcon
-                      key={button.key}
-                      onClick={() => onAction(button.action)}
-                      variant="tertiary"
-                      accent="neutral"
-                      disabled={button.disabled}
-                      aria-label={t("onboarding.buttons.back", "Back")}
-                    >
-                      <ChevronLeftIcon fontSize="small" />
-                    </ActionIcon>
-                  ))}
-                </div>
-                {actions}
+            {showProgress && (
+              <div
+                className={styles.progressTrack}
+                role="progressbar"
+                aria-valuenow={stepIndex + 1}
+                aria-valuemin={1}
+                aria-valuemax={stepCount}
+                aria-label={t(
+                  "onboarding.stepOf",
+                  "Step {{current}} of {{total}}",
+                  {
+                    current: stepIndex + 1,
+                    total: stepCount,
+                  },
+                )}
+              >
+                {Array.from({ length: stepCount }, (_, index) => (
+                  <span
+                    key={index}
+                    className={`${styles.progressSeg} ${
+                      index <= stepIndex ? styles.progressSegDone : ""
+                    }`}
+                  />
+                ))}
               </div>
             )}
+
+            <div className={styles.divider} />
+
+            <div className={styles.content}>
+              <div className={styles.heroPanel}>
+                <div className={styles.heroArt} key={`hero-${slideKey}`}>
+                  {hero}
+                </div>
+              </div>
+
+              <div key={`title-${slideKey}`} className={styles.titleNew}>
+                {title}
+              </div>
+
+              <div key={`body-${slideKey}`} className={styles.bodyNew}>
+                {body}
+                <style>{`.${styles.bodyNew} strong{color: var(--c-text); font-weight: 600;}`}</style>
+              </div>
+
+              <div className={styles.footer}>
+                {backButtons.length === 0 ? (
+                  <div className={styles.footerEnd}>{actions}</div>
+                ) : (
+                  <div className={styles.footerBetween}>
+                    <div className={styles.footerGroup}>
+                      {backButtons.map((button) => (
+                        <ActionIcon
+                          key={button.key}
+                          onClick={() => onAction(button.action)}
+                          variant="tertiary"
+                          accent="neutral"
+                          disabled={button.disabled}
+                          aria-label={t("onboarding.buttons.back", "Back")}
+                        >
+                          <ChevronLeftIcon fontSize="small" />
+                        </ActionIcon>
+                      ))}
+                    </div>
+                    {actions}
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-    </Modal>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
   );
 }

--- a/frontend/editor/src/core/components/onboarding/slides/FirstLoginSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/FirstLoginSlide.tsx
@@ -125,7 +125,7 @@ function FirstLoginForm({
                 icon="info-rounded"
                 width={20}
                 height={20}
-                style={{ color: "var(--c-primary)", flexShrink: 0 }}
+                style={{ color: "var(--c-accent-text)", flexShrink: 0 }}
               />
               <span>
                 {t(

--- a/frontend/editor/src/core/components/onboarding/slides/SecurityCheckSlide.tsx
+++ b/frontend/editor/src/core/components/onboarding/slides/SecurityCheckSlide.tsx
@@ -26,7 +26,7 @@ export default function SecurityCheckSlide({
               icon="error"
               width={20}
               height={20}
-              style={{ color: "var(--c-danger)", flexShrink: 0 }}
+              style={{ color: "var(--color-red-dark)", flexShrink: 0 }}
             />
             <span>
               {i18n.t(

--- a/frontend/editor/src/core/components/pageEditor/BulkSelectionPanel.stories.tsx
+++ b/frontend/editor/src/core/components/pageEditor/BulkSelectionPanel.stories.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BulkSelectionPanel from "@app/components/pageEditor/BulkSelectionPanel";
+
+/** A document of `n` pages in the shape the panel reads. */
+const doc = (n: number) => ({
+  pages: Array.from({ length: n }, (_, i) => ({
+    id: `page-${i + 1}`,
+    pageNumber: i + 1,
+  })),
+});
+
+/**
+ * Selecting pages by typing a range rather than clicking thumbnails. The CSV
+ * field is the whole point of the panel, so the stories drive it with real
+ * state — typing into a static snapshot would prove nothing.
+ */
+const meta: Meta<typeof BulkSelectionPanel> = {
+  title: "PageEditor/BulkSelectionPanel",
+  component: BulkSelectionPanel,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof BulkSelectionPanel>;
+
+function Demo({
+  initialCsv = "",
+  selected = [],
+  pages = 24,
+}: {
+  initialCsv?: string;
+  selected?: string[];
+  pages?: number;
+}) {
+  const [csvInput, setCsvInput] = useState(initialCsv);
+  return (
+    <BulkSelectionPanel
+      csvInput={csvInput}
+      setCsvInput={setCsvInput}
+      selectedPageIds={selected}
+      displayDocument={doc(pages)}
+      onUpdatePagesFromCSV={() => {}}
+    />
+  );
+}
+
+/** Nothing selected yet. */
+export const Empty: Story = { render: () => <Demo /> };
+
+/** A typed range, with the matching pages selected. */
+export const WithRange: Story = {
+  render: () => (
+    <Demo
+      initialCsv="1-5"
+      selected={["page-1", "page-2", "page-3", "page-4", "page-5"]}
+    />
+  ),
+};
+
+/** A mixed expression — individual pages and ranges together. */
+export const MixedExpression: Story = {
+  render: () => (
+    <Demo initialCsv="1,4-6,12" selected={["page-1", "page-4", "page-12"]} />
+  ),
+};
+
+/** Every page selected. */
+export const AllSelected: Story = {
+  render: () => (
+    <Demo
+      pages={8}
+      initialCsv="1-8"
+      selected={Array.from({ length: 8 }, (_, i) => `page-${i + 1}`)}
+    />
+  ),
+};
+
+/** A single-page document, where ranges have little to do. */
+export const SinglePage: Story = {
+  render: () => <Demo pages={1} />,
+};
+
+/** A long document, to check the summary stays readable as counts grow. */
+export const LongDocument: Story = {
+  render: () => (
+    <Demo
+      pages={480}
+      initialCsv="1-200"
+      selected={Array.from({ length: 200 }, (_, i) => `page-${i + 1}`)}
+    />
+  ),
+};

--- a/frontend/editor/src/core/components/pageEditor/PageSelectByNumberButton.stories.tsx
+++ b/frontend/editor/src/core/components/pageEditor/PageSelectByNumberButton.stories.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import PageSelectByNumberButton from "@app/components/pageEditor/PageSelectByNumberButton";
+
+const doc = (n: number) => ({
+  pages: Array.from({ length: n }, (_, i) => ({
+    id: `page-${i + 1}`,
+    pageNumber: i + 1,
+  })),
+});
+
+/**
+ * The toolbar affordance that opens bulk page selection. It disables itself
+ * when there are no pages to select, so an empty document offers no dead
+ * control.
+ */
+const meta: Meta<typeof PageSelectByNumberButton> = {
+  title: "PageEditor/PageSelectByNumberButton",
+  component: PageSelectByNumberButton,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof PageSelectByNumberButton>;
+
+function Demo({
+  totalPages = 24,
+  disabled = false,
+  initialCsv = "",
+  selected = [],
+}: {
+  totalPages?: number;
+  disabled?: boolean;
+  initialCsv?: string;
+  selected?: string[];
+}) {
+  const [csvInput, setCsvInput] = useState(initialCsv);
+  return (
+    <PageSelectByNumberButton
+      disabled={disabled}
+      totalPages={totalPages}
+      label="Select pages by number"
+      csvInput={csvInput}
+      setCsvInput={setCsvInput}
+      selectedPageIds={selected}
+      displayDocument={doc(totalPages)}
+      updatePagesFromCSV={() => {}}
+    />
+  );
+}
+
+/** Available — click to open the selection popover. */
+export const Default: Story = { render: () => <Demo /> };
+
+/** A selection already in place. */
+export const WithSelection: Story = {
+  render: () => (
+    <Demo initialCsv="2,5-9" selected={["page-2", "page-5", "page-9"]} />
+  ),
+};
+
+/** Explicitly disabled, e.g. while the document is still loading. */
+export const Disabled: Story = { render: () => <Demo disabled /> };
+
+/** No pages: the control disables itself regardless of the `disabled` prop. */
+export const NoPages: Story = { render: () => <Demo totalPages={0} /> };
+
+/** A single page — selectable, but ranges have little to do. */
+export const SinglePage: Story = { render: () => <Demo totalPages={1} /> };

--- a/frontend/editor/src/core/components/pageEditor/PageSelectByNumberButton.tsx
+++ b/frontend/editor/src/core/components/pageEditor/PageSelectByNumberButton.tsx
@@ -35,16 +35,17 @@ export default function PageSelectByNumberButton({
     >
       <div>
         <Popover position="left" withArrow shadow="md" offset={8}>
+          {/* The button is the target, not a wrapper: Popover.Target puts
+              aria-haspopup and aria-expanded on whatever it wraps, and
+              aria-expanded is not a permitted attribute on a plain div. */}
           <Popover.Target>
-            <div style={{ display: "inline-flex" }}>
-              <ActionIcon
-                variant="tertiary"
-                disabled={disabled || totalPages === 0}
-                aria-label={label}
-              >
-                <LocalIcon icon="pin-end" width="1.5rem" height="1.5rem" />
-              </ActionIcon>
-            </div>
+            <ActionIcon
+              variant="tertiary"
+              disabled={disabled || totalPages === 0}
+              aria-label={label}
+            >
+              <LocalIcon icon="pin-end" width="1.5rem" height="1.5rem" />
+            </ActionIcon>
           </Popover.Target>
           <Popover.Dropdown>
             <div style={{ minWidth: "24rem", maxWidth: "32rem" }}>

--- a/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.stories.tsx
+++ b/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.stories.tsx
@@ -1,0 +1,48 @@
+/**
+ * The page-selection expression field at the top of the bulk selection panel —
+ * a title with a syntax-guide tooltip, an optional "Advanced" switch, and the
+ * comma/range input itself.
+ *
+ * Two things decide what renders. The clear button in the input's right section
+ * appears only while the expression is non-empty, and the Advanced switch is
+ * present only when the caller passes an `advancedOpened` boolean at all —
+ * panels that have no advanced mode omit the prop and get no switch.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import PageSelectionInput from "@app/components/pageEditor/bulkSelectionPanel/PageSelectionInput";
+
+const meta = {
+  title: "PageEditor/BulkSelectionPanel/PageSelectionInput",
+  component: PageSelectionInput,
+  args: {
+    csvInput: "",
+    setCsvInput: () => {},
+    onUpdatePagesFromCSV: () => {},
+    onClear: () => {},
+  },
+} satisfies Meta<typeof PageSelectionInput>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Empty: placeholder syntax only, and no clear affordance to offer yet. */
+export const Default: Story = {};
+
+/** A non-empty expression reveals the clear button beside the input. */
+export const WithExpression: Story = {
+  args: { csvInput: "1,3,5-10" },
+};
+
+/** Passing `advancedOpened` adds the Advanced switch to the header row. */
+export const WithAdvancedToggle: Story = {
+  args: { advancedOpened: false, onToggleAdvanced: () => {} },
+};
+
+/** The switch on, as it sits while the advanced panel below is expanded. */
+export const AdvancedOpened: Story = {
+  args: {
+    csvInput: "odd & 1-50",
+    advancedOpened: true,
+    onToggleAdvanced: () => {},
+  },
+};

--- a/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.tsx
+++ b/frontend/editor/src/core/components/pageEditor/bulkSelectionPanel/PageSelectionInput.tsx
@@ -60,7 +60,7 @@ const PageSelectionInput = ({
               size="sm"
               checked={!!advancedOpened}
               onChange={(e) => onToggleAdvanced?.(e.currentTarget.checked)}
-              title={t("bulkSelection.advanced.title", "Advanced")}
+              aria-label={t("bulkSelection.advanced.title", "Advanced")}
               className={classes.advancedSwitch}
             />
           </Flex>

--- a/frontend/editor/src/core/components/shared/AppConfigModalLazy.stories.tsx
+++ b/frontend/editor/src/core/components/shared/AppConfigModalLazy.stories.tsx
@@ -1,0 +1,29 @@
+/**
+ * Lazy wrapper around the settings modal: it renders nothing until opened, so
+ * the heavy config bundle is only fetched when someone asks for settings.
+ *
+ * Sections come from the build's registry, and hosts can add their own or hide
+ * ones they cannot run.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AppConfigModalLazy from "@app/components/shared/AppConfigModalLazy";
+
+const meta: Meta<typeof AppConfigModalLazy> = {
+  title: "Shared/AppConfigModalLazy",
+  component: AppConfigModalLazy,
+  parameters: { layout: "fullscreen" },
+  args: { opened: false, onClose: () => {}, urlSync: false },
+};
+export default meta;
+
+type Story = StoryObj<typeof AppConfigModalLazy>;
+
+/** Closed, which is the state it spends nearly all its life in. */
+export const Closed: Story = {};
+
+export const Opened: Story = { args: { opened: true } };
+
+/** A host that cannot run a registry section drops it by key. */
+export const WithHiddenSection: Story = {
+  args: { opened: true, hiddenSectionKeys: ["about"] as never },
+};

--- a/frontend/editor/src/core/components/shared/AppSwitcher.stories.tsx
+++ b/frontend/editor/src/core/components/shared/AppSwitcher.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AppSwitcher } from "@app/components/shared/AppSwitcher";
+
+/**
+ * The sidebar brand header. Core has no admin portal to switch to, so this is
+ * just the logo — builds that bundle the portal shadow this file with a version
+ * whose logo doubles as the editor⇄processor switcher. Both states matter here
+ * because the rail collapses.
+ */
+const meta: Meta<typeof AppSwitcher> = {
+  title: "Shared/AppSwitcher",
+  component: AppSwitcher,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AppSwitcher>;
+
+/** Expanded rail — mark and wordmark. */
+export const Expanded: Story = {};
+
+/** Collapsed rail — icon only. */
+export const Collapsed: Story = { args: { collapsed: true } };
+
+/** Both, to compare the mark's optical size between the two rail widths. */
+export const BothStates: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "3rem", alignItems: "center" }}>
+      <AppSwitcher />
+      <AppSwitcher collapsed />
+    </div>
+  ),
+};

--- a/frontend/editor/src/core/components/shared/Badge.stories.tsx
+++ b/frontend/editor/src/core/components/shared/Badge.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Badge from "@app/components/shared/Badge";
+
+/** Small inline label. `colored` takes an explicit palette so callers can tint
+ *  a badge to whatever the surrounding feature already uses. */
+const meta: Meta<typeof Badge> = {
+  title: "Shared/Badge",
+  component: Badge,
+  parameters: { layout: "centered" },
+  args: { children: "Beta" },
+};
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+/** Default tone. */
+export const Default: Story = {};
+
+/** The three sizes together, so their baselines can be compared. */
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+      <Badge size="sm">Small</Badge>
+      <Badge size="md">Medium</Badge>
+      <Badge size="lg">Large</Badge>
+    </div>
+  ),
+};
+
+/** Explicitly tinted. The pairing is the caller's to get right — these use the
+ *  semantic tokens rather than raw hues so they hold up in both themes. */
+export const Colored: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+      <Badge
+        variant="colored"
+        backgroundColor="var(--c-success-solid)"
+        textColor="var(--c-text-on-primary)"
+      >
+        Active
+      </Badge>
+      <Badge
+        variant="colored"
+        backgroundColor="var(--c-warning-solid)"
+        textColor="var(--c-text-on-primary)"
+      >
+        Pending
+      </Badge>
+      <Badge
+        variant="colored"
+        backgroundColor="var(--c-danger-solid)"
+        textColor="var(--c-text-on-primary)"
+      >
+        Failed
+      </Badge>
+    </div>
+  ),
+};
+
+/** A long label, to check it stays on one line rather than breaking the row. */
+export const LongLabel: Story = {
+  args: { children: "Requires the AI engine" },
+};
+
+/** A numeral, the other common use. */
+export const Count: Story = { args: { children: "12", size: "sm" } };

--- a/frontend/editor/src/core/components/shared/BrandMarks.stories.tsx
+++ b/frontend/editor/src/core/components/shared/BrandMarks.stories.tsx
@@ -1,0 +1,128 @@
+/**
+ * The brand marks and the chrome controls that sit beside them. Grouped in one
+ * file because each is a handful of props and they are always seen together in
+ * the app's top-left corner.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button, Dropdown } from "@app/ui";
+import { AppSwitchMenuItems } from "@app/components/shared/AppSwitch";
+import { LogoIcon } from "@app/components/shared/LogoIcon";
+import { SidebarToggleIcon } from "@app/components/shared/SidebarToggleIcon";
+import { Wordmark } from "@app/components/shared/Wordmark";
+
+const meta: Meta = {
+  title: "Shared/Brand marks",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+const Row = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      gap: "1.25rem",
+      padding: "0.75rem 0",
+    }}
+  >
+    <span
+      style={{
+        width: 190,
+        fontSize: "0.78rem",
+        color: "var(--c-text-muted)",
+        fontFamily: "var(--font-mono, monospace)",
+      }}
+    >
+      {label}
+    </span>
+    {children}
+  </div>
+);
+
+/** The wordmark, at rest and muted. Both swap asset with the theme, so switch
+ *  the toolbar theme to check the dark pairing. */
+export const WordmarkVariants: StoryObj = {
+  render: () => (
+    <div>
+      <Row label="default">
+        <Wordmark alt="Stirling PDF" style={{ height: 28 }} />
+      </Row>
+      <Row label="muted">
+        <Wordmark muted alt="Stirling PDF" style={{ height: 28 }} />
+      </Row>
+      <Row label="small">
+        <Wordmark alt="Stirling PDF" style={{ height: 18 }} />
+      </Row>
+    </div>
+  ),
+};
+
+/** The icon-only mark, at the sizes the chrome uses it. */
+export const LogoIconSizes: StoryObj = {
+  render: () => (
+    <div>
+      <Row label="16">
+        <LogoIcon alt="Stirling" style={{ height: 16 }} />
+      </Row>
+      <Row label="24">
+        <LogoIcon alt="Stirling" style={{ height: 24 }} />
+      </Row>
+      <Row label="40">
+        <LogoIcon alt="Stirling" style={{ height: 40 }} />
+      </Row>
+    </div>
+  ),
+};
+
+/** The sidebar toggle. `mirrored` points it at the opposite edge, so the same
+ *  glyph serves a left and a right rail. */
+export const SidebarToggle: StoryObj = {
+  render: () => (
+    <div>
+      <Row label="default">
+        <SidebarToggleIcon />
+      </Row>
+      <Row label="mirrored">
+        <SidebarToggleIcon mirrored />
+      </Row>
+      <Row label="size 28">
+        <SidebarToggleIcon size={28} />
+      </Row>
+      <Row label="mirrored, size 28">
+        <SidebarToggleIcon mirrored size={28} />
+      </Row>
+    </div>
+  ),
+};
+
+/** Switching between the editor and the processor. `AppSwitchMenuItems` is a
+ *  fragment of dropdown items rather than a standalone menu, so it is shown in
+ *  the Dropdown its callers mount it in. The app you are already in shows as
+ *  current and is not offered as a destination. */
+function AppSwitchDemo({ current }: { current: "editor" | "processor" }) {
+  return (
+    <Dropdown.Root defaultOpen>
+      <Dropdown.Trigger>
+        <Button variant="tertiary">Switch app</Button>
+      </Dropdown.Trigger>
+      <Dropdown.Menu>
+        <AppSwitchMenuItems current={current} onSwitch={() => {}} />
+      </Dropdown.Menu>
+    </Dropdown.Root>
+  );
+}
+
+export const AppSwitchFromEditor: StoryObj = {
+  render: () => <AppSwitchDemo current="editor" />,
+};
+
+/** The same menu seen from the processor. */
+export const AppSwitchFromProcessor: StoryObj = {
+  render: () => <AppSwitchDemo current="processor" />,
+};

--- a/frontend/editor/src/core/components/shared/CardSelector.stories.tsx
+++ b/frontend/editor/src/core/components/shared/CardSelector.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import CardSelector from "@app/components/shared/CardSelector";
+import {
+  METHOD_OPTIONS,
+  type MethodOption,
+  type SplitMethod,
+} from "@app/constants/splitConstants";
+
+/**
+ * A stack of choice cards, each labelled from an i18n prefix + name pair.
+ * Driven here by the Split tool's real method options rather than invented
+ * keys, so the labels are the ones users actually see and the story does not
+ * introduce translation keys that have to be maintained.
+ */
+const meta: Meta<typeof CardSelector<SplitMethod, MethodOption>> = {
+  title: "Shared/CardSelector",
+  component: CardSelector,
+  parameters: { layout: "padded" },
+  args: { onSelect: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof CardSelector<SplitMethod, MethodOption>>;
+
+/** Every split method. */
+export const Default: Story = { args: { options: METHOD_OPTIONS } };
+
+/** A short list — two choices. */
+export const FewOptions: Story = {
+  args: { options: METHOD_OPTIONS.slice(0, 2) },
+};
+
+/** A single choice, where the selector is really just a confirmation. */
+export const SingleOption: Story = {
+  args: { options: METHOD_OPTIONS.slice(0, 1) },
+};
+
+/** Inert while the tool is busy or its endpoint is still resolving. */
+export const Disabled: Story = {
+  args: { options: METHOD_OPTIONS, disabled: true },
+};
+
+/** Nothing available — e.g. every method needs an endpoint that is switched
+ *  off. */
+export const Empty: Story = { args: { options: [] } };

--- a/frontend/editor/src/core/components/shared/CardSelector.tsx
+++ b/frontend/editor/src/core/components/shared/CardSelector.tsx
@@ -57,6 +57,20 @@ const CardSelector = <T, K extends CardOption<T>>({
               radius="md"
               w="100%"
               h={"2.8rem"}
+              // A choice card is a control: without these it is a div with an
+              // onClick, so the option cannot be reached or chosen by keyboard.
+              // aria-disabled rather than removal keeps the option visible and
+              // explains why it is inert.
+              role="button"
+              tabIndex={disabled ? -1 : 0}
+              aria-disabled={disabled || undefined}
+              onKeyDown={(e) => {
+                if (disabled) return;
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleOptionClick(option.value);
+                }
+              }}
               style={{
                 cursor: disabled ? "default" : "pointer",
                 backgroundColor: "var(--mantine-color-gray-2)",

--- a/frontend/editor/src/core/components/shared/DropdownListWithFooter.tsx
+++ b/frontend/editor/src/core/components/shared/DropdownListWithFooter.tsx
@@ -56,7 +56,7 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
   value,
   onChange,
   items,
-  placeholder,
+  placeholder = "Select option",
   disabled = false,
   label,
   header,
@@ -73,7 +73,6 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
   zIndex = Z_INDEX_AUTOMATE_DROPDOWN,
 }) => {
   const { t } = useTranslation();
-  const resolvedPlaceholder = placeholder ?? t("dropdownList.selectOption");
   const [searchTerm, setSearchTerm] = useState("");
 
   const isMultiValue = Array.isArray(value);
@@ -102,7 +101,7 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
 
   const getDisplayText = () => {
     if (selectedValues.length === 0) {
-      return resolvedPlaceholder;
+      return placeholder;
     } else if (selectedValues.length === 1) {
       const selectedItem = items.find(
         (item) => item.value === selectedValues[0],
@@ -135,7 +134,11 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
         zIndex={zIndex}
       >
         <Popover.Target>
+          {/* A real button: Popover.Target stamps aria-haspopup/aria-expanded on
+              its child, and those are only permitted on an actual control. */}
           <Box
+            component="button"
+            type="button"
             style={{
               border:
                 "light-dark(1px solid var(--mantine-color-gray-3), 1px solid var(--mantine-color-dark-4))",
@@ -143,6 +146,9 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
               padding: "8px 12px",
               backgroundColor:
                 "light-dark(var(--mantine-color-white), var(--mantine-color-dark-6))",
+              color: "inherit",
+              textAlign: "left",
+              width: "100%",
               opacity: disabled ? 0.6 : 1,
               cursor: disabled ? "not-allowed" : "pointer",
               minHeight: "36px",
@@ -202,8 +208,8 @@ const DropdownListWithFooter: React.FC<DropdownListWithFooterProps> = ({
                 <Box style={{ padding: "12px", textAlign: "center" }}>
                   <Text size="sm" c="dimmed">
                     {searchable && searchTerm
-                      ? t("dropdownList.noResults")
-                      : t("dropdownList.noItems")}
+                      ? "No results found"
+                      : "No items available"}
                   </Text>
                 </Box>
               ) : (

--- a/frontend/editor/src/core/components/shared/EditableSecretField.tsx
+++ b/frontend/editor/src/core/components/shared/EditableSecretField.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useId, useState, useRef, useEffect } from "react";
 import { PasswordInput, Group, Tooltip, TextInput } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { ActionIcon } from "@app/ui/ActionIcon";
@@ -27,12 +27,12 @@ export default function EditableSecretField({
   description,
   value,
   onChange,
-  placeholder,
+  placeholder = "Enter value",
   disabled = false,
   error,
 }: EditableSecretFieldProps) {
   const { t } = useTranslation();
-  const resolvedPlaceholder = placeholder ?? t("common.enterValue");
+  const fieldId = useId();
   const [isEditing, setIsEditing] = useState(false);
   const [tempValue, setTempValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -67,6 +67,7 @@ export default function EditableSecretField({
     <div>
       {label && (
         <label
+          htmlFor={fieldId}
           style={{
             display: "block",
             marginBottom: 4,
@@ -92,7 +93,13 @@ export default function EditableSecretField({
       {isMasked && !isEditing ? (
         // Masked value from backend: show display + Edit button
         <Group gap="xs" align="flex-end">
-          <TextInput value="••••••••" disabled style={{ flex: 1 }} readOnly />
+          <TextInput
+            id={fieldId}
+            value="••••••••"
+            disabled
+            style={{ flex: 1 }}
+            readOnly
+          />
           <Tooltip label={t("editSecret")} withArrow>
             <ActionIcon
               variant="secondary"
@@ -111,10 +118,11 @@ export default function EditableSecretField({
       ) : isEditing ? (
         // Edit mode: normal password input
         <PasswordInput
+          id={fieldId}
           ref={inputRef}
           value={tempValue}
           onChange={(e) => setTempValue(e.currentTarget.value)}
-          placeholder={resolvedPlaceholder}
+          placeholder={placeholder}
           disabled={disabled}
           error={error}
           autoComplete="new-password"
@@ -126,9 +134,10 @@ export default function EditableSecretField({
       ) : (
         // Normal password input: empty or user typing
         <PasswordInput
+          id={fieldId}
           value={value}
           onChange={(e) => onChange(e.currentTarget.value)}
-          placeholder={resolvedPlaceholder}
+          placeholder={placeholder}
           disabled={disabled}
           error={error}
           autoComplete="new-password"

--- a/frontend/editor/src/core/components/shared/EncryptedPdfUnlockModal.tsx
+++ b/frontend/editor/src/core/components/shared/EncryptedPdfUnlockModal.tsx
@@ -73,7 +73,7 @@ const EncryptedPdfUnlockModal = ({
             autoFocus
           />
           {errorMessage ? (
-            <Text c="red" size="sm">
+            <Text c="var(--color-red-dark)" size="sm">
               {errorMessage}
             </Text>
           ) : null}

--- a/frontend/editor/src/core/components/shared/ErrorBoundary.tsx
+++ b/frontend/editor/src/core/components/shared/ErrorBoundary.tsx
@@ -88,7 +88,7 @@ export default class ErrorBoundary extends React.Component<
             margin: "0 auto",
           }}
         >
-          <Text size="lg" fw={500} c="red">
+          <Text size="lg" fw={500} c="var(--color-red-dark)">
             Something went wrong
           </Text>
           {process.env.NODE_ENV === "development" && this.state.error && (

--- a/frontend/editor/src/core/components/shared/FileDropdownMenu.tsx
+++ b/frontend/editor/src/core/components/shared/FileDropdownMenu.tsx
@@ -34,7 +34,12 @@ export const FileDropdownMenu: React.FC<FileDropdownMenuProps> = ({
   return (
     <Menu trigger="click" position="bottom" width="30rem">
       <Menu.Target>
+        {/* Menu.Target stamps aria-haspopup/aria-expanded on its child; those are
+            only permitted once the element declares a control role. It stays a
+            div because it renders inside the workbench SegmentedControl's
+            <label>, which may not contain interactive content. */}
         <div
+          role="button"
           style={{ ...viewOptionStyle, cursor: "pointer", maxWidth: "100%" }}
         >
           {switchingTo === "viewer" ? (

--- a/frontend/editor/src/core/components/shared/FileGrid.tsx
+++ b/frontend/editor/src/core/components/shared/FileGrid.tsx
@@ -91,6 +91,7 @@ const FileGrid = ({
 
             {showSort && (
               <Select
+                aria-label={t("fileManager.sortBy", "Sort files")}
                 data={[
                   {
                     value: "date",

--- a/frontend/editor/src/core/components/shared/FilePickerModal.tsx
+++ b/frontend/editor/src/core/components/shared/FilePickerModal.tsx
@@ -189,6 +189,13 @@ const FilePickerModal = ({
                           checked={isSelected}
                           onChange={() => toggleFileSelection(fileId)}
                           onClick={(e) => e.stopPropagation()}
+                          aria-label={t(
+                            "fileUpload.selectFile",
+                            "Select {{name}}",
+                            {
+                              name: file.name,
+                            },
+                          )}
                         />
 
                         {/* Thumbnail */}
@@ -239,7 +246,7 @@ const FilePickerModal = ({
 
             {/* Selection summary */}
             {selectedFileIds.length > 0 && (
-              <Text size="sm" c="blue" ta="center">
+              <Text size="sm" c="var(--c-accent-text)" ta="center">
                 {selectedFileIds.length}{" "}
                 {t("fileManager.filesSelected", "files selected")}
               </Text>

--- a/frontend/editor/src/core/components/shared/FileSelectorPicker.module.css
+++ b/frontend/editor/src/core/components/shared/FileSelectorPicker.module.css
@@ -134,7 +134,7 @@
 }
 
 .slimTabUpload:hover:not(:disabled) {
-  color: var(--mantine-color-blue-filled);
+  color: var(--c-accent-text);
   background: color-mix(in srgb, var(--mantine-color-blue-1) 35%, transparent);
 }
 

--- a/frontend/editor/src/core/components/shared/FileSelectorPicker.tsx
+++ b/frontend/editor/src/core/components/shared/FileSelectorPicker.tsx
@@ -404,6 +404,7 @@ export function FileSelectorPicker({
             }}
             aria-expanded={isOpen}
             aria-haspopup="listbox"
+            aria-disabled={disabled || undefined}
           >
             <Text
               size="sm"

--- a/frontend/editor/src/core/components/shared/FileSidebar.css
+++ b/frontend/editor/src/core/components/shared/FileSidebar.css
@@ -129,14 +129,14 @@
 }
 
 .file-sidebar-drop-overlay-icon {
-  color: var(--mantine-color-blue-6, var(--c-primary)) !important;
+  color: var(--c-accent-text) !important;
   font-size: 28px !important;
 }
 
 .file-sidebar-drop-overlay-text {
   font-size: 13px;
   font-weight: 600;
-  color: var(--mantine-color-blue-6, var(--c-primary));
+  color: var(--c-accent-text);
 }
 
 /* ---- Search row ---- */
@@ -605,7 +605,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background-color: var(--mantine-color-blue-6, var(--c-primary));
+  background-color: var(--c-accent-text);
   color: var(--c-text-on-primary);
   font-size: 12px;
   font-weight: 600;

--- a/frontend/editor/src/core/components/shared/FileSidebarFileItem.css
+++ b/frontend/editor/src/core/components/shared/FileSidebarFileItem.css
@@ -183,7 +183,7 @@
 }
 
 .file-sidebar-file-item.selected .file-sidebar-file-name {
-  color: var(--c-accent-fg);
+  color: var(--c-accent-text);
 }
 
 .file-sidebar-file-meta-row {
@@ -208,7 +208,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  color: var(--c-primary);
+  color: var(--c-accent-text);
 }
 
 /* ---- Folder membership tags ---- */
@@ -302,7 +302,7 @@
 }
 
 .file-sidebar-file-item.viewed .file-sidebar-file-name {
-  color: var(--c-success);
+  color: var(--color-green-dark);
 }
 
 .file-sidebar-file-item.viewed .file-sidebar-file-check {
@@ -321,7 +321,7 @@
 /* Always show eye for the currently viewed file */
 .file-sidebar-file-item.viewed .file-sidebar-eye-btn {
   opacity: 1;
-  color: var(--c-success);
+  color: var(--color-green-dark);
 }
 
 .file-sidebar-eye-btn:hover {

--- a/frontend/editor/src/core/components/shared/HoverActionMenu.stories.tsx
+++ b/frontend/editor/src/core/components/shared/HoverActionMenu.stories.tsx
@@ -74,3 +74,32 @@ export const WithDisabledAction: Story = {
     ],
   },
 };
+
+/** Seated outside the card's edge rather than inside it. */
+export const OutsidePosition: Story = {
+  args: { show: true, actions, position: "outside" },
+};
+
+/** An action hidden outright — dropped rather than greyed. */
+export const WithHiddenAction: Story = {
+  args: {
+    show: true,
+    actions: [actions[0], { ...actions[1], hidden: true }, actions[2]],
+  },
+};
+
+/** Every action hidden: the menu renders nothing at all, so a card with no
+ *  available actions gets no empty affordance. */
+export const AllHidden: Story = {
+  args: { show: true, actions: actions.map((a) => ({ ...a, hidden: true })) },
+};
+
+/** A single action. */
+export const SingleAction: Story = {
+  args: { show: true, actions: [actions[2]] },
+};
+
+/** Revealed by CSS hover rather than React state — hover the card. */
+export const CssHoverVisibility: Story = {
+  args: { show: false, actions, visibility: "cssHover" },
+};

--- a/frontend/editor/src/core/components/shared/InfoBanner.tsx
+++ b/frontend/editor/src/core/components/shared/InfoBanner.tsx
@@ -27,7 +27,7 @@ const toneStyles: Record<
   warning: {
     background: "var(--mantine-color-orange-0)",
     border: "var(--mantine-color-orange-3)",
-    text: "var(--mantine-color-orange-9)",
+    text: "var(--color-amber-dark)",
     icon: "var(--mantine-color-orange-7)",
     buttonColor: "orange",
   },

--- a/frontend/editor/src/core/components/shared/LandingActions.stories.tsx
+++ b/frontend/editor/src/core/components/shared/LandingActions.stories.tsx
@@ -1,0 +1,83 @@
+/**
+ * The row of upload actions on the landing screen. Which buttons appear is
+ * decided between props, the app config, and the viewport — the mobile-upload
+ * affordance and the browse-files entry are both conditional — so the stories
+ * vary those rather than exposing them as controls.
+ *
+ * The wording and icons come from the file-action hooks, which desktop builds
+ * override; these render the web variants.
+ */
+import { useRef } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LandingActions } from "@app/components/shared/LandingActions";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+
+/** Enough of the config for the actions to decide what to offer. */
+const CONFIG = { storageEnabled: false, enableMobileUpload: true };
+
+function Harness(config: Partial<typeof CONFIG>) {
+  return function Wrapped() {
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+    return (
+      <AppConfigProvider
+        initialConfig={{ ...CONFIG, ...config } as never}
+        bootstrapMode="non-blocking"
+        autoFetch={false}
+      >
+        {/* Only openFilesModal is read. The real provider reaches FileContext
+            and NavigationContext, so a slice is supplied instead. */}
+        <FilesModalContext.Provider
+          value={
+            { openFilesModal: () => {} } as unknown as FilesModalContextType
+          }
+        >
+          <LandingActions
+            fileInputRef={fileInputRef}
+            onUploadClick={() => {}}
+            onMobileUploadClick={() => {}}
+            onFileSelect={() => {}}
+          />
+        </FilesModalContext.Provider>
+      </AppConfigProvider>
+    );
+  };
+}
+
+const meta: Meta<typeof LandingActions> = {
+  title: "Shared/LandingActions",
+  component: LandingActions,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof LandingActions>;
+
+export const Default: Story = { render: Harness({}) };
+
+/** With storage on, the actions also offer the stored-files browser. */
+export const StorageEnabled: Story = {
+  render: Harness({ storageEnabled: true }),
+};
+
+/** Mobile upload off removes the phone affordance entirely. */
+export const NoMobileUpload: Story = {
+  render: Harness({ enableMobileUpload: false }),
+};
+
+/**
+ * Narrow viewports take the mobile branch, which reflows the row and swaps
+ * some buttons for icon-only controls.
+ */
+export const Mobile: Story = {
+  render: Harness({}),
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};
+
+export const MobileWithStorage: Story = {
+  render: Harness({ storageEnabled: true }),
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};

--- a/frontend/editor/src/core/components/shared/MobileUploadModal.tsx
+++ b/frontend/editor/src/core/components/shared/MobileUploadModal.tsx
@@ -397,7 +397,16 @@ export default function MobileUploadModal({
               boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
             }}
           >
-            <QRCodeSVG value={mobileUrl} size={256} level="H" includeMargin />
+            <QRCodeSVG
+              value={mobileUrl}
+              size={256}
+              level="H"
+              includeMargin
+              title={t(
+                "mobileUpload.qrCodeTitle",
+                "QR code linking to the mobile upload page",
+              )}
+            />
           </Box>
 
           {filesReceived > 0 && (

--- a/frontend/editor/src/core/components/shared/ObscuredOverlay/ObscuredOverlay.module.css
+++ b/frontend/editor/src/core/components/shared/ObscuredOverlay/ObscuredOverlay.module.css
@@ -12,7 +12,7 @@
   padding: 16px;
   color: #ffffff;
   font-weight: 600;
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(0, 0, 0, 0.62);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   border: 1px solid rgba(255, 255, 255, 0.06);

--- a/frontend/editor/src/core/components/shared/PageEditorFileDropdown.stories.tsx
+++ b/frontend/editor/src/core/components/shared/PageEditorFileDropdown.stories.tsx
@@ -1,0 +1,91 @@
+/**
+ * The workbench control that reports how many files the page editor is showing
+ * and opens a menu to change the set. The menu itself lists every file with a
+ * colour swatch, a selection checkbox and a drag handle for reordering, plus an
+ * entry that opens the files modal.
+ *
+ * The trigger is what the stories can show: it renders the selected/total
+ * counts, and swaps its icon for a spinner while the workbench is switching
+ * into the page editor. The menu opens on click, so it is not a separate story.
+ */
+import type { CSSProperties } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PageEditorFileDropdown } from "@app/components/shared/PageEditorFileDropdown";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+import type { FileId } from "@app/types/file";
+
+const FILES = [
+  {
+    fileId: "file-1" as FileId,
+    name: "quarterly-report.pdf",
+    isSelected: true,
+  },
+  {
+    fileId: "file-2" as FileId,
+    name: "invoice-2026-01.pdf",
+    versionNumber: 2,
+    isSelected: true,
+  },
+  {
+    fileId: "file-3" as FileId,
+    name: "scan-of-contract.pdf",
+    isSelected: false,
+  },
+];
+
+/** Each file's swatch is looked up by id; missing ids fall back to the first colour. */
+const FILE_COLOUR_MAP = new Map<string, number>(
+  FILES.map((file, index) => [file.fileId as string, index]),
+);
+
+/** Matches the workbench segmented control the trigger renders inside. */
+const VIEW_OPTION_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const meta = {
+  title: "Shared/PageEditorFileDropdown",
+  component: PageEditorFileDropdown,
+  parameters: { layout: "centered" },
+  args: {
+    files: FILES,
+    onToggleSelection: () => {},
+    onReorder: () => {},
+    viewOptionStyle: VIEW_OPTION_STYLE,
+    fileColorMap: FILE_COLOUR_MAP,
+    selectedCount: 2,
+    totalCount: 3,
+  },
+  decorators: [
+    (Story) => (
+      // Only openFilesModal is read, by the menu's "Add File" row. The real
+      // provider reaches FileContext and NavigationContext, so a slice is used.
+      <FilesModalContext.Provider
+        value={{ openFilesModal: () => {} } as unknown as FilesModalContextType}
+      >
+        <Story />
+      </FilesModalContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof PageEditorFileDropdown>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Part of the set selected, which is the usual state. */
+export const Default: Story = {};
+
+/** Every file selected. */
+export const AllSelected: Story = {
+  args: { selectedCount: 3 },
+};
+
+/** While the workbench switches into the page editor, a spinner takes the icon's place. */
+export const Switching: Story = {
+  args: { switchingTo: "pageEditor" },
+};

--- a/frontend/editor/src/core/components/shared/PageEditorFileDropdown.tsx
+++ b/frontend/editor/src/core/components/shared/PageEditorFileDropdown.tsx
@@ -175,7 +175,12 @@ export const PageEditorFileDropdown: React.FC<PageEditorFileDropdownProps> = ({
   return (
     <Menu trigger="click" position="bottom" width="40rem">
       <Menu.Target>
+        {/* role="button" so the aria-haspopup/aria-expanded Menu.Target stamps on
+            this element are permitted. It stays a div because it renders inside
+            the workbench SegmentedControl's <label>, which may not contain
+            interactive content. */}
         <div
+          role="button"
           className="ph-no-capture"
           style={{ ...viewOptionStyle, cursor: "pointer" }}
         >

--- a/frontend/editor/src/core/components/shared/TextInput.stories.tsx
+++ b/frontend/editor/src/core/components/shared/TextInput.stories.tsx
@@ -1,0 +1,75 @@
+/**
+ * The shared single-line text field: an optional leading icon, the input, and a
+ * trailing clear button.
+ *
+ * The clear button is the only conditional piece — it appears when the value has
+ * non-whitespace content, the caller has not opted out via `showClearButton`,
+ * and the field is neither disabled nor read-only. Everything else (padding,
+ * icon gutter) follows from those same choices, so the stories vary them
+ * instead of exposing them as controls.
+ *
+ * The field is controlled, so each story wraps it in local state — otherwise
+ * typing would appear to do nothing.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SearchIcon from "@mui/icons-material/Search";
+import {
+  TextInput,
+  type TextInputProps,
+} from "@app/components/shared/TextInput";
+
+function Controlled({ value, onChange: _onChange, ...props }: TextInputProps) {
+  const [current, setCurrent] = useState(value);
+  return (
+    <div style={{ width: "22rem" }}>
+      <TextInput {...props} value={current} onChange={setCurrent} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Shared/TextInput",
+  component: TextInput,
+  parameters: { layout: "padded" },
+  args: {
+    id: "story-text-input",
+    name: "story-text-input",
+    value: "",
+    onChange: () => {},
+    placeholder: "Search files",
+    "aria-label": "Search files",
+  },
+  render: (args) => <Controlled {...args} />,
+} satisfies Meta<typeof TextInput>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Empty and unadorned: placeholder only, and no clear button to show yet. */
+export const Default: Story = {};
+
+/** With content, the trailing clear button appears and the input reserves room for it. */
+export const WithValue: Story = {
+  args: { value: "quarterly report" },
+};
+
+/** A leading icon indents the text; the clear button still owns the other end. */
+export const WithIcon: Story = {
+  args: { value: "invoice", icon: <SearchIcon fontSize="small" /> },
+};
+
+/** Callers that own their own reset opt out, leaving the value flush to the edge. */
+export const WithoutClearButton: Story = {
+  args: { value: "locked in", showClearButton: false },
+};
+
+/** Disabled suppresses the clear button and greys the field out. */
+export const Disabled: Story = {
+  args: { value: "cannot edit", disabled: true },
+};
+
+/** Read-only keeps the field's normal appearance but drops the clear button. */
+export const ReadOnly: Story = {
+  args: { value: "reference value", readOnly: true },
+};

--- a/frontend/editor/src/core/components/shared/ThemeProvider.tsx
+++ b/frontend/editor/src/core/components/shared/ThemeProvider.tsx
@@ -9,7 +9,10 @@ import {
 import { MantineProvider } from "@mantine/core";
 import { useIsomorphicEffect } from "@mantine/hooks";
 import { usePreferences } from "@app/contexts/PreferencesContext";
-import { mantineTheme } from "@app/theme/mantineTheme";
+import {
+  mantineTheme,
+  editorCssVariablesResolver,
+} from "@app/theme/mantineTheme";
 import { ToastProvider } from "@app/components/toast";
 import ToastRenderer from "@app/components/toast/ToastRenderer";
 import { ToastPortalBinder } from "@app/components/toast";
@@ -91,6 +94,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     <ThemeContext.Provider value={value}>
       <MantineProvider
         theme={mantineTheme}
+        cssVariablesResolver={editorCssVariablesResolver}
         defaultColorScheme={colorScheme}
         forceColorScheme={colorScheme}
       >

--- a/frontend/editor/src/core/components/shared/ToolPanelHeader.css
+++ b/frontend/editor/src/core/components/shared/ToolPanelHeader.css
@@ -34,7 +34,7 @@
   height: 1.75rem;
   border-radius: 9999px;
   background: var(--mantine-color-blue-light);
-  color: var(--mantine-color-blue-filled);
+  color: var(--c-accent-text);
   flex-shrink: 0;
 }
 
@@ -79,15 +79,15 @@
     var(--mantine-color-blue-filled) 18%,
     transparent
   );
-  color: var(--mantine-color-blue-3, var(--mantine-color-blue-filled));
+  color: var(--c-accent-text);
 }
 
 /* Dark mode: the subtle gray close button is too dim against the dark rail —
    brighten it to a clearly-visible light grey (near-white on hover). */
 [data-mantine-color-scheme="dark"] .sui-panelhdr__close {
-  color: var(--mantine-color-gray-4);
+  color: var(--c-text-subtle);
 }
 
 [data-mantine-color-scheme="dark"] .sui-panelhdr__close:hover {
-  color: var(--mantine-color-gray-2);
+  color: var(--c-text-subtle);
 }

--- a/frontend/editor/src/core/components/shared/UpdateModal.tsx
+++ b/frontend/editor/src/core/components/shared/UpdateModal.tsx
@@ -227,10 +227,12 @@ const UpdateModal: React.FC<UpdateModalProps> = ({
     : sortedVersions.slice(0, 10);
 
   return (
-    <Modal
+    // Composed rather than the plain <Modal>, because only Modal.Content lands
+    // props on the role="dialog" element — the modal draws its own header, so
+    // the dialog needs an aria-label to have an accessible name.
+    <Modal.Root
       opened={opened}
       onClose={canClose ? onClose : () => undefined}
-      withCloseButton={false}
       centered
       size="xl"
       padding={0}
@@ -241,680 +243,709 @@ const UpdateModal: React.FC<UpdateModalProps> = ({
         content: { overflow: "hidden" },
       }}
     >
-      {/* ── Header ─────────────────────────────────────────────────────────── */}
-      <Box style={{ padding: "24px 28px 16px", flexShrink: 0 }}>
-        <Group justify="space-between" align="flex-start" wrap="nowrap">
-          <Group gap="md" align="flex-start" wrap="nowrap">
-            <Box
-              style={{
-                width: 48,
-                height: 48,
-                borderRadius: "50%",
-                background: "var(--mantine-color-blue-filled)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                flexShrink: 0,
-              }}
-            >
-              <SystemUpdateAltIcon style={{ fontSize: 26, color: "white" }} />
-            </Box>
-            <Box>
-              <Text fw={700} size="xl" lh={1.3}>
-                {t("update.modalTitle", "Update Available")}
-              </Text>
-              <Text size="sm" c="dimmed" mt={2}>
-                {t(
-                  "update.modalSubtitle",
-                  "A new version of Stirling-PDF is ready to install.",
-                )}
-              </Text>
-            </Box>
-          </Group>
-          {canClose && (
-            <ActionIcon
-              onClick={onClose}
-              size="lg"
-              variant="tertiary"
-              aria-label={t("update.closeModal", "Close update modal")}
-            >
-              <LocalIcon icon="close-rounded" width={20} height={20} />
-            </ActionIcon>
-          )}
-        </Group>
-      </Box>
-
-      {/* ── Scrollable content ─────────────────────────────────────────────── */}
-      <Box style={{ flex: 1, overflowY: "auto", padding: "0 28px 16px" }}>
-        <Stack gap="lg">
-          {/* Version comparison */}
-          <Box
-            style={{
-              border:
-                "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
-              borderRadius: 12,
-              padding: "24px 28px",
-              background:
-                "color-mix(in srgb, var(--mantine-color-body) 100%, transparent)",
-            }}
-          >
-            <Group justify="center" align="center" wrap="nowrap" gap="xl">
-              <Stack gap={2} align="center">
-                <Text size="xs" c="dimmed" tt="uppercase" fw={600} lh={1}>
-                  {t("update.current", "Current Version")}
-                </Text>
-                <Text fw={800} fz={32} lh={1.1}>
-                  {currentVersion}
-                </Text>
-              </Stack>
-              <ArrowForwardIcon
-                style={{
-                  fontSize: 28,
-                  color: "var(--mantine-color-dimmed)",
-                  flexShrink: 0,
-                }}
-              />
-              <Stack gap={2} align="center">
-                <Text size="xs" c="dimmed" tt="uppercase" fw={600} lh={1}>
-                  {t("update.latest", "Latest Version")}
-                </Text>
-                <Group gap="sm" align="center">
-                  <Text fw={800} fz={32} c="blue" lh={1.1}>
-                    {updateSummary.latest_version}
+      <Modal.Overlay />
+      <Modal.Content
+        radius="lg"
+        aria-label={t("update.modalTitle", "Update Available")}
+      >
+        <Modal.Body>
+          {/* ── Header ─────────────────────────────────────────────────────────── */}
+          <Box style={{ padding: "24px 28px 16px", flexShrink: 0 }}>
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+              <Group gap="md" align="flex-start" wrap="nowrap">
+                <Box
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: "50%",
+                    background: "var(--mantine-color-blue-filled)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexShrink: 0,
+                  }}
+                >
+                  <SystemUpdateAltIcon
+                    style={{ fontSize: 26, color: "white" }}
+                  />
+                </Box>
+                <Box>
+                  <Text fw={700} size="xl" lh={1.3}>
+                    {t("update.modalTitle", "Update Available")}
                   </Text>
-                  {(isStable || updateSummary.latest_stable_version) && (
-                    // `variant="filled" color="green"` produced an acid-green
-                    // pill that was noisy in light mode and oddly washed out
-                    // in dark mode. `light` gives a soft teal-ish chip that
-                    // reads well in both themes.
-                    <Badge
-                      color="teal"
-                      variant="light"
-                      size="sm"
-                      radius="sm"
-                      style={{ marginTop: 4 }}
-                    >
-                      {t("update.stable", "STABLE")}
-                    </Badge>
-                  )}
-                </Group>
-              </Stack>
+                  <Text size="sm" c="dimmed" mt={2}>
+                    {t(
+                      "update.modalSubtitle",
+                      "A new version of Stirling-PDF is ready to install.",
+                    )}
+                  </Text>
+                </Box>
+              </Group>
+              {canClose && (
+                <ActionIcon
+                  onClick={onClose}
+                  size="lg"
+                  variant="tertiary"
+                  aria-label={t("update.closeModal", "Close update modal")}
+                >
+                  <LocalIcon icon="close-rounded" width={20} height={20} />
+                </ActionIcon>
+              )}
             </Group>
           </Box>
 
-          {/* Priority badge + recommendation — compact single line. When the
+          {/* ── Scrollable content ─────────────────────────────────────────────── */}
+          <Box style={{ flex: 1, overflowY: "auto", padding: "0 28px 16px" }}>
+            <Stack gap="lg">
+              {/* Version comparison */}
+              <Box
+                style={{
+                  border:
+                    "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
+                  borderRadius: 12,
+                  padding: "24px 28px",
+                  background:
+                    "color-mix(in srgb, var(--mantine-color-body) 100%, transparent)",
+                }}
+              >
+                <Group justify="center" align="center" wrap="nowrap" gap="xl">
+                  <Stack gap={2} align="center">
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={600} lh={1}>
+                      {t("update.current", "Current Version")}
+                    </Text>
+                    <Text fw={800} fz={32} lh={1.1}>
+                      {currentVersion}
+                    </Text>
+                  </Stack>
+                  <ArrowForwardIcon
+                    style={{
+                      fontSize: 28,
+                      color: "var(--mantine-color-dimmed)",
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Stack gap={2} align="center">
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={600} lh={1}>
+                      {t("update.latest", "Latest Version")}
+                    </Text>
+                    <Group gap="sm" align="center">
+                      <Text fw={800} fz={32} c="var(--c-accent-text)" lh={1.1}>
+                        {updateSummary.latest_version}
+                      </Text>
+                      {(isStable || updateSummary.latest_stable_version) && (
+                        // `variant="filled" color="green"` produced an acid-green
+                        // pill that was noisy in light mode and oddly washed out
+                        // in dark mode. `light` gives a soft teal-ish chip that
+                        // reads well in both themes.
+                        <Badge
+                          color="teal"
+                          variant="light"
+                          size="sm"
+                          radius="sm"
+                          style={{ marginTop: 4 }}
+                        >
+                          {t("update.stable", "STABLE")}
+                        </Badge>
+                      )}
+                    </Group>
+                  </Stack>
+                </Group>
+              </Box>
+
+              {/* Priority badge + recommendation — compact single line. When the
               update contains breaking changes we surface a compact inline
               chip here rather than a separate full-width orange banner; the
               specific per-version detail lives in Version History below. */}
-          <Group gap="sm" align="center" px={4}>
-            <Badge color={priorityColor} variant="filled" size="lg" radius="sm">
-              {getPriorityLabel(updateSummary.max_priority)}
-            </Badge>
-            {updateSummary.any_breaking && (
-              <Badge
-                color="orange"
-                variant="light"
-                size="lg"
-                radius="sm"
-                leftSection={<WarningAmberIcon style={{ fontSize: 14 }} />}
-              >
-                {t("update.breaking", "Breaking")}
-              </Badge>
-            )}
-            <Text size="sm" c="dimmed" style={{ flex: 1 }}>
-              {updateSummary.recommended_action ||
-                t(
-                  "update.defaultRecommendation",
-                  "This update contains important fixes and improvements.",
+              <Group gap="sm" align="center" px={4}>
+                <Badge
+                  color={priorityColor}
+                  variant="filled"
+                  size="lg"
+                  radius="sm"
+                >
+                  {getPriorityLabel(updateSummary.max_priority)}
+                </Badge>
+                {updateSummary.any_breaking && (
+                  <Badge
+                    color="orange"
+                    variant="light"
+                    size="lg"
+                    radius="sm"
+                    leftSection={<WarningAmberIcon style={{ fontSize: 14 }} />}
+                  >
+                    {t("update.breaking", "Breaking")}
+                  </Badge>
                 )}
-            </Text>
-          </Group>
+                <Text size="sm" c="dimmed" style={{ flex: 1 }}>
+                  {updateSummary.recommended_action ||
+                    t(
+                      "update.defaultRecommendation",
+                      "This update contains important fixes and improvements.",
+                    )}
+                </Text>
+              </Group>
 
-          {/* Admin permissions required — shown when can_install_updates
+              {/* Admin permissions required — shown when can_install_updates
               reported that msiexec would need UAC elevation this user
               can't satisfy. Placed right after the priority row so it's
               the first thing users see when they open the modal and the
               Install Now button (below) is disabled as a result. */}
-          {desktopInstall && installBlocked && (
-            <Alert
-              variant="light"
-              color="orange"
-              radius="md"
-              icon={<WarningAmberIcon style={{ fontSize: 18 }} />}
-              title={t(
-                "desktopUpdate.blocked.title",
-                "Administrator permissions required",
+              {desktopInstall && installBlocked && (
+                <Alert
+                  variant="light"
+                  color="orange"
+                  radius="md"
+                  icon={<WarningAmberIcon style={{ fontSize: 18 }} />}
+                  title={t(
+                    "desktopUpdate.blocked.title",
+                    "Administrator permissions required",
+                  )}
+                >
+                  <Text size="sm">
+                    {t(
+                      "desktopUpdate.blocked.message",
+                      "Stirling-PDF does not have permission to update itself on this machine.",
+                    )}{" "}
+                    <Anchor
+                      href={WINDOWS_INSTALL_DOCS_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={handleExternalLink(WINDOWS_INSTALL_DOCS_URL)}
+                    >
+                      {t(
+                        "desktopUpdate.blocked.docsLink",
+                        "View installation documentation",
+                      )}
+                    </Anchor>
+                  </Text>
+                </Alert>
               )}
-            >
-              <Text size="sm">
-                {t(
-                  "desktopUpdate.blocked.message",
-                  "Stirling-PDF does not have permission to update itself on this machine.",
-                )}{" "}
-                <Anchor
-                  href={WINDOWS_INSTALL_DOCS_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={handleExternalLink(WINDOWS_INSTALL_DOCS_URL)}
-                >
-                  {t(
-                    "desktopUpdate.blocked.docsLink",
-                    "View installation documentation",
-                  )}
-                </Anchor>
-              </Text>
-            </Alert>
-          )}
 
-          {/* What's New card */}
-          <Box
-            style={{
-              background:
-                "color-mix(in srgb, var(--mantine-color-blue-filled) 8%, transparent)",
-              borderRadius: 12,
-              padding: "16px 20px",
-              border:
-                "1px solid color-mix(in srgb, var(--mantine-color-blue-filled) 15%, transparent)",
-            }}
-          >
-            <Group justify="space-between" align="center">
-              <Group gap={8}>
-                <StarIcon
-                  style={{
-                    fontSize: 18,
-                    color: "var(--mantine-color-blue-filled)",
-                  }}
-                />
-                <Text fw={600} size="sm">
-                  {t("update.whatsNewIn", "What's new in")}{" "}
-                  {updateSummary.latest_version}
-                </Text>
-              </Group>
-              <Group gap="sm">
-                <Text
-                  size="sm"
-                  component="a"
-                  href={`https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${updateSummary.latest_version}`}
-                  target="_blank"
-                  onClick={handleExternalLink(
-                    `https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${updateSummary.latest_version}`,
-                  )}
-                  c="blue"
-                  style={{
-                    textDecoration: "none",
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 4,
-                  }}
-                >
-                  {t("update.releaseNotes", "Release Notes")}{" "}
-                  <OpenInNewIcon style={{ fontSize: 14 }} />
-                </Text>
-                <Text
-                  size="sm"
-                  component="a"
-                  href="https://github.com/Stirling-Tools/Stirling-PDF/releases"
-                  target="_blank"
-                  onClick={handleExternalLink(
-                    "https://github.com/Stirling-Tools/Stirling-PDF/releases",
-                  )}
-                  c="dimmed"
-                  style={{
-                    textDecoration: "none",
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 4,
-                  }}
-                >
-                  {t("update.allReleases", "All Releases")}{" "}
-                  <OpenInNewIcon style={{ fontSize: 14 }} />
-                </Text>
-              </Group>
-            </Group>
-          </Box>
-
-          {/* Migration guides */}
-          {updateSummary.migration_guides &&
-            updateSummary.migration_guides.length > 0 && (
-              <Box>
-                <Text fw={600} size="sm" mb={4}>
-                  {t("update.migrationGuides", "Migration Guides")}
-                </Text>
-                <Text size="xs" c="dimmed" mb="sm">
-                  {t(
-                    "update.migrationGuidesDesc",
-                    "Review important changes before updating.",
-                  )}
-                </Text>
-                <Stack gap={0}>
-                  {updateSummary.migration_guides.map((guide, idx) => (
-                    <Box
-                      key={idx}
+              {/* What's New card */}
+              <Box
+                style={{
+                  background:
+                    "color-mix(in srgb, var(--mantine-color-blue-filled) 8%, transparent)",
+                  borderRadius: 12,
+                  padding: "16px 20px",
+                  border:
+                    "1px solid color-mix(in srgb, var(--mantine-color-blue-filled) 15%, transparent)",
+                }}
+              >
+                <Group justify="space-between" align="center">
+                  <Group gap={8}>
+                    <StarIcon
                       style={{
-                        borderTop:
-                          idx === 0
-                            ? "1px solid var(--c-border-subtle, var(--mantine-color-default-border))"
-                            : undefined,
-                        borderBottom:
-                          "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
-                        padding: "10px 12px",
+                        fontSize: 18,
+                        color: "var(--c-accent-text)",
+                      }}
+                    />
+                    <Text fw={600} size="sm">
+                      {t("update.whatsNewIn", "What's new in")}{" "}
+                      {updateSummary.latest_version}
+                    </Text>
+                  </Group>
+                  <Group gap="sm">
+                    <Text
+                      size="sm"
+                      component="a"
+                      href={`https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${updateSummary.latest_version}`}
+                      target="_blank"
+                      onClick={handleExternalLink(
+                        `https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${updateSummary.latest_version}`,
+                      )}
+                      c="var(--c-accent-text)"
+                      style={{
+                        textDecoration: "none",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
                       }}
                     >
-                      <Group
-                        justify="space-between"
-                        align="center"
-                        wrap="nowrap"
-                      >
-                        <Group gap="sm" style={{ flex: 1 }}>
-                          <Box
-                            style={{
-                              width: 8,
-                              height: 8,
-                              borderRadius: "50%",
-                              background: "var(--mantine-color-green-filled)",
-                              flexShrink: 0,
-                            }}
-                          />
-                          <Text fw={600} size="sm">
-                            {guide.version}
-                          </Text>
-                          <Text size="xs" c="dimmed" lineClamp={1}>
-                            {guide.notes}
-                          </Text>
-                        </Group>
-                        <Button
-                          as="a"
-                          href={guide.url}
-                          target="_blank"
-                          onClick={handleExternalLink(guide.url)}
-                          variant="secondary"
-                          size="sm"
-                          rightSection={
-                            <OpenInNewIcon style={{ fontSize: 12 }} />
-                          }
-                        >
-                          {t("update.viewGuide", "View Guide")}
-                        </Button>
-                      </Group>
-                    </Box>
-                  ))}
-                </Stack>
+                      {t("update.releaseNotes", "Release Notes")}{" "}
+                      <OpenInNewIcon style={{ fontSize: 14 }} />
+                    </Text>
+                    <Text
+                      size="sm"
+                      component="a"
+                      href="https://github.com/Stirling-Tools/Stirling-PDF/releases"
+                      target="_blank"
+                      onClick={handleExternalLink(
+                        "https://github.com/Stirling-Tools/Stirling-PDF/releases",
+                      )}
+                      c="dimmed"
+                      style={{
+                        textDecoration: "none",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                      }}
+                    >
+                      {t("update.allReleases", "All Releases")}{" "}
+                      <OpenInNewIcon style={{ fontSize: 14 }} />
+                    </Text>
+                  </Group>
+                </Group>
               </Box>
-            )}
 
-          {/* ── Version history ─────────────────────────────────────────────── */}
-          <Divider />
-          {loading ? (
-            <Center py="lg">
-              <Group gap="sm">
-                <Loader size="sm" />
-                <Text size="sm" c="dimmed">
-                  {t(
-                    "update.loadingDetailedInfo",
-                    "Loading version details...",
-                  )}
-                </Text>
-              </Group>
-            </Center>
-          ) : visibleVersions.length > 0 ? (
-            <Box>
-              <Group justify="space-between" align="center" mb="sm">
-                <Text fw={600} size="sm">
-                  {t("update.versionHistory", "Version History")}
-                </Text>
-                <Text size="xs" c="dimmed">
-                  {sortedVersions.length}{" "}
-                  {sortedVersions.length === 1 ? "version" : "versions"}
-                </Text>
-              </Group>
-              <Stack gap={0}>
-                {visibleVersions.map((version, index) => {
-                  const isExpanded = expandedVersions.has(index);
-                  return (
-                    <Box
-                      key={index}
-                      style={{
-                        borderTop:
-                          index === 0
-                            ? "1px solid var(--c-border-subtle, var(--mantine-color-default-border))"
-                            : undefined,
-                        borderBottom:
-                          "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
-                      }}
-                    >
-                      <Group
-                        justify="space-between"
-                        align="center"
-                        p="xs"
-                        px="sm"
-                        style={{ cursor: "pointer" }}
-                        onClick={() => toggleVersion(index)}
-                      >
-                        <Group gap="sm" style={{ flex: 1 }}>
-                          <Text fw={700} size="sm" style={{ minWidth: 50 }}>
-                            {version.version}
-                          </Text>
-                          <Badge
-                            color={getPriorityColor(version.priority)}
-                            size="xs"
-                            variant="light"
-                          >
-                            {getPriorityLabel(version.priority)}
-                          </Badge>
-                          {version.compatibility.breaking_changes && (
-                            <Badge color="orange" size="xs" variant="light">
-                              {t("update.breaking", "Breaking")}
-                            </Badge>
-                          )}
-                          {!isExpanded && version.announcement?.title && (
-                            <Text
-                              size="xs"
-                              c="dimmed"
-                              lineClamp={1}
-                              style={{ flex: 1 }}
-                            >
-                              {version.announcement.title}
-                            </Text>
-                          )}
-                        </Group>
-                        <Group gap={4}>
-                          <Button
-                            as="a"
-                            href={`https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${version.version}`}
-                            target="_blank"
-                            variant="tertiary"
-                            size="sm"
-                            onClick={handleExternalLink(
-                              `https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${version.version}`,
-                            )}
-                            rightSection={
-                              <OpenInNewIcon style={{ fontSize: 11 }} />
-                            }
-                          >
-                            {t("update.notes", "Notes")}
-                          </Button>
-                          {isExpanded ? (
-                            <ExpandLessIcon
-                              style={{
-                                fontSize: 18,
-                                color: "var(--mantine-color-dimmed)",
-                              }}
-                            />
-                          ) : (
-                            <ExpandMoreIcon
-                              style={{
-                                fontSize: 18,
-                                color: "var(--mantine-color-dimmed)",
-                              }}
-                            />
-                          )}
-                        </Group>
-                      </Group>
-                      <Collapse in={isExpanded}>
+              {/* Migration guides */}
+              {updateSummary.migration_guides &&
+                updateSummary.migration_guides.length > 0 && (
+                  <Box>
+                    <Text fw={600} size="sm" mb={4}>
+                      {t("update.migrationGuides", "Migration Guides")}
+                    </Text>
+                    <Text size="xs" c="dimmed" mb="sm">
+                      {t(
+                        "update.migrationGuidesDesc",
+                        "Review important changes before updating.",
+                      )}
+                    </Text>
+                    <Stack gap={0}>
+                      {updateSummary.migration_guides.map((guide, idx) => (
                         <Box
-                          px="sm"
-                          pb="sm"
+                          key={idx}
                           style={{
                             borderTop:
+                              idx === 0
+                                ? "1px solid var(--c-border-subtle, var(--mantine-color-default-border))"
+                                : undefined,
+                            borderBottom:
+                              "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
+                            padding: "10px 12px",
+                          }}
+                        >
+                          <Group
+                            justify="space-between"
+                            align="center"
+                            wrap="nowrap"
+                          >
+                            <Group gap="sm" style={{ flex: 1 }}>
+                              <Box
+                                style={{
+                                  width: 8,
+                                  height: 8,
+                                  borderRadius: "50%",
+                                  background:
+                                    "var(--mantine-color-green-filled)",
+                                  flexShrink: 0,
+                                }}
+                              />
+                              <Text fw={600} size="sm">
+                                {guide.version}
+                              </Text>
+                              <Text size="xs" c="dimmed" lineClamp={1}>
+                                {guide.notes}
+                              </Text>
+                            </Group>
+                            <Button
+                              as="a"
+                              href={guide.url}
+                              target="_blank"
+                              onClick={handleExternalLink(guide.url)}
+                              variant="secondary"
+                              size="sm"
+                              rightSection={
+                                <OpenInNewIcon style={{ fontSize: 12 }} />
+                              }
+                            >
+                              {t("update.viewGuide", "View Guide")}
+                            </Button>
+                          </Group>
+                        </Box>
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
+
+              {/* ── Version history ─────────────────────────────────────────────── */}
+              <Divider />
+              {loading ? (
+                <Center py="lg">
+                  <Group gap="sm">
+                    <Loader size="sm" />
+                    <Text size="sm" c="dimmed">
+                      {t(
+                        "update.loadingDetailedInfo",
+                        "Loading version details...",
+                      )}
+                    </Text>
+                  </Group>
+                </Center>
+              ) : visibleVersions.length > 0 ? (
+                <Box>
+                  <Group justify="space-between" align="center" mb="sm">
+                    <Text fw={600} size="sm">
+                      {t("update.versionHistory", "Version History")}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {sortedVersions.length}{" "}
+                      {sortedVersions.length === 1 ? "version" : "versions"}
+                    </Text>
+                  </Group>
+                  <Stack gap={0}>
+                    {visibleVersions.map((version, index) => {
+                      const isExpanded = expandedVersions.has(index);
+                      return (
+                        <Box
+                          key={index}
+                          style={{
+                            borderTop:
+                              index === 0
+                                ? "1px solid var(--c-border-subtle, var(--mantine-color-default-border))"
+                                : undefined,
+                            borderBottom:
                               "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
                           }}
                         >
-                          <Stack gap="sm" mt="sm">
-                            {version.announcement?.message && (
-                              <Text
-                                size="sm"
-                                c="dimmed"
-                                style={{ lineHeight: 1.6 }}
-                              >
-                                {version.announcement.message}
+                          <Group
+                            justify="space-between"
+                            align="center"
+                            p="xs"
+                            px="sm"
+                            style={{ cursor: "pointer" }}
+                            onClick={() => toggleVersion(index)}
+                          >
+                            <Group gap="sm" style={{ flex: 1 }}>
+                              <Text fw={700} size="sm" style={{ minWidth: 50 }}>
+                                {version.version}
                               </Text>
-                            )}
-                            {version.compatibility.breaking_changes && (
-                              <Alert
+                              <Badge
+                                color={getPriorityColor(version.priority)}
+                                size="xs"
                                 variant="light"
-                                color="orange"
-                                radius="sm"
-                                icon={
-                                  <WarningAmberIcon style={{ fontSize: 16 }} />
-                                }
-                                title={t(
-                                  "update.breakingChanges",
-                                  "Breaking Changes",
-                                )}
                               >
-                                <Text size="sm">
-                                  {version.compatibility.breaking_description ||
-                                    t(
-                                      "update.breakingChangesDefault",
-                                      "This version contains breaking changes.",
-                                    )}
+                                {getPriorityLabel(version.priority)}
+                              </Badge>
+                              {version.compatibility.breaking_changes && (
+                                <Badge color="orange" size="xs" variant="light">
+                                  {t("update.breaking", "Breaking")}
+                                </Badge>
+                              )}
+                              {!isExpanded && version.announcement?.title && (
+                                <Text
+                                  size="xs"
+                                  c="dimmed"
+                                  lineClamp={1}
+                                  style={{ flex: 1 }}
+                                >
+                                  {version.announcement.title}
                                 </Text>
-                                {version.compatibility.migration_guide_url && (
-                                  <Button
-                                    as="a"
-                                    href={
-                                      version.compatibility.migration_guide_url
-                                    }
-                                    target="_blank"
-                                    onClick={handleExternalLink(
-                                      version.compatibility
-                                        .migration_guide_url ?? "",
-                                    )}
-                                    variant="secondary"
-                                    accent="warning"
-                                    size="sm"
-                                    style={{
-                                      marginTop: "var(--mantine-spacing-xs)",
-                                    }}
-                                    rightSection={
-                                      <OpenInNewIcon style={{ fontSize: 14 }} />
-                                    }
-                                  >
-                                    {t(
-                                      "update.migrationGuide",
-                                      "Migration Guide",
-                                    )}
-                                  </Button>
+                              )}
+                            </Group>
+                            <Group gap={4}>
+                              <Button
+                                as="a"
+                                href={`https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${version.version}`}
+                                target="_blank"
+                                variant="tertiary"
+                                size="sm"
+                                onClick={handleExternalLink(
+                                  `https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${version.version}`,
                                 )}
-                              </Alert>
-                            )}
-                          </Stack>
+                                rightSection={
+                                  <OpenInNewIcon style={{ fontSize: 11 }} />
+                                }
+                              >
+                                {t("update.notes", "Notes")}
+                              </Button>
+                              {isExpanded ? (
+                                <ExpandLessIcon
+                                  style={{
+                                    fontSize: 18,
+                                    color: "var(--mantine-color-dimmed)",
+                                  }}
+                                />
+                              ) : (
+                                <ExpandMoreIcon
+                                  style={{
+                                    fontSize: 18,
+                                    color: "var(--mantine-color-dimmed)",
+                                  }}
+                                />
+                              )}
+                            </Group>
+                          </Group>
+                          <Collapse in={isExpanded}>
+                            <Box
+                              px="sm"
+                              pb="sm"
+                              style={{
+                                borderTop:
+                                  "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
+                              }}
+                            >
+                              <Stack gap="sm" mt="sm">
+                                {version.announcement?.message && (
+                                  <Text
+                                    size="sm"
+                                    c="dimmed"
+                                    style={{ lineHeight: 1.6 }}
+                                  >
+                                    {version.announcement.message}
+                                  </Text>
+                                )}
+                                {version.compatibility.breaking_changes && (
+                                  <Alert
+                                    variant="light"
+                                    color="orange"
+                                    radius="sm"
+                                    icon={
+                                      <WarningAmberIcon
+                                        style={{ fontSize: 16 }}
+                                      />
+                                    }
+                                    title={t(
+                                      "update.breakingChanges",
+                                      "Breaking Changes",
+                                    )}
+                                  >
+                                    <Text size="sm">
+                                      {version.compatibility
+                                        .breaking_description ||
+                                        t(
+                                          "update.breakingChangesDefault",
+                                          "This version contains breaking changes.",
+                                        )}
+                                    </Text>
+                                    {version.compatibility
+                                      .migration_guide_url && (
+                                      <Button
+                                        as="a"
+                                        href={
+                                          version.compatibility
+                                            .migration_guide_url
+                                        }
+                                        target="_blank"
+                                        onClick={handleExternalLink(
+                                          version.compatibility
+                                            .migration_guide_url ?? "",
+                                        )}
+                                        variant="secondary"
+                                        accent="warning"
+                                        size="sm"
+                                        style={{
+                                          marginTop:
+                                            "var(--mantine-spacing-xs)",
+                                        }}
+                                        rightSection={
+                                          <OpenInNewIcon
+                                            style={{ fontSize: 14 }}
+                                          />
+                                        }
+                                      >
+                                        {t(
+                                          "update.migrationGuide",
+                                          "Migration Guide",
+                                        )}
+                                      </Button>
+                                    )}
+                                  </Alert>
+                                )}
+                              </Stack>
+                            </Box>
+                          </Collapse>
                         </Box>
-                      </Collapse>
-                    </Box>
-                  );
-                })}
-              </Stack>
-              {sortedVersions.length > 10 && (
-                <Center mt="sm">
-                  <Button
-                    variant="tertiary"
-                    size="sm"
-                    onClick={() => setShowAllVersions(!showAllVersions)}
-                  >
-                    {showAllVersions
-                      ? t("update.showLess", "Show fewer versions")
-                      : t("update.showMore", {
-                          defaultValue: "Show all {{count}} versions",
-                          count: sortedVersions.length,
-                        })}
-                  </Button>
-                </Center>
-              )}
-            </Box>
-          ) : null}
+                      );
+                    })}
+                  </Stack>
+                  {sortedVersions.length > 10 && (
+                    <Center mt="sm">
+                      <Button
+                        variant="tertiary"
+                        size="sm"
+                        onClick={() => setShowAllVersions(!showAllVersions)}
+                      >
+                        {showAllVersions
+                          ? t("update.showLess", "Show fewer versions")
+                          : t("update.showMore", {
+                              defaultValue: "Show all {{count}} versions",
+                              count: sortedVersions.length,
+                            })}
+                      </Button>
+                    </Center>
+                  )}
+                </Box>
+              ) : null}
 
-          {/* Desktop install progress */}
-          {desktopInstall && desktopInstall.state !== "idle" && (
-            <Box
-              style={{
-                border:
-                  "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
-                borderRadius: 12,
-                padding: "16px 20px",
-              }}
-            >
-              {(desktopInstall.state === "downloading" ||
-                desktopInstall.state === "installing") && (
-                <Stack gap="sm">
-                  <Group justify="space-between" align="center">
-                    <Text size="sm" fw={600}>
-                      {desktopInstall.state === "downloading"
-                        ? t(
-                            "desktopUpdate.downloading",
-                            "Downloading update...",
-                          )
-                        : t("desktopUpdate.installing", "Installing update...")}
-                    </Text>
-                    {desktopInstall.progress &&
-                      desktopInstall.progress.total !== null && (
-                        <Text size="xs" c="dimmed">
-                          {formatBytes(desktopInstall.progress.downloaded)} /{" "}
-                          {formatBytes(desktopInstall.progress.total)}
+              {/* Desktop install progress */}
+              {desktopInstall && desktopInstall.state !== "idle" && (
+                <Box
+                  style={{
+                    border:
+                      "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
+                    borderRadius: 12,
+                    padding: "16px 20px",
+                  }}
+                >
+                  {(desktopInstall.state === "downloading" ||
+                    desktopInstall.state === "installing") && (
+                    <Stack gap="sm">
+                      <Group justify="space-between" align="center">
+                        <Text size="sm" fw={600}>
+                          {desktopInstall.state === "downloading"
+                            ? t(
+                                "desktopUpdate.downloading",
+                                "Downloading update...",
+                              )
+                            : t(
+                                "desktopUpdate.installing",
+                                "Installing update...",
+                              )}
                         </Text>
+                        {desktopInstall.progress &&
+                          desktopInstall.progress.total !== null && (
+                            <Text size="xs" c="dimmed">
+                              {formatBytes(desktopInstall.progress.downloaded)}{" "}
+                              / {formatBytes(desktopInstall.progress.total)}
+                            </Text>
+                          )}
+                      </Group>
+                      <Progress
+                        value={
+                          desktopInstall.state === "installing"
+                            ? 100
+                            : (desktopInstall.progress?.percent ?? 0)
+                        }
+                        size="lg"
+                        animated
+                        radius="xl"
+                      />
+                      {desktopInstall.state === "installing" && (
+                        <Alert variant="light" color="blue" radius="sm" py="xs">
+                          <Text size="xs">
+                            {t(
+                              "desktopUpdate.installingWarning",
+                              "The app will close automatically to complete the installation.",
+                            )}
+                          </Text>
+                        </Alert>
                       )}
-                  </Group>
-                  <Progress
-                    value={
-                      desktopInstall.state === "installing"
-                        ? 100
-                        : (desktopInstall.progress?.percent ?? 0)
-                    }
-                    size="lg"
-                    animated
-                    radius="xl"
-                  />
-                  {desktopInstall.state === "installing" && (
-                    <Alert variant="light" color="blue" radius="sm" py="xs">
-                      <Text size="xs">
-                        {t(
-                          "desktopUpdate.installingWarning",
-                          "The app will close automatically to complete the installation.",
-                        )}
-                      </Text>
+                    </Stack>
+                  )}
+                  {desktopInstall.state === "ready-to-restart" && (
+                    <Alert
+                      icon={<CheckCircleOutlineIcon />}
+                      color="green"
+                      variant="light"
+                      radius="md"
+                      title={t("desktopUpdate.readyToRestart", "Update Ready")}
+                    >
+                      {t(
+                        "desktopUpdate.restartMessage",
+                        "The update has been installed. Restart the app to finish.",
+                      )}
                     </Alert>
                   )}
-                </Stack>
-              )}
-              {desktopInstall.state === "ready-to-restart" && (
-                <Alert
-                  icon={<CheckCircleOutlineIcon />}
-                  color="green"
-                  variant="light"
-                  radius="md"
-                  title={t("desktopUpdate.readyToRestart", "Update Ready")}
-                >
-                  {t(
-                    "desktopUpdate.restartMessage",
-                    "The update has been installed. Restart the app to finish.",
+                  {desktopInstall.state === "error" && (
+                    <Alert
+                      icon={<ErrorOutlineIcon />}
+                      color="red"
+                      variant="light"
+                      radius="md"
+                      title={t("desktopUpdate.updateFailed", "Update Failed")}
+                    >
+                      {desktopInstall.errorMessage ??
+                        t(
+                          "desktopUpdate.updateFailedMessage",
+                          "Failed to download or install the update.",
+                        )}
+                    </Alert>
                   )}
-                </Alert>
+                </Box>
               )}
-              {desktopInstall.state === "error" && (
-                <Alert
-                  icon={<ErrorOutlineIcon />}
-                  color="red"
-                  variant="light"
-                  radius="md"
-                  title={t("desktopUpdate.updateFailed", "Update Failed")}
-                >
-                  {desktopInstall.errorMessage ??
-                    t(
-                      "desktopUpdate.updateFailedMessage",
-                      "Failed to download or install the update.",
-                    )}
-                </Alert>
-              )}
-            </Box>
-          )}
-        </Stack>
-      </Box>
+            </Stack>
+          </Box>
 
-      {/* ── Sticky footer ──────────────────────────────────────────────────── */}
-      <Box
-        style={{
-          borderTop:
-            "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
-          padding: "16px 28px",
-          flexShrink: 0,
-        }}
-      >
-        <Group justify="flex-end" gap="sm">
-          <Button
-            variant="secondary"
-            onClick={handleLater}
-            disabled={!canClose}
-            size="md"
+          {/* ── Sticky footer ──────────────────────────────────────────────────── */}
+          <Box
+            style={{
+              borderTop:
+                "1px solid var(--c-border-subtle, var(--mantine-color-default-border))",
+              padding: "16px 28px",
+              flexShrink: 0,
+            }}
           >
-            {t("update.later", "Later")}
-          </Button>
-          {desktopInstall ? (
-            desktopInstall.state === "ready-to-restart" ? (
+            <Group justify="flex-end" gap="sm">
               <Button
+                variant="secondary"
+                onClick={handleLater}
+                disabled={!canClose}
                 size="md"
-                leftSection={<RestartAltIcon style={{ fontSize: 20 }} />}
-                onClick={() => void desktopInstall.actions.restartApp()}
               >
-                {t("desktopUpdate.restartNow", "Restart Now")}
+                {t("update.later", "Later")}
               </Button>
-            ) : desktopInstall.state === "idle" ||
-              desktopInstall.state === "error" ? (
-              <>
-                {/* When install is blocked (non-admin) or the tauri updater
+              {desktopInstall ? (
+                desktopInstall.state === "ready-to-restart" ? (
+                  <Button
+                    size="md"
+                    leftSection={<RestartAltIcon style={{ fontSize: 20 }} />}
+                    onClick={() => void desktopInstall.actions.restartApp()}
+                  >
+                    {t("desktopUpdate.restartNow", "Restart Now")}
+                  </Button>
+                ) : desktopInstall.state === "idle" ||
+                  desktopInstall.state === "error" ? (
+                  <>
+                    {/* When install is blocked (non-admin) or the tauri updater
                       failed, the user still needs a way forward — show a
                       "Download Latest" link to the GitHub release page as a
                       fallback alongside the disabled Install Now button. */}
-                {(installBlocked || desktopInstall.state === "error") &&
-                  downloadUrl && (
+                    {(installBlocked || desktopInstall.state === "error") &&
+                      downloadUrl && (
+                        <Button
+                          as="a"
+                          href={downloadUrl}
+                          target="_blank"
+                          onClick={handleExternalLink(downloadUrl)}
+                          variant="secondary"
+                          size="md"
+                          leftSection={
+                            <DownloadIcon style={{ fontSize: 16 }} />
+                          }
+                        >
+                          {t("update.downloadLatest", "Download Latest")}
+                        </Button>
+                      )}
                     <Button
-                      as="a"
-                      href={downloadUrl}
-                      target="_blank"
-                      onClick={handleExternalLink(downloadUrl)}
-                      variant="secondary"
                       size="md"
-                      leftSection={<DownloadIcon style={{ fontSize: 16 }} />}
+                      leftSection={<DownloadIcon style={{ fontSize: 20 }} />}
+                      onClick={() => void desktopInstall.actions.startInstall()}
+                      disabled={installBlocked}
                     >
-                      {t("update.downloadLatest", "Download Latest")}
+                      <Box>
+                        <Text size="sm" fw={700} lh={1.2}>
+                          {t("desktopUpdate.installNow", "Install Now")}
+                        </Text>
+                        <Text size="xs" lh={1.2} style={{ opacity: 0.7 }}>
+                          {formatSize(downloadSizeBytes)}
+                        </Text>
+                      </Box>
                     </Button>
-                  )}
-                <Button
-                  size="md"
-                  leftSection={<DownloadIcon style={{ fontSize: 20 }} />}
-                  onClick={() => void desktopInstall.actions.startInstall()}
-                  disabled={installBlocked}
-                >
-                  <Box>
-                    <Text size="sm" fw={700} lh={1.2}>
-                      {t("desktopUpdate.installNow", "Install Now")}
-                    </Text>
-                    <Text size="xs" lh={1.2} style={{ opacity: 0.7 }}>
-                      {formatSize(downloadSizeBytes)}
-                    </Text>
-                  </Box>
-                </Button>
-              </>
-            ) : null
-          ) : (
-            // Tauri updater not available at all — only show the external
-            // download link. This is the fallback when latest.json is
-            // unreachable, the pubkey is wrong, signatures don't match, etc.
-            downloadUrl && (
-              <Button
-                as="a"
-                href={downloadUrl}
-                target="_blank"
-                onClick={handleExternalLink(downloadUrl)}
-                size="md"
-                leftSection={<DownloadIcon style={{ fontSize: 20 }} />}
-              >
-                {t("update.downloadLatest", "Download Latest")}
-              </Button>
-            )
-          )}
-        </Group>
-      </Box>
-    </Modal>
+                  </>
+                ) : null
+              ) : (
+                // Tauri updater not available at all — only show the external
+                // download link. This is the fallback when latest.json is
+                // unreachable, the pubkey is wrong, signatures don't match, etc.
+                downloadUrl && (
+                  <Button
+                    as="a"
+                    href={downloadUrl}
+                    target="_blank"
+                    onClick={handleExternalLink(downloadUrl)}
+                    size="md"
+                    leftSection={<DownloadIcon style={{ fontSize: 20 }} />}
+                  >
+                    {t("update.downloadLatest", "Download Latest")}
+                  </Button>
+                )
+              )}
+            </Group>
+          </Box>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
   );
 };
 

--- a/frontend/editor/src/core/components/shared/ViewerInlineControls.stories.tsx
+++ b/frontend/editor/src/core/components/shared/ViewerInlineControls.stories.tsx
@@ -1,0 +1,128 @@
+/**
+ * The zoom controls that appear in the workbench bar while the viewer is the
+ * active workbench. They render nothing anywhere else, so every story here has
+ * to say the workbench is "viewer".
+ *
+ * Zoom is pushed at the component rather than pulled: it seeds from
+ * getZoomState() and then subscribes for updates, so the fixture below hands
+ * back a fixed level and a subscription that never fires. The Live story wires
+ * the subscription up properly so the slider and buttons actually move.
+ */
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ViewerInlineControls } from "@app/components/shared/ViewerInlineControls";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+import {
+  NavigationStateContext,
+  type NavigationContextStateValue,
+} from "@app/contexts/NavigationContext";
+
+/** Only `workbench` is read; the rest of navigation state is irrelevant here. */
+function navState(workbench: string) {
+  return { workbench } as unknown as NavigationContextStateValue;
+}
+
+/** A viewer that reports one zoom level and never publishes another. */
+function staticViewer(zoomPercent: number) {
+  return {
+    getZoomState: () => ({ zoomPercent }),
+    registerImmediateZoomUpdate: () => () => {},
+    zoomActions: {
+      zoomIn: () => {},
+      zoomOut: () => {},
+      setZoomLevel: () => {},
+    },
+  } as unknown as ViewerContextType;
+}
+
+function Fixture({
+  zoomPercent = 100,
+  workbench = "viewer",
+}: {
+  zoomPercent?: number;
+  workbench?: string;
+}) {
+  return (
+    <NavigationStateContext.Provider value={navState(workbench)}>
+      <ViewerContext.Provider value={staticViewer(zoomPercent)}>
+        <ViewerInlineControls />
+      </ViewerContext.Provider>
+    </NavigationStateContext.Provider>
+  );
+}
+
+const meta: Meta<typeof ViewerInlineControls> = {
+  title: "Shared/ViewerInlineControls",
+  component: ViewerInlineControls,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ViewerInlineControls>;
+
+export const Default: Story = { render: () => <Fixture /> };
+
+/** The slider clamps to 20–500, so these two sit at its ends. */
+export const MinimumZoom: Story = { render: () => <Fixture zoomPercent={20} /> };
+
+export const MaximumZoom: Story = {
+  render: () => <Fixture zoomPercent={500} />,
+};
+
+/** Levels outside the slider's range still clamp rather than overflow it. */
+export const BeyondSliderRange: Story = {
+  render: () => <Fixture zoomPercent={900} />,
+};
+
+/** Any other workbench renders nothing at all. */
+export const NotViewerWorkbench: Story = {
+  render: () => <Fixture workbench="fileManager" />,
+};
+
+/**
+ * The controls driving real state: the zoom actions publish through the same
+ * subscription the component registers, which is how the app wires them.
+ */
+export const Live: Story = {
+  render: function Live() {
+    const [zoom, setZoom] = useState(100);
+    const listener = useRef<((pct: number) => void) | null>(null);
+
+    const publish = useCallback((pct: number) => {
+      const clamped = Math.min(Math.max(pct, 20), 500);
+      setZoom(clamped);
+      listener.current?.(clamped);
+    }, []);
+
+    const viewer = useMemo(
+      () =>
+        ({
+          getZoomState: () => ({ zoomPercent: zoom }),
+          registerImmediateZoomUpdate: (cb: (pct: number) => void) => {
+            listener.current = cb;
+            return () => {
+              listener.current = null;
+            };
+          },
+          zoomActions: {
+            zoomIn: () => publish(zoom + 25),
+            zoomOut: () => publish(zoom - 25),
+            setZoomLevel: (level: number) => publish(level * 100),
+          },
+          // Rebuilt per zoom so the seed value stays current.
+        }) as unknown as ViewerContextType,
+      [zoom, publish],
+    );
+
+    return (
+      <NavigationStateContext.Provider value={navState("viewer")}>
+        <ViewerContext.Provider value={viewer}>
+          <ViewerInlineControls />
+        </ViewerContext.Provider>
+      </NavigationStateContext.Provider>
+    );
+  },
+};

--- a/frontend/editor/src/core/components/shared/ViewerInlineControls.tsx
+++ b/frontend/editor/src/core/components/shared/ViewerInlineControls.tsx
@@ -62,6 +62,9 @@ export function ViewerInlineControls() {
             track: { height: 3 },
           }}
           label={null}
+          // The thumb carries role="slider"; thumbLabel is what names it, and
+          // Slider writes an empty aria-label over anything else.
+          thumbLabel={t("viewer.zoomLevel", "Zoom level")}
         />
       </div>
 

--- a/frontend/editor/src/core/components/shared/WorkbenchBar.css
+++ b/frontend/editor/src/core/components/shared/WorkbenchBar.css
@@ -55,7 +55,7 @@
 
 .workbench-bar-view-btn.active {
   background-color: var(--c-primary-subtle);
-  color: var(--c-accent-fg);
+  color: var(--c-accent-text);
 }
 
 .workbench-bar-view-btn.workbench-bar-back-btn {
@@ -65,7 +65,7 @@
 
 .workbench-bar-view-btn.workbench-bar-back-btn:hover {
   background-color: color-mix(in srgb, var(--c-primary) 12%, transparent);
-  color: var(--c-accent-fg);
+  color: var(--c-accent-text);
 }
 
 .workbench-bar-view-btn svg {

--- a/frontend/editor/src/core/components/shared/ZipWarningModal.tsx
+++ b/frontend/editor/src/core/components/shared/ZipWarningModal.tsx
@@ -18,7 +18,7 @@ const WARNING_ICON_STYLE: CSSProperties = {
   fontSize: 36,
   display: "block",
   margin: "0 auto 8px",
-  color: "var(--mantine-color-blue-6)",
+  color: "var(--c-accent-text)",
 };
 
 const ZipWarningModal = ({

--- a/frontend/editor/src/core/components/shared/config/configSections/GeneralSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/GeneralSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useId, useState, useEffect } from "react";
 import {
   Paper,
   Stack,
@@ -83,6 +83,15 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
   desktopUpdateMode,
 }) => {
   const { t } = useTranslation();
+  // Each setting is a row of label text next to a bare control, so the controls
+  // are named by pointing at that text rather than by a <label> association.
+  const labelIds = useId();
+  const updateModeLabelId = `${labelIds}-update-mode`;
+  const viewerZoomLabelId = `${labelIds}-viewer-zoom`;
+  const hideToolsLabelId = `${labelIds}-hide-tools`;
+  const hideConversionsLabelId = `${labelIds}-hide-conversions`;
+  const autoUnzipLabelId = `${labelIds}-auto-unzip`;
+  const autoUnzipLimitLabelId = `${labelIds}-auto-unzip-limit`;
   const { preferences, updatePreference } = usePreferences();
   const { config } = useAppConfig();
   const { setTheme, themeMode } = useTheme();
@@ -209,7 +218,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                 icon="admin-panel-settings-rounded"
                 width="1.2rem"
                 height="1.2rem"
-                style={{ color: "var(--mantine-color-blue-6)" }}
+                style={{ color: "var(--c-accent-text)" }}
               />
               <Text
                 fw={600}
@@ -248,7 +257,6 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
               href="https://docs.stirlingpdf.com/Configuration/System%20and%20Security/"
               target="_blank"
               size="sm"
-              style={{ color: "var(--mantine-color-blue-6)" }}
             >
               {t(
                 "settings.general.enableFeatures.learnMore",
@@ -305,7 +313,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                     </Text>
                   </Text>
                   {mismatchVersion && (
-                    <Text size="sm" c="red" mt={4}>
+                    <Text size="sm" c="var(--color-red-dark)" mt={4}>
                       {t(
                         "settings.general.updates.versionMismatch",
                         "Warning: A mismatch has been detected between the client version and the AppConfig version. Using different versions can lead to compatibility issues, errors, and security risks. Please ensure that server and client are using the same version.",
@@ -336,7 +344,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                       "Latest Version",
                     )}
                     :{" "}
-                    <Text component="span" fw={500} c="blue">
+                    <Text component="span" fw={500} c="var(--c-accent-text)">
                       {updateSummary.latest_version}
                     </Text>
                   </Text>
@@ -391,7 +399,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
             {desktopUpdateMode && (
               <Stack gap="xs">
                 <Group gap="xs" align="center">
-                  <Text fw={600} size="sm">
+                  <Text id={updateModeLabelId} fw={600} size="sm">
                     {t(
                       "settings.general.updates.updateBehavior",
                       "Update behavior",
@@ -422,6 +430,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                       )}
                 </Text>
                 <Select
+                  aria-labelledby={updateModeLabelId}
                   disabled={desktopUpdateMode.locked}
                   value={desktopUpdateMode.mode}
                   onChange={(value) => {
@@ -622,7 +631,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
             }}
           >
             <div style={{ flex: 1, minWidth: 0 }}>
-              <Text fw={500} size="sm">
+              <Text id={viewerZoomLabelId} fw={500} size="sm">
                 {t("settings.general.defaultViewerZoom", "Default reader zoom")}
               </Text>
               <Text size="xs" c="dimmed" mt={4}>
@@ -633,6 +642,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
               </Text>
             </div>
             <Select
+              aria-labelledby={viewerZoomLabelId}
               value={preferences.defaultViewerZoom}
               onChange={(val: string | null) => {
                 if (val)
@@ -677,7 +687,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
             }}
           >
             <div style={{ flex: 1, minWidth: 0 }}>
-              <Text fw={500} size="sm">
+              <Text id={hideToolsLabelId} fw={500} size="sm">
                 {t(
                   "settings.general.hideUnavailableTools",
                   "Hide unavailable tools",
@@ -691,6 +701,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
               </Text>
             </div>
             <Switch
+              aria-labelledby={hideToolsLabelId}
               checked={preferences.hideUnavailableTools}
               onChange={(event) =>
                 updatePreference(
@@ -708,7 +719,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
             }}
           >
             <div style={{ flex: 1, minWidth: 0 }}>
-              <Text fw={500} size="sm">
+              <Text id={hideConversionsLabelId} fw={500} size="sm">
                 {t(
                   "settings.general.hideUnavailableConversions",
                   "Hide unavailable conversions",
@@ -722,6 +733,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
               </Text>
             </div>
             <Switch
+              aria-labelledby={hideConversionsLabelId}
               checked={preferences.hideUnavailableConversions}
               onChange={(event) =>
                 updatePreference(
@@ -749,7 +761,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
               }}
             >
               <div style={{ flex: 1, minWidth: 0 }}>
-                <Text fw={500} size="sm">
+                <Text id={autoUnzipLabelId} fw={500} size="sm">
                   {t("settings.general.autoUnzip", "Auto-unzip API responses")}
                 </Text>
                 <Text size="xs" c="dimmed" mt={4}>
@@ -760,6 +772,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                 </Text>
               </div>
               <Switch
+                aria-labelledby={autoUnzipLabelId}
                 checked={preferences.autoUnzip}
                 onChange={(event) =>
                   updatePreference("autoUnzip", event.currentTarget.checked)
@@ -786,7 +799,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
               }}
             >
               <div style={{ flex: 1, minWidth: 0 }}>
-                <Text fw={500} size="sm">
+                <Text id={autoUnzipLimitLabelId} fw={500} size="sm">
                   {t(
                     "settings.general.autoUnzipFileLimit",
                     "Auto-unzip file limit",
@@ -800,6 +813,7 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
                 </Text>
               </div>
               <NumberInput
+                aria-labelledby={autoUnzipLimitLabelId}
                 value={fileLimitInput}
                 onChange={setFileLimitInput}
                 onBlur={() => {

--- a/frontend/editor/src/core/components/shared/config/configSections/Overview.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/Overview.tsx
@@ -13,7 +13,7 @@ const Overview: React.FC = () => {
 
     return (
       <Stack gap="xs" mb="md">
-        <Text fw={600} size="md" c="blue">
+        <Text fw={600} size="md" c="var(--c-accent-text)">
           {title}
         </Text>
         <Stack gap="xs" pl="md">

--- a/frontend/editor/src/core/components/shared/config/configSections/ProviderCard.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/ProviderCard.tsx
@@ -270,7 +270,7 @@ export default function ProviderCard({
                 href={provider.documentationUrl}
                 target="_blank"
                 size="xs"
-                c="blue"
+                c="var(--c-accent-text)"
               >
                 {t(
                   "admin.settings.connections.documentation",

--- a/frontend/editor/src/core/components/shared/filePreview/DocumentThumbnail.tsx
+++ b/frontend/editor/src/core/components/shared/filePreview/DocumentThumbnail.tsx
@@ -33,6 +33,23 @@ const DocumentThumbnail: React.FC<DocumentThumbnailProps> = ({
 }) => {
   if (!file) return null;
 
+  // A thumbnail that takes a click is a control; without these it is a div, so
+  // the file cannot be opened by keyboard. Only applied when a handler was
+  // given — a decorative thumbnail should not take a tab stop.
+  const interactive = onClick
+    ? {
+        role: "button",
+        tabIndex: 0,
+        onClick,
+        onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onClick();
+          }
+        },
+      }
+    : {};
+
   const containerStyle: React.CSSProperties = {
     position: "relative",
     cursor: onClick ? "pointer" : "default",
@@ -47,7 +64,7 @@ const DocumentThumbnail: React.FC<DocumentThumbnailProps> = ({
 
   if (thumbnail && !isEncrypted) {
     return (
-      <Box style={containerStyle} onClick={onClick}>
+      <Box style={containerStyle} {...interactive}>
         <PrivateContent>
           <img
             src={thumbnail}
@@ -77,7 +94,7 @@ const DocumentThumbnail: React.FC<DocumentThumbnailProps> = ({
 
   if (isEncrypted) {
     return (
-      <Box style={containerStyle} onClick={onClick}>
+      <Box style={containerStyle} {...interactive}>
         <div
           style={{
             display: "flex",
@@ -100,7 +117,7 @@ const DocumentThumbnail: React.FC<DocumentThumbnailProps> = ({
               fontWeight: 700,
               letterSpacing: "0.08em",
               textTransform: "uppercase",
-              color: "var(--mantine-color-red-6)",
+              color: "var(--color-red-dark)",
               background: "rgba(220,38,38,0.1)",
               padding: "2px 8px",
               borderRadius: "6px",
@@ -116,7 +133,7 @@ const DocumentThumbnail: React.FC<DocumentThumbnailProps> = ({
 
   if (isLoading) {
     return (
-      <Box style={containerStyle} onClick={onClick}>
+      <Box style={containerStyle} {...interactive}>
         <Stack
           align="center"
           justify="center"
@@ -136,7 +153,7 @@ const DocumentThumbnail: React.FC<DocumentThumbnailProps> = ({
   const ext = detectFileExtension(file.name ?? "").toUpperCase();
 
   return (
-    <Box style={containerStyle} onClick={onClick}>
+    <Box style={containerStyle} {...interactive}>
       <Center
         style={{
           width: "100%",

--- a/frontend/editor/src/core/components/shared/signing/CreateSessionFlow.tsx
+++ b/frontend/editor/src/core/components/shared/signing/CreateSessionFlow.tsx
@@ -51,7 +51,10 @@ const StepWrapper: React.FC<StepWrapperProps> = ({
           : isCompleted
             ? "var(--mantine-color-gray-light)"
             : "transparent",
-        opacity: !isActive && !isCompleted ? 0.6 : 1,
+        // Pending steps recede via a muted text colour rather than opacity,
+        // which would drag their labels below the contrast floor.
+        color:
+          !isActive && !isCompleted ? "var(--c-text-muted)" : "var(--c-text)",
       }}
     >
       <Group gap="sm" mb={isActive ? "md" : 0}>

--- a/frontend/editor/src/core/components/shared/sliderWithInput/SliderWithInput.tsx
+++ b/frontend/editor/src/core/components/shared/sliderWithInput/SliderWithInput.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Slider, Text, Group, NumberInput } from "@mantine/core";
 
 interface Props {
@@ -21,9 +22,10 @@ export default function SliderWithInput({
   step = 1,
   suffix = "%",
 }: Props) {
+  const labelId = useId();
   return (
     <div>
-      <Text size="sm" fw={500} mb={8}>
+      <Text id={labelId} size="sm" fw={500} mb={8}>
         {label}
       </Text>
       <Group gap="md" align="center">
@@ -35,6 +37,9 @@ export default function SliderWithInput({
             value={value}
             onChange={onChange}
             disabled={disabled}
+            // Mantine's slider thumb is a div, not an input, so the heading
+            // above cannot name it through a <label> association.
+            thumbLabel={label}
           />
         </div>
         <NumberInput
@@ -46,6 +51,7 @@ export default function SliderWithInput({
           disabled={disabled}
           suffix={suffix}
           style={{ width: 90 }}
+          aria-labelledby={labelId}
         />
       </Group>
     </div>

--- a/frontend/editor/src/core/components/shared/wetSignature/DrawSignatureCanvas.tsx
+++ b/frontend/editor/src/core/components/shared/wetSignature/DrawSignatureCanvas.tsx
@@ -129,6 +129,13 @@ export const DrawSignatureCanvas: React.FC<DrawSignatureCanvasProps> = ({
             onChange={setPenColor}
             format="hex"
             size="xs"
+            // The saturation area and hue bar are role="slider" divs; these are
+            // their only accessible names.
+            saturationLabel={t(
+              "colorPicker.saturation",
+              "Saturation and brightness",
+            )}
+            hueLabel={t("colorPicker.hue", "Hue")}
           />
         </div>
         <div style={{ flex: 2 }}>
@@ -144,6 +151,12 @@ export const DrawSignatureCanvas: React.FC<DrawSignatureCanvasProps> = ({
             max={10}
             step={1}
             disabled={disabled}
+            // The thumb is a div, so the heading above cannot name it.
+            thumbLabel={t(
+              "certSign.collab.signRequest.penSize",
+              "Pen Size: {{size}}px",
+              { size: penSize },
+            )}
             marks={[
               { value: 1, label: "1" },
               { value: 5, label: "5" },

--- a/frontend/editor/src/core/components/shared/wetSignature/TypeSignatureText.tsx
+++ b/frontend/editor/src/core/components/shared/wetSignature/TypeSignatureText.tsx
@@ -118,6 +118,12 @@ export const TypeSignatureText: React.FC<TypeSignatureTextProps> = ({
           max={80}
           step={2}
           disabled={disabled}
+          // The thumb is a div, so the heading above cannot name it.
+          thumbLabel={t(
+            "certSign.collab.signRequest.fontSize",
+            "Font Size: {{size}}px",
+            { size: fontSize },
+          )}
           marks={[
             { value: 20, label: "20" },
             { value: 50, label: "50" },
@@ -130,7 +136,18 @@ export const TypeSignatureText: React.FC<TypeSignatureTextProps> = ({
         <Text size="sm" mb={4}>
           {t("certSign.collab.signRequest.textColor", "Text Color")}
         </Text>
-        <ColorPicker value={color} onChange={onColorChange} format="hex" />
+        <ColorPicker
+          value={color}
+          onChange={onColorChange}
+          format="hex"
+          // The saturation area and hue bar are role="slider" divs; these are
+          // their only accessible names.
+          saturationLabel={t(
+            "colorPicker.saturation",
+            "Saturation and brightness",
+          )}
+          hueLabel={t("colorPicker.hue", "Hue")}
+        />
       </div>
 
       {/* Preview */}

--- a/frontend/editor/src/core/components/shared/wetSignature/UploadSignatureImage.tsx
+++ b/frontend/editor/src/core/components/shared/wetSignature/UploadSignatureImage.tsx
@@ -124,7 +124,7 @@ export const UploadSignatureImage: React.FC<UploadSignatureImageProps> = ({
       )}
 
       {error && (
-        <Text size="xs" c="red">
+        <Text size="xs" c="var(--color-red-dark)">
           {error}
         </Text>
       )}

--- a/frontend/editor/src/core/components/tools/FullscreenToolList.stories.tsx
+++ b/frontend/editor/src/core/components/tools/FullscreenToolList.stories.tsx
@@ -1,0 +1,167 @@
+/**
+ * The tool list behind the fullscreen picker. It has two shapes: with no search
+ * term it shows a Quick Access block above the full catalogue; while searching
+ * it shows flat match groups and drops Quick Access entirely.
+ *
+ * Two details decide whether anything renders at all, so the fixture below is
+ * built around them: tools are grouped by `categoryId`, and Quick Access only
+ * accepts entries that carry a component or a link. An entry with neither is
+ * treated as "coming soon" and never reaches the list.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import FullscreenToolList from "@app/components/tools/FullscreenToolList";
+import {
+  ToolCategoryId,
+  SubcategoryId,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
+import type { ToolId } from "@app/types/toolId";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  ToolWorkflowContext,
+  type ToolWorkflowContextValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+
+function tool(
+  name: string,
+  categoryId: ToolCategoryId,
+  subcategoryId: SubcategoryId,
+): ToolRegistryEntry {
+  return {
+    icon: <BuildRoundedIcon />,
+    name,
+    // Entries with neither a component nor a link are filtered out of Quick
+    // Access and render disabled elsewhere.
+    component: () => null,
+    description: `${name} — what this tool does, in one line.`,
+    categoryId,
+    subcategoryId,
+    automationSettings: null,
+  } as ToolRegistryEntry;
+}
+
+const REGISTRY: Record<string, ToolRegistryEntry> = {
+  rotate: tool(
+    "Rotate pages",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.PAGE_FORMATTING,
+  ),
+  compress: tool(
+    "Compress",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.GENERAL,
+  ),
+  redact: tool(
+    "Redact",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.DOCUMENT_SECURITY,
+  ),
+  sign: tool("Sign", ToolCategoryId.STANDARD_TOOLS, SubcategoryId.SIGNING),
+  extract: tool(
+    "Extract pages",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.EXTRACTION,
+  ),
+  removeBlanks: tool(
+    "Remove blank pages",
+    ToolCategoryId.ADVANCED_TOOLS,
+    SubcategoryId.REMOVAL,
+  ),
+};
+
+const ALL_TOOLS = Object.entries(REGISTRY).map(([id, entry]) => ({
+  item: [id as ToolId, entry] as [ToolId, ToolRegistryEntry],
+}));
+
+function Harness({
+  filteredTools = ALL_TOOLS,
+  searchQuery = "",
+  showDescriptions = false,
+  selectedToolKey = null,
+  favoriteTools = [] as string[],
+}: {
+  filteredTools?: typeof ALL_TOOLS;
+  searchQuery?: string;
+  showDescriptions?: boolean;
+  selectedToolKey?: string | null;
+  favoriteTools?: string[];
+}) {
+  const workflow = {
+    toolRegistry: REGISTRY,
+    favoriteTools,
+    isFavorite: (id: string) => favoriteTools.includes(id),
+    toggleFavorite: () => {},
+    toolAvailability: {},
+  } as unknown as ToolWorkflowContextValue;
+
+  return (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled: true } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <ToolWorkflowContext.Provider value={workflow}>
+          <div style={{ width: 420 }}>
+            <FullscreenToolList
+              filteredTools={filteredTools}
+              searchQuery={searchQuery}
+              showDescriptions={showDescriptions}
+              selectedToolKey={selectedToolKey}
+              matchedTextMap={new Map()}
+              onSelect={() => {}}
+            />
+          </div>
+        </ToolWorkflowContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}
+
+const meta: Meta<typeof FullscreenToolList> = {
+  title: "Tools/Fullscreen/FullscreenToolList",
+  component: FullscreenToolList,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FullscreenToolList>;
+
+/** No search term: Quick Access above the full catalogue. */
+export const Default: Story = { render: () => <Harness /> };
+
+/** Descriptions turn each row into the taller detailed form. */
+export const WithDescriptions: Story = {
+  render: () => <Harness showDescriptions />,
+};
+
+/** Favourites join the recommended tools in the Quick Access block. */
+export const WithFavourites: Story = {
+  render: () => <Harness favoriteTools={["redact", "sign"]} />,
+};
+
+export const SelectedTool: Story = {
+  render: () => <Harness selectedToolKey="redact" />,
+};
+
+/** Searching drops Quick Access and flattens the results into match groups. */
+export const Searching: Story = {
+  render: () => (
+    <Harness
+      searchQuery="re"
+      filteredTools={ALL_TOOLS.filter(({ item }) =>
+        item[1].name.toLowerCase().includes("re"),
+      )}
+    />
+  ),
+};
+
+/** A search that matches nothing still renders its empty state. */
+export const NoMatches: Story = {
+  render: () => <Harness searchQuery="zzzz" filteredTools={[]} />,
+};

--- a/frontend/editor/src/core/components/tools/FullscreenToolList.tsx
+++ b/frontend/editor/src/core/components/tools/FullscreenToolList.tsx
@@ -255,19 +255,14 @@ const FullscreenToolList = ({
                 >
                   {getSubcategoryIcon(subcategoryId)}
                 </span>
-                <Text
-                  size="sm"
-                  fw={600}
-                  tt="uppercase"
-                  lts={0.5}
-                  style={{
-                    color: categoryColor,
-                  }}
-                >
+                {/* The icon and the section border already carry the category
+                    hue. These are decorative fills — restating one as text
+                    colour drops the label under 4.5:1 on the app surface. */}
+                <Text size="sm" fw={600} tt="uppercase" lts={0.5}>
                   {getSubcategoryLabel(t, subcategoryId)}
                 </Text>
               </div>
-              <Badge size="sm" variant="colored" color={categoryColor}>
+              <Badge size="sm" variant="default">
                 {tools.length}
               </Badge>
             </header>

--- a/frontend/editor/src/core/components/tools/FullscreenToolSurface.stories.tsx
+++ b/frontend/editor/src/core/components/tools/FullscreenToolSurface.stories.tsx
@@ -1,0 +1,160 @@
+/**
+ * The fullscreen tool picker's surface: a search field, a details switch, and
+ * the whole catalogue beneath them.
+ *
+ * The surface is a portal onto the body, absolutely placed from the `geometry`
+ * the sidebar measures for it — with no geometry it renders nothing at all,
+ * which is how it stays out of the way before the panel has been laid out.
+ * Everything else is passed straight through to the list: the search term
+ * decides whether Quick Access survives, and the details switch decides whether
+ * each row carries its description.
+ *
+ * The list rows are ToolButtons, which read the registry, favourites, hotkeys
+ * and app config, so those contexts are stubbed rather than provided in full.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import FullscreenToolSurface from "@app/components/tools/FullscreenToolSurface";
+import {
+  ToolCategoryId,
+  SubcategoryId,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
+import type { ToolId } from "@app/types/toolId";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  ToolWorkflowContext,
+  type ToolWorkflowContextValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+
+function tool(
+  name: string,
+  categoryId: ToolCategoryId,
+  subcategoryId: SubcategoryId,
+): ToolRegistryEntry {
+  return {
+    icon: <BuildRoundedIcon />,
+    name,
+    // Entries with neither a component nor a link count as "coming soon" and
+    // are dropped from Quick Access, which would empty out half the surface.
+    component: () => null,
+    description: `${name} — what this tool does, in one line.`,
+    categoryId,
+    subcategoryId,
+    automationSettings: null,
+  } as ToolRegistryEntry;
+}
+
+const REGISTRY: Record<string, ToolRegistryEntry> = {
+  rotate: tool(
+    "Rotate pages",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.PAGE_FORMATTING,
+  ),
+  compress: tool(
+    "Compress",
+    ToolCategoryId.RECOMMENDED_TOOLS,
+    SubcategoryId.GENERAL,
+  ),
+  redact: tool(
+    "Redact",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.DOCUMENT_SECURITY,
+  ),
+  sign: tool("Sign", ToolCategoryId.STANDARD_TOOLS, SubcategoryId.SIGNING),
+  extract: tool(
+    "Extract pages",
+    ToolCategoryId.STANDARD_TOOLS,
+    SubcategoryId.EXTRACTION,
+  ),
+  removeBlanks: tool(
+    "Remove blank pages",
+    ToolCategoryId.ADVANCED_TOOLS,
+    SubcategoryId.REMOVAL,
+  ),
+};
+
+const ALL_TOOLS = Object.entries(REGISTRY).map(([id, entry]) => ({
+  item: [id as ToolId, entry] as [ToolId, ToolRegistryEntry],
+}));
+
+/** Roughly the rail the sidebar hands over: inset from the right-hand edge. */
+const GEOMETRY = { left: 32, top: 32, width: 720, height: 560 };
+
+const withStubs = (Story: React.ComponentType) => (
+  <AppConfigProvider
+    initialConfig={{ premiumEnabled: true } as never}
+    bootstrapMode="non-blocking"
+    autoFetch={false}
+  >
+    <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+      <ToolWorkflowContext.Provider
+        value={
+          {
+            toolRegistry: REGISTRY,
+            favoriteTools: [],
+            isFavorite: () => false,
+            toggleFavorite: () => {},
+            toolAvailability: {},
+          } as unknown as ToolWorkflowContextValue
+        }
+      >
+        <Story />
+      </ToolWorkflowContext.Provider>
+    </HotkeyContext.Provider>
+  </AppConfigProvider>
+);
+
+const meta: Meta<typeof FullscreenToolSurface> = {
+  title: "Tools/Fullscreen/FullscreenToolSurface",
+  component: FullscreenToolSurface,
+  parameters: { layout: "fullscreen" },
+  args: {
+    searchQuery: "",
+    toolRegistry: REGISTRY,
+    filteredTools: ALL_TOOLS,
+    selectedToolKey: null,
+    showDescriptions: false,
+    matchedTextMap: new Map(),
+    geometry: GEOMETRY,
+    onSearchChange: () => {},
+    onSelect: () => {},
+    onToggleDescriptions: () => {},
+    onExitFullscreenMode: () => {},
+  },
+  decorators: [withStubs],
+};
+export default meta;
+
+type Story = StoryObj<typeof FullscreenToolSurface>;
+
+/** The full catalogue, Quick Access first. */
+export const Default: Story = {};
+
+/** The details switch on: every row grows to carry its description. */
+export const WithDescriptions: Story = { args: { showDescriptions: true } };
+
+/** Searching narrows the surface to matches and drops Quick Access. */
+export const Searching: Story = {
+  args: {
+    searchQuery: "re",
+    filteredTools: ALL_TOOLS.filter(({ item }) =>
+      item[1].name.toLowerCase().includes("re"),
+    ),
+  },
+};
+
+/** A search with no matches still fills the surface with its empty state. */
+export const NoMatches: Story = {
+  args: { searchQuery: "zzzz", filteredTools: [] },
+};
+
+/** The open tool is marked in the list. */
+export const SelectedTool: Story = { args: { selectedToolKey: "redact" } };
+
+/** Before the panel has been measured there is nowhere to place the surface. */
+export const NotYetMeasured: Story = { args: { geometry: null } };

--- a/frontend/editor/src/core/components/tools/SearchResults.stories.tsx
+++ b/frontend/editor/src/core/components/tools/SearchResults.stories.tsx
@@ -1,0 +1,137 @@
+/**
+ * Search results in the tool picker: matched tools grouped by subcategory,
+ * or an empty state when nothing matches.
+ *
+ * Each row is a ToolButton, which reads the tool registry, favourites, hotkey
+ * bindings and app config. Mounting ToolWorkflowProvider would stand up the
+ * whole registry and its navigation chain, so the fixture supplies the handful
+ * of fields the rows actually read.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import SearchResults from "@app/components/tools/SearchResults";
+import {
+  ToolCategoryId,
+  SubcategoryId,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
+import type { ToolId } from "@app/types/toolId";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  ToolWorkflowDataContext,
+  ToolWorkflowActionsContext,
+  type ToolWorkflowDataValue,
+  type ToolWorkflowActionsValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+
+function tool(name: string, subcategoryId: SubcategoryId): ToolRegistryEntry {
+  return {
+    icon: <BuildRoundedIcon />,
+    name,
+    // An entry with neither a component nor a link is treated as "coming soon"
+    // and renders disabled, which would flatten every story into one look.
+    component: () => null,
+    description: `${name} — what this tool does, in one line.`,
+    categoryId: ToolCategoryId.STANDARD_TOOLS,
+    subcategoryId,
+    automationSettings: null,
+  } as ToolRegistryEntry;
+}
+
+const MATCHES = [
+  {
+    item: ["redact", tool("Redact", SubcategoryId.DOCUMENT_SECURITY)] as [
+      ToolId,
+      ToolRegistryEntry,
+    ],
+  },
+  {
+    item: ["sign", tool("Sign", SubcategoryId.SIGNING)] as [
+      ToolId,
+      ToolRegistryEntry,
+    ],
+  },
+  {
+    item: ["watermark", tool("Watermark", SubcategoryId.EXTRACTION)] as [
+      ToolId,
+      ToolRegistryEntry,
+    ],
+  },
+];
+
+function Harness({
+  filteredTools = MATCHES,
+  searchQuery = "e",
+  favourites = [] as string[],
+}: {
+  filteredTools?: typeof MATCHES;
+  searchQuery?: string;
+  favourites?: string[];
+}) {
+  const data = {
+    isFavorite: (id: string) => favourites.includes(id),
+    toolAvailability: {},
+    toolRegistry: {},
+    favoriteTools: favourites,
+  } as unknown as ToolWorkflowDataValue;
+
+  return (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled: true } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <ToolWorkflowDataContext.Provider value={data}>
+          <ToolWorkflowActionsContext.Provider
+            value={
+              {
+                toggleFavorite: () => {},
+                handleToolSelect: () => {},
+              } as unknown as ToolWorkflowActionsValue
+            }
+          >
+            <div style={{ width: 380 }}>
+              <SearchResults
+                filteredTools={filteredTools}
+                onSelect={() => {}}
+                searchQuery={searchQuery}
+              />
+            </div>
+          </ToolWorkflowActionsContext.Provider>
+        </ToolWorkflowDataContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}
+
+const meta: Meta<typeof SearchResults> = {
+  title: "Tools/SearchResults",
+  component: SearchResults,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchResults>;
+
+/** Matches across several subcategories, each with its own heading. */
+export const Default: Story = { render: () => <Harness /> };
+
+/** A single match, which is the common case for a specific query. */
+export const SingleMatch: Story = {
+  render: () => <Harness filteredTools={[MATCHES[0]]} searchQuery="redact" />,
+};
+
+/** Nothing matched: the results give way to the empty state. */
+export const NoMatches: Story = {
+  render: () => <Harness filteredTools={[]} searchQuery="zzzz" />,
+};
+
+/** Favourited tools carry a filled star. */
+export const WithFavourites: Story = {
+  render: () => <Harness favourites={["sign"]} />,
+};

--- a/frontend/editor/src/core/components/tools/ToolPanel.stories.tsx
+++ b/frontend/editor/src/core/components/tools/ToolPanel.stories.tsx
@@ -1,0 +1,179 @@
+/**
+ * The body of the right rail: the viewer's mini toolbar, then exactly one of
+ * three things beneath it.
+ *
+ * Which one is a chain of checks on workflow state rather than a prop. A search
+ * term while the all-tools view is open wins outright and shows the matches;
+ * otherwise the panel shows the tool picker, compact until the rail expands into
+ * the full catalogue; otherwise it shows the open tool, or an invitation to pick
+ * one. The fourth branch — a tool actually rendered — needs the real registry
+ * behind ToolRenderer, so it is covered by that component's own stories.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import DrawIcon from "@mui/icons-material/Draw";
+import CommentIcon from "@mui/icons-material/Comment";
+import ToolPanel from "@app/components/tools/ToolPanel";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+import { WorkbenchBarContext } from "@app/contexts/WorkbenchBarContext";
+import {
+  ToolCategoryId,
+  SubcategoryId,
+  type ToolRegistryEntry,
+} from "@app/data/toolsTaxonomy";
+import type { ToolId } from "@app/types/toolId";
+
+function tool(
+  name: string,
+  categoryId: ToolCategoryId,
+  subcategoryId: SubcategoryId,
+): ToolRegistryEntry {
+  return {
+    icon: <BuildRoundedIcon />,
+    name,
+    // Without a component or a link an entry counts as "coming soon", which
+    // renders every row disabled.
+    component: () => null,
+    description: `${name} — what this tool does, in one line.`,
+    categoryId,
+    subcategoryId,
+    automationSettings: null,
+  } as ToolRegistryEntry;
+}
+
+const FILTERED_TOOLS = [
+  [
+    "rotate",
+    tool(
+      "Rotate pages",
+      ToolCategoryId.RECOMMENDED_TOOLS,
+      SubcategoryId.PAGE_FORMATTING,
+    ),
+  ],
+  [
+    "compress",
+    tool("Compress", ToolCategoryId.RECOMMENDED_TOOLS, SubcategoryId.GENERAL),
+  ],
+  [
+    "redact",
+    tool(
+      "Redact",
+      ToolCategoryId.STANDARD_TOOLS,
+      SubcategoryId.DOCUMENT_SECURITY,
+    ),
+  ],
+  ["sign", tool("Sign", ToolCategoryId.STANDARD_TOOLS, SubcategoryId.SIGNING)],
+  [
+    "removeBlanks",
+    tool(
+      "Remove blank pages",
+      ToolCategoryId.ADVANCED_TOOLS,
+      SubcategoryId.REMOVAL,
+    ),
+  ],
+].map(([id, entry]) => ({
+  item: [id as ToolId, entry as ToolRegistryEntry] as [
+    ToolId,
+    ToolRegistryEntry,
+  ],
+}));
+
+/** The viewer bar only shows buttons filed under the tool-panel section. */
+const VIEWER_BAR_BUTTONS = [
+  {
+    id: "annotate",
+    section: "tool-panel",
+    ariaLabel: "Annotate",
+    icon: <DrawIcon />,
+  },
+  {
+    id: "comment",
+    section: "tool-panel",
+    ariaLabel: "Comment",
+    icon: <CommentIcon />,
+  },
+];
+
+const withWorkbenchBar = (Story: () => React.ReactElement) => (
+  <WorkbenchBarContext.Provider
+    value={
+      {
+        buttons: VIEWER_BAR_BUTTONS,
+        actions: {},
+        allButtonsDisabled: false,
+      } as never
+    }
+  >
+    <div
+      style={{
+        width: 380,
+        height: "80vh",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Story />
+    </div>
+  </WorkbenchBarContext.Provider>
+);
+
+const workflow = (overrides: Record<string, unknown>) =>
+  withToolContexts({
+    workbench: "viewer",
+    workflow: {
+      searchQuery: "",
+      filteredTools: FILTERED_TOOLS,
+      selectedToolKey: null,
+      handleToolSelect: () => {},
+      setPreviewFile: () => {},
+      ...overrides,
+    },
+  });
+
+const meta: Meta<typeof ToolPanel> = {
+  title: "Tools/ToolPanel",
+  component: ToolPanel,
+  parameters: { layout: "fullscreen" },
+  args: { allToolsView: false, onShowAllTools: () => {} },
+  decorators: [workflow({ leftPanelView: "toolPicker" }), withWorkbenchBar],
+};
+export default meta;
+
+type Story = StoryObj<typeof ToolPanel>;
+
+/** Resting state: the compact picker of pinned and recommended tools. */
+export const Default: Story = {};
+
+/** Expanded into the full categorised catalogue. */
+export const AllTools: Story = { args: { allToolsView: true } };
+
+/** A search term in the all-tools view replaces the picker with its matches. */
+export const Searching: Story = {
+  args: { allToolsView: true },
+  decorators: [
+    workflow({
+      leftPanelView: "toolPicker",
+      searchQuery: "re",
+      filteredTools: FILTERED_TOOLS.filter(({ item }) =>
+        item[1].name.toLowerCase().includes("re"),
+      ),
+    }),
+  ],
+};
+
+/** A search that matches nothing still leaves the empty state in place. */
+export const SearchWithNoMatches: Story = {
+  args: { allToolsView: true },
+  decorators: [
+    workflow({
+      leftPanelView: "toolPicker",
+      searchQuery: "zzzz",
+      filteredTools: [],
+    }),
+  ],
+};
+
+/** Past the picker with no tool open — the panel asks for one. */
+export const NoToolSelected: Story = {
+  decorators: [workflow({ leftPanelView: "toolContent" })],
+};

--- a/frontend/editor/src/core/components/tools/ToolPanelViewerBar.stories.tsx
+++ b/frontend/editor/src/core/components/tools/ToolPanelViewerBar.stories.tsx
@@ -1,0 +1,76 @@
+/**
+ * The row of viewer controls that appears inside the tool panel. It renders
+ * only while the viewer is the active workbench, and takes its buttons from the
+ * workbench bar rather than declaring them.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import PrintIcon from "@mui/icons-material/Print";
+import DownloadIcon from "@mui/icons-material/Download";
+import { ToolPanelViewerBar } from "@app/components/tools/ToolPanelViewerBar";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+import { WorkbenchBarContext } from "@app/contexts/WorkbenchBarContext";
+
+/** The bar renders only the "tool-panel" section, and names each control from
+ *  ariaLabel (falling back to a string tooltip) — not from `label`. */
+const BUTTONS = [
+  {
+    id: "zoom",
+    section: "tool-panel",
+    ariaLabel: "Zoom in",
+    icon: <ZoomInIcon />,
+    onClick: () => {},
+  },
+  {
+    id: "print",
+    section: "tool-panel",
+    ariaLabel: "Print",
+    icon: <PrintIcon />,
+    onClick: () => {},
+  },
+  {
+    id: "download",
+    section: "tool-panel",
+    ariaLabel: "Download",
+    icon: <DownloadIcon />,
+    onClick: () => {},
+  },
+];
+
+function bar(buttons: typeof BUTTONS, allButtonsDisabled = false) {
+  return (Story: () => React.ReactElement) => (
+    <WorkbenchBarContext.Provider
+      value={{ buttons, actions: {}, allButtonsDisabled } as never}
+    >
+      <Story />
+    </WorkbenchBarContext.Provider>
+  );
+}
+
+const meta: Meta<typeof ToolPanelViewerBar> = {
+  title: "Tools/ToolPanelViewerBar",
+  component: ToolPanelViewerBar,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ToolPanelViewerBar>;
+
+export const Default: Story = {
+  decorators: [bar(BUTTONS), withToolContexts({ workbench: "viewer" })],
+};
+
+/** Everything disabled, which is how the bar looks while a tool is running. */
+export const AllDisabled: Story = {
+  decorators: [bar(BUTTONS, true), withToolContexts({ workbench: "viewer" })],
+};
+
+/** A single control, the minimum the bar ever shows. */
+export const OneButton: Story = {
+  decorators: [bar([BUTTONS[0]]), withToolContexts({ workbench: "viewer" })],
+};
+
+/** Any other workbench and the bar renders nothing. */
+export const NotViewerWorkbench: Story = {
+  decorators: [bar(BUTTONS), withToolContexts({ workbench: "fileManager" })],
+};

--- a/frontend/editor/src/core/components/tools/ToolRenderer.tsx
+++ b/frontend/editor/src/core/components/tools/ToolRenderer.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import { useTranslation } from "react-i18next";
 import { useToolWorkflow } from "@app/contexts/ToolWorkflowContext";
 import { BaseToolProps } from "@app/types/tool";
 import { ToolId } from "@app/types/toolId";
@@ -15,7 +14,6 @@ const ToolRenderer = ({
   onComplete,
   onError,
 }: ToolRendererProps) => {
-  const { t } = useTranslation();
   // Get the tool from context (instead of direct hook call)
   const { toolRegistry } = useToolWorkflow();
   const selectedTool =
@@ -29,7 +27,7 @@ const ToolRenderer = ({
   }
 
   if (!selectedTool || !selectedTool.component) {
-    return <div>{t("toolRenderer.notFound", { tool: selectedToolKey })}</div>;
+    return <div>Tool not found: {selectedToolKey}</div>;
   }
 
   const ToolComponent = selectedTool.component;

--- a/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings.stories.tsx
@@ -1,0 +1,92 @@
+/**
+ * How the page number looks: margin, size, face, zero padding and the optional
+ * text wrapped around it. This is the other half of the Add Page Numbers
+ * settings — the position panel places the number, this one styles it — and
+ * every parameter here is one that panel does not render.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddPageNumbersAppearanceSettings from "@app/components/tools/addPageNumbers/AddPageNumbersAppearanceSettings";
+import {
+  defaultParameters,
+  type AddPageNumbersParameters,
+} from "@app/components/tools/addPageNumbers/useAddPageNumbersParameters";
+
+function Demo({
+  overrides,
+  disabled,
+}: {
+  overrides?: Partial<AddPageNumbersParameters>;
+  disabled?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddPageNumbersParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <AddPageNumbersAppearanceSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+    />
+  );
+}
+
+const meta: Meta<typeof AddPageNumbersAppearanceSettings> = {
+  title: "Tools/AddPageNumbers/AppearanceSettings",
+  component: AddPageNumbersAppearanceSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AddPageNumbersAppearanceSettings>;
+
+/** Defaults: medium margin, 12pt Times, no padding, no custom text. */
+export const Default: Story = { render: () => <Demo /> };
+
+/** The margin extremes, which decide how far the number sits from the edge. */
+export const SmallMargin: Story = {
+  render: () => <Demo overrides={{ customMargin: "small" }} />,
+};
+
+export const ExtraLargeMargin: Story = {
+  render: () => <Demo overrides={{ customMargin: "x-large" }} />,
+};
+
+export const CourierFace: Story = {
+  render: () => <Demo overrides={{ fontType: "Courier" }} />,
+};
+
+export const LargeType: Story = {
+  render: () => <Demo overrides={{ fontSize: 24 }} />,
+};
+
+/** Padding to a fixed width, for documents whose numbers must sort as text. */
+export const ZeroPadded: Story = {
+  render: () => <Demo overrides={{ zeroPad: 3 }} />,
+};
+
+/** `{n}` is the placeholder the number is substituted into. */
+export const CustomText: Story = {
+  render: () => <Demo overrides={{ customText: "Page {n}" }} />,
+};
+
+/** Everything at once, which is where the fields crowd if they are going to. */
+export const FullyCustomised: Story = {
+  render: () => (
+    <Demo
+      overrides={{
+        customMargin: "large",
+        fontType: "Helvetica",
+        fontSize: 18,
+        zeroPad: 4,
+        customText: "Section 3 — page {n}",
+      }}
+    />
+  ),
+};
+
+/** Disabled while the tool is running. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAutomationSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersAutomationSettings.stories.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddPageNumbersAutomationSettings from "@app/components/tools/addPageNumbers/AddPageNumbersAutomationSettings";
+import {
+  defaultParameters,
+  type AddPageNumbersParameters,
+} from "@app/components/tools/addPageNumbers/useAddPageNumbersParameters";
+
+/** Page-number settings in the form the pipeline builder embeds. */
+const meta: Meta<typeof AddPageNumbersAutomationSettings> = {
+  title: "Tools/AddPageNumbers/AddPageNumbersAutomationSettings",
+  component: AddPageNumbersAutomationSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AddPageNumbersAutomationSettings>;
+
+function Demo({
+  overrides,
+  disabled,
+}: {
+  overrides?: Partial<AddPageNumbersParameters>;
+  disabled?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddPageNumbersParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <AddPageNumbersAutomationSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+    />
+  );
+}
+
+/** Defaults: Times 12pt, starting at 1, no custom text. */
+export const Default: Story = { render: () => <Demo /> };
+
+/** A custom template around the number. */
+export const CustomText: Story = {
+  render: () => <Demo overrides={{ customText: "Page {n} of {total}" }} />,
+};
+
+/** Numbering only part of the document, starting mid-way. */
+export const PageRangeAndOffset: Story = {
+  render: () => (
+    <Demo overrides={{ pagesToNumber: "3-12,15", startingNumber: 7 }} />
+  ),
+};
+
+/** Zero-padded numbers, for documents filed by page. */
+export const ZeroPadded: Story = {
+  render: () => <Demo overrides={{ zeroPad: 3 }} />,
+};
+
+/** A different face and a larger size. */
+export const CourierLarge: Story = {
+  render: () => <Demo overrides={{ fontType: "Courier", fontSize: 24 }} />,
+};
+
+/** Inert. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersPositionSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/AddPageNumbersPositionSettings.stories.tsx
@@ -1,0 +1,87 @@
+/**
+ * Where the page number lands, and what it says. The position is a 1–9 grid
+ * read like a numeric keypad — 1 is bottom-left, 9 is top-right — so the
+ * stories walk the corners rather than exposing position as a control.
+ *
+ * With no file the preview falls back to a blank page outline; passing a real
+ * document is what makes it render a thumbnail, which stories cannot do.
+ *
+ * The preview reads only the position and the page range, so the appearance
+ * parameters (font, margin, custom text, zero padding) are deliberately not
+ * varied here — this panel does not render them, and a story that set them
+ * would be indistinguishable from the default.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddPageNumbersPositionSettings from "@app/components/tools/addPageNumbers/AddPageNumbersPositionSettings";
+import {
+  defaultParameters,
+  type AddPageNumbersParameters,
+} from "@app/components/tools/addPageNumbers/useAddPageNumbersParameters";
+
+function Demo({
+  overrides,
+  disabled,
+  showQuickGrid,
+}: {
+  overrides?: Partial<AddPageNumbersParameters>;
+  disabled?: boolean;
+  showQuickGrid?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddPageNumbersParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <AddPageNumbersPositionSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+      showQuickGrid={showQuickGrid}
+    />
+  );
+}
+
+const meta: Meta<typeof AddPageNumbersPositionSettings> = {
+  title: "Tools/AddPageNumbers/PositionSettings",
+  component: AddPageNumbersPositionSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AddPageNumbersPositionSettings>;
+
+/** Bottom centre — where numbering conventionally sits, and the default. */
+export const Default: Story = { render: () => <Demo /> };
+
+export const TopLeft: Story = {
+  render: () => <Demo overrides={{ position: 7 }} />,
+};
+
+export const TopRight: Story = {
+  render: () => <Demo overrides={{ position: 9 }} />,
+};
+
+export const BottomLeft: Story = {
+  render: () => <Demo overrides={{ position: 1 }} />,
+};
+
+/** Numbering that starts partway through, for a document split across files. */
+export const StartingNumber: Story = {
+  render: () => <Demo overrides={{ startingNumber: 42 }} />,
+};
+
+/** A range rather than the whole document. */
+export const PageRange: Story = {
+  render: () => <Demo overrides={{ pagesToNumber: "2-8,10" }} />,
+};
+
+/** Without the quick grid the position is set from the preview alone. */
+export const NoQuickGrid: Story = {
+  render: () => <Demo showQuickGrid={false} />,
+};
+
+/** Disabled while the tool is running. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/addPageNumbers/PageNumberPreview.module.css
+++ b/frontend/editor/src/core/components/tools/addPageNumbers/PageNumberPreview.module.css
@@ -126,6 +126,6 @@
 /* Preview disclaimer */
 .previewDisclaimer {
   margin-top: 8px;
-  opacity: 0.7;
+  color: var(--c-text-muted);
   font-size: 12px;
 }

--- a/frontend/editor/src/core/components/tools/addStamp/AddStampAutomationSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addStamp/AddStampAutomationSettings.stories.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddStampAutomationSettings from "@app/components/tools/addStamp/AddStampAutomationSettings";
+import {
+  defaultParameters,
+  type AddStampParameters,
+} from "@app/components/tools/addStamp/useAddStampParameters";
+
+/** Stamp settings in the form the pipeline builder embeds. */
+const meta: Meta<typeof AddStampAutomationSettings> = {
+  title: "Tools/AddStamp/AddStampAutomationSettings",
+  component: AddStampAutomationSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AddStampAutomationSettings>;
+
+function Demo({
+  overrides,
+  disabled,
+}: {
+  overrides?: Partial<AddStampParameters>;
+  disabled?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddStampParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <AddStampAutomationSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+    />
+  );
+}
+
+/** Defaults — no stamp text entered yet. */
+export const Default: Story = { render: () => <Demo /> };
+
+/** A typical text stamp. */
+export const TextStamp: Story = {
+  render: () => <Demo overrides={{ stampText: "CONFIDENTIAL" }} />,
+};
+
+/** Rotated and part-transparent, the usual watermark-style stamp. */
+export const RotatedTranslucent: Story = {
+  render: () => (
+    <Demo overrides={{ stampText: "DRAFT", rotation: 45, opacity: 30 }} />
+  ),
+};
+
+/** A non-Roman alphabet, which selects a different embedded face. */
+export const JapaneseAlphabet: Story = {
+  render: () => (
+    <Demo overrides={{ stampText: "社外秘", alphabet: "japanese" }} />
+  ),
+};
+
+/** Applied to a page range rather than the whole document. */
+export const PageRange: Story = {
+  render: () => (
+    <Demo overrides={{ stampText: "EXHIBIT A", pageNumbers: "1,4-9" }} />
+  ),
+};
+
+/** Inert. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.stories.tsx
@@ -1,0 +1,96 @@
+/**
+ * Placement and formatting for the stamp tool. The three formatting controls —
+ * size, rotation, opacity — share one slider, and `_activePill` decides which
+ * of them is showing, so each pill gets its own story rather than a control.
+ *
+ * Position is the same 1–9 keypad grid the page-number tool uses.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StampPositionFormattingSettings from "@app/components/tools/addStamp/StampPositionFormattingSettings";
+import {
+  defaultParameters,
+  type AddStampParameters,
+} from "@app/components/tools/addStamp/useAddStampParameters";
+
+function Demo({
+  overrides,
+  disabled,
+  showPositionGrid = true,
+}: {
+  overrides?: Partial<AddStampParameters>;
+  disabled?: boolean;
+  showPositionGrid?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AddStampParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <StampPositionFormattingSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+      showPositionGrid={showPositionGrid}
+    />
+  );
+}
+
+const meta: Meta<typeof StampPositionFormattingSettings> = {
+  title: "Tools/AddStamp/PositionFormattingSettings",
+  component: StampPositionFormattingSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof StampPositionFormattingSettings>;
+
+export const Default: Story = { render: () => <Demo /> };
+
+/** The formatting pills each swap in a different slider. */
+export const RotationActive: Story = {
+  render: () => <Demo overrides={{ _activePill: "rotation" }} />,
+};
+
+export const OpacityActive: Story = {
+  render: () => <Demo overrides={{ _activePill: "opacity" }} />,
+};
+
+/** An image stamp has no font size, so that control becomes a scale instead. */
+export const ImageStamp: Story = {
+  render: () => <Demo overrides={{ stampType: "image" }} />,
+};
+
+export const ImageStampRotated: Story = {
+  render: () => (
+    <Demo overrides={{ stampType: "image", _activePill: "rotation" }} />
+  ),
+};
+
+/** Corners of the placement grid. */
+export const TopLeftPosition: Story = {
+  render: () => <Demo overrides={{ position: 7 }} />,
+};
+
+export const CentrePosition: Story = {
+  render: () => <Demo overrides={{ position: 5 }} />,
+};
+
+/** Values at the ends of their ranges, where the sliders sit hard over. */
+export const FullyRotated: Story = {
+  render: () => <Demo overrides={{ _activePill: "rotation", rotation: 180 }} />,
+};
+
+export const NearlyTransparent: Story = {
+  render: () => <Demo overrides={{ _activePill: "opacity", opacity: 10 }} />,
+};
+
+/** Automation drives position numerically, so the grid is hidden there. */
+export const WithoutPositionGrid: Story = {
+  render: () => <Demo showPositionGrid={false} />,
+};
+
+/** Disabled while the tool is running. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addStamp/StampPositionFormattingSettings.tsx
@@ -34,6 +34,16 @@ const StampPositionFormattingSettings = ({
 }: StampPositionFormattingSettingsProps) => {
   const { t } = useTranslation();
 
+  // Each formatting pill shows a number field and a slider driving the same
+  // value. The heading above them is plain text, so both controls carry the
+  // label themselves rather than being left unnamed.
+  const sizeLabel =
+    parameters.stampType === "image"
+      ? t("AddStampRequest.imageSize", "Image Size")
+      : t("AddStampRequest.fontSize", "Font Size");
+  const rotationLabel = t("AddStampRequest.rotation", "Rotation");
+  const opacityLabel = t("AddStampRequest.opacity", "Opacity");
+
   return (
     <Stack gap="md" justify="space-between">
       {/* Position Grid - shown in automation settings */}
@@ -144,11 +154,7 @@ const StampPositionFormattingSettings = ({
       {/* Single slider bound to selected pill */}
       {parameters._activePill === "fontSize" && (
         <Stack gap="xs">
-          <Text className={styles.labelText}>
-            {parameters.stampType === "image"
-              ? t("AddStampRequest.imageSize", "Image Size")
-              : t("AddStampRequest.fontSize", "Font Size")}
-          </Text>
+          <Text className={styles.labelText}>{sizeLabel}</Text>
           <Group className={styles.sliderGroup} align="center">
             <NumberInput
               value={parameters.fontSize}
@@ -164,6 +170,7 @@ const StampPositionFormattingSettings = ({
               size="sm"
               className={styles.numberInput}
               disabled={disabled}
+              aria-label={sizeLabel}
             />
             <Slider
               value={parameters.fontSize}
@@ -173,15 +180,14 @@ const StampPositionFormattingSettings = ({
               step={1}
               className={styles.slider}
               disabled={disabled}
+              thumbLabel={sizeLabel}
             />
           </Group>
         </Stack>
       )}
       {parameters._activePill === "rotation" && (
         <Stack gap="xs">
-          <Text className={styles.labelText}>
-            {t("AddStampRequest.rotation", "Rotation")}
-          </Text>
+          <Text className={styles.labelText}>{rotationLabel}</Text>
           <Group className={styles.sliderGroup} align="center">
             <NumberInput
               value={parameters.rotation}
@@ -195,6 +201,7 @@ const StampPositionFormattingSettings = ({
               className={styles.numberInput}
               hideControls
               disabled={disabled}
+              aria-label={rotationLabel}
             />
             <Slider
               value={parameters.rotation}
@@ -203,15 +210,15 @@ const StampPositionFormattingSettings = ({
               max={180}
               step={1}
               className={styles.sliderWide}
+              disabled={disabled}
+              thumbLabel={rotationLabel}
             />
           </Group>
         </Stack>
       )}
       {parameters._activePill === "opacity" && (
         <Stack gap="xs">
-          <Text className={styles.labelText}>
-            {t("AddStampRequest.opacity", "Opacity")}
-          </Text>
+          <Text className={styles.labelText}>{opacityLabel}</Text>
           <Group className={styles.sliderGroup} align="center">
             <NumberInput
               value={parameters.opacity}
@@ -224,6 +231,7 @@ const StampPositionFormattingSettings = ({
               size="sm"
               className={styles.numberInput}
               disabled={disabled}
+              aria-label={opacityLabel}
             />
             <Slider
               value={parameters.opacity}
@@ -232,6 +240,8 @@ const StampPositionFormattingSettings = ({
               max={100}
               step={1}
               className={styles.slider}
+              disabled={disabled}
+              thumbLabel={opacityLabel}
             />
           </Group>
         </Stack>

--- a/frontend/editor/src/core/components/tools/addStamp/StampPreview.module.css
+++ b/frontend/editor/src/core/components/tools/addStamp/StampPreview.module.css
@@ -119,7 +119,7 @@
 /* Preview disclaimer */
 .previewDisclaimer {
   margin-top: 8px;
-  opacity: 0.7;
+  color: var(--c-text-muted);
   font-size: 12px;
 }
 

--- a/frontend/editor/src/core/components/tools/addStamp/StampPreview.tsx
+++ b/frontend/editor/src/core/components/tools/addStamp/StampPreview.tsx
@@ -393,6 +393,7 @@ export default function StampPreview({
           <div
             className={`${styles.stampItem} ${styles.stampItemGridMode}`}
             style={style.item as React.CSSProperties}
+            data-user-content-preview=""
           >
             {(parameters.stampText || "").split("\n").map((line, idx) => (
               <span

--- a/frontend/editor/src/core/components/tools/addWatermark/WatermarkStyleSettings.tsx
+++ b/frontend/editor/src/core/components/tools/addWatermark/WatermarkStyleSettings.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Stack, Text, NumberInput } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { AddWatermarkParameters } from "@app/hooks/tools/addWatermark/useAddWatermarkParameters";
@@ -17,15 +18,20 @@ const WatermarkStyleSettings = ({
   disabled = false,
 }: WatermarkStyleSettingsProps) => {
   const { t } = useTranslation();
+  const rotationLabelId = useId();
+  const opacityLabelId = useId();
+  const widthLabelId = useId();
+  const heightLabelId = useId();
 
   return (
     <Stack gap="md">
       {/* Appearance Settings */}
       <Stack gap="sm">
-        <Text size="sm" fw={500}>
+        <Text id={rotationLabelId} size="sm" fw={500}>
           {t("watermark.settings.rotation", "Rotation (degrees)")}
         </Text>
         <NumberInput
+          aria-labelledby={rotationLabelId}
           value={parameters.rotation}
           onChange={(value) =>
             onParameterChange(
@@ -40,10 +46,11 @@ const WatermarkStyleSettings = ({
           disabled={disabled}
         />
 
-        <Text size="sm" fw={500}>
+        <Text id={opacityLabelId} size="sm" fw={500}>
           {t("watermark.settings.opacity", "Opacity (%)")}
         </Text>
         <NumberInput
+          aria-labelledby={opacityLabelId}
           value={parameters.opacity}
           onChange={(value) =>
             onParameterChange(
@@ -61,10 +68,11 @@ const WatermarkStyleSettings = ({
 
       {/* Spacing Settings */}
       <Stack gap="sm">
-        <Text size="sm" fw={500}>
+        <Text id={widthLabelId} size="sm" fw={500}>
           {t("watermark.settings.spacing.width", "Width Spacing")}
         </Text>
         <NumberInput
+          aria-labelledby={widthLabelId}
           value={parameters.widthSpacer}
           onChange={(value) =>
             onParameterChange(
@@ -79,10 +87,11 @@ const WatermarkStyleSettings = ({
           disabled={disabled}
         />
 
-        <Text size="sm" fw={500}>
+        <Text id={heightLabelId} size="sm" fw={500}>
           {t("watermark.settings.spacing.height", "Height Spacing")}
         </Text>
         <NumberInput
+          aria-labelledby={heightLabelId}
           value={parameters.heightSpacer}
           onChange={(value) =>
             onParameterChange(

--- a/frontend/editor/src/core/components/tools/addWatermark/WatermarkTextStyle.tsx
+++ b/frontend/editor/src/core/components/tools/addWatermark/WatermarkTextStyle.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Stack, Text, Select, ColorInput } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { AddWatermarkParameters } from "@app/hooks/tools/addWatermark/useAddWatermarkParameters";
@@ -19,14 +20,17 @@ const WatermarkTextStyle = ({
   disabled = false,
 }: WatermarkTextStyleProps) => {
   const { t } = useTranslation();
+  const colorLabelId = useId();
+  const alphabetLabelId = useId();
 
   return (
     <Stack gap="sm">
       <Stack gap="xs">
-        <Text size="xs" fw={500}>
+        <Text id={colorLabelId} size="xs" fw={500}>
           {t("watermark.settings.color", "Colour")}
         </Text>
         <ColorInput
+          aria-labelledby={colorLabelId}
           value={parameters.customColor}
           onChange={(value) => onParameterChange("customColor", value)}
           disabled={disabled}
@@ -39,10 +43,11 @@ const WatermarkTextStyle = ({
       </Stack>
 
       <Stack gap="xs">
-        <Text size="xs" fw={500}>
+        <Text id={alphabetLabelId} size="xs" fw={500}>
           {t("watermark.settings.alphabet", "Alphabet")}
         </Text>
         <Select
+          aria-labelledby={alphabetLabelId}
           value={parameters.alphabet}
           onChange={(value) => value && onParameterChange("alphabet", value)}
           data={alphabetOptions}

--- a/frontend/editor/src/core/components/tools/autoRotate/AutoRotateAutomationSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/autoRotate/AutoRotateAutomationSettings.stories.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AutoRotateAutomationSettings from "@app/components/tools/autoRotate/AutoRotateAutomationSettings";
+import {
+  defaultParameters,
+  type AutoRotateParameters,
+} from "@app/hooks/tools/autoRotate/useAutoRotateParameters";
+
+/** The same detection controls as the tool panel, in the form the pipeline
+ *  builder embeds — a plain parameters object with a change callback rather
+ *  than the tool's own hook. */
+const meta: Meta<typeof AutoRotateAutomationSettings> = {
+  title: "Tools/AutoRotate/AutoRotateAutomationSettings",
+  component: AutoRotateAutomationSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AutoRotateAutomationSettings>;
+
+function Demo({
+  overrides,
+  disabled,
+}: {
+  overrides?: Partial<AutoRotateParameters>;
+  disabled?: boolean;
+}) {
+  const [parameters, setParameters] = useState<AutoRotateParameters>({
+    ...defaultParameters,
+    ...overrides,
+  });
+  return (
+    <AutoRotateAutomationSettings
+      parameters={parameters}
+      onParameterChange={(key, value) =>
+        setParameters((prev) => ({ ...prev, [key]: value }))
+      }
+      disabled={disabled}
+    />
+  );
+}
+
+/** Defaults. */
+export const Default: Story = { render: () => <Demo /> };
+
+/** Forced to text-direction detection. */
+export const TextOnly: Story = {
+  render: () => <Demo overrides={{ detectionMode: "text" }} />,
+};
+
+/** Forced to OCR orientation detection. */
+export const OsdOnly: Story = {
+  render: () => <Demo overrides={{ detectionMode: "osd" }} />,
+};
+
+/** A high confidence floor. */
+export const StrictConfidence: Story = {
+  render: () => <Demo overrides={{ confidenceThreshold: 85 }} />,
+};
+
+/** Inert. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/autoRotate/AutoRotateReport.stories.tsx
+++ b/frontend/editor/src/core/components/tools/autoRotate/AutoRotateReport.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AutoRotateReport from "@app/components/tools/autoRotate/AutoRotateReport";
+import type {
+  AutoRotatePageResult,
+  AutoRotateReport as ReportData,
+} from "@app/hooks/tools/autoRotate/useAutoRotateOperation";
+
+const page = (
+  pageNumber: number,
+  over: Partial<AutoRotatePageResult> = {},
+): AutoRotatePageResult => ({
+  pageNumber,
+  currentRotation: 0,
+  correction: 0,
+  confidence: 96,
+  method: "text",
+  apply: true,
+  ...over,
+});
+
+const report = (pages: AutoRotatePageResult[]): ReportData => ({
+  pages,
+  totalPages: pages.length,
+  pagesToRotate: pages.filter((p) => p.apply && p.correction !== 0).length,
+  detectedByText: pages.filter((p) => p.method === "text").length,
+  detectedByOsd: pages.filter((p) => p.method === "osd").length,
+  inferred: pages.filter((p) => p.method === "inferred").length,
+  undetected: pages.filter((p) => p.confidence === null).length,
+});
+
+/** What auto-rotate decided, per page: how each page's orientation was
+ *  detected, how confident that was, and whether a correction will be applied. */
+const meta: Meta<typeof AutoRotateReport> = {
+  title: "Tools/AutoRotate/AutoRotateReport",
+  component: AutoRotateReport,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AutoRotateReport>;
+
+/** A mixed document: text detection, an OCR fallback, and a page left alone. */
+export const Default: Story = {
+  args: {
+    reports: [
+      {
+        fileName: "contract-2026.pdf",
+        report: report([
+          page(1),
+          page(2, { correction: 90, currentRotation: 270 }),
+          page(3, { method: "osd", confidence: 12.4, correction: 180 }),
+          page(4, { confidence: null, apply: false, note: "No text found" }),
+        ]),
+      },
+    ],
+  },
+};
+
+/** Nothing needed correcting. */
+export const NothingToRotate: Story = {
+  args: {
+    reports: [
+      { fileName: "already-upright.pdf", report: report([page(1), page(2)]) },
+    ],
+  },
+};
+
+/** Several files in one run — each keeps its own breakdown. */
+export const MultipleFiles: Story = {
+  args: {
+    reports: [
+      {
+        fileName: "scans-batch-a.pdf",
+        report: report([page(1, { correction: 90 }), page(2)]),
+      },
+      {
+        fileName: "scans-batch-b.pdf",
+        report: report([
+          page(1, { method: "osd", confidence: 8.1, correction: 270 }),
+          page(2, { confidence: null, apply: false }),
+        ]),
+      },
+    ],
+  },
+};
+
+/** A long document, to check the per-page list stays readable as it grows. */
+export const LongDocument: Story = {
+  args: {
+    reports: [
+      {
+        fileName: "deposition-transcript.pdf",
+        report: report(
+          Array.from({ length: 40 }, (_, i) =>
+            page(i + 1, {
+              correction: i % 3 === 0 ? 90 : 0,
+              method: i % 5 === 0 ? "osd" : "text",
+              confidence: i % 7 === 0 ? null : 70 + (i % 30),
+              apply: i % 7 !== 0,
+            }),
+          ),
+        ),
+      },
+    ],
+  },
+};
+
+/** No files analysed yet. */
+export const Empty: Story = { args: { reports: [] } };

--- a/frontend/editor/src/core/components/tools/autoRotate/AutoRotateReport.tsx
+++ b/frontend/editor/src/core/components/tools/autoRotate/AutoRotateReport.tsx
@@ -118,7 +118,16 @@ const AutoRotateReport = ({ reports }: AutoRotateReportProps) => {
 
           {/* A per-page list rather than a table: the tool panel is too narrow
               for five columns, which truncated the badges and wrapped notes. */}
-          <ScrollArea.Autosize mah={300}>
+          {/* The per-page list scrolls but holds no control of its own, so it
+              needs a tab stop to be reachable without a mouse. */}
+          <ScrollArea.Autosize
+            mah={300}
+            viewportProps={{
+              tabIndex: 0,
+              role: "group",
+              "aria-label": t("autoRotate.report.pages", "Per-page results"),
+            }}
+          >
             <Stack gap={0}>
               {report.pages.map((page, index) => {
                 const confidence = confidenceValue(page);

--- a/frontend/editor/src/core/components/tools/autoRotate/AutoRotateSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/autoRotate/AutoRotateSettings.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AutoRotateSettings from "@app/components/tools/autoRotate/AutoRotateSettings";
+import {
+  defaultParameters,
+  validateAutoRotateParameters,
+  type AutoRotateParameters,
+} from "@app/hooks/tools/autoRotate/useAutoRotateParameters";
+import { useStoryParameters } from "@app/components/tools/shared/storyParameters";
+
+/** How pages are detected before rotation: `auto` tries embedded text first
+ *  and falls back to OCR orientation detection; the other modes force one. */
+const meta: Meta<typeof AutoRotateSettings> = {
+  title: "Tools/AutoRotate/AutoRotateSettings",
+  component: AutoRotateSettings,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof AutoRotateSettings>;
+
+function Demo({
+  overrides,
+  disabled,
+}: {
+  overrides?: Partial<AutoRotateParameters>;
+  disabled?: boolean;
+}) {
+  const parameters = useStoryParameters<AutoRotateParameters>(
+    { ...defaultParameters, ...overrides },
+    { endpointName: "auto-rotate", validate: validateAutoRotateParameters },
+  );
+  return <AutoRotateSettings parameters={parameters} disabled={disabled} />;
+}
+
+/** Defaults: automatic detection, inference on. */
+export const Default: Story = { render: () => <Demo /> };
+
+/** Text-direction detection only — no OCR pass. */
+export const TextOnly: Story = {
+  render: () => <Demo overrides={{ detectionMode: "text" }} />,
+};
+
+/** OCR orientation detection only, where the pages carry no extractable text. */
+export const OsdOnly: Story = {
+  render: () => <Demo overrides={{ detectionMode: "osd" }} />,
+};
+
+/** A high confidence floor — only strongly-detected pages get corrected. */
+export const StrictConfidence: Story = {
+  render: () => <Demo overrides={{ confidenceThreshold: 85 }} />,
+};
+
+/** Undetected pages left alone rather than taking the document consensus. */
+export const InferenceOff: Story = {
+  render: () => <Demo overrides={{ inferUndetected: false }} />,
+};
+
+/** Inert while the tool is running. */
+export const Disabled: Story = { render: () => <Demo disabled /> };

--- a/frontend/editor/src/core/components/tools/automate/AutomationImportModal.tsx
+++ b/frontend/editor/src/core/components/tools/automate/AutomationImportModal.tsx
@@ -104,6 +104,11 @@ export default function AutomationImportModal({
     }
   };
 
+  const dropzoneLabel = t(
+    "automate.importModal.dropzoneAriaLabel",
+    "Drop an automation JSON file here",
+  );
+
   const formatLabel =
     parsed?.format === "automate"
       ? t("automate.importModal.detectedAutomation", "Automate JSON")
@@ -133,10 +138,10 @@ export default function AutomationImportModal({
           accept={["application/json", "text/plain"]}
           multiple={false}
           maxSize={10 * 1024 * 1024}
-          aria-label={t(
-            "automate.importModal.dropzoneAriaLabel",
-            "Drop an automation JSON file here",
-          )}
+          aria-label={dropzoneLabel}
+          // Dropzone's own aria-label lands on the wrapper; the hidden file
+          // input it renders needs naming separately.
+          inputProps={{ "aria-label": dropzoneLabel }}
         >
           <Group
             gap="md"
@@ -207,7 +212,7 @@ export default function AutomationImportModal({
                 })}
               </Text>
               {parsed.unresolvedOperations.length > 0 && (
-                <Text size="xs" c="orange">
+                <Text size="xs" c="var(--color-amber-dark)">
                   {t("automate.importModal.unresolved", "Unmapped: {{ops}}", {
                     ops: parsed.unresolvedOperations.join(", "),
                   })}

--- a/frontend/editor/src/core/components/tools/automate/AutomationRun.tsx
+++ b/frontend/editor/src/core/components/tools/automate/AutomationRun.tsx
@@ -216,7 +216,7 @@ export default function AutomationRun({
                   {step.name}
                 </Text>
                 {step.error && (
-                  <Text size="xs" c="red" mt="xs">
+                  <Text size="xs" c="var(--color-red-dark)" mt="xs">
                     {step.error}
                   </Text>
                 )}

--- a/frontend/editor/src/core/components/tools/automate/IconSelector.tsx
+++ b/frontend/editor/src/core/components/tools/automate/IconSelector.tsx
@@ -92,7 +92,16 @@ export default function IconSelector({
                 return (
                   <Tooltip key={option.value} label={option.label}>
                     <Box
+                      role="button"
+                      tabIndex={0}
+                      aria-label={option.label}
                       onClick={() => handleIconSelect(option.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleIconSelect(option.value);
+                        }
+                      }}
                       style={{
                         display: "flex",
                         alignItems: "center",

--- a/frontend/editor/src/core/components/tools/bookletImposition/BookletImpositionSettings.tsx
+++ b/frontend/editor/src/core/components/tools/bookletImposition/BookletImpositionSettings.tsx
@@ -70,7 +70,7 @@ const BookletImpositionSettings = ({
         {/* Manual Duplex Pass Selection - only show when double-sided is OFF */}
         {!parameters.doubleSided && (
           <Stack gap="xs" ml="lg">
-            <Text size="sm" fw={500} c="orange">
+            <Text size="sm" fw={500} c="var(--color-amber-dark)">
               {t("bookletImposition.manualDuplex.title", "Manual Duplex Mode")}
             </Text>
             <Text size="xs" c="dimmed">
@@ -97,7 +97,7 @@ const BookletImpositionSettings = ({
               disabled={disabled}
             />
 
-            <Text size="xs" c="blue" fs="italic">
+            <Text size="xs" c="var(--c-accent-text)" fs="italic">
               {parameters.duplexPass === "FIRST"
                 ? t(
                     "bookletImposition.duplexPass.firstInstructions",

--- a/frontend/editor/src/core/components/tools/certSign/modals/CertificateConfigModal.tsx
+++ b/frontend/editor/src/core/components/tools/certSign/modals/CertificateConfigModal.tsx
@@ -249,7 +249,7 @@ export const CertificateConfigModal: React.FC<CertificateConfigModalProps> = ({
               fontSize="small"
               style={{ color: "var(--mantine-color-green-6)" }}
             />
-            <Text size="sm" c="green">
+            <Text size="sm" c="var(--color-green-dark)">
               {t(
                 "certSign.collab.signRequest.certModal.certValidUntil",
                 "Certificate valid until {{date}}",
@@ -271,7 +271,7 @@ export const CertificateConfigModal: React.FC<CertificateConfigModalProps> = ({
               fontSize="small"
               style={{ color: "var(--mantine-color-red-6)" }}
             />
-            <Text size="sm" c="red">
+            <Text size="sm" c="var(--color-red-dark)">
               {t(
                 "certSign.collab.signRequest.certModal.certInvalid",
                 "Certificate invalid: {{error}}",

--- a/frontend/editor/src/core/components/tools/certSign/panels/SignRequestPanel.tsx
+++ b/frontend/editor/src/core/components/tools/certSign/panels/SignRequestPanel.tsx
@@ -318,7 +318,7 @@ const SignRequestPanel = ({ data }: SignRequestPanelProps) => {
         fullWidth
         style={{
           backgroundColor: "var(--c-surface-raised)",
-          color: "var(--c-primary)",
+          color: "var(--c-accent-text)",
           border: "1px solid var(--c-border)",
         }}
       >

--- a/frontend/editor/src/core/components/tools/certSign/steps/AddSignaturesStep.tsx
+++ b/frontend/editor/src/core/components/tools/certSign/steps/AddSignaturesStep.tsx
@@ -135,7 +135,7 @@ export const AddSignaturesStep: React.FC<AddSignaturesStepProps> = ({
       </Paper>
 
       {placementMode && (
-        <Text size="xs" c="blue" ta="center">
+        <Text size="xs" c="var(--c-accent-text)" ta="center">
           {t(
             "certSign.collab.signRequest.steps.clickMultipleTimes",
             "Click on the PDF multiple times to place signatures. Drag any signature to move or resize it.",

--- a/frontend/editor/src/core/components/tools/compare/ComparePixelWorkbenchView.tsx
+++ b/frontend/editor/src/core/components/tools/compare/ComparePixelWorkbenchView.tsx
@@ -188,7 +188,7 @@ const ComparePixelWorkbenchView = ({
       {result.warnings.length > 0 && (
         <Stack gap={4}>
           {result.warnings.map((w, i) => (
-            <Text key={i} size="xs" c="yellow.7">
+            <Text key={i} size="xs" c="var(--color-amber-dark)">
               {w}
             </Text>
           ))}

--- a/frontend/editor/src/core/components/tools/compress/CompressSettings.tsx
+++ b/frontend/editor/src/core/components/tools/compress/CompressSettings.tsx
@@ -116,6 +116,7 @@ const CompressSettings = ({
               style={{ flex: 1 }}
             />
             <Select
+              aria-label={t("compress.settings.desiredSizeUnit", "Size unit")}
               value={parameters.fileSizeUnit}
               onChange={(value) => {
                 // Prevent deselection - if value is null/undefined, keep the current value
@@ -244,6 +245,8 @@ const CompressSettings = ({
               }}
               disabled={disabled || imageMagickAvailable === false}
               label={null}
+              // The thumb is a div, so the heading above cannot name it.
+              thumbLabel={t("compress.lineArt.detailLevel", "Detail level")}
               marks={[
                 { value: 1 },
                 { value: 2 },

--- a/frontend/editor/src/core/components/tools/convert/ConvertFromEmailSettings.tsx
+++ b/frontend/editor/src/core/components/tools/convert/ConvertFromEmailSettings.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Stack, Text, NumberInput, Checkbox } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { ConvertParameters } from "@app/hooks/tools/convert/useConvertParameters";
@@ -17,6 +18,7 @@ const ConvertFromEmailSettings = ({
   disabled = false,
 }: ConvertFromEmailSettingsProps) => {
   const { t } = useTranslation();
+  const maxSizeLabelId = useId();
 
   return (
     <Stack gap="sm" data-testid="email-settings">
@@ -39,10 +41,11 @@ const ConvertFromEmailSettings = ({
 
       {parameters.emailOptions.includeAttachments && (
         <Stack gap="xs">
-          <Text size="xs" fw={500}>
+          <Text id={maxSizeLabelId} size="xs" fw={500}>
             {t("convert.maxAttachmentSize", "Maximum attachment size (MB)")}:
           </Text>
           <NumberInput
+            aria-labelledby={maxSizeLabelId}
             value={parameters.emailOptions.maxAttachmentSizeMB}
             onChange={(value) =>
               onParameterChange("emailOptions", {

--- a/frontend/editor/src/core/components/tools/convert/ConvertFromWebSettings.tsx
+++ b/frontend/editor/src/core/components/tools/convert/ConvertFromWebSettings.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Stack, Text, NumberInput, Slider } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { ConvertParameters } from "@app/hooks/tools/convert/useConvertParameters";
@@ -17,6 +18,8 @@ const ConvertFromWebSettings = ({
   disabled = false,
 }: ConvertFromWebSettingsProps) => {
   const { t } = useTranslation();
+  const zoomLabelId = useId();
+  const zoomLabel = t("convert.zoomLevel", "Zoom Level");
 
   return (
     <Stack gap="sm" data-testid="web-settings">
@@ -25,10 +28,11 @@ const ConvertFromWebSettings = ({
       </Text>
 
       <Stack gap="xs">
-        <Text size="xs" fw={500}>
-          {t("convert.zoomLevel", "Zoom Level")}:
+        <Text id={zoomLabelId} size="xs" fw={500}>
+          {zoomLabel}:
         </Text>
         <NumberInput
+          aria-labelledby={zoomLabelId}
           value={parameters.htmlOptions.zoomLevel}
           onChange={(value) =>
             onParameterChange("htmlOptions", {
@@ -55,6 +59,8 @@ const ConvertFromWebSettings = ({
           step={0.1}
           disabled={disabled}
           data-testid="zoom-level-slider"
+          // The thumb is a div, so the heading above cannot name it.
+          thumbLabel={zoomLabel}
         />
       </Stack>
     </Stack>

--- a/frontend/editor/src/core/components/tools/convert/ConvertToPdfaSettings.tsx
+++ b/frontend/editor/src/core/components/tools/convert/ConvertToPdfaSettings.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Stack, Text, Select, Alert, Checkbox } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { ConvertParameters } from "@app/hooks/tools/convert/useConvertParameters";
@@ -24,6 +25,7 @@ const ConvertToPdfaSettings = ({
   const { t } = useTranslation();
   const { hasDigitalSignatures, isChecking } =
     usePdfSignatureDetection(selectedFiles);
+  const outputFormatLabelId = useId();
 
   const pdfaFormatOptions = [
     { value: "pdfa-1", label: "PDF/A-1b" },
@@ -49,10 +51,11 @@ const ConvertToPdfaSettings = ({
       )}
 
       <Stack gap="xs">
-        <Text size="xs" fw={500}>
+        <Text id={outputFormatLabelId} size="xs" fw={500}>
           {t("convert.outputFormat", "Output Format")}:
         </Text>
         <Select
+          aria-labelledby={outputFormatLabelId}
           value={parameters.pdfaOptions.outputFormat}
           onChange={(value) =>
             onParameterChange("pdfaOptions", {

--- a/frontend/editor/src/core/components/tools/convert/GroupedFormatDropdown.tsx
+++ b/frontend/editor/src/core/components/tools/convert/GroupedFormatDropdown.tsx
@@ -8,7 +8,6 @@ import {
   useMantineTheme,
 } from "@mantine/core";
 import { Button } from "@app/ui/Button";
-import { useTranslation } from "react-i18next";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import CloudOutlinedIcon from "@mui/icons-material/CloudOutlined";
 import { Z_INDEX_AUTOMATE_DROPDOWN } from "@app/styles/zIndex";
@@ -35,7 +34,7 @@ interface GroupedFormatDropdownProps {
 
 const GroupedFormatDropdown = ({
   value,
-  placeholder,
+  placeholder = "Select an option",
   options,
   onChange,
   disabled = false,
@@ -44,8 +43,6 @@ const GroupedFormatDropdown = ({
   withinPortal = true,
   zIndex = Z_INDEX_AUTOMATE_DROPDOWN,
 }: GroupedFormatDropdownProps) => {
-  const { t } = useTranslation();
-  const resolvedPlaceholder = placeholder ?? t("dropdownList.selectOption");
   const [dropdownOpened, setDropdownOpened] = useState(false);
   const theme = useMantineTheme();
 
@@ -63,12 +60,12 @@ const GroupedFormatDropdown = ({
   }, [options]);
 
   const selectedLabel = useMemo(() => {
-    if (!value) return resolvedPlaceholder;
+    if (!value) return placeholder;
     const selected = options.find((opt) => opt.value === value);
     return selected
       ? `${selected.group} (${selected.label})`
       : value.toUpperCase();
-  }, [value, options, resolvedPlaceholder]);
+  }, [value, options, placeholder]);
 
   const handleOptionSelect = (selectedValue: string) => {
     onChange(selectedValue);

--- a/frontend/editor/src/core/components/tools/fullscreen/CompactToolItem.stories.tsx
+++ b/frontend/editor/src/core/components/tools/fullscreen/CompactToolItem.stories.tsx
@@ -1,0 +1,125 @@
+/**
+ * A single row in the fullscreen tool list. What it shows beyond the name is
+ * decided elsewhere: the hotkey comes from HotkeyContext, the favourite star
+ * and availability from ToolWorkflowContext, and whether premium tools are
+ * offered at all from AppConfig.
+ *
+ * Mounting ToolWorkflowProvider would stand up the whole tool registry and its
+ * navigation chain, so the fixture supplies the three fields the row reads.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BuildRoundedIcon from "@mui/icons-material/BuildRounded";
+import CompactToolItem from "@app/components/tools/fullscreen/CompactToolItem";
+import type { ToolRegistryEntry } from "@app/data/toolsTaxonomy";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import {
+  ToolWorkflowContext,
+  type ToolWorkflowContextValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+
+const TOOL: ToolRegistryEntry = {
+  icon: <BuildRoundedIcon />,
+  name: "Rotate pages",
+  // A registry entry with no component and no link is treated as "coming
+  // soon" and renders disabled, which would make every story below identical.
+  component: () => null,
+  description: "Turn pages through 90, 180 or 270 degrees.",
+  categoryId: "organise" as never,
+  subcategoryId: "pageOperations" as never,
+  automationSettings: null,
+} as ToolRegistryEntry;
+
+/** Availability is keyed by tool id; anything absent counts as available. */
+function fixture({
+  isFavorite = false,
+  available = true,
+}: { isFavorite?: boolean; available?: boolean } = {}) {
+  return {
+    isFavorite: () => isFavorite,
+    toggleFavorite: () => {},
+    toolAvailability: available ? {} : { rotate: { available: false } },
+  } as unknown as ToolWorkflowContextValue;
+}
+
+function Harness({
+  tool = TOOL,
+  isSelected = false,
+  isFavorite = false,
+  available = true,
+  premiumEnabled = true,
+}: {
+  tool?: ToolRegistryEntry;
+  isSelected?: boolean;
+  isFavorite?: boolean;
+  available?: boolean;
+  premiumEnabled?: boolean;
+}) {
+  return (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      {/* The row shows a tool's hotkey when one is bound; none are here. */}
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <ToolWorkflowContext.Provider
+          value={fixture({ isFavorite, available })}
+        >
+          <div style={{ width: 320 }}>
+            <CompactToolItem
+              id="rotate"
+              tool={tool}
+              isSelected={isSelected}
+              onClick={() => {}}
+            />
+          </div>
+        </ToolWorkflowContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}
+
+const meta: Meta<typeof CompactToolItem> = {
+  title: "Tools/Fullscreen/CompactToolItem",
+  component: CompactToolItem,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof CompactToolItem>;
+
+export const Default: Story = { render: () => <Harness /> };
+
+export const Selected: Story = { render: () => <Harness isSelected /> };
+
+export const Favourited: Story = { render: () => <Harness isFavorite /> };
+
+/** Alpha tools carry a badge next to the name. */
+export const AlphaTool: Story = {
+  render: () => (
+    <Harness tool={{ ...TOOL, versionStatus: "alpha" } as ToolRegistryEntry} />
+  ),
+};
+
+/** A long name has to truncate rather than push the row wider. */
+export const LongName: Story = {
+  render: () => (
+    <Harness
+      tool={
+        {
+          ...TOOL,
+          name: "Convert scanned documents to searchable PDF with OCR",
+        } as ToolRegistryEntry
+      }
+    />
+  ),
+};
+
+/** Unavailable tools render disabled, which also hides the favourite star. */
+export const Unavailable: Story = {
+  render: () => <Harness available={false} />,
+};

--- a/frontend/editor/src/core/components/tools/ocr/LanguagePicker.module.css
+++ b/frontend/editor/src/core/components/tools/ocr/LanguagePicker.module.css
@@ -93,7 +93,7 @@
 }
 
 .languagePickerLink {
-  color: var(--c-accent-fg);
+  color: var(--c-accent-text);
   text-decoration: underline;
   cursor: pointer;
 }

--- a/frontend/editor/src/core/components/tools/ocr/LanguagePicker.tsx
+++ b/frontend/editor/src/core/components/tools/ocr/LanguagePicker.tsx
@@ -29,14 +29,13 @@ export interface LanguagePickerProps {
 const LanguagePicker: React.FC<LanguagePickerProps> = ({
   value,
   onChange,
-  placeholder,
+  placeholder = "Select languages",
   disabled = false,
   label,
   languagesEndpoint = "/api/v1/ui-data/ocr-pdf",
   autoFillFromBrowserLanguage = true,
 }) => {
   const { t, i18n } = useTranslation();
-  const resolvedPlaceholder = placeholder ?? t("dropdownList.selectLanguages");
   const [availableLanguages, setAvailableLanguages] = useState<DropdownItem[]>(
     [],
   );
@@ -156,20 +155,21 @@ const LanguagePicker: React.FC<LanguagePickerProps> = ({
             "Looking for additional languages?",
           )}
         </Text>
+        {/* A real anchor: it was styled as a link and opened one, but as a
+            Text with an onClick it could not be reached by keyboard and gave
+            no target cue on hover. */}
         <Text
+          component="a"
+          href="https://docs.stirlingpdf.com/Configuration/OCR"
+          target="_blank"
+          rel="noopener noreferrer"
           size="xs"
           style={{
-            color: "var(--c-primary)",
+            color: "var(--c-accent-text)",
             cursor: "pointer",
             textDecoration: "underline",
             textAlign: "center",
           }}
-          onClick={() =>
-            window.open(
-              "https://docs.stirlingpdf.com/Configuration/OCR",
-              "_blank",
-            )
-          }
         >
           {t("ocr.languagePicker.viewSetupGuide", "View setup guide →")}
         </Text>
@@ -182,7 +182,7 @@ const LanguagePicker: React.FC<LanguagePickerProps> = ({
       value={value}
       onChange={(newValue) => onChange(newValue as string[])}
       items={availableLanguages}
-      placeholder={resolvedPlaceholder}
+      placeholder={placeholder}
       disabled={disabled}
       label={label}
       footer={footer}

--- a/frontend/editor/src/core/components/tools/pdfTextEditor/FontStatusPanel.tsx
+++ b/frontend/editor/src/core/components/tools/pdfTextEditor/FontStatusPanel.tsx
@@ -167,7 +167,7 @@ const FontDetailItem = ({ analysis }: { analysis: FontAnalysis }) => {
             {/* Warnings */}
             {analysis.warnings.length > 0 && (
               <Box>
-                <Text size="xs" c="orange" fw={500}>
+                <Text size="xs" c="var(--color-amber-dark)" fw={500}>
                   {t("pdfTextEditor.fontAnalysis.warnings", "Warnings")}:
                 </Text>
                 <List size="xs" spacing={2} withPadding>
@@ -183,7 +183,7 @@ const FontDetailItem = ({ analysis }: { analysis: FontAnalysis }) => {
             {/* Suggestions */}
             {analysis.suggestions.length > 0 && (
               <Box>
-                <Text size="xs" c="blue" fw={500}>
+                <Text size="xs" c="var(--c-accent-text)" fw={500}>
                   {t("pdfTextEditor.fontAnalysis.suggestions", "Notes")}:
                 </Text>
                 <List size="xs" spacing={2} withPadding>

--- a/frontend/editor/src/core/components/tools/pdfTextEditor/PdfTextEditorView.tsx
+++ b/frontend/editor/src/core/components/tools/pdfTextEditor/PdfTextEditorView.tsx
@@ -1406,6 +1406,17 @@ const PdfTextEditorView = ({ data }: PdfTextEditorViewProps) => {
     clearSelection();
   };
 
+  // Clicking the page backdrop deselects, but that is mouse-only: without this
+  // a keyboard user has no way out of a selection. The backdrop itself stays a
+  // plain surface — it is a canvas, not a control.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") handleBackgroundClick();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
   const handleSelectionInteraction = useCallback(
     (groupId: string, groupIndex: number, event: React.MouseEvent): boolean => {
       const multiSelect = event.metaKey || event.ctrlKey;
@@ -1683,7 +1694,7 @@ const PdfTextEditorView = ({ data }: PdfTextEditorViewProps) => {
           >
             <Stack align="center" gap="md" style={{ pointerEvents: "none" }}>
               <UploadFileIcon
-                sx={{ fontSize: 48, color: "var(--mantine-color-blue-5)" }}
+                sx={{ fontSize: 48, color: "var(--c-accent-text)" }}
               />
               <Text size="lg" fw={600}>
                 {t("pdfTextEditor.empty.title", "No document loaded")}

--- a/frontend/editor/src/core/components/tools/removeBlanks/RemoveBlanksSettings.tsx
+++ b/frontend/editor/src/core/components/tools/removeBlanks/RemoveBlanksSettings.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
   Stack,
   Text,
@@ -25,6 +26,11 @@ const RemoveBlanksSettings = ({
   disabled = false,
 }: RemoveBlanksSettingsProps) => {
   const { t } = useTranslation();
+  const whitePercentLabelId = useId();
+  const whitePercentLabel = t(
+    "removeBlanks.whitePercent.label",
+    "White Percent",
+  );
 
   return (
     <Stack gap="lg" mt="md">
@@ -46,11 +52,12 @@ const RemoveBlanksSettings = ({
       </Stack>
 
       <Stack gap="xs">
-        <Text size="sm" fw={500}>
-          {t("removeBlanks.whitePercent.label", "White Percent")}
+        <Text id={whitePercentLabelId} size="sm" fw={500}>
+          {whitePercentLabel}
         </Text>
         <Group align="center">
           <NumberInput
+            aria-labelledby={whitePercentLabelId}
             value={parameters.whitePercent}
             onChange={(v) =>
               onParameterChange("whitePercent", typeof v === "number" ? v : 0.1)
@@ -71,6 +78,8 @@ const RemoveBlanksSettings = ({
             step={0.1}
             style={{ flex: 1 }}
             disabled={disabled}
+            // The thumb is a div, so the heading above cannot name it.
+            thumbLabel={whitePercentLabel}
           />
         </Group>
       </Stack>

--- a/frontend/editor/src/core/components/tools/replaceColor/ReplaceColorSettings.tsx
+++ b/frontend/editor/src/core/components/tools/replaceColor/ReplaceColorSettings.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Stack, Text, Select, ColorInput } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { ReplaceColorParameters } from "@app/hooks/tools/replaceColor/useReplaceColorParameters";
@@ -18,6 +19,10 @@ const ReplaceColorSettings = ({
   disabled = false,
 }: ReplaceColorSettingsProps) => {
   const { t } = useTranslation();
+  const operationLabelId = useId();
+  const highContrastLabelId = useId();
+  const textColorLabelId = useId();
+  const backgroundColorLabelId = useId();
 
   const replaceAndInvertOptions = [
     {
@@ -60,10 +65,11 @@ const ReplaceColorSettings = ({
   return (
     <Stack gap="md">
       <Stack gap="xs">
-        <Text size="sm" fw={500}>
+        <Text id={operationLabelId} size="sm" fw={500}>
           {t("replaceColor.labels.colourOperation", "Colour operation")}
         </Text>
         <Select
+          aria-labelledby={operationLabelId}
           value={parameters.replaceAndInvertOption}
           onChange={(value) =>
             value &&
@@ -83,10 +89,11 @@ const ReplaceColorSettings = ({
 
       {parameters.replaceAndInvertOption === "HIGH_CONTRAST_COLOR" && (
         <Stack gap="xs">
-          <Text size="sm" fw={500}>
+          <Text id={highContrastLabelId} size="sm" fw={500}>
             {t("replace-color.selectText.5", "High contrast color options")}
           </Text>
           <Select
+            aria-labelledby={highContrastLabelId}
             value={parameters.highContrastColorCombination}
             onChange={(value) =>
               value &&
@@ -108,10 +115,11 @@ const ReplaceColorSettings = ({
       {parameters.replaceAndInvertOption === "CUSTOM_COLOR" && (
         <>
           <Stack gap="xs">
-            <Text size="sm" fw={500}>
+            <Text id={textColorLabelId} size="sm" fw={500}>
               {t("replace-color.selectText.10", "Choose text Color")}
             </Text>
             <ColorInput
+              aria-labelledby={textColorLabelId}
               value={parameters.textColor}
               onChange={(value) => onParameterChange("textColor", value)}
               format="hex"
@@ -124,10 +132,11 @@ const ReplaceColorSettings = ({
           </Stack>
 
           <Stack gap="xs">
-            <Text size="sm" fw={500}>
+            <Text id={backgroundColorLabelId} size="sm" fw={500}>
               {t("replace-color.selectText.11", "Choose background Color")}
             </Text>
             <ColorInput
+              aria-labelledby={backgroundColorLabelId}
               value={parameters.backGroundColor}
               onChange={(value) => onParameterChange("backGroundColor", value)}
               format="hex"

--- a/frontend/editor/src/core/components/tools/shared/FileStatusIndicator.stories.tsx
+++ b/frontend/editor/src/core/components/tools/shared/FileStatusIndicator.stories.tsx
@@ -1,0 +1,50 @@
+/**
+ * The strip above a tool's controls telling you whether you have enough files
+ * selected. It reads the loaded-file list and the files-modal opener from
+ * context, and compares what is selected against the tool's minimum.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import FileStatusIndicator from "@app/components/tools/shared/FileStatusIndicator";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+import type { StirlingFile } from "@app/types/fileContext";
+
+const file = (name: string) => ({ name }) as unknown as StirlingFile;
+
+const meta: Meta<typeof FileStatusIndicator> = {
+  title: "Tools/Shared/FileStatusIndicator",
+  component: FileStatusIndicator,
+  parameters: { layout: "padded" },
+  decorators: [withToolContexts()],
+};
+export default meta;
+
+type Story = StoryObj<typeof FileStatusIndicator>;
+
+/** Nothing selected against a tool needing one file. */
+export const NoneSelected: Story = { args: { selectedFiles: [], minFiles: 1 } };
+
+export const OneSelected: Story = {
+  args: { selectedFiles: [file("report.pdf")], minFiles: 1 },
+};
+
+/** A tool needing two files, with only one to hand. */
+export const BelowMinimum: Story = {
+  args: { selectedFiles: [file("report.pdf")], minFiles: 2 },
+};
+
+export const MinimumMet: Story = {
+  args: {
+    selectedFiles: [file("report.pdf"), file("appendix.pdf")],
+    minFiles: 2,
+  },
+};
+
+/** Well past the minimum, which is the merge and combine case. */
+export const ManySelected: Story = {
+  args: {
+    selectedFiles: Array.from({ length: 7 }, (_, i) =>
+      file(`scan-${String(i + 1).padStart(2, "0")}.pdf`),
+    ),
+    minFiles: 2,
+  },
+};

--- a/frontend/editor/src/core/components/tools/shared/NoToolsFound.stories.tsx
+++ b/frontend/editor/src/core/components/tools/shared/NoToolsFound.stories.tsx
@@ -1,11 +1,26 @@
+/**
+ * What the tool picker shows when a search matches nothing. A single line, no
+ * props — the whole component is its message.
+ */
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import NoToolsFound from "@app/components/tools/shared/NoToolsFound";
 
-const meta = {
+const meta: Meta<typeof NoToolsFound> = {
   title: "Tools/Shared/NoToolsFound",
   component: NoToolsFound,
-} satisfies Meta<typeof NoToolsFound>;
+  parameters: { layout: "padded" },
+};
 export default meta;
-type Story = StoryObj<typeof meta>;
+
+type Story = StoryObj<typeof NoToolsFound>;
 
 export const Default: Story = {};
+
+/** In the narrow rail the picker actually occupies. */
+export const InRail: Story = {
+  render: () => (
+    <div style={{ width: 240, border: "1px solid var(--c-border)" }}>
+      <NoToolsFound />
+    </div>
+  ),
+};

--- a/frontend/editor/src/core/components/tools/shared/NumberInputWithUnit.tsx
+++ b/frontend/editor/src/core/components/tools/shared/NumberInputWithUnit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useId, useState, useEffect } from "react";
 import { Stack, Text, NumberInput } from "@mantine/core";
 
 interface NumberInputWithUnitProps {
@@ -20,6 +20,7 @@ const NumberInputWithUnit = ({
   max,
   disabled = false,
 }: NumberInputWithUnitProps) => {
+  const labelId = useId();
   const [localValue, setLocalValue] = useState<number | string>(value);
 
   // Sync local value when external value changes
@@ -34,6 +35,7 @@ const NumberInputWithUnit = ({
   return (
     <Stack gap="xs" style={{ flex: 1 }}>
       <Text
+        id={labelId}
         size="xs"
         fw={500}
         style={{
@@ -51,6 +53,7 @@ const NumberInputWithUnit = ({
         min={min}
         max={max}
         disabled={disabled}
+        aria-labelledby={labelId}
         rightSection={
           <Text size="sm" c="dimmed" pr="sm">
             {unit}

--- a/frontend/editor/src/core/components/tools/shared/OperationButton.stories.tsx
+++ b/frontend/editor/src/core/components/tools/shared/OperationButton.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import OperationButton from "@app/components/tools/shared/OperationButton";
+
+/**
+ * The run control every tool panel ends with. When it can't run it stays
+ * visible and explains why rather than disappearing — the reason is what tells
+ * the user what to fix.
+ */
+const meta: Meta<typeof OperationButton> = {
+  title: "Tools/Shared/OperationButton",
+  component: OperationButton,
+  parameters: { layout: "padded" },
+  args: { onClick: () => {}, submitText: "Rotate" },
+};
+export default meta;
+
+type Story = StoryObj<typeof OperationButton>;
+
+/** Ready to run. */
+export const Default: Story = {};
+
+/** Mid-run. */
+export const Loading: Story = {
+  args: { isLoading: true, loadingText: "Rotating…" },
+};
+
+/* ── Why it can't run ─────────────────────────────────────────────────────── */
+
+/** No files chosen yet. */
+export const NoFiles: Story = {
+  args: { disabled: true, disabledReason: "noFiles" },
+};
+
+/** Files still hydrating. */
+export const FilesLoading: Story = {
+  args: { disabled: true, disabledReason: "filesLoading" },
+};
+
+/** Parameters incomplete or invalid. */
+export const InvalidParams: Story = {
+  args: { disabled: true, disabledReason: "invalidParams" },
+};
+
+/** The backend endpoint this tool needs is switched off. */
+export const EndpointUnavailable: Story = {
+  args: { disabled: true, disabledReason: "endpointUnavailable" },
+};
+
+/** Read-only viewer mode. */
+export const ViewerMode: Story = {
+  args: { disabled: true, disabledReason: "viewerMode" },
+};
+
+/** Disabled with no stated reason — the bare fallback. */
+export const DisabledNoReason: Story = { args: { disabled: true } };
+
+/* ── Appearance ───────────────────────────────────────────────────────────── */
+
+/** Secondary weight, for a tool whose run isn't the primary action. */
+export const Outline: Story = { args: { variant: "outline" } };
+
+/** Lowest weight. */
+export const Subtle: Story = { args: { variant: "subtle" } };
+
+/** Destructive tools take the danger accent. */
+export const Destructive: Story = {
+  args: { color: "red", submitText: "Redact permanently" },
+};
+
+/** Spanning the panel. */
+export const FullWidth: Story = { args: { fullWidth: true } };
+
+/** Marked as running server-side, for tools that can't work purely locally. */
+export const WithCloudBadge: Story = { args: { showCloudBadge: true } };

--- a/frontend/editor/src/core/components/tools/shared/ResultsPreview.stories.tsx
+++ b/frontend/editor/src/core/components/tools/shared/ResultsPreview.stories.tsx
@@ -44,3 +44,47 @@ export const Empty: Story = {
     files: [],
   },
 };
+
+/** A 1x1 transparent PNG — enough to fill the thumbnail slot without shipping
+ *  a fixture image into the repo. */
+const PIXEL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+/** Several results with thumbnails — the navigation controls appear and wrap. */
+export const MultipleFiles: Story = {
+  args: {
+    files: files.map((f) => ({ ...f, thumbnail: PIXEL })),
+  },
+};
+
+/** Files present but no thumbnails, so the metadata carries the preview. */
+export const NoThumbnails: Story = {
+  args: {
+    files: files.slice(0, 2),
+  },
+};
+
+/** A custom empty message, for tools whose "no results" means something
+ *  specific. */
+export const CustomEmptyMessage: Story = {
+  args: {
+    files: [],
+    emptyMessage: "No pages matched the redaction pattern.",
+  },
+};
+
+/** A long filename, to check it truncates rather than widening the panel. */
+export const LongFilename: Story = {
+  args: {
+    files: [
+      {
+        file: makeFile(
+          "2026-08-quarterly-consolidated-financial-statements-final-signed.pdf",
+          "application/pdf",
+          245_760,
+        ),
+        thumbnail: PIXEL,
+      },
+    ],
+  },
+};

--- a/frontend/editor/src/core/components/tools/shared/ScopedOperationButton.stories.tsx
+++ b/frontend/editor/src/core/components/tools/shared/ScopedOperationButton.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * The run button on a tool panel, with wording that follows what it will act
+ * on. In the viewer it says "this file"; elsewhere it counts the selection.
+ *
+ * The viewer's "this file" hint needs more than one document actually loaded
+ * into FileContext, which these stories do not seed — so the variants below
+ * cover the selection-count path and the ways the hint is suppressed.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ScopedOperationButton } from "@app/components/tools/shared/ScopedOperationButton";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+import type { StirlingFile } from "@app/types/fileContext";
+
+const file = (name: string) => ({ name }) as unknown as StirlingFile;
+
+const THREE = [
+  file("report.pdf"),
+  file("appendix.pdf"),
+  file("cover-letter.pdf"),
+];
+
+const meta: Meta<typeof ScopedOperationButton> = {
+  title: "Tools/Shared/ScopedOperationButton",
+  component: ScopedOperationButton,
+  parameters: { layout: "padded" },
+  args: { selectedFiles: [file("report.pdf")], submitText: "Compress" },
+  decorators: [withToolContexts({ workbench: "viewer" })],
+};
+export default meta;
+
+type Story = StoryObj<typeof ScopedOperationButton>;
+
+/** One file selected: no scope suffix to add. */
+export const Default: Story = {};
+
+/** Outside the viewer, a multi-file selection is counted in the label. */
+export const CountsSelection: Story = {
+  args: { selectedFiles: THREE },
+  decorators: [withToolContexts({ workbench: "fileEditor" })],
+};
+
+/** Hints off: the label stays bare however many files are selected. */
+export const ScopeHintsDisabled: Story = {
+  args: { selectedFiles: THREE, disableScopeHints: true },
+  decorators: [withToolContexts({ workbench: "fileEditor" })],
+};
+
+export const Loading: Story = {
+  args: { isLoading: true, loadingText: "Compressing…" },
+};
+
+export const Disabled: Story = { args: { disabled: true } };
+
+/** The viewer-only lockout, which also suppresses the scope wording. */
+export const ViewerModeBlocked: Story = {
+  args: { selectedFiles: THREE, disabledReason: "viewerMode", disabled: true },
+  decorators: [withToolContexts({ workbench: "fileEditor" })],
+};
+
+/** An outline button, which some panels use for secondary operations. */
+export const OutlineVariant: Story = { args: { variant: "outline" } };

--- a/frontend/editor/src/core/components/tools/shared/SuggestedToolsSection.stories.tsx
+++ b/frontend/editor/src/core/components/tools/shared/SuggestedToolsSection.stories.tsx
@@ -1,0 +1,76 @@
+/**
+ * The "what next" strip shown after a tool finishes. The list is a fixed set of
+ * suggestions with the tool you are already in filtered out, so the interesting
+ * variation is which one is current.
+ *
+ * A suggestion the tool registry knows about gets the registry's own navigation
+ * rather than the fallback path — but both produce the same href, differing
+ * only in what the click does, so there is no story for it: it would render
+ * identically to the default.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SuggestedToolsSection } from "@app/components/tools/shared/SuggestedToolsSection";
+import {
+  NavigationStateContext,
+  type NavigationContextStateValue,
+} from "@app/contexts/NavigationContext";
+import {
+  ToolWorkflowContext,
+  ToolWorkflowActionsContext,
+  type ToolWorkflowContextValue,
+  type ToolWorkflowActionsValue,
+} from "@app/contexts/ToolWorkflowContext";
+
+function Harness({ selectedTool = null }: { selectedTool?: string | null }) {
+  return (
+    <NavigationStateContext.Provider
+      value={{ selectedTool } as unknown as NavigationContextStateValue}
+    >
+      <ToolWorkflowContext.Provider
+        value={
+          {
+            getSelectedTool: () => null,
+          } as unknown as ToolWorkflowContextValue
+        }
+      >
+        <ToolWorkflowActionsContext.Provider
+          value={
+            {
+              handleToolSelect: () => {},
+            } as unknown as ToolWorkflowActionsValue
+          }
+        >
+          <div style={{ maxWidth: 360 }}>
+            <SuggestedToolsSection />
+          </div>
+        </ToolWorkflowActionsContext.Provider>
+      </ToolWorkflowContext.Provider>
+    </NavigationStateContext.Provider>
+  );
+}
+
+const meta: Meta<typeof SuggestedToolsSection> = {
+  title: "Tools/Shared/SuggestedToolsSection",
+  component: SuggestedToolsSection,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SuggestedToolsSection>;
+
+/** Nothing selected, so every suggestion is offered. */
+export const Default: Story = { render: () => <Harness /> };
+
+/** The current tool drops out of its own suggestion list. */
+export const CurrentToolExcluded: Story = {
+  render: () => <Harness selectedTool="compress" />,
+};
+
+/** Narrow column, where the rows have to hold their layout. */
+export const Narrow: Story = {
+  render: () => (
+    <div style={{ width: 220 }}>
+      <Harness />
+    </div>
+  ),
+};

--- a/frontend/editor/src/core/components/tools/shared/ToolStep.tsx
+++ b/frontend/editor/src/core/components/tools/shared/ToolStep.tsx
@@ -109,9 +109,8 @@ const ToolStep = ({
       <div
         style={{
           padding: "0.5rem",
-          opacity: isCollapsed ? 0.8 : 1,
           color: isCollapsed ? "var(--mantine-color-dimmed)" : "inherit",
-          transition: "opacity 0.2s ease, color 0.2s ease",
+          transition: "color 0.2s ease",
         }}
       >
         {/* Chevron icon to collapse/expand the step */}

--- a/frontend/editor/src/core/components/tools/shared/ToolWorkflowTitle.stories.tsx
+++ b/frontend/editor/src/core/components/tools/shared/ToolWorkflowTitle.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ToolWorkflowTitle } from "@app/components/tools/shared/ToolWorkflowTitle";
+
+/** The heading every tool panel opens with, optionally with a description line
+ *  and an info tooltip. */
+const meta: Meta<typeof ToolWorkflowTitle> = {
+  title: "Tools/Shared/ToolWorkflowTitle",
+  component: ToolWorkflowTitle,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ToolWorkflowTitle>;
+
+/** Title alone. */
+export const Default: Story = { args: { title: "Rotate" } };
+
+/** With a line explaining what the tool does. */
+export const WithDescription: Story = {
+  args: {
+    title: "Auto-rotate",
+    description:
+      "Detects each page's orientation and straightens the ones that need it.",
+  },
+};
+
+/** An info affordance next to the title, for tools whose behaviour needs
+ *  qualifying beyond a single line. */
+export const WithTooltip: Story = {
+  args: {
+    title: "Redact",
+    description: "Permanently removes the selected content.",
+    tooltip: {
+      header: { title: "About redaction" },
+      content:
+        "Redaction rewrites the page content stream — the removed text cannot be recovered from the output file.",
+    },
+  },
+};
+
+/** A long title, to check it wraps rather than pushing the panel wider. */
+export const LongTitle: Story = {
+  args: {
+    title: "Convert scanned images to a searchable PDF document",
+    description: "Runs OCR over every page and embeds the recognised text.",
+  },
+};

--- a/frontend/editor/src/core/components/tools/shared/storyParameters.ts
+++ b/frontend/editor/src/core/components/tools/shared/storyParameters.ts
@@ -1,0 +1,46 @@
+/**
+ * Story helper for tool settings panels.
+ *
+ * Most settings panels take a whole parameters *hook* rather than a plain
+ * object, so a story can't just pass args — it needs the hook's shape, with
+ * state that actually updates when the panel writes to it. `useStoryParameters`
+ * builds that from real React state, so a story stays interactive (type in a
+ * field, watch it hold) instead of freezing on a static snapshot.
+ */
+import { useCallback, useMemo, useState } from "react";
+import type { BaseParametersHook } from "@app/hooks/tools/shared/useBaseParameters";
+
+export interface StoryParametersOptions<T> {
+  /** Endpoint the real hook would report; only a few panels surface it. */
+  endpointName?: string;
+  /** Validity gate, mirroring the tool's own validateFn. Defaults to always valid. */
+  validate?: (params: T) => boolean;
+}
+
+/** A live BaseParametersHook backed by story state. */
+export function useStoryParameters<T extends object>(
+  initial: T,
+  { endpointName = "story", validate }: StoryParametersOptions<T> = {},
+): BaseParametersHook<T> {
+  const [parameters, setParameters] = useState<T>(initial);
+
+  const updateParameter = useCallback(
+    <K extends keyof T>(parameter: K, value: T[K]) =>
+      setParameters((prev) => ({ ...prev, [parameter]: value })),
+    [],
+  );
+
+  const resetParameters = useCallback(() => setParameters(initial), [initial]);
+
+  return useMemo(
+    () => ({
+      parameters,
+      setParameters,
+      updateParameter,
+      resetParameters,
+      validateParameters: () => validate?.(parameters) ?? true,
+      getEndpointName: () => endpointName,
+    }),
+    [parameters, updateParameter, resetParameters, validate, endpointName],
+  );
+}

--- a/frontend/editor/src/core/components/tools/showJS/ShowJSView.css
+++ b/frontend/editor/src/core/components/tools/showJS/ShowJSView.css
@@ -129,7 +129,7 @@
 .showjs-outline-button {
   background: transparent;
   border: 1px solid currentColor;
-  color: var(--mantine-color-blue-5);
+  color: var(--c-accent-text);
 }
 
 .showjs-scrollarea {

--- a/frontend/editor/src/core/components/tools/sign/PenSizeSelector.tsx
+++ b/frontend/editor/src/core/components/tools/sign/PenSizeSelector.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
 import { TextInput, Combobox, useCombobox } from "@mantine/core";
 
 interface PenSizeSelectorProps {
@@ -19,12 +18,10 @@ const PenSizeSelector = ({
   onValueChange,
   onInputChange,
   disabled = false,
-  placeholder,
+  placeholder = "Type or select pen size (1-200)",
   style,
   size,
 }: PenSizeSelectorProps) => {
-  const { t } = useTranslation();
-  const resolvedPlaceholder = placeholder ?? t("sign.penSizePlaceholder");
   const combobox = useCombobox();
 
   const penSizeOptions = ["1", "2", "3", "4", "5", "8", "10", "12", "15", "20"];
@@ -44,7 +41,7 @@ const PenSizeSelector = ({
     >
       <Combobox.Target>
         <TextInput
-          placeholder={resolvedPlaceholder}
+          placeholder={placeholder}
           size={size}
           value={inputValue}
           onChange={(event) => {

--- a/frontend/editor/src/core/components/tools/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/tools/storyFixtures.tsx
@@ -1,0 +1,127 @@
+/**
+ * Shared context slices for the tool-panel stories.
+ *
+ * These components sit under providers that reach most of the app — the tool
+ * workflow stands up the registry and navigation, the workbench bar derives its
+ * buttons from the whole workbench. Each component here reads only a handful of
+ * fields, so the slices below supply those instead. What a story mounts is then
+ * an honest record of what its component actually depends on.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import {
+  NavigationStateContext,
+  type NavigationContextStateValue,
+} from "@app/contexts/NavigationContext";
+import {
+  ToolWorkflowContext,
+  ToolWorkflowDataContext,
+  ToolWorkflowActionsContext,
+  type ToolWorkflowContextValue,
+  type ToolWorkflowDataValue,
+  type ToolWorkflowActionsValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+
+export interface ToolContextOptions {
+  /** Which workbench is active; several components render only in one. */
+  workbench?: string;
+  /** Favourited tool ids, for anything drawing a star. */
+  favourites?: string[];
+  /** Index the viewer is showing, for scope-aware copy. */
+  activeFileIndex?: number;
+  /** Extra viewer fields for components that reach further into it. */
+  viewer?: Partial<Record<string, unknown>>;
+  /** Extra workflow fields — search state, panel view, the open tool. */
+  workflow?: Partial<Record<string, unknown>>;
+}
+
+export function withToolContexts({
+  workbench = "viewer",
+  favourites = [],
+  activeFileIndex = 0,
+  viewer = {},
+  workflow = {},
+}: ToolContextOptions = {}) {
+  return (Story: () => ReactElement): ReactElement => (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled: true } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <NavigationStateContext.Provider
+          value={{ workbench } as unknown as NavigationContextStateValue}
+        >
+          <ToolWorkflowContext.Provider
+            value={
+              {
+                getSelectedTool: () => null,
+                toolPanelMode: "normal",
+                leftPanelView: "tools",
+                readerMode: false,
+                ...workflow,
+              } as unknown as ToolWorkflowContextValue
+            }
+          >
+            <ToolWorkflowDataContext.Provider
+              value={
+                {
+                  isFavorite: (id: string) => favourites.includes(id),
+                  toolAvailability: {},
+                  toolRegistry: {},
+                  favoriteTools: favourites,
+                } as unknown as ToolWorkflowDataValue
+              }
+            >
+              <ToolWorkflowActionsContext.Provider
+                value={
+                  {
+                    toggleFavorite: () => {},
+                    handleToolSelect: () => {},
+                  } as unknown as ToolWorkflowActionsValue
+                }
+              >
+                <ViewerContext.Provider
+                  value={
+                    {
+                      activeFileIndex,
+                      ...viewer,
+                    } as unknown as ViewerContextType
+                  }
+                >
+                  <FilesModalContext.Provider
+                    value={
+                      {
+                        openFilesModal: () => {},
+                        onFileUpload: () => {},
+                      } as unknown as FilesModalContextType
+                    }
+                  >
+                    {/* Real FileContext: the file list drives scope-aware copy,
+                        and it stands up standalone with no files. */}
+                    <FileContextProvider>
+                      <Story />
+                    </FileContextProvider>
+                  </FilesModalContext.Provider>
+                </ViewerContext.Provider>
+              </ToolWorkflowActionsContext.Provider>
+            </ToolWorkflowDataContext.Provider>
+          </ToolWorkflowContext.Provider>
+        </NavigationStateContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/tools/toolPicker/FavoriteStar.tsx
+++ b/frontend/editor/src/core/components/tools/toolPicker/FavoriteStar.tsx
@@ -29,7 +29,11 @@ const FavoriteStar: React.FC<FavoriteStarProps> = ({
 
   return (
     <ActionIcon
+      // A span, not a button: this renders inside the tool row's own button in
+      // the fullscreen tool lists, and a control may not nest inside a control.
+      // role="button" is still required for the aria-label to be permitted.
       as="span"
+      role="button"
       variant="tertiary"
       shape="circle"
       size={SIZE_MAP[size]}

--- a/frontend/editor/src/core/components/tools/validateSignature/ValidateSignatureResults.stories.tsx
+++ b/frontend/editor/src/core/components/tools/validateSignature/ValidateSignatureResults.stories.tsx
@@ -1,0 +1,189 @@
+/**
+ * The report shown after validating signatures. A signature's badge is derived
+ * rather than given: a failed cryptographic check is Invalid, anything that
+ * passes but carries a trust caveat — self-signed, expired, revoked, or content
+ * appended after signing — downgrades to a warning, and only a clean signature
+ * reads as Valid. Each fixture below sets the fields that produce one of those
+ * three, rather than naming the status directly.
+ *
+ * The download row offers whichever report formats the operation produced, so
+ * stories vary `operation.files` to show it with one format and with all three.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import ValidateSignatureResults from "@app/components/tools/validateSignature/ValidateSignatureResults";
+import type {
+  SignatureValidationReportEntry,
+  SignatureValidationSignature,
+} from "@app/types/validateSignature";
+import type { ValidateSignatureOperationHook } from "@app/hooks/tools/validateSignature/useValidateSignatureOperation";
+import {
+  NavigationStateContext,
+  type NavigationContextStateValue,
+} from "@app/contexts/NavigationContext";
+import {
+  ToolWorkflowContext,
+  ToolWorkflowActionsContext,
+  type ToolWorkflowContextValue,
+  type ToolWorkflowActionsValue,
+} from "@app/contexts/ToolWorkflowContext";
+
+function signature(
+  id: string,
+  overrides: Partial<SignatureValidationSignature> = {},
+): SignatureValidationSignature {
+  return {
+    id,
+    valid: true,
+    chainValid: true,
+    trustValid: true,
+    notExpired: true,
+    coversEntireDocument: true,
+    revocationChecked: true,
+    revocationStatus: "good",
+    signerName: "A. Whitfield",
+    signatureDate: "2026-02-11T14:05:00Z",
+    reason: "Approval",
+    location: "Manchester, UK",
+    issuerDN: "CN=Example Issuing CA, O=Example Trust",
+    subjectDN: "CN=A. Whitfield, O=Example Ltd",
+    serialNumber: "3F:AA:19:04",
+    validFrom: "2025-06-01T00:00:00Z",
+    validUntil: "2027-06-01T00:00:00Z",
+    signatureAlgorithm: "SHA256withRSA",
+    keySize: 2048,
+    version: "1",
+    keyUsages: ["digitalSignature", "nonRepudiation"],
+    selfSigned: false,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+function entry(
+  fileName: string,
+  signatures: SignatureValidationSignature[],
+): SignatureValidationReportEntry {
+  return {
+    fileId: fileName,
+    fileName,
+    signatures,
+    fileSize: 184_320,
+    lastModified: Date.parse("2026-02-11T14:06:00Z"),
+  };
+}
+
+const file = (name: string) => new File(["report"], name);
+
+/** No report files means the download row has nothing to offer. */
+function op(names: string[] = []): ValidateSignatureOperationHook {
+  return {
+    files: names.map(file),
+  } as unknown as ValidateSignatureOperationHook;
+}
+
+const VALID = entry("contract-signed.pdf", [signature("sig-1")]);
+
+/** Cryptographically sound, but the document grew after it was signed. */
+const WARNING = entry("addendum-appended.pdf", [
+  signature("sig-1", { coversEntireDocument: false }),
+]);
+
+/** A self-signed certificate that is not a trust anchor. */
+const SELF_SIGNED = entry("internal-memo.pdf", [
+  signature("sig-1", { selfSigned: true, trustValid: false }),
+]);
+
+const INVALID = entry("tampered.pdf", [signature("sig-1", { valid: false })]);
+
+/** A backend error against one file, which reads as invalid too. */
+const ERRORED = entry("unreadable.pdf", [
+  signature("sig-1", { errorMessage: "Signature could not be parsed" }),
+]);
+
+/**
+ * The report ends with a "what next" strip of suggested tools, which reaches
+ * navigation and the tool workflow. Only three fields are read between them, so
+ * the decorator supplies those rather than mounting either provider.
+ */
+const withSuggestedTools = (Story: () => React.ReactElement) => (
+  <NavigationStateContext.Provider
+    value={{ selectedTool: null } as unknown as NavigationContextStateValue}
+  >
+    <ToolWorkflowContext.Provider
+      value={
+        { getSelectedTool: () => null } as unknown as ToolWorkflowContextValue
+      }
+    >
+      <ToolWorkflowActionsContext.Provider
+        value={
+          { handleToolSelect: () => {} } as unknown as ToolWorkflowActionsValue
+        }
+      >
+        <Story />
+      </ToolWorkflowActionsContext.Provider>
+    </ToolWorkflowContext.Provider>
+  </NavigationStateContext.Provider>
+);
+
+const meta: Meta<typeof ValidateSignatureResults> = {
+  title: "Tools/ValidateSignature/Results",
+  component: ValidateSignatureResults,
+  parameters: { layout: "padded" },
+  decorators: [withSuggestedTools],
+  args: {
+    operation: op(["report.pdf"]),
+    isLoading: false,
+    errorMessage: null,
+    results: [VALID],
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ValidateSignatureResults>;
+
+export const Valid: Story = {};
+
+export const TrustWarning: Story = { args: { results: [WARNING] } };
+
+export const SelfSignedWarning: Story = { args: { results: [SELF_SIGNED] } };
+
+export const Invalid: Story = { args: { results: [INVALID] } };
+
+export const SignatureError: Story = { args: { results: [ERRORED] } };
+
+/** The summary counts across a mixed batch, which is the usual real case. */
+export const MixedBatch: Story = {
+  args: { results: [VALID, WARNING, INVALID, SELF_SIGNED] },
+};
+
+/** Several signatures on one document, each judged separately. */
+export const MultipleSignatures: Story = {
+  args: {
+    results: [
+      entry("counter-signed.pdf", [
+        signature("sig-1"),
+        signature("sig-2", { selfSigned: true, trustValid: false }),
+        signature("sig-3", { valid: false }),
+      ]),
+    ],
+  },
+};
+
+/** Nothing validated yet. */
+export const Loading: Story = { args: { isLoading: true, results: [] } };
+
+/** Still working, with partial results already on screen. */
+export const LoadingWithResults: Story = {
+  args: { isLoading: true, results: [VALID] },
+};
+
+export const Empty: Story = { args: { results: [] } };
+
+export const WithError: Story = {
+  args: { errorMessage: "The validation service did not respond." },
+};
+
+/** All three report formats available to download. */
+export const AllReportFormats: Story = {
+  args: { operation: op(["report.pdf", "report.csv", "report.json"]) },
+};

--- a/frontend/editor/src/core/components/tools/validateSignature/reportView/SignatureSection.tsx
+++ b/frontend/editor/src/core/components/tools/validateSignature/reportView/SignatureSection.tsx
@@ -96,7 +96,7 @@ const SignatureSection = ({
           <SignatureStatusBadge signature={signature} />
         </Group>
         {signature.errorMessage && (
-          <Text c="red" size="sm">
+          <Text c="var(--color-red-dark)" size="sm">
             {signature.errorMessage}
           </Text>
         )}

--- a/frontend/editor/src/core/components/tools/validateSignature/reportView/SignatureStatusBadge.tsx
+++ b/frontend/editor/src/core/components/tools/validateSignature/reportView/SignatureStatusBadge.tsx
@@ -18,35 +18,40 @@ const SignatureStatusBadge = ({
     neutral: "status-badge status-badge--neutral",
   } as const;
 
+  // With no details there is nothing to open, so the badge stays a plain label.
+  // Popover.Target stamps aria-haspopup/aria-expanded onto whatever it wraps,
+  // and those are only permitted on an element that is actually a control.
+  if (status.details.length === 0) {
+    return (
+      <Badge className={classMap[status.kind]} variant="light">
+        {status.label}
+      </Badge>
+    );
+  }
+
   return (
-    <Popover
-      withinPortal
-      position="bottom"
-      withArrow
-      shadow="md"
-      disabled={status.details.length === 0}
-    >
+    <Popover withinPortal position="bottom" withArrow shadow="md">
       <Popover.Target>
         <Badge
+          component="button"
+          type="button"
           className={classMap[status.kind]}
           variant="light"
-          style={{ cursor: status.details.length ? "pointer" : "default" }}
+          style={{ cursor: "pointer" }}
         >
           {status.label}
         </Badge>
       </Popover.Target>
-      {status.details.length > 0 && (
-        <Popover.Dropdown>
-          <Text size="sm" fw={600} mb={4}>
-            {t("details", "Details")}
+      <Popover.Dropdown>
+        <Text size="sm" fw={600} mb={4}>
+          {t("details", "Details")}
+        </Text>
+        {status.details.map((d, i) => (
+          <Text size="sm" key={i}>
+            - {d}
           </Text>
-          {status.details.map((d, i) => (
-            <Text size="sm" key={i}>
-              - {d}
-            </Text>
-          ))}
-        </Popover.Dropdown>
-      )}
+        ))}
+      </Popover.Dropdown>
     </Popover>
   );
 };

--- a/frontend/editor/src/core/components/viewer/AttachmentSidebar.css
+++ b/frontend/editor/src/core/components/viewer/AttachmentSidebar.css
@@ -55,7 +55,7 @@
 }
 
 .attachment-item:hover .attachment-item__download-icon {
-  color: var(--mantine-color-blue-6);
+  color: var(--c-accent-text);
   transform: scale(1.1);
 }
 

--- a/frontend/editor/src/core/components/viewer/AttachmentSidebar.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/AttachmentSidebar.stories.tsx
@@ -1,0 +1,101 @@
+/**
+ * The viewer's attachments rail: embedded files a PDF carries, each downloadable.
+ *
+ * The sidebar owns its own fetch. On mount it asks the viewer's attachment
+ * bridge for the current document's attachments, and what it shows is that
+ * request's outcome: pending, failed, empty, or a list. Two things gate the
+ * fetch entirely — the bridge must report attachment support (it polls until it
+ * does, so an unsupported viewer sits on that notice), and there must be a
+ * document key to fetch for. These stories drive the states from the bridge
+ * rather than from props, because that is where the states actually come from.
+ *
+ * The sidebar is `position: fixed` and offsets itself left of whichever other
+ * rails are open, so the stories render full-screen.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { PdfAttachmentObject } from "@embedpdf/models";
+import { AttachmentSidebar } from "@app/components/viewer/AttachmentSidebar";
+import { withToolContexts } from "@app/components/tools/storyFixtures";
+
+const ATTACHMENTS = [
+  {
+    name: "site-survey.xlsx",
+    size: 48_128,
+    description: "Measurements taken on site",
+  },
+  { name: "contract-appendix.pdf", size: 1_204_992 },
+  { name: "photos.zip", size: 18_874_368, description: "Progress photographs" },
+] as unknown as PdfAttachmentObject[];
+
+/** Never settles, which is what the sidebar shows as "loading". */
+const pending = () => new Promise<PdfAttachmentObject[]>(() => {});
+
+function withAttachments(
+  getAttachments: () => Promise<PdfAttachmentObject[] | null>,
+  hasAttachmentSupport = true,
+) {
+  return withToolContexts({
+    viewer: {
+      hasAttachmentSupport: () => hasAttachmentSupport,
+      toggleAttachmentSidebar: () => {},
+      attachmentActions: {
+        getAttachments,
+        downloadAttachment: () => {},
+        clearAttachments: () => {},
+        setLocalAttachments: () => {},
+      },
+    },
+  });
+}
+
+const meta: Meta<typeof AttachmentSidebar> = {
+  title: "Viewer/AttachmentSidebar",
+  component: AttachmentSidebar,
+  parameters: { layout: "fullscreen" },
+  args: {
+    visible: true,
+    thumbnailVisible: false,
+    bookmarkVisible: false,
+    documentCacheKey: "report.pdf#1",
+  },
+  decorators: [withAttachments(async () => ATTACHMENTS)],
+};
+export default meta;
+
+type Story = StoryObj<typeof AttachmentSidebar>;
+
+/** A document carrying three attachments. */
+export const Default: Story = {};
+
+/** The fetch is still in flight. */
+export const Loading: Story = { decorators: [withAttachments(pending)] };
+
+/**
+ * The bridge failed. "Document not open" errors are retried silently, so this
+ * uses a genuine failure — the one case that surfaces with a retry control.
+ */
+export const LoadFailed: Story = {
+  decorators: [
+    withAttachments(async () => {
+      throw new Error("Attachment stream could not be read");
+    }),
+  ],
+};
+
+/** A document with no attachments, offering the tool that adds one. */
+export const NoAttachments: Story = {
+  decorators: [withAttachments(async () => [])],
+};
+
+/** No document open, so there is nothing to fetch for. */
+export const NoDocument: Story = { args: { documentCacheKey: undefined } };
+
+/** A viewer whose attachment bridge never registers. */
+export const UnsupportedViewer: Story = {
+  decorators: [withAttachments(async () => ATTACHMENTS, false)],
+};
+
+/** Thumbnails and bookmarks are open too, so the rail shifts left of both. */
+export const AlongsideOtherSidebars: Story = {
+  args: { thumbnailVisible: true, bookmarkVisible: true },
+};

--- a/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/AttachmentSidebar.tsx
@@ -292,15 +292,10 @@ export const AttachmentSidebar = ({
       >
         <div
           className="attachment-item"
+          /* The row carries a labelled download button of its own, so making
+             the row a button too nests one control inside another. The click
+             stays as a mouse convenience; the keyboard path is the button. */
           onClick={(event) => handleDownload(attachment, event)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              handleDownload(attachment, event as any);
-            }
-          }}
         >
           <div className="attachment-item__content">
             <Text size="sm" fw={500} className="attachment-item__title">
@@ -445,7 +440,7 @@ export const AttachmentSidebar = ({
 
           {attachmentSupport && documentCacheKey && currentError && (
             <Stack gap="xs" align="center" className="sidebar-base__error">
-              <Text size="sm" c="red" ta="center">
+              <Text size="sm" c="var(--color-red-dark)" ta="center">
                 {currentError}
               </Text>
               <ActionIcon

--- a/frontend/editor/src/core/components/viewer/BookmarkSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/BookmarkSidebar.tsx
@@ -792,7 +792,7 @@ export const BookmarkSidebar = ({
 
           {bookmarkSupport && documentCacheKey && currentError && (
             <Stack gap="xs" align="center" className="sidebar-base__error">
-              <Text size="sm" c="red" ta="center">
+              <Text size="sm" c="var(--color-red-dark)" ta="center">
                 {currentError}
               </Text>
               <Button variant="secondary" size="sm" onClick={requestReload}>
@@ -882,7 +882,7 @@ export const BookmarkSidebar = ({
                   disabled={isSavingBookmark}
                 />
                 {addBookmarkError && (
-                  <Text size="xs" c="red">
+                  <Text size="xs" c="var(--color-red-dark)">
                     {addBookmarkError}
                   </Text>
                 )}
@@ -964,7 +964,7 @@ export const BookmarkSidebar = ({
                 icon="bookmark-add-rounded"
                 width="0.95rem"
                 height="0.95rem"
-                style={{ color: "var(--mantine-color-blue-5)" }}
+                style={{ color: "var(--c-accent-text)" }}
               />
               <Text
                 size="xs"

--- a/frontend/editor/src/core/components/viewer/CommentsSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/CommentsSidebar.tsx
@@ -289,7 +289,7 @@ function AnnotationTypeIcon({ ann }: { ann: PdfAnnotationObject }) {
       icon={iconName}
       width="1.25rem"
       height="1.25rem"
-      style={{ flexShrink: 0, color: "var(--mantine-color-blue-5)" }}
+      style={{ flexShrink: 0, color: "var(--c-accent-text)" }}
     />
   );
 }
@@ -1139,7 +1139,10 @@ export function CommentsSidebar({
                                                       );
                                                     }}
                                                   >
-                                                    <Text size="xs" c="blue">
+                                                    <Text
+                                                      size="xs"
+                                                      c="var(--c-accent-text)"
+                                                    >
                                                       {t(
                                                         "annotation.editText",
                                                         "Edit",

--- a/frontend/editor/src/core/components/viewer/EmbedPdfViewer.tsx
+++ b/frontend/editor/src/core/components/viewer/EmbedPdfViewer.tsx
@@ -1174,7 +1174,7 @@ const EmbedPdfViewerContent = ({
 
       {!effectiveFile ? (
         <Center style={{ flex: 1 }}>
-          <Text c="red">
+          <Text c="var(--color-red-dark)">
             {t(
               "viewer.error.noFileProvided",
               "Error: No file provided to viewer",

--- a/frontend/editor/src/core/components/viewer/LayerSidebar.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/LayerSidebar.stories.tsx
@@ -1,0 +1,63 @@
+/**
+ * The viewer's optional-content rail: a PDF's layers, each toggleable, with the
+ * change written back into the document after a short debounce.
+ *
+ * Nothing here is passed in as data. The sidebar reads the layers itself, out of
+ * the PDF blob it is handed, so its states are the outcomes of that read: no
+ * document to read, a read in flight, and a read that failed. The two remaining
+ * outcomes — a layered document and one with no layers — need a real PDF parsed
+ * through pdf.js, which a story cannot fabricate, so they are not covered here.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+import { LayerSidebar } from "@app/components/viewer/LayerSidebar";
+
+const withViewer = (Story: React.ComponentType) => (
+  <ViewerContext.Provider
+    value={{ toggleLayerSidebar: () => {} } as unknown as ViewerContextType}
+  >
+    <div style={{ height: "80vh" }}>
+      <Story />
+    </div>
+  </ViewerContext.Provider>
+);
+
+/** A blob whose bytes never arrive, holding the read open. */
+const stalledFile = {
+  arrayBuffer: () => new Promise<ArrayBuffer>(() => {}),
+} as unknown as Blob;
+
+/** Not a PDF, so the parse rejects and the sidebar reports the failure. */
+const unreadableFile = new Blob(["not a pdf"], { type: "application/pdf" });
+
+const meta: Meta<typeof LayerSidebar> = {
+  title: "Viewer/LayerSidebar",
+  component: LayerSidebar,
+  parameters: { layout: "fullscreen" },
+  args: {
+    visible: true,
+    rightOffset: 0,
+    onApplyLayers: async () => {},
+    onLayersDetected: () => {},
+  },
+  decorators: [withViewer],
+};
+export default meta;
+
+type Story = StoryObj<typeof LayerSidebar>;
+
+/** No document open — there is nothing to read layers from. */
+export const NoDocument: Story = {};
+
+/** The PDF is being parsed for optional-content groups. */
+export const Loading: Story = {
+  args: { file: stalledFile, documentCacheKey: "stalled" },
+};
+
+/** The parse failed; the reason is shown rather than an empty list. */
+export const LoadFailed: Story = {
+  args: { file: unreadableFile, documentCacheKey: "unreadable" },
+};

--- a/frontend/editor/src/core/components/viewer/LayerSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/LayerSidebar.tsx
@@ -407,7 +407,7 @@ export function LayerSidebar({
 
           {status === "error" && (
             <div className="sidebar-base__error">
-              <Text size="sm" c="red" ta="center">
+              <Text size="sm" c="var(--color-red-dark)" ta="center">
                 {loadError ?? "Failed to load layers."}
               </Text>
             </div>

--- a/frontend/editor/src/core/components/viewer/LocalEmbedPDF.tsx
+++ b/frontend/editor/src/core/components/viewer/LocalEmbedPDF.tsx
@@ -486,7 +486,11 @@ export function LocalEmbedPDF({
       <Center h="100%" w="100%">
         <Stack align="center" gap="md">
           <div style={{ fontSize: "24px" }}>❌</div>
-          <Text c="red" size="sm" style={{ textAlign: "center" }}>
+          <Text
+            c="var(--color-red-dark)"
+            size="sm"
+            style={{ textAlign: "center" }}
+          >
             Error loading PDF engine: {error.message}
           </Text>
         </Stack>

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.stories.tsx
@@ -1,0 +1,126 @@
+/**
+ * The floating toolbar under the document: page navigation, spread mode, the
+ * colour filter and zoom.
+ *
+ * Its props are near-vestigial — everything on show comes from the viewer
+ * context's bridge state. The page position decides which of the four
+ * navigation buttons are disabled (you cannot go back from page one, or forward
+ * from the last), a single-page document also locks the spread toggle, and
+ * `pdfRenderMode` cycles normal → dark → sepia, changing both the icon and
+ * whether the button reads as active. Rather than stand up the EmbedPDF
+ * pipeline behind those bridges, these stories supply the slice of context the
+ * toolbar reads.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+import { PdfViewerToolbar } from "@app/components/viewer/PdfViewerToolbar";
+
+interface ToolbarState {
+  currentPage: number;
+  totalPages: number;
+  zoomPercent?: number;
+  isDualPage?: boolean;
+  pdfRenderMode?: "normal" | "dark" | "sepia";
+}
+
+function viewerValue({
+  currentPage,
+  totalPages,
+  zoomPercent = 140,
+  isDualPage = false,
+  pdfRenderMode = "normal",
+}: ToolbarState): ViewerContextType {
+  // The toolbar mirrors bridge state into local state through these
+  // registrations; returning a no-op unregister is all a story needs.
+  const noopRegister = () => () => {};
+
+  return {
+    getScrollState: () => ({ currentPage, totalPages }),
+    getZoomState: () => ({ currentZoom: zoomPercent / 100, zoomPercent }),
+    getSpreadState: () => ({
+      spreadMode: isDualPage ? "odd" : "none",
+      isDualPage,
+    }),
+    scrollActions: {
+      scrollToPage: () => {},
+      scrollToFirstPage: () => {},
+      scrollToLastPage: () => {},
+    },
+    zoomActions: {
+      zoomIn: () => {},
+      zoomOut: () => {},
+      setZoomLevel: () => {},
+    },
+    spreadActions: { toggleSpreadMode: () => {} },
+    registerImmediateScrollUpdate: noopRegister,
+    registerImmediateZoomUpdate: noopRegister,
+    registerImmediateSpreadUpdate: noopRegister,
+    pdfRenderMode,
+    cyclePdfRenderMode: () => {},
+  } as unknown as ViewerContextType;
+}
+
+const withViewer = (state: ToolbarState) => (Story: React.ComponentType) => (
+  <ViewerContext.Provider value={viewerValue(state)}>
+    <Story />
+  </ViewerContext.Provider>
+);
+
+const meta: Meta<typeof PdfViewerToolbar> = {
+  title: "Viewer/PdfViewerToolbar",
+  component: PdfViewerToolbar,
+  parameters: { layout: "centered" },
+  decorators: [withViewer({ currentPage: 5, totalPages: 12 })],
+};
+export default meta;
+
+type Story = StoryObj<typeof PdfViewerToolbar>;
+
+/** Part-way through a document: every control is live. */
+export const Default: Story = {};
+
+/** On page one, so both backward controls are disabled. */
+export const FirstPage: Story = {
+  decorators: [withViewer({ currentPage: 1, totalPages: 12 })],
+};
+
+/** On the last page, so both forward controls are disabled. */
+export const LastPage: Story = {
+  decorators: [withViewer({ currentPage: 12, totalPages: 12 })],
+};
+
+/** A one-page document: navigation and the spread toggle have nowhere to go. */
+export const SinglePageDocument: Story = {
+  decorators: [withViewer({ currentPage: 1, totalPages: 1 })],
+};
+
+/** Two-up reading — the toggle is active and offers the way back. */
+export const DualPageSpread: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, isDualPage: true }),
+  ],
+};
+
+/** The dark colour filter is on; the button now offers sepia next. */
+export const DarkFilter: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, pdfRenderMode: "dark" }),
+  ],
+};
+
+/** Sepia is the last step of the cycle, so the button offers to clear it. */
+export const SepiaFilter: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, pdfRenderMode: "sepia" }),
+  ],
+};
+
+/** Zoomed well in: the slider sits near its ceiling and the readout follows. */
+export const ZoomedIn: Story = {
+  decorators: [
+    withViewer({ currentPage: 5, totalPages: 12, zoomPercent: 320 }),
+  ],
+};

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
@@ -334,6 +334,7 @@ export function PdfViewerToolbar({
             max={500}
             step={5}
             onChange={(val) => zoomActions.setZoomLevel?.(val / 100)}
+            thumbLabel={t("viewer.zoomLevel", "Zoom level")}
             size="xs"
             styles={{
               root: { minWidth: "6rem", width: "6rem", flexShrink: 0 },

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
@@ -192,6 +192,9 @@ export function PdfViewerToolbar({
 
       {/* Page Input */}
       <NumberInput
+        /* Only the page count sits beside it, as plain text — the field itself
+           carries no name without this. */
+        aria-label={t("viewer.pageNumber", "Page number")}
         value={pageInput}
         onChange={(value) => {
           const page = Number(value);

--- a/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.stories.tsx
@@ -1,0 +1,151 @@
+/**
+ * The measurement overlay that sits above a rendered page. Everything here is
+ * SVG drawn in screen coordinates: the layer is normally mounted inside the
+ * viewer's own <svg>, so these stories supply that wrapper themselves and place
+ * measurements at fixed points rather than deriving them from a real page.
+ *
+ * The label layout is the interesting behaviour — labels are hidden, shown, or
+ * expanded depending on zoom, crowding, and which measurement is hovered — so
+ * each visibility mode gets a story rather than a control.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  RulerMeasurementLayer,
+  type RulerRenderedMeasurement,
+} from "@app/components/viewer/RulerMeasurementLayer";
+import type { MeasureScale } from "@app/utils/measurementTypes";
+
+const SCALE: MeasureScale = { factor: 0.05, ratio: 100, unit: "m" };
+
+function rendered(
+  id: string,
+  startS: { x: number; y: number },
+  endS: { x: number; y: number },
+  measureScale: MeasureScale | null = null,
+): RulerRenderedMeasurement {
+  const distPts = Math.hypot(endS.x - startS.x, endS.y - startS.y);
+  return {
+    // Screen and page coordinates coincide here: the stories render at zoom 1
+    // against a single page, so no projection is involved.
+    measurement: {
+      id,
+      start: { ...startS, pageIndex: 0 },
+      end: { ...endS, pageIndex: 0 },
+    },
+    startS,
+    endS,
+    distPts,
+    measureScale,
+  };
+}
+
+const MEASUREMENTS = [
+  rendered("a", { x: 80, y: 90 }, { x: 320, y: 90 }),
+  rendered("b", { x: 120, y: 150 }, { x: 300, y: 260 }),
+  rendered("c", { x: 360, y: 120 }, { x: 480, y: 300 }),
+];
+
+/** Close enough together that the crowding rules start dropping idle labels. */
+const CROWDED = [
+  rendered("a", { x: 60, y: 80 }, { x: 150, y: 80 }),
+  rendered("b", { x: 60, y: 110 }, { x: 150, y: 110 }),
+  rendered("c", { x: 60, y: 140 }, { x: 150, y: 140 }),
+  rendered("d", { x: 60, y: 170 }, { x: 150, y: 170 }),
+  rendered("e", { x: 170, y: 80 }, { x: 260, y: 80 }),
+  rendered("f", { x: 170, y: 110 }, { x: 260, y: 110 }),
+];
+
+const noop = () => {};
+
+const meta: Meta<typeof RulerMeasurementLayer> = {
+  title: "Viewer/RulerMeasurementLayer",
+  component: RulerMeasurementLayer,
+  parameters: { layout: "fullscreen" },
+  args: {
+    measurements: MEASUREMENTS,
+    zoom: 1,
+    selectedId: null,
+    hoveredId: null,
+    labelVisibilityMode: "hideSmall",
+    isInteractionPassthroughActive: false,
+    onSelect: noop,
+    onDelete: noop,
+    onHoverChange: noop,
+    onClearAll: noop,
+    onCycleLabelVisibilityMode: noop,
+  },
+  render: (args) => (
+    <div style={{ background: "var(--c-surface-sunken)", padding: "1rem" }}>
+      {/* Coordinates are fixed but the canvas is not, so the viewBox scales the
+          page rather than letting a narrow frame scroll it. */}
+      <svg
+        viewBox="0 0 560 360"
+        width="100%"
+        style={{
+          display: "block",
+          background: "var(--c-surface-raised)",
+          borderRadius: 4,
+        }}
+      >
+        <RulerMeasurementLayer {...args} />
+      </svg>
+    </div>
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof RulerMeasurementLayer>;
+
+export const Default: Story = {};
+
+/** Nothing measured yet: the toolbar controls are not drawn at all. */
+export const Empty: Story = { args: { measurements: [] } };
+
+export const Selected: Story = { args: { selectedId: "b" } };
+
+/** Hovering expands the label to its multi-line form. */
+export const Hovered: Story = { args: { hoveredId: "a" } };
+
+/** With a scale applied the label gains the converted real-world distance. */
+export const Scaled: Story = {
+  args: {
+    measurements: MEASUREMENTS.map((m) => ({ ...m, measureScale: SCALE })),
+    hoveredId: "a",
+  },
+};
+
+export const LabelsShowAll: Story = { args: { labelVisibilityMode: "showAll" } };
+
+export const LabelsHidden: Story = { args: { labelVisibilityMode: "hideAll" } };
+
+/** hideSmall drops idle labels that would collide; showAll forces them back. */
+export const CrowdedHideSmall: Story = { args: { measurements: CROWDED } };
+
+export const CrowdedShowAll: Story = {
+  args: { measurements: CROWDED, labelVisibilityMode: "showAll" },
+};
+
+/** Mid-draw: the first point is placed and the line follows the cursor. */
+export const DrawingInProgress: Story = {
+  args: {
+    measurements: [],
+    firstPoint: { x: 120, y: 120 },
+    cursor: { x: 380, y: 240 },
+    liveLine: {
+      startS: { x: 120, y: 120 },
+      endS: { x: 380, y: 240 },
+      measureScale: SCALE,
+    },
+  },
+};
+
+/**
+ * While another tool owns the pointer the overlay stops taking hits, so its
+ * measurements render but do not respond to hover or selection.
+ */
+export const InteractionPassthrough: Story = {
+  args: { isInteractionPassthroughActive: true },
+};
+
+/** Zoomed in, the stroke and label sizing compensate so they stay readable. */
+export const ZoomedIn: Story = { args: { zoom: 2.5 } };

--- a/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerMeasurementLayer.tsx
@@ -56,6 +56,27 @@ interface LabelBox {
 interface MeasurementLineLabels {
   scaled: string;
   physical: string;
+  delete: string;
+}
+
+/**
+ * The overlay's controls live inside the SVG, where there is no <button> to
+ * inherit from: a bare <g onClick> is invisible to assistive technology and
+ * unreachable by keyboard. These props supply what the element would otherwise
+ * get for free — a role, a name, focusability, and Enter/Space activation.
+ */
+function svgButtonProps(label: string, activate: () => void) {
+  return {
+    role: "button",
+    tabIndex: 0,
+    "aria-label": label,
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key !== "Enter" && e.key !== " ") return;
+      e.preventDefault();
+      e.stopPropagation();
+      activate();
+    },
+  };
 }
 
 export const RULER_DOT_RADIUS = 5;
@@ -623,6 +644,7 @@ function MeasurementLine({
           />
           <g
             style={{ cursor: "pointer" }}
+            {...svgButtonProps(labels.delete, () => onDelete(id))}
             onClick={(e) => {
               e.stopPropagation();
               onDelete(id);
@@ -761,6 +783,7 @@ export function RulerMeasurementLayer({
     () => ({
       scaled: t("ruler.scaled", "Scaled"),
       physical: t("ruler.physicalValues", "Physical"),
+      delete: t("ruler.deleteMeasurement", "Delete measurement"),
     }),
     [t],
   );
@@ -883,6 +906,7 @@ export function RulerMeasurementLayer({
             data-ruler-interactive="true"
             data-ruler-control="true"
             style={{ pointerEvents: "all", cursor: "pointer" }}
+            {...svgButtonProps(t("ruler.clearAll", "Clear all"), onClearAll)}
             onClick={(e) => {
               e.stopPropagation();
               onClearAll();
@@ -915,6 +939,7 @@ export function RulerMeasurementLayer({
             data-ruler-interactive="true"
             data-ruler-control="true"
             style={{ pointerEvents: "all", cursor: "pointer" }}
+            {...svgButtonProps(labelModeButtonLabel, onCycleLabelVisibilityMode)}
             onClick={(e) => {
               e.stopPropagation();
               onCycleLabelVisibilityMode();

--- a/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Second half of calibration: the user has drawn a line over something of known
+ * size, and this dialog turns that into a scale. The measured page distance is
+ * given; the real-world distance is what it asks for.
+ *
+ * The chosen unit is remembered between calibrations, so `defaultUnit` only
+ * applies the first time — stories that care about the unit set it explicitly.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ScaleCalibrationDialog,
+  type ScaleCalibrationMeasurement,
+} from "@app/components/viewer/ScaleCalibrationDialog";
+
+const MEASUREMENT: ScaleCalibrationMeasurement = {
+  start: { x: 100, y: 220, pageIndex: 0 },
+  end: { x: 388, y: 220, pageIndex: 0 },
+  pdfDistancePts: 288,
+};
+
+/** Short enough that the derived ratio lands in a different order of magnitude. */
+const SHORT_MEASUREMENT: ScaleCalibrationMeasurement = {
+  start: { x: 100, y: 220, pageIndex: 0 },
+  end: { x: 118, y: 220, pageIndex: 0 },
+  pdfDistancePts: 18,
+};
+
+const noop = () => {};
+
+const meta: Meta<typeof ScaleCalibrationDialog> = {
+  title: "Viewer/ScaleCalibrationDialog",
+  component: ScaleCalibrationDialog,
+  parameters: { layout: "centered" },
+  args: {
+    opened: true,
+    measurement: MEASUREMENT,
+    defaultUnit: "m",
+    onApplyScale: noop,
+    onClose: noop,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleCalibrationDialog>;
+
+/** Waiting for input: the page distance is shown, the preview is not. */
+export const Default: Story = {};
+
+export const ImperialDefault: Story = { args: { defaultUnit: "ft" } };
+
+export const ShortMeasurement: Story = {
+  args: { measurement: SHORT_MEASUREMENT },
+};
+
+/**
+ * Applying with no distance entered is the error path — the dialog can also be
+ * opened before a measurement exists, which leaves the page distance blank.
+ */
+export const NoMeasurement: Story = { args: { measurement: null } };
+
+export const Closed: Story = { args: { opened: false } };

--- a/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleCalibrationDialog.tsx
@@ -124,11 +124,14 @@ export function ScaleCalibrationDialog({
       title={t("scaleSettings.calibrationTitle", "Calibrate Scale")}
       centered
       size="sm"
+      closeButtonProps={{ "aria-label": t("common.close", "Close") }}
     >
       <Stack gap="md">
         {/* Show paper distance automatically */}
+        {/* Mantine's own "dimmed" is too light to clear 4.5:1, so muted text
+            comes from the design system's token instead. */}
         {measurement && (
-          <Text size="sm" c="dimmed">
+          <Text size="sm" c="var(--c-text-muted)">
             {t(
               "scaleSettings.calibrationPaperDistance",
               "Measured page distance: {{distance}}",
@@ -166,7 +169,7 @@ export function ScaleCalibrationDialog({
 
         {/* Preview: show calculated scale */}
         {previewScale && (
-          <Text size="sm" c="blue">
+          <Text size="sm" fw={600}>
             {t(
               "scaleSettings.calculatedScale",
               "Calculated scale (1 page unit = X real units)",

--- a/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.stories.tsx
@@ -1,0 +1,64 @@
+/**
+ * The scale picker that opens from the measurement toolbar. Presets apply and
+ * close immediately; the custom ratio waits for Apply. The panel mirrors an
+ * incoming `currentScale` into its own fields, so the stories drive it through
+ * that prop rather than reaching into state.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ScaleSettingsPanel } from "@app/components/viewer/ScaleSettingsPanel";
+import type { MeasureScale } from "@app/utils/measurementTypes";
+
+/** 1:100 in metres — one of the presets, so the panel shows it as selected. */
+const PRESET_SCALE: MeasureScale = { factor: 0.05, ratio: 100, unit: "m" };
+
+/** A ratio no preset offers, which leaves the preset row unselected. */
+const CUSTOM_SCALE: MeasureScale = { factor: 0.0175, ratio: 35, unit: "ft" };
+
+/** Calibrated scales carry no ratio — the panel labels them "(custom)". */
+const CALIBRATED_SCALE: MeasureScale = {
+  factor: 0.0223,
+  ratio: null,
+  unit: "cm",
+};
+
+const noop = () => {};
+
+const meta: Meta<typeof ScaleSettingsPanel> = {
+  title: "Viewer/ScaleSettingsPanel",
+  component: ScaleSettingsPanel,
+  // The panel sets its own 300px floor; padded gives it room without the
+  // centred frame clipping into a scroll container.
+  parameters: { layout: "padded" },
+  args: {
+    onApplyScale: noop,
+    onResetScale: noop,
+    onStartCalibration: noop,
+    onCancelCalibration: noop,
+    onClose: noop,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScaleSettingsPanel>;
+
+/** No scale set: the active-scale strip is muted and Reset is not offered. */
+export const Default: Story = {};
+
+export const PresetSelected: Story = { args: { currentScale: PRESET_SCALE } };
+
+export const CustomRatio: Story = { args: { currentScale: CUSTOM_SCALE } };
+
+export const CalibratedScale: Story = {
+  args: { currentScale: CALIBRATED_SCALE },
+};
+
+/** Calibration running: the button flips to its active state. */
+export const Calibrating: Story = { args: { isCalibrationActive: true } };
+
+/**
+ * Calibration is disabled when the viewer supplies no handler for it — the
+ * panel is reachable in contexts that cannot start a calibration draw.
+ */
+export const CalibrationUnavailable: Story = {
+  args: { onStartCalibration: undefined },
+};

--- a/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.tsx
+++ b/frontend/editor/src/core/components/viewer/ScaleSettingsPanel.tsx
@@ -254,7 +254,9 @@ export function ScaleSettingsPanel({
             />
           </div>
         </Group>
-        <Text size="xs" c="dimmed" mt="xs">
+        {/* Mantine's own "dimmed" is too light to clear 4.5:1 at this size, so
+            muted text comes from the design system's token instead. */}
+        <Text size="xs" c="var(--c-text-muted)" mt="xs">
           {t(
             "scaleSettings.ratioHelp",
             "Ratio: 1 page unit = X real-world units",
@@ -271,12 +273,14 @@ export function ScaleSettingsPanel({
         style={{
           padding: "0.5rem",
           backgroundColor: currentScale
-            ? "rgba(30, 136, 229, 0.1)"
-            : "rgba(158, 158, 158, 0.1)",
+            ? "var(--c-primary-tint)"
+            : "var(--c-surface-sunken)",
           borderRadius: "4px",
         }}
       >
-        <Text size="xs" c={currentScale ? "blue" : "dimmed"}>
+        {/* The tint carries the "a scale is active" signal; the text stays at
+            full contrast rather than restating it in the accent hue. */}
+        <Text size="xs" c={currentScale ? undefined : "var(--c-text-muted)"}>
           <strong>{t("scaleSettings.activeScale", "Active Scale")}:</strong>{" "}
           {currentScale && currentScale.ratio
             ? generateScaleLabel(currentScale.ratio, currentScale.unit)

--- a/frontend/editor/src/core/components/viewer/SidebarBase.css
+++ b/frontend/editor/src/core/components/viewer/SidebarBase.css
@@ -40,7 +40,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--mantine-color-blue-6);
+  color: var(--c-accent-text);
   font-size: 1.1rem;
 }
 

--- a/frontend/editor/src/core/components/viewer/ThumbnailSidebar.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/ThumbnailSidebar.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+import { ThumbnailSidebar } from "@app/components/viewer/ThumbnailSidebar";
+
+/**
+ * The viewer's page rail. Each thumbnail jumps the viewer to that page, so
+ * they are controls rather than pictures — `aria-current` marks the page being
+ * viewed, which the highlight alone only conveys visually.
+ *
+ * The sidebar reads the viewer context for page counts and thumbnail
+ * rendering. Rather than standing up a ViewerProvider (and the document
+ * pipeline behind it), these stories supply the small slice of context the
+ * sidebar actually touches.
+ */
+function viewerValue(
+  currentPage: number,
+  totalPages: number,
+): ViewerContextType {
+  return {
+    getScrollState: () => ({ currentPage, totalPages }),
+    scrollActions: { scrollToPage: () => {} },
+    // No renderer in a story, so no thumbnail images — the page frames,
+    // numbering and selected state are what these stories are for.
+    getThumbnailAPI: () => null,
+  } as unknown as ViewerContextType;
+}
+
+const withViewer =
+  (currentPage: number, totalPages: number) => (Story: React.ComponentType) => (
+    <ViewerContext.Provider value={viewerValue(currentPage, totalPages)}>
+      <div style={{ height: "80vh", display: "flex" }}>
+        <Story />
+      </div>
+    </ViewerContext.Provider>
+  );
+
+const meta: Meta<typeof ThumbnailSidebar> = {
+  title: "Viewer/ThumbnailSidebar",
+  component: ThumbnailSidebar,
+  parameters: { layout: "fullscreen" },
+  args: { visible: true, onToggle: () => {}, activeFileId: "file-1" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ThumbnailSidebar>;
+
+/** A short document, viewing page 1. */
+export const Default: Story = {
+  decorators: [withViewer(1, 8)],
+};
+
+/** Part-way through — the current page is marked, not just tinted. */
+export const MidDocument: Story = {
+  decorators: [withViewer(5, 8)],
+};
+
+/** A long document, so the rail scrolls. */
+export const LongDocument: Story = {
+  decorators: [withViewer(12, 120)],
+};
+
+/** A single-page document: the rail still lists it. */
+export const SinglePage: Story = {
+  decorators: [withViewer(1, 1)],
+};
+
+/** Nothing loaded yet — no pages to list. */
+export const NoPages: Story = {
+  decorators: [withViewer(0, 0)],
+};
+
+/** Collapsed. */
+export const Hidden: Story = {
+  args: { visible: false },
+  decorators: [withViewer(1, 8)],
+};

--- a/frontend/editor/src/core/components/viewer/ThumbnailSidebar.tsx
+++ b/frontend/editor/src/core/components/viewer/ThumbnailSidebar.tsx
@@ -216,7 +216,27 @@ export function ThumbnailSidebar({
                   (_, pageIndex) => (
                     <Box
                       key={pageIndex}
+                      // Each thumbnail jumps the viewer to that page, so it is
+                      // a control. aria-current marks the page being viewed,
+                      // which the highlight alone only conveys visually.
+                      role="button"
+                      tabIndex={0}
+                      aria-label={t("viewer.thumbnails.goToPage", {
+                        defaultValue: "Go to page {{page}}",
+                        page: pageIndex + 1,
+                      })}
+                      aria-current={
+                        scrollState.currentPage === pageIndex + 1
+                          ? "true"
+                          : undefined
+                      }
                       onClick={() => handlePageClick(pageIndex)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handlePageClick(pageIndex);
+                        }
+                      }}
                       style={{
                         cursor: "pointer",
                         borderRadius: "8px",
@@ -306,7 +326,7 @@ export function ThumbnailSidebar({
                           fontWeight: 500,
                           color:
                             scrollState.currentPage === pageIndex + 1
-                              ? "var(--color-primary-500)"
+                              ? "var(--c-accent-text)"
                               : "var(--c-text-subtle)",
                         }}
                       >

--- a/frontend/editor/src/core/components/viewer/nonpdf/JsonViewer.tsx
+++ b/frontend/editor/src/core/components/viewer/nonpdf/JsonViewer.tsx
@@ -47,7 +47,7 @@ export function JsonViewer({ file }: JsonViewerProps) {
             flexShrink: 0,
           }}
         >
-          <Text size="xs" c="red">
+          <Text size="xs" c="var(--color-red-dark)">
             {t("viewer.nonPdf.invalidJson")}
           </Text>
         </Paper>

--- a/frontend/editor/src/core/components/viewer/nonpdf/MarkdownRenderer.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/nonpdf/MarkdownRenderer.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { renderMarkdown } from "@app/components/viewer/nonpdf/MarkdownRenderer";
+
+/**
+ * How a `.md` file is rendered in the non-PDF viewer. `renderMarkdown` returns
+ * nodes rather than a component, so the stories render its output directly —
+ * the same thing the viewer mounts.
+ */
+const meta: Meta = {
+  title: "Viewer/NonPdf/MarkdownRenderer",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+const Doc = ({ md }: { md: string }) => <div>{renderMarkdown(md)}</div>;
+
+/** Headings, emphasis, a list and a link — ordinary prose. */
+export const Prose: StoryObj = {
+  render: () => (
+    <Doc
+      md={[
+        "# Release notes",
+        "",
+        "The **August** build focuses on _throughput_.",
+        "",
+        "## Highlights",
+        "",
+        "- Batch processing is no longer serialised",
+        "- Thumbnails render off the main thread",
+        "- See the [changelog](https://example.com/changelog)",
+      ].join("\n")}
+    />
+  ),
+};
+
+/** A fenced code block — the case with its own renderer override. */
+export const CodeBlock: StoryObj = {
+  render: () => (
+    <Doc
+      md={[
+        "Run the container:",
+        "",
+        "```bash",
+        "docker run -p 8080:8080 stirlingtools/stirling-pdf:latest",
+        "```",
+      ].join("\n")}
+    />
+  ),
+};
+
+/** A GFM table, which also has its own overrides for header and cell. */
+export const Table: StoryObj = {
+  render: () => (
+    <Doc
+      md={[
+        "| Format | Input | Output |",
+        "| --- | :-: | ---: |",
+        "| PDF | yes | yes |",
+        "| DOCX | yes | no |",
+        "| PNG | yes | yes |",
+      ].join("\n")}
+    />
+  ),
+};
+
+/** A wide table and a long code line — both must scroll inside the viewer
+ *  rather than widening it. */
+export const WideContent: StoryObj = {
+  render: () => (
+    <Doc
+      md={[
+        "```json",
+        '{ "id": "doc_01HQ8ZK3", "source": "s3://bucket/very/long/object/key/contract-2026-final-signed.pdf", "status": "complete" }',
+        "```",
+        "",
+        "| Field | Type | Description | Example | Notes |",
+        "| --- | --- | --- | --- | --- |",
+        "| id | string | Stable identifier | doc_01HQ8ZK3 | Opaque |",
+        "| status | enum | queued / complete / failed | complete | Poll or subscribe |",
+      ].join("\n")}
+    />
+  ),
+};
+
+/** Blockquote and nested list, the remaining common blocks. */
+export const QuotesAndNesting: StoryObj = {
+  render: () => (
+    <Doc
+      md={[
+        "> Redaction rewrites the page content stream.",
+        "",
+        "1. Select the region",
+        "   - Drag to extend",
+        "   - Shift-click to add another",
+        "2. Apply",
+      ].join("\n")}
+    />
+  ),
+};
+
+/** An empty document. */
+export const Empty: StoryObj = { render: () => <Doc md="" /> };

--- a/frontend/editor/src/core/components/viewer/nonpdf/TextViewer.tsx
+++ b/frontend/editor/src/core/components/viewer/nonpdf/TextViewer.tsx
@@ -122,7 +122,7 @@ export function TextViewer({ file, isMarkdown }: TextViewerProps) {
                       paddingRight: 16,
                       paddingLeft: 4,
                       textAlign: "right",
-                      color: "var(--mantine-color-gray-5)",
+                      color: "var(--c-text-muted)",
                       userSelect: "none",
                       borderRight: "1px solid var(--mantine-color-gray-2)",
                       minWidth: `${String(lines.length).length + 1}ch`,

--- a/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
@@ -451,6 +451,7 @@ export function useViewerWorkbenchBarButtons(
                 <Slider
                   value={speechRate}
                   onChange={handleSpeechRateChange}
+                  thumbLabel={readAloudSpeedLabel}
                   min={0.5}
                   max={2}
                   step={0.1}

--- a/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
@@ -200,18 +200,18 @@ export function useViewerWorkbenchBarButtons(
               opened={isSearchInterfaceVisible}
               onClose={viewer.searchInterfaceActions.close}
             >
+              {/* The button is the target: Popover.Target puts aria-expanded
+                  on whatever it wraps, which a plain div may not carry. */}
               <Popover.Target>
-                <div style={{ display: "inline-flex" }}>
-                  <ActionIcon
-                    variant="tertiary"
-                    className="workbench-bar-action-icon"
-                    disabled={disabled}
-                    aria-label={searchLabel}
-                    onClick={viewer.searchInterfaceActions.toggle}
-                  >
-                    <LocalIcon icon="search" width="1rem" height="1rem" />
-                  </ActionIcon>
-                </div>
+                <ActionIcon
+                  variant="tertiary"
+                  className="workbench-bar-action-icon"
+                  disabled={disabled}
+                  aria-label={searchLabel}
+                  onClick={viewer.searchInterfaceActions.toggle}
+                >
+                  <LocalIcon icon="search" width="1rem" height="1rem" />
+                </ActionIcon>
               </Popover.Target>
               <Popover.Dropdown>
                 <div style={{ minWidth: "20rem" }}>

--- a/frontend/editor/src/core/contexts/FileManagerContext.tsx
+++ b/frontend/editor/src/core/contexts/FileManagerContext.tsx
@@ -29,7 +29,7 @@ import { openFilesFromDisk } from "@app/services/openFilesFromDisk";
 export { pendingFilePathMappings } from "@app/services/pendingFilePathMappings";
 
 // Type for the context value - now contains everything directly
-interface FileManagerContextValue {
+export interface FileManagerContextValue {
   // State
   activeSource: "recent" | "local" | "drive";
   storageFilter: "all" | "local" | "sharedWithMe" | "sharedByMe";
@@ -80,8 +80,11 @@ interface FileManagerContextValue {
   modalHeight: string;
 }
 
-// Create the context
-const FileManagerContext = createContext<FileManagerContextValue | null>(null);
+// Create the context. Exported so a test or story can mount a component
+// against a slice of the value instead of the whole provider chain.
+export const FileManagerContext = createContext<FileManagerContextValue | null>(
+  null,
+);
 
 // Provider component props
 interface FileManagerProviderProps {

--- a/frontend/editor/src/core/contexts/FilesModalContext.tsx
+++ b/frontend/editor/src/core/contexts/FilesModalContext.tsx
@@ -26,7 +26,7 @@ import {
   readResponseHeader,
 } from "@app/services/shareBundleUtils";
 
-interface FilesModalContextType {
+export interface FilesModalContextType {
   isFilesModalOpen: boolean;
   openFilesModal: (options?: {
     insertAfterPage?: number;
@@ -41,7 +41,10 @@ interface FilesModalContextType {
   setOnModalClose: (callback: () => void) => void;
 }
 
-const FilesModalContext = createContext<FilesModalContextType | null>(null);
+// Exported so a test or story can mount a component against a slice of the
+// value: the provider itself pulls in FileContext and NavigationContext.
+export const FilesModalContext =
+  createContext<FilesModalContextType | null>(null);
 
 export const FilesModalProvider: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/frontend/editor/src/core/contexts/HotkeyContext.tsx
+++ b/frontend/editor/src/core/contexts/HotkeyContext.tsx
@@ -22,7 +22,7 @@ import { ToolCategoryId, ToolRegistryEntry } from "@app/data/toolsTaxonomy";
 
 type Bindings = Partial<Record<ToolId, HotkeyBinding>>;
 
-interface HotkeyContextValue {
+export interface HotkeyContextValue {
   hotkeys: Bindings;
   defaults: Bindings;
   isMac: boolean;
@@ -38,7 +38,12 @@ interface HotkeyContextValue {
   getDisplayParts: (binding: HotkeyBinding | null | undefined) => string[];
 }
 
-const HotkeyContext = createContext<HotkeyContextValue | undefined>(undefined);
+// Exported so a component that only reads a slice of this (HotkeyDisplay wants
+// getDisplayParts) can be mounted without HotkeyProvider, which pulls in the
+// whole tool-workflow chain behind it.
+export const HotkeyContext = createContext<HotkeyContextValue | undefined>(
+  undefined,
+);
 
 const STORAGE_KEY = "stirlingpdf.hotkeys";
 

--- a/frontend/editor/src/core/contexts/NavigationContext.tsx
+++ b/frontend/editor/src/core/contexts/NavigationContext.tsx
@@ -128,8 +128,11 @@ export interface NavigationContextActionsValue {
   actions: NavigationContextActions;
 }
 
-// Create contexts
-const NavigationStateContext = createContext<
+// Create contexts. The state context is exported so a test or story can mount a
+// component against a slice of it: the provider itself reaches the tool
+// registry, which is far more than a component reading one navigation field
+// needs standing up.
+export const NavigationStateContext = createContext<
   NavigationContextStateValue | undefined
 >(undefined);
 const NavigationActionsContext = createContext<

--- a/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
+++ b/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
@@ -58,7 +58,7 @@ export interface CustomWorkbenchViewInstance extends CustomWorkbenchViewRegistra
   data: any;
 }
 
-interface ToolWorkflowContextValue extends ToolWorkflowState {
+export interface ToolWorkflowContextValue extends ToolWorkflowState {
   // Tool management (from hook)
   selectedToolKey: ToolId | null;
   selectedTool: ToolRegistryEntry | null;
@@ -116,7 +116,10 @@ const __GLOBAL_CONTEXT_KEY__ = "__ToolWorkflowContext__";
 const existingContext = (globalThis as any)[__GLOBAL_CONTEXT_KEY__] as
   | React.Context<ToolWorkflowContextValue | undefined>
   | undefined;
-const ToolWorkflowContext =
+// Exported so a test or story can mount a component against a slice of the
+// value. The provider itself stands up the whole tool registry and navigation
+// chain, which is far more than a component reading a few fields needs.
+export const ToolWorkflowContext =
   existingContext ??
   createContext<ToolWorkflowContextValue | undefined>(undefined);
 if (!existingContext) {
@@ -156,10 +159,14 @@ export interface ToolWorkflowDataValue {
   isFavorite: (toolId: ToolId) => boolean;
 }
 
-const ToolWorkflowActionsContext = createContext<
+// Exported alongside ToolWorkflowContext so a story can supply the callbacks a
+// component reaches for without standing up the provider.
+export const ToolWorkflowActionsContext = createContext<
   ToolWorkflowActionsValue | undefined
 >(undefined);
-const ToolWorkflowDataContext = createContext<
+// Exported alongside the other two so a story can supply the registry and
+// favourites a component reads without standing up the provider.
+export const ToolWorkflowDataContext = createContext<
   ToolWorkflowDataValue | undefined
 >(undefined);
 

--- a/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
+++ b/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
@@ -21,7 +21,9 @@ interface WorkbenchBarContextValue {
   clear: () => void;
 }
 
-const WorkbenchBarContext = createContext<WorkbenchBarContextValue | undefined>(
+// Exported so a story can supply the bar's buttons without the provider,
+// which derives them from the whole workbench.
+export const WorkbenchBarContext = createContext<WorkbenchBarContextValue | undefined>(
   undefined,
 );
 

--- a/frontend/editor/src/core/pages/MobileScannerPage.tsx
+++ b/frontend/editor/src/core/pages/MobileScannerPage.tsx
@@ -1107,7 +1107,7 @@ export default function MobileScannerPage() {
                 <PhotoCameraRoundedIcon
                   style={{
                     fontSize: "3rem",
-                    color: "var(--mantine-color-blue-6)",
+                    color: "var(--c-accent-text)",
                   }}
                 />
                 <Text size="lg" fw={600}>

--- a/frontend/editor/src/core/styles/index.css
+++ b/frontend/editor/src/core/styles/index.css
@@ -62,7 +62,7 @@ code {
 }
 
 .stirling-link {
-  color: var(--mantine-color-blue-6);
+  color: var(--c-accent-text);
   text-decoration: none;
   font-weight: 500;
   transition: color 0.2s ease;

--- a/frontend/editor/src/core/styles/theme.css
+++ b/frontend/editor/src/core/styles/theme.css
@@ -43,7 +43,9 @@
     var(--p-green-500) 15%,
     transparent
   ); /* Transparent green for active badge */
-  --file-active-badge-fg: var(--p-green-700); /* Green text for active badge */
+  /* green-700 on the 15% tint measures 4.05:1, under the 4.5:1 this badge's
+     size needs; green-800 clears it. */
+  --file-active-badge-fg: var(--p-green-800);
   --file-active-badge-border: color-mix(
     in srgb,
     var(--p-green-500) 30%,
@@ -61,6 +63,8 @@
   --gray-100: 243 244 246;
   --gray-200: 229 231 235;
   --gray-300: 209 213 219;
+  /* Channel form of gray-400. Only for decorative fills/borders — as text it
+     reaches 2.3:1, so label copy uses --gray-600. */
   --gray-400: 156 163 175;
   --gray-500: 107 114 128;
   --gray-600: 75 85 99;
@@ -86,9 +90,9 @@
   --color-primary-900: var(--p-blue-700);
 
   /* Success (green) */
-  --color-green-50: var(--p-green-500);
-  --color-green-100: var(--p-green-500);
-  --color-green-200: var(--p-green-500);
+  --color-green-50: var(--p-green-50);
+  --color-green-100: var(--p-green-100);
+  --color-green-200: var(--p-green-200);
   --color-green-300: var(--p-green-500);
   --color-green-400: var(--p-green-500);
   --color-green-500: var(--p-green-500);
@@ -98,9 +102,9 @@
   --color-green-900: var(--p-green-700);
 
   /* Warning (yellow) */
-  --color-yellow-50: var(--p-amber-400);
-  --color-yellow-100: var(--p-amber-400);
-  --color-yellow-200: var(--p-amber-400);
+  --color-yellow-50: var(--p-amber-50);
+  --color-yellow-100: var(--p-amber-100);
+  --color-yellow-200: var(--p-amber-200);
   --color-yellow-300: var(--p-amber-400);
   --color-yellow-400: var(--p-amber-400);
 
@@ -131,9 +135,9 @@
   --color-yellow-800: var(--p-amber-600);
   --color-yellow-900: var(--p-amber-600);
 
-  --color-red-50: var(--p-red-400);
-  --color-red-100: var(--p-red-400);
-  --color-red-200: var(--p-red-400);
+  --color-red-50: var(--p-red-50);
+  --color-red-100: var(--p-red-100);
+  --color-red-200: var(--p-red-200);
   --color-red-300: var(--p-red-400);
   --color-red-400: var(--p-red-400);
   --color-red-500: var(--p-red-500);
@@ -584,7 +588,7 @@
 
 /* Plan section button colors */
 .plan-button:not(:disabled):not([data-disabled]) {
-  background-color: var(--p-azure-500) !important;
+  background-color: var(--p-azure-700) !important;
 }
 
 [data-mantine-color-scheme="dark"]

--- a/frontend/editor/src/core/theme/colors.css
+++ b/frontend/editor/src/core/theme/colors.css
@@ -36,6 +36,15 @@ html[data-app-theme="light"] {
   --c-success: var(--p-green-600);
   --c-danger: var(--p-red-600);
   --c-warning: var(--p-amber-600);
+  /* Solid fills that carry a white label. Deeper than the --c-<tone> values
+     above, which are picked for surfaces, borders and icons where the 3:1
+     non-text floor applies. Scheme-independent: a filled badge reads white on
+     either ground. */
+  --c-success-solid: var(--p-green-700);
+  --c-danger-solid: var(--p-red-600);
+  --c-warning-solid: var(--p-amber-700);
+  --c-neutral-solid: var(--p-gray-600);
+  --c-accent-solid: var(--p-blue-600);
   /* Highlight/flash (search hits, compare jump-to) — same in both themes. */
   --c-highlight: var(--p-flash-yellow);
   /* Stirling brand red (auth CTAs) — a fixed brand colour, same in both themes. */
@@ -165,7 +174,15 @@ html[data-app-theme="custom"] {
   --c-primary-hover: color-mix(in srgb, var(--c-primary) 80%, var(--p-black));
   --c-primary-subtle: color-mix(in srgb, var(--c-primary) 14%, transparent);
   --c-text-on-primary: var(--p-white);
-  --c-accent-fg: var(--c-primary);
+  /* Accent used as TEXT: --c-primary and its 80% hover both land under
+     4.5:1 on the accent-tinted surfaces they appear on (chips, links,
+     outline buttons), so accent copy takes a deeper step of the hue. */
+  --c-accent-text: var(--p-blue-700);
+  /* The accent as a foreground. Custom themes overwrite this from
+     --user-accent-fg, which is already forced dark enough on light bases;
+     the default build has to make the same guarantee, so it takes the text
+     step rather than the raw fill. */
+  --c-accent-fg: var(--c-accent-text);
 
   /* Primary-tinted surfaces (light base). Neutralised by the default override. */
   --c-bg: color-mix(in srgb, var(--c-primary) 7%, var(--p-paper));
@@ -194,7 +211,11 @@ html[data-app-theme="custom"] {
   --color-primary-300: color-mix(in srgb, var(--c-primary) 55%, var(--p-white));
   --color-primary-400: color-mix(in srgb, var(--c-primary) 78%, var(--p-white));
   --color-primary-500: var(--c-primary);
-  --color-primary-600: color-mix(in srgb, var(--c-primary) 88%, var(--p-black));
+  /* Shade 600 is the ramp's text-capable step — Mantine maps it to shade 6,
+     which drives link colour and the tuple's default text. At 88% it lands
+     at 4.2:1 on the page, so it mixes further down. Filled surfaces read
+     from --mantine-primary-color-filled (= --c-primary) and are unaffected. */
+  --color-primary-600: color-mix(in srgb, var(--c-primary) 75%, var(--p-black));
   --color-primary-700: color-mix(in srgb, var(--c-primary) 74%, var(--p-black));
   --color-primary-800: color-mix(in srgb, var(--c-primary) 60%, var(--p-black));
   --color-primary-900: color-mix(in srgb, var(--c-primary) 46%, var(--p-black));
@@ -211,7 +232,9 @@ html[data-app-theme="custom"] {
     var(--c-primary) 18%,
     transparent
   );
-  --mantine-primary-color-light-color: var(--c-primary);
+  /* Text of the light/subtle variants — the fill value only reaches ~3:1 on
+     its own tint, so accent copy takes the deeper step. */
+  --mantine-primary-color-light-color: var(--c-accent-text);
 
   /* Brand-tint family — re-derived from --c-primary so legacy accents harmonise to the chosen hue. */
 
@@ -280,6 +303,7 @@ html[data-app-theme="custom"] {
 
 /* ── DARK — editor dark theme: neutral text/borders/icons + accent-tinted surfaces (default override opts out). After :root so it wins for dark. ── */
 html[data-app-theme="custom"][data-mantine-color-scheme="dark"] {
+  --c-accent-text: var(--p-blue-400);
   /* Neutral text / borders / overlay (not accent-tinted). */
   --c-text: var(--p-snow);
   --c-text-muted: var(--p-zinc-200);

--- a/frontend/editor/src/core/theme/colors.css
+++ b/frontend/editor/src/core/theme/colors.css
@@ -374,3 +374,14 @@ html[data-app-theme="custom"][data-accent="default"][data-mantine-color-scheme="
   --c-border: var(--p-c-28282d);
   --c-border-subtle: var(--p-zinc-700);
 }
+
+/* ── MANTINE MUTED TEXT ───────────────────────────────────────────────────── */
+/* Mantine's stock "dimmed" is #868e96, which measures ~3:1 against the app's
+   surfaces — short of the 4.5:1 that body-size text needs. Pointing it at the
+   semantic muted token fixes every `c="dimmed"` at once, and follows the theme
+   rather than staying a fixed grey that only ever suited light mode. */
+/* Doubled selector: Mantine declares this on :root too, and its stylesheet
+   loads later, so a single :root here would lose on source order. */
+:root:root {
+  --mantine-color-dimmed: var(--c-text-muted);
+}

--- a/frontend/editor/src/core/theme/mantineTheme.ts
+++ b/frontend/editor/src/core/theme/mantineTheme.ts
@@ -3,6 +3,7 @@ import {
   MantineColorsTuple,
   MantineTheme,
   MantineThemeComponent,
+  type CSSVariablesResolver,
 } from "@mantine/core";
 
 // Define color tuples using CSS variables
@@ -45,6 +46,21 @@ const yellow: MantineColorsTuple = [
   "var(--color-yellow-900)",
 ];
 
+// Mantine falls back to its own palette for any colour name the theme does not
+// define, which is how stock reds/blues (failing contrast) reached the UI.
+const red: MantineColorsTuple = [
+  "var(--color-red-50)",
+  "var(--color-red-100)",
+  "var(--color-red-200)",
+  "var(--color-red-300)",
+  "var(--color-red-400)",
+  "var(--color-red-500)",
+  "var(--color-red-600)",
+  "var(--color-red-700)",
+  "var(--color-red-800)",
+  "var(--color-red-900)",
+];
+
 const gray: MantineColorsTuple = [
   "var(--color-gray-50)",
   "var(--color-gray-100)",
@@ -72,6 +88,55 @@ const dark: MantineColorsTuple = [
   "#050506", // dark-9  — deepest
 ];
 
+/**
+ * Mantine derives the "light" variant's text colour from the palette itself,
+ * landing around 3.7:1 on its own tint — too low for badge/button labels. Point
+ * each hue's light-variant text at the accessible on-light shade instead.
+ */
+export const editorCssVariablesResolver: CSSVariablesResolver = () => ({
+  variables: {},
+  light: {
+    // Link colour: Mantine derives it from the accent's shade 6.
+    "--mantine-color-anchor": "var(--c-accent-text)",
+    "--mantine-color-primary-light-color": "var(--c-accent-text)",
+    "--mantine-color-blue-light-color": "var(--c-accent-text)",
+    "--mantine-color-red-light-color": "var(--color-red-dark)",
+    "--mantine-color-green-light-color": "var(--color-green-dark)",
+    "--mantine-color-yellow-light-color": "var(--color-amber-dark)",
+    // Colour names the app never registers still reach Mantine's own palette
+    // through `color="..."` props, so pin their light-variant text too.
+    "--mantine-color-orange-light-color": "var(--color-amber-dark)",
+    "--mantine-color-indigo-light-color": "var(--p-indigo-600)",
+    "--mantine-color-grape-light-color": "var(--color-purple-dark)",
+    "--mantine-color-teal-light-color": "var(--color-green-dark)",
+    "--mantine-color-cyan-light-color": "var(--c-accent-text)",
+    // Mantine's own semantic slots. The -text variants back input errors and
+    // text-only variants; the -filled ones back solid badges, and the stock
+    // orange and grey are too light to carry a white label.
+    "--mantine-color-dimmed": "var(--c-text-muted)",
+    "--mantine-color-error": "var(--color-red-dark)",
+    "--mantine-color-red-text": "var(--color-red-dark)",
+    "--mantine-color-green-text": "var(--color-green-dark)",
+    "--mantine-color-orange-text": "var(--color-amber-dark)",
+    "--mantine-color-blue-text": "var(--c-accent-text)",
+    "--mantine-color-orange-filled": "var(--p-amber-700)",
+    "--mantine-color-green-filled": "var(--p-green-700)",
+    "--mantine-color-yellow-filled": "var(--p-amber-700)",
+    // Outline variants paint their label with the hue's -outline slot, which
+    // defaults to the solid fill and is therefore too light to read.
+    "--mantine-color-red-outline": "var(--color-red-dark)",
+    "--mantine-color-green-outline": "var(--color-green-dark)",
+    "--mantine-color-teal-outline": "var(--color-green-dark)",
+    "--mantine-color-orange-outline": "var(--color-amber-dark)",
+    "--mantine-color-yellow-outline": "var(--color-amber-dark)",
+    "--mantine-color-blue-outline": "var(--c-accent-text)",
+    "--mantine-color-primary-outline": "var(--c-accent-text)",
+    "--mantine-color-teal-filled": "var(--p-green-700)",
+    "--mantine-color-gray-filled": "var(--p-gray-600)",
+  },
+  dark: {},
+});
+
 export const mantineTheme = createTheme({
   // Primary color
   primaryColor: "primary",
@@ -79,6 +144,11 @@ export const mantineTheme = createTheme({
   // Color palette
   colors: {
     primary,
+    // `blue` is the same ramp as `primary`: components written against Mantine's
+    // default palette name still land on the app's accent instead of stock blue.
+    blue: primary,
+    teal: green,
+    red,
     green,
     yellow,
     gray,
@@ -124,6 +194,35 @@ export const mantineTheme = createTheme({
 
   // Component customizations
   components: {
+    // Mantine renders the modal/drawer dismiss control as an icon-only button
+    // with no text, so without a name it is unreachable by screen reader. The
+    // app's own Modal wrapper (@app/ui/Modal) names itself; this covers the
+    // components that still mount Mantine's Modal directly. Pass a translated
+    // aria-label at the call site where the control means more than "close".
+    Anchor: {
+      styles: {
+        root: {
+          // Mantine links default to the accent shade, which reads at 4.4:1 on
+          // the page; accent copy has its own deeper token.
+          color: "var(--c-accent-text)",
+        },
+      },
+    },
+    CloseButton: {
+      defaultProps: { "aria-label": "Close" },
+    },
+    ColorInput: {
+      // Mantine ships the eye-dropper trigger as an icon-only button with no
+      // accessible name.
+      defaultProps: {
+        eyeDropperButtonProps: {
+          "aria-label": "Pick a colour from the screen",
+        },
+      },
+    },
+    Drawer: {
+      defaultProps: { closeButtonProps: { "aria-label": "Close" } },
+    },
     Button: {
       styles: {
         root: {
@@ -336,6 +435,7 @@ export const mantineTheme = createTheme({
     },
 
     Modal: {
+      defaultProps: { closeButtonProps: { "aria-label": "Close" } },
       styles: {
         content: {
           backgroundColor: "var(--c-surface)",

--- a/frontend/editor/src/core/theme/primitives.css
+++ b/frontend/editor/src/core/theme/primitives.css
@@ -12,9 +12,10 @@
   --p-gray-400: #9ca3af;
   --p-gray-500: #6b7280;
   /* Subtle body text in light mode. gray-500 clears 4.5:1 on pure white but
-     only reaches 4.39:1 on the --p-paper canvas; this is the same hue nudged
-     dark enough to pass (4.87:1) while staying lighter than gray-600. */
-  --p-gray-550: #646b76;
+     falls under it on the --p-paper canvas; this is the same hue nudged dark
+     enough to pass on the tinted surfaces too (4.94:1 on the blue banner tint,
+     the darkest ground it lands on) while staying lighter than gray-600. */
+  --p-gray-550: #5d636d;
   --p-gray-600: #4b5563;
   --p-gray-700: #374151;
   --p-gray-800: #1f2937;
@@ -41,15 +42,28 @@
   --p-blue-500: #3b82f6;
   --p-blue-600: #2563eb;
   --p-blue-700: #1d4ed8;
+  --p-green-50: #f0fdf4;
+  --p-green-100: #dcfce7;
+  --p-green-200: #bbf7d0;
   --p-green-500: #22c55e;
   --p-green-600: #16a34a;
   --p-green-700: #15803d;
+  --p-green-800: #166534;
+  --p-amber-50: #fffbeb;
+  --p-amber-100: #fef3c7;
+  --p-amber-200: #fde68a;
   --p-amber-400: #fbbf24;
   --p-amber-500: #f59e0b;
   --p-amber-600: #d97706;
+  --p-amber-700: #b45309;
+  --p-amber-800: #92400e;
+  --p-red-50: #fef2f2;
+  --p-red-100: #fee2e2;
+  --p-red-200: #fecaca;
   --p-red-400: #f87171;
   --p-red-500: #ef4444;
   --p-red-600: #dc2626;
+  --p-red-700: #b91c1c;
 
   /* Brand-red + ai-accent scales, consumed by core/ui/accents.css. */
   --p-brand-red-200: #d9a8a8;
@@ -63,6 +77,7 @@
   --p-indigo-300: #a5b4fc;
   --p-indigo-400: #818cf8;
   --p-indigo-500: #6366f1;
+  --p-indigo-600: #4f46e5;
   --p-indigo-800: #3730a3;
 
   /* Extended accent/status/neutral weights referenced by app CSS. */
@@ -137,6 +152,7 @@
   --p-c-2d3560: #2d3560;
   --p-emerald-400: #34d399;
   --p-azure-650: #3a7be8;
+  --p-azure-700: #0a6ac9;
   --p-navy-500: #3b4b6e;
   --p-c-475569: #475569;
   --p-c-334155: #334155;
@@ -145,13 +161,13 @@
   --p-c-545454: #545454;
   --p-azure-450: #5b9bf7;
   --p-c-64748b: #64748b;
-  --p-c-656d76: #656d76;
+  --p-c-656d76: #5f6772;
   --p-c-6e7781: #6e7781;
   --p-violet-600: #7c3aed;
   --p-c-7e7e7e: #7e7e7e;
   --p-c-8250df: #8250df;
   --p-violet-500: #8b5cf6;
-  --p-c-8c959f: #8c959f;
+  --p-c-8c959f: #57606a;
   --p-blue-200: #93c5fd;
   --p-c-94a3b8: #94a3b8;
   --p-code-type: #953800;

--- a/frontend/editor/src/core/tokens/base.css
+++ b/frontend/editor/src/core/tokens/base.css
@@ -29,7 +29,7 @@ button {
 }
 
 a {
-  color: var(--c-primary);
+  color: var(--c-accent-text);
   text-decoration: none;
 }
 a:hover {

--- a/frontend/editor/src/core/tokens/tokens.css
+++ b/frontend/editor/src/core/tokens/tokens.css
@@ -25,6 +25,14 @@
   --color-text-on-accent: #ffffff;
 
   /* Brand / status */
+  --color-blue: var(--p-blue-500);
+  --color-blue-light: color-mix(in srgb, var(--p-blue-500) 13%, var(--p-white));
+  --color-blue-border: color-mix(
+    in srgb,
+    var(--p-blue-500) 40%,
+    var(--p-white)
+  );
+  --color-blue-dark: var(--p-blue-700);
   --color-purple: var(--p-blue-400);
   --color-purple-light: color-mix(
     in srgb,
@@ -36,7 +44,11 @@
     var(--p-blue-400) 40%,
     var(--p-white)
   );
-  --color-purple-dark: var(--p-blue-600);
+  /* The -dark shades are the on-light TEXT colours (accents.css --_text and
+     status copy). They have to clear 4.5:1 on the tinted -light surfaces they
+     sit on, not just on the page, which is why they sit well below the base
+     hue rather than one step under it. */
+  --color-purple-dark: var(--p-blue-700);
   --color-green: var(--p-green-500);
   --color-green-light: color-mix(
     in srgb,
@@ -48,11 +60,11 @@
     var(--p-green-500) 40%,
     var(--p-white)
   );
-  --color-green-dark: var(--p-green-600);
+  --color-green-dark: var(--p-green-800);
   --color-red: var(--p-red-500);
   --color-red-light: color-mix(in srgb, var(--p-red-500) 13%, var(--p-white));
   --color-red-border: color-mix(in srgb, var(--p-red-500) 40%, var(--p-white));
-  --color-red-dark: var(--p-red-600);
+  --color-red-dark: var(--p-red-700);
   --color-amber: var(--p-amber-500);
   --color-amber-light: color-mix(
     in srgb,
@@ -64,7 +76,7 @@
     var(--p-amber-500) 42%,
     var(--p-white)
   );
-  --color-amber-dark: var(--p-amber-600);
+  --color-amber-dark: var(--p-amber-800);
   --color-orange: var(--p-amber-600);
   --color-orange-light: color-mix(
     in srgb,
@@ -100,7 +112,9 @@
   --color-tooltip-text: var(--p-gray-50);
 
   /* Navigation */
-  --color-section-label: var(--p-gray-400);
+  /* Form/section labels are small uppercase text, so they need a real text
+     shade: gray-400 only reaches 2.3:1 on the page background. */
+  --color-section-label: var(--p-gray-600);
 
   /* Header */
   --color-search-border-hover: var(--p-gray-300);
@@ -162,6 +176,8 @@
   --code-bg-alt: var(--p-c-eef1f4);
   --code-bg-header: var(--p-c-eaeef2);
   --code-text: var(--p-c-1f2328);
+  /* Both sit on --code-bg-header, the darkest of the code grounds, so they run
+     deeper than a plain "dim/muted" pair would on white. */
   --code-dim: var(--p-c-656d76);
   --code-muted: var(--p-c-8c959f);
   --code-keyword: var(--p-c-cf222e);
@@ -180,6 +196,10 @@
   /* Bumped from #475569 (fails AA) — see light-theme note. */
   --color-text-placeholder: var(--p-gray-600);
 
+  --color-blue: var(--p-blue-500);
+  --color-blue-light: var(--p-zinc-750);
+  --color-blue-border: var(--p-zinc-600);
+  --color-blue-dark: var(--p-blue-400);
   --color-purple: var(--p-blue-400);
   --color-purple-light: var(--p-zinc-750);
   --color-purple-border: var(--p-zinc-600);

--- a/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
+++ b/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
@@ -572,6 +572,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={12}
                   value={inkWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setInkWidth}
                 />
               </Box>
@@ -587,6 +588,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={highlightOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setHighlightOpacity}
                 />
               </Box>
@@ -601,6 +603,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={underlineOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setUnderlineOpacity}
                 />
               </Box>
@@ -615,6 +618,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={20}
                   value={freehandHighlighterWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setFreehandHighlighterWidth}
                 />
               </Box>
@@ -630,6 +634,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={8}
                     max={32}
                     value={textSize}
+                    thumbLabel={t("annotation.fontSize", "Font size")}
                     onChange={setTextSize}
                   />
                 </Box>
@@ -785,6 +790,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={10}
                     max={100}
                     value={shapeOpacity}
+                    thumbLabel={t("annotation.opacity", "Opacity")}
                     onChange={(value) => {
                       setShapeOpacity(value);
                       setShapeStrokeOpacity(value);
@@ -802,6 +808,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                         min={1}
                         max={12}
                         value={shapeThickness}
+                        thumbLabel={t("annotation.strokeWidth", "Width")}
                         onChange={setShapeThickness}
                       />
                     </>
@@ -815,6 +822,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                           min={0}
                           max={12}
                           value={shapeThickness}
+                          thumbLabel={t("annotation.strokeWidth", "Stroke")}
                           onChange={setShapeThickness}
                         />
                       </Box>

--- a/frontend/editor/src/core/tools/formFill/FieldInput.stories.tsx
+++ b/frontend/editor/src/core/tools/formFill/FieldInput.stories.tsx
@@ -1,0 +1,160 @@
+/**
+ * The widget used for one PDF form field, in both the tool panel and the viewer
+ * sidebar.
+ *
+ * The field's own metadata picks the control: a text field becomes a textarea
+ * once it is marked multiline, a listbox becomes a multi-select once it allows
+ * more than one choice, and a type the component has no widget for (a signature
+ * or push button) falls back to a plain text input. Options carry two parallel
+ * arrays — the values stored in the PDF and the labels shown to the user — so
+ * the dropdowns below deliberately differ between the two.
+ *
+ * The widget reads its own value out of the form-fill value store rather than
+ * from a prop, so the fixture seeds the store by loading the same field.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FieldInput } from "@app/tools/formFill/FieldInput";
+import { field, withFormFill } from "@app/tools/formFill/storyFixtures";
+import type { FormField } from "@app/tools/formFill/types";
+
+const TEXT = field({
+  name: "fullName",
+  label: "Full name",
+  value: "Jordan Blake",
+});
+
+const MULTILINE = field({
+  name: "address",
+  label: "Address",
+  multiline: true,
+  value: "12 Cathedral Road\nCardiff\nCF11 9LJ",
+  tooltip: "Include the postcode",
+});
+
+const CHECKBOX = field({
+  name: "agreeToTerms",
+  label: "I agree to the terms",
+  type: "checkbox",
+  value: "Yes",
+  widgets: [
+    { pageIndex: 0, x: 72, y: 300, width: 14, height: 14, exportValue: "Yes" },
+  ],
+});
+
+const COMBOBOX = field({
+  name: "country",
+  label: "Country",
+  type: "combobox",
+  value: "uk",
+  options: ["uk", "fr", "de"],
+  displayOptions: ["United Kingdom", "France", "Germany"],
+});
+
+const LISTBOX = field({
+  name: "department",
+  label: "Department",
+  type: "listbox",
+  value: "ops",
+  options: ["ops", "legal", "finance"],
+  displayOptions: ["Operations", "Legal", "Finance"],
+});
+
+const MULTI_LISTBOX = field({
+  name: "interests",
+  label: "Interests",
+  type: "listbox",
+  multiSelect: true,
+  value: "print,archive",
+  options: ["print", "archive", "share"],
+  displayOptions: ["Printing", "Archiving", "Sharing"],
+});
+
+const RADIO = field({
+  name: "delivery",
+  label: "Delivery",
+  type: "radio",
+  value: "1",
+  options: ["Post", "Courier", "Collection"],
+  widgets: [
+    { pageIndex: 0, x: 72, y: 380, width: 14, height: 14, exportValue: "post" },
+    {
+      pageIndex: 0,
+      x: 72,
+      y: 400,
+      width: 14,
+      height: 14,
+      exportValue: "courier",
+    },
+    {
+      pageIndex: 0,
+      x: 72,
+      y: 420,
+      width: 14,
+      height: 14,
+      exportValue: "collection",
+    },
+  ],
+});
+
+const READ_ONLY = field({
+  name: "reference",
+  label: "Reference number",
+  readOnly: true,
+  value: "INV-20418",
+});
+
+const SIGNATURE = field({
+  name: "signature",
+  label: "Signature",
+  type: "signature",
+});
+
+/** Each story mounts the store with only the field it is showing. */
+const story = (target: FormField): StoryObj<typeof FieldInput> => ({
+  args: { field: target },
+  decorators: [withFormFill({ fields: [target] })],
+});
+
+const meta: Meta<typeof FieldInput> = {
+  title: "Tools/FormFill/FieldInput",
+  component: FieldInput,
+  parameters: { layout: "padded" },
+  args: { field: TEXT, onValueChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof FieldInput>;
+
+/** A single-line text field. */
+export const Text: Story = story(TEXT);
+
+/** Multiline text grows into an auto-sizing textarea. */
+export const MultilineText: Story = story(MULTILINE);
+
+/** A checkbox carries its own label, unlike the other widgets. */
+export const Checkbox: Story = story(CHECKBOX);
+
+/** A combobox: searchable, clearable, showing display labels. */
+export const Combobox: Story = story(COMBOBOX);
+
+/** A single-choice listbox, which renders as the same select. */
+export const Listbox: Story = story(LISTBOX);
+
+/** A multi-select listbox stores its choices as one comma-joined value. */
+export const MultiSelectListbox: Story = story(MULTI_LISTBOX);
+
+/** Radio widgets become one option each, keyed by widget position. */
+export const RadioGroup: Story = story(RADIO);
+
+/** A read-only field is shown but cannot be edited. */
+export const ReadOnly: Story = story(READ_ONLY);
+
+/** Signature fields have no widget of their own, so they fall back to text. */
+export const UnsupportedType: Story = story(SIGNATURE);

--- a/frontend/editor/src/core/tools/formFill/FieldInput.tsx
+++ b/frontend/editor/src/core/tools/formFill/FieldInput.tsx
@@ -15,7 +15,6 @@ import {
   MultiSelect,
   Stack,
 } from "@mantine/core";
-import { useTranslation } from "react-i18next";
 import { useFieldValue } from "@app/tools/formFill/FormFillContext";
 import type { FormField } from "@app/tools/formFill/types";
 
@@ -32,7 +31,7 @@ function FieldInputInner({
     (v: string) => onValueChange(field.name, v),
     [onValueChange, field.name],
   );
-  const { t } = useTranslation();
+
   switch (field.type) {
     case "text":
       if (field.multiline) {
@@ -41,10 +40,7 @@ function FieldInputInner({
             size="xs"
             value={value}
             onChange={(e) => onChange(e.currentTarget.value)}
-            placeholder={
-              field.tooltip ||
-              `${t("formFill.placeholderEnter", "Enter")} ${field.label}`
-            }
+            placeholder={field.tooltip || `Enter ${field.label}`}
             disabled={field.readOnly}
             autosize
             minRows={2}
@@ -58,10 +54,7 @@ function FieldInputInner({
           size="xs"
           value={value}
           onChange={(e) => onChange(e.currentTarget.value)}
-          placeholder={
-            field.tooltip ||
-            `${t("formFill.placeholderEnter", "Enter")} ${field.label}`
-          }
+          placeholder={field.tooltip || `Enter ${field.label}`}
           disabled={field.readOnly}
           styles={{ input: { fontSize: "0.8125rem" } }}
         />
@@ -92,7 +85,7 @@ function FieldInputInner({
           data={comboData}
           value={value || null}
           onChange={(v) => onChange(v || "")}
-          placeholder={`${t("formFill.placeholderSelect", "Select")} ${field.label}`}
+          placeholder={`Select ${field.label}`}
           clearable
           searchable
           disabled={field.readOnly}
@@ -116,7 +109,7 @@ function FieldInputInner({
             data={listData}
             value={selectedValues}
             onChange={(vals) => onChange(vals.join(","))}
-            placeholder={`${t("formFill.placeholderSelect", "Select")} ${field.label}`}
+            placeholder={`Select ${field.label}`}
             searchable
             disabled={field.readOnly}
             aria-label={field.label || field.name}
@@ -131,7 +124,7 @@ function FieldInputInner({
           data={listData}
           value={value || null}
           onChange={(v) => onChange(v || "")}
-          placeholder={`${t("formFill.placeholderSelect", "Select")} ${field.label}`}
+          placeholder={`Select ${field.label}`}
           clearable
           searchable
           disabled={field.readOnly}

--- a/frontend/editor/src/core/tools/formFill/FormFieldSidebar.stories.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormFieldSidebar.stories.tsx
@@ -1,0 +1,40 @@
+/**
+ * The right-hand list of a PDF's form fields, used when the form-fill tool
+ * itself is not open.
+ *
+ * The sidebar is a view onto form-fill state: it groups whatever fields were
+ * parsed out of the document by the page their first widget sits on, and shows
+ * a loading or empty notice when there are none to group. Each card carries the
+ * field's type icon, a "req" marker when it is mandatory and its tooltip as a
+ * hint; signature and button fields get a card but no input, since neither is
+ * fillable from a list. The focused field — set by clicking a widget on the page
+ * — is highlighted and scrolled into view.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FormFieldSidebar } from "@app/tools/formFill/FormFieldSidebar";
+import { withFormFill } from "@app/tools/formFill/storyFixtures";
+
+const meta: Meta<typeof FormFieldSidebar> = {
+  title: "Tools/FormFill/FormFieldSidebar",
+  component: FormFieldSidebar,
+  parameters: { layout: "fullscreen" },
+  args: { visible: true, onToggle: () => {} },
+  decorators: [withFormFill()],
+};
+export default meta;
+
+type Story = StoryObj<typeof FormFieldSidebar>;
+
+/** A form spanning two pages, so the list carries a divider for each. */
+export const Default: Story = {};
+
+/** A field focused from the page: its card is marked and scrolled to. */
+export const ActiveField: Story = {
+  decorators: [withFormFill({ activeField: "country" })],
+};
+
+/** The document is still being parsed for fields. */
+export const Loading: Story = { decorators: [withFormFill({ pending: true })] };
+
+/** A PDF with no form in it at all. */
+export const NoFields: Story = { decorators: [withFormFill({ fields: [] })] };

--- a/frontend/editor/src/core/tools/formFill/FormFill.module.css
+++ b/frontend/editor/src/core/tools/formFill/FormFill.module.css
@@ -222,7 +222,7 @@
   margin-top: 0.25rem;
   font-size: 0.6875rem;
   font-weight: 500;
-  color: var(--mantine-color-red-6);
+  color: var(--color-red-dark);
 }
 
 .emptyState {

--- a/frontend/editor/src/core/tools/formFill/FormFill.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormFill.tsx
@@ -436,7 +436,7 @@ const FormFill = (_props: BaseToolProps) => {
                 >
                   <Loader size={14} />
                   <Text size="xs" c="dimmed">
-                    {t("formFill.analyzingFields", "Analysing form fields...")}
+                    Analysing form fields...
                   </Text>
                 </div>
                 <Skeleton height={48} radius="sm" />
@@ -464,12 +464,10 @@ const FormFill = (_props: BaseToolProps) => {
                 <div>
                   <div className={styles.progressRow}>
                     <span className={styles.progressLabel}>
-                      {filledCount} / {fillableCount}{" "}
-                      {t("formFill.filled", "filled")}
+                      {filledCount} / {fillableCount} filled
                       {requiredCount > 0 && (
                         <span style={{ marginLeft: "0.5rem", opacity: 0.7 }}>
-                          ({filledRequiredCount}/{requiredCount}{" "}
-                          {t("formFill.requiredAbbreviation", "req")}.)
+                          ({filledRequiredCount}/{requiredCount} req.)
                         </span>
                       )}
                     </span>
@@ -590,10 +588,7 @@ const FormFill = (_props: BaseToolProps) => {
                 <div className={styles.emptyState}>
                   <DescriptionIcon className={styles.emptyStateIcon} />
                   <span className={styles.emptyStateText}>
-                    {t(
-                      "formFill.noFields",
-                      "No fillable form fields found in this PDF.",
-                    )}
+                    No fillable form fields found in this PDF.
                   </span>
                 </div>
               )}
@@ -610,7 +605,7 @@ const FormFill = (_props: BaseToolProps) => {
                       style={i === 0 ? { marginTop: 0 } : undefined}
                     >
                       <Text className={styles.pageDividerLabel}>
-                        {t("page", "Page")} {pageIdx + 1}
+                        Page {pageIdx + 1}
                       </Text>
                     </div>
 

--- a/frontend/editor/src/core/tools/formFill/FormSaveBar.stories.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormSaveBar.stories.tsx
@@ -1,0 +1,57 @@
+/**
+ * The banner that drops into the corner of the viewer when the open PDF turns
+ * out to have fillable fields.
+ *
+ * It is a prompt, not a panel: it appears only when the document has fields the
+ * user could fill (signature and button fields do not count), they are finished
+ * loading, the form-fill tool is not already open with its own save controls,
+ * and the user has not dismissed it. Until something is actually typed it just
+ * announces the form; editing a value adds the unsaved badge and the two ways
+ * out — apply the changes back into the viewer, or download the filled copy.
+ * The download is held while an export policy is running against the file.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FormSaveBar } from "@app/tools/formFill/FormSaveBar";
+import { STORY_PDF, withFormFill } from "@app/tools/formFill/storyFixtures";
+
+const meta: Meta<typeof FormSaveBar> = {
+  title: "Tools/FormFill/FormSaveBar",
+  component: FormSaveBar,
+  parameters: { layout: "fullscreen" },
+  args: {
+    file: STORY_PDF,
+    isFormFillToolActive: false,
+    onApply: async () => {},
+  },
+  decorators: [
+    withFormFill(),
+    (Story) => (
+      // The bar pins itself to the top-right of the viewport it sits in.
+      <div style={{ position: "relative", height: "60vh" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof FormSaveBar>;
+
+/** Fields found, nothing typed yet. */
+export const Default: Story = {};
+
+/** A value has been edited, so the save actions appear. */
+export const UnsavedChanges: Story = {
+  decorators: [withFormFill({ filled: { fullName: "Jordan Blake" } })],
+};
+
+/** A policy is running against the file, so it cannot leave the app yet. */
+export const DownloadBlockedByPolicy: Story = {
+  args: { policyEnforcing: true },
+  decorators: [withFormFill({ filled: { fullName: "Jordan Blake" } })],
+};
+
+/** The form-fill tool is open and owns saving, so the bar stays away. */
+export const HiddenWhileToolOpen: Story = {
+  args: { isFormFillToolActive: true },
+};

--- a/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
+++ b/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
@@ -1,0 +1,133 @@
+/**
+ * Form-fill context for the formFill stories.
+ *
+ * Every form-fill component reads its fields and values from FormFillProvider,
+ * and the provider only ever gets them by asking a data provider to parse a real
+ * PDF. Both shipped providers need either the pdfium WASM module or the backend,
+ * neither of which exists in a story — so these helpers hand the provider a stub
+ * that returns fixed fields, and drive it the way the app does: fetch on mount,
+ * then type into the form.
+ */
+import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import {
+  FormFillProvider,
+  useFormFill,
+} from "@app/tools/formFill/FormFillContext";
+import type { IFormDataProvider } from "@app/tools/formFill/providers/types";
+import type { FormField } from "@app/tools/formFill/types";
+
+/** Stands in for the open document; the stub provider never reads its bytes. */
+export const STORY_PDF = new Blob(["%PDF-1.7"], { type: "application/pdf" });
+
+export function field(
+  overrides: Partial<FormField> & { name: string },
+): FormField {
+  return {
+    label: overrides.name,
+    type: "text",
+    value: "",
+    options: null,
+    displayOptions: null,
+    required: false,
+    readOnly: false,
+    multiSelect: false,
+    multiline: false,
+    tooltip: null,
+    widgets: [{ pageIndex: 0, x: 72, y: 120, width: 220, height: 22 }],
+    ...overrides,
+  };
+}
+
+/** A small cross-section of field types, as a filled-in form would carry. */
+export const SAMPLE_FIELDS: FormField[] = [
+  field({ name: "fullName", label: "Full name", required: true }),
+  field({
+    name: "address",
+    label: "Address",
+    multiline: true,
+    tooltip: "Include the postcode",
+  }),
+  field({
+    name: "agreeToTerms",
+    label: "I agree to the terms",
+    type: "checkbox",
+  }),
+  field({
+    name: "country",
+    label: "Country",
+    type: "combobox",
+    options: ["uk", "fr", "de"],
+    displayOptions: ["United Kingdom", "France", "Germany"],
+  }),
+  field({
+    name: "reference",
+    label: "Reference number",
+    readOnly: true,
+    value: "INV-20418",
+  }),
+  field({
+    name: "signature",
+    label: "Signature",
+    type: "signature",
+    widgets: [{ pageIndex: 1, x: 72, y: 480, width: 180, height: 60 }],
+  }),
+];
+
+export interface FormFillOptions {
+  /** Fields the stub provider reports for the document. */
+  fields?: FormField[];
+  /** Hold the fetch open, so the form stays in its loading state. */
+  pending?: boolean;
+  /** Values applied after load — this is what marks the form dirty. */
+  filled?: Record<string, string>;
+  /** Field to focus, as clicking its widget on the page would. */
+  activeField?: string;
+}
+
+function stubProvider({
+  fields = SAMPLE_FIELDS,
+  pending = false,
+}: FormFillOptions): IFormDataProvider {
+  return {
+    name: "pdf-lib",
+    fetchFields: () =>
+      pending ? new Promise<FormField[]>(() => {}) : Promise.resolve(fields),
+    fillForm: async () => STORY_PDF,
+  };
+}
+
+/**
+ * Drives the provider once on mount. The fetch is what populates the fields and
+ * seeds the value store; anything applied afterwards counts as user input.
+ */
+function FormFillLoader({
+  filled,
+  activeField,
+  children,
+}: FormFillOptions & { children: ReactNode }) {
+  const { fetchFields, setValue, setActiveField } = useFormFill();
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void fetchFields(STORY_PDF, "story-document").then(() => {
+      Object.entries(filled ?? {}).forEach(([name, value]) =>
+        setValue(name, value),
+      );
+      if (activeField) setActiveField(activeField);
+    });
+  }, [fetchFields, setValue, setActiveField, filled, activeField]);
+
+  return <>{children}</>;
+}
+
+export function withFormFill(options: FormFillOptions = {}) {
+  return (Story: () => ReactElement): ReactElement => (
+    <FormFillProvider provider={stubProvider(options)}>
+      <FormFillLoader {...options}>
+        <Story />
+      </FormFillLoader>
+    </FormFillProvider>
+  );
+}

--- a/frontend/editor/src/core/ui/Banner.css
+++ b/frontend/editor/src/core/ui/Banner.css
@@ -45,16 +45,16 @@
 }
 
 .sui-banner--info .sui-banner__icon {
-  color: var(--c-primary);
+  color: var(--c-accent-text);
 }
 .sui-banner--success .sui-banner__icon {
-  color: var(--color-green);
+  color: var(--color-green-dark);
 }
 .sui-banner--warning .sui-banner__icon {
   color: var(--color-amber-dark);
 }
 .sui-banner--danger .sui-banner__icon {
-  color: var(--color-red);
+  color: var(--color-red-dark);
 }
 
 .sui-banner__body {

--- a/frontend/editor/src/core/ui/Button.tsx
+++ b/frontend/editor/src/core/ui/Button.tsx
@@ -153,6 +153,13 @@ const ButtonRoot = forwardRef<HTMLButtonElement, ButtonProps>(
     const iconOnly =
       !hasLabel && !fullWidth && (!!leftSection || !!rightSection || loading);
 
+    // A button whose label is momentarily absent while loading still needs an
+    // accessible name; the spinner and any icon are decorative.
+    const fallbackLabel =
+      !hasLabel && loading && !rest["aria-label"] && !rest["aria-labelledby"]
+        ? "Loading"
+        : undefined;
+
     // px/py override p for their axis; each stays undefined (= size default) if unset.
     const padX = px ?? p;
     const padY = py ?? p;
@@ -217,6 +224,7 @@ const ButtonRoot = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Comp
         {...rest}
+        aria-label={rest["aria-label"] ?? fallbackLabel}
         ref={ref}
         component={as}
         variant={MANTINE_VARIANT[variant]}

--- a/frontend/editor/src/core/ui/ChatFABButton.tsx
+++ b/frontend/editor/src/core/ui/ChatFABButton.tsx
@@ -25,7 +25,12 @@ export function ChatFABButton({
     .join(" ");
 
   return (
-    <button type="button" className={classes} {...rest}>
+    <button
+      type="button"
+      className={classes}
+      aria-label="Open assistant"
+      {...rest}
+    >
       {/* Decorative: the button itself carries the accessible name. */}
       <span aria-hidden="true" style={{ display: "inline-flex" }}>
         <BrandMark height="1.875rem" />

--- a/frontend/editor/src/core/ui/ChatFABWindow.stories.tsx
+++ b/frontend/editor/src/core/ui/ChatFABWindow.stories.tsx
@@ -54,7 +54,7 @@ function MockChat() {
               maxWidth: "80%",
               background:
                 m.role === "user"
-                  ? "#3b82f6"
+                  ? "var(--c-accent-text)"
                   : "var(--c-surface-sunken, #f3f4f6)",
               color: m.role === "user" ? "#fff" : "inherit",
               borderRadius: 10,
@@ -129,7 +129,7 @@ export const Toggle: Story = {
             position: "absolute",
             bottom: -48,
             right: 0,
-            background: "#3b82f6",
+            background: "var(--c-accent-text)",
             color: "#fff",
             border: "none",
             borderRadius: 8,

--- a/frontend/editor/src/core/ui/ChatFABWindow.tsx
+++ b/frontend/editor/src/core/ui/ChatFABWindow.tsx
@@ -33,10 +33,14 @@ export function ChatFABWindow({
     .join(" ");
 
   return (
+    // The closed panel stays mounted so it can animate, so `inert` is what keeps
+    // its controls out of the tab order while aria-hidden keeps them off the
+    // accessibility tree.
     <div
       className={classes}
       style={style}
       aria-hidden={!open}
+      inert={!open}
       onDoubleClick={onDoubleClick}
     >
       {children}

--- a/frontend/editor/src/core/ui/Chip.tsx
+++ b/frontend/editor/src/core/ui/Chip.tsx
@@ -74,11 +74,11 @@ export function Chip({
 
   // Interactive chips are a <span>, so add button semantics + Enter/Space activation.
   const interactive = !!onClick && !loading;
-  const interactiveProps = interactive
+  const removable = !!onRemove && !loading;
+  const buttonProps = interactive
     ? {
         role: "button",
         tabIndex: 0,
-        onClick,
         onKeyDown: (e: KeyboardEvent<HTMLElement>) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -87,6 +87,14 @@ export function Chip({
         },
       }
     : {};
+  // A removable chip carries Mantine's remove <button> inside the pill root, and
+  // a control may not nest inside a control — so the button semantics move to
+  // the label, leaving the two as siblings. The click handler stays on the root
+  // either way, so the whole chip remains the pointer target.
+  const rootProps = {
+    ...(interactive ? { onClick } : {}),
+    ...(removable ? {} : buttonProps),
+  };
 
   return (
     <MantinePill
@@ -94,9 +102,9 @@ export function Chip({
       className={classes}
       style={style}
       size={size}
-      withRemoveButton={!!onRemove && !loading}
+      withRemoveButton={removable}
       onRemove={onRemove}
-      {...interactiveProps}
+      {...rootProps}
     >
       {showDot && <span className="sui-chip__dot" aria-hidden />}
       {loading ? (
@@ -106,7 +114,9 @@ export function Chip({
           {leadingIcon}
         </span>
       ) : null}
-      <span className="sui-chip__label">{children}</span>
+      <span className="sui-chip__label" {...(removable ? buttonProps : {})}>
+        {children}
+      </span>
       {trailingIcon && !onRemove && (
         <span className="sui-chip__icon" aria-hidden>
           {trailingIcon}

--- a/frontend/editor/src/core/ui/CodeBlock.tsx
+++ b/frontend/editor/src/core/ui/CodeBlock.tsx
@@ -70,7 +70,15 @@ export function CodeBlock({
           </Button>
         )}
       </div>
-      <pre className="sui-code__pre" style={{ maxHeight }}>
+      {/* Focusable and named: long samples scroll, and a scrollable region needs
+          to be reachable by keyboard to be scrolled at all. */}
+      <pre
+        className="sui-code__pre"
+        style={{ maxHeight }}
+        tabIndex={0}
+        role="group"
+        aria-label={t("common.codeSample", "Code sample")}
+      >
         <code>{code}</code>
       </pre>
     </div>

--- a/frontend/editor/src/core/ui/Drawer.tsx
+++ b/frontend/editor/src/core/ui/Drawer.tsx
@@ -74,7 +74,9 @@ export function Drawer({
         role="presentation"
       />
       <FocusTrap active>
-        <aside
+        {/* A plain div, not <aside>: ARIA in HTML does not permit role="dialog"
+            on a complementary landmark. */}
+        <div
           className={[
             "sui-drawer",
             `sui-drawer--${side}`,
@@ -128,7 +130,7 @@ export function Drawer({
           )}
           <div className="sui-drawer__body">{children}</div>
           {footer && <footer className="sui-drawer__footer">{footer}</footer>}
-        </aside>
+        </div>
       </FocusTrap>
     </>,
     document.body,

--- a/frontend/editor/src/core/ui/Dropdown.css
+++ b/frontend/editor/src/core/ui/Dropdown.css
@@ -54,7 +54,7 @@
 
 .sui-dd__item.is-active {
   background: var(--c-primary-subtle);
-  color: var(--c-accent-fg);
+  color: var(--c-accent-text);
   font-weight: 500;
 }
 

--- a/frontend/editor/src/core/ui/EmptyState.css
+++ b/frontend/editor/src/core/ui/EmptyState.css
@@ -22,7 +22,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--c-primary);
+  color: var(--c-accent-text);
 }
 
 .sui-empty__title {

--- a/frontend/editor/src/core/ui/FormField.css
+++ b/frontend/editor/src/core/ui/FormField.css
@@ -14,7 +14,9 @@
 }
 
 .sui-field__required {
-  color: var(--color-red);
+  /* The base red is a fill colour; as text on the form background it only
+     reaches 3.4:1. */
+  color: var(--color-red-dark);
 }
 
 .sui-field__control {
@@ -29,5 +31,5 @@
 }
 
 .sui-field--error .sui-field__help {
-  color: var(--color-red);
+  color: var(--color-red-dark);
 }

--- a/frontend/editor/src/core/ui/Forms.stories.tsx
+++ b/frontend/editor/src/core/ui/Forms.stories.tsx
@@ -182,6 +182,7 @@ export const Slider_Confidence: Story = {
             step={0.01}
             onChange={setV}
             formatValue={(x) => x.toFixed(2)}
+            aria-label="Minimum confidence"
           />
         </FormField>
       );
@@ -203,6 +204,7 @@ export const Slider_Retention: Story = {
             step={1}
             onChange={setDays}
             formatValue={(d) => `${d} days`}
+            aria-label="Retain artifacts for"
           />
         </FormField>
       );
@@ -262,6 +264,7 @@ export const FullForm: Story = {
               step={0.01}
               onChange={setConf}
               formatValue={(v) => v.toFixed(2)}
+              aria-label="Confidence gate"
             />
           </FormField>
           <FormField label="Alerts">

--- a/frontend/editor/src/core/ui/ListRow.css
+++ b/frontend/editor/src/core/ui/ListRow.css
@@ -36,23 +36,23 @@
   background: var(--c-surface-sunken);
 }
 .sui-listrow__leading[data-tone="success"] {
-  color: var(--color-green);
+  color: var(--color-green-dark);
   background: color-mix(in srgb, var(--color-green) 14%, transparent);
 }
 .sui-listrow__leading[data-tone="warning"] {
-  color: var(--color-amber);
+  color: var(--color-amber-dark);
   background: color-mix(in srgb, var(--color-amber) 14%, transparent);
 }
 .sui-listrow__leading[data-tone="danger"] {
-  color: var(--color-red);
+  color: var(--color-red-dark);
   background: color-mix(in srgb, var(--color-red) 14%, transparent);
 }
 .sui-listrow__leading[data-tone="info"] {
-  color: var(--c-primary);
+  color: var(--c-accent-text);
   background: color-mix(in srgb, var(--c-primary) 14%, transparent);
 }
 .sui-listrow__leading[data-tone="purple"] {
-  color: var(--color-purple);
+  color: var(--color-purple-dark);
   background: color-mix(in srgb, var(--color-purple) 14%, transparent);
 }
 

--- a/frontend/editor/src/core/ui/MantineForms.css
+++ b/frontend/editor/src/core/ui/MantineForms.css
@@ -55,7 +55,7 @@
 /* Pills match SUI's Chip component: small rounded tags. */
 .sui-mantine-pill {
   background: var(--c-primary-tint) !important;
-  color: var(--c-primary-hover) !important;
+  color: var(--c-accent-text) !important;
   border: 1px solid var(--c-primary-border) !important;
   border-radius: var(--radius-sm) !important;
   font-size: 0.75rem !important;

--- a/frontend/editor/src/core/ui/MantineForms.stories.tsx
+++ b/frontend/editor/src/core/ui/MantineForms.stories.tsx
@@ -444,6 +444,7 @@ export const Slider_Default: Story = {
             max={1}
             step={0.01}
             formatValue={(x) => x.toFixed(2)}
+            aria-label="Confidence threshold"
           />
         </FormField>
       );
@@ -465,6 +466,7 @@ export const Slider_WithMarks: Story = {
             max={365}
             step={1}
             formatValue={(d) => `${d}d`}
+            aria-label="Retain artifacts for"
             marks={[
               { value: 30, label: "30d" },
               { value: 90, label: "90d" },
@@ -492,6 +494,7 @@ export const Slider_NoLabel: Story = {
             max={100}
             step={1}
             showValue={false}
+            aria-label="Opacity"
           />
         </FormField>
       );

--- a/frontend/editor/src/core/ui/MethodBadge.css
+++ b/frontend/editor/src/core/ui/MethodBadge.css
@@ -15,7 +15,7 @@
   border-color: var(--color-green-border);
 }
 .sui-method--post {
-  color: var(--c-primary);
+  color: var(--c-accent-text);
   background: var(--c-primary-tint);
   border-color: var(--c-primary-border);
 }

--- a/frontend/editor/src/core/ui/MetricCard.css
+++ b/frontend/editor/src/core/ui/MetricCard.css
@@ -83,10 +83,10 @@
   font-size: 0.6875rem;
 }
 .sui-metric__delta--up {
-  color: var(--color-green);
+  color: var(--color-green-dark);
 }
 .sui-metric__delta--down {
-  color: var(--color-red);
+  color: var(--color-red-dark);
 }
 .sui-metric__delta--flat,
 .sui-metric__desc {

--- a/frontend/editor/src/core/ui/Modal.stories.tsx
+++ b/frontend/editor/src/core/ui/Modal.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "@app/ui/Button";
+import { Modal } from "@app/ui/Modal";
+
+/**
+ * The shared dialog primitive. Focus trapping and restoration are delegated to
+ * Mantine's FocusTrap; the body takes a tab stop of its own only while it
+ * actually overflows, so a dialog full of controls gains no stray stop.
+ */
+const meta: Meta<typeof Modal> = {
+  title: "Primitives/Modal",
+  component: Modal,
+  parameters: { layout: "fullscreen" },
+  args: { open: true, onClose: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+const Body = () => (
+  <p style={{ margin: 0 }}>
+    Removing this file also removes it from the two pipelines that reference it.
+    This cannot be undone.
+  </p>
+);
+
+const Actions = () => (
+  <>
+    <Button variant="tertiary">Cancel</Button>
+    <Button accent="danger">Delete</Button>
+  </>
+);
+
+/** Title, body and footer actions. */
+export const Default: Story = {
+  args: { title: "Delete file", footer: <Actions />, children: <Body /> },
+};
+
+/** A title that needs qualifying. */
+export const WithSubtitle: Story = {
+  args: {
+    title: "Delete file",
+    subtitle: "contract-2026-final.pdf",
+    footer: <Actions />,
+    children: <Body />,
+  },
+};
+
+/** No visible title, so `ariaLabel` supplies the dialog's accessible name. */
+export const LabelledWithoutTitle: Story = {
+  args: { ariaLabel: "Session expired", children: <Body /> },
+};
+
+/** The four widths: sm 24rem, md 32rem, lg 48rem, xl 64rem. */
+export const WidthSm: Story = {
+  args: { title: "Small", width: "sm", children: <Body /> },
+};
+export const WidthMd: Story = {
+  args: { title: "Medium", width: "md", children: <Body /> },
+};
+export const WidthLg: Story = {
+  args: { title: "Large", width: "lg", children: <Body /> },
+};
+export const WidthXl: Story = {
+  args: { title: "Extra large", width: "xl", children: <Body /> },
+};
+
+/** Body longer than the viewport scrolls inside the dialog, not the page. It
+ *  holds no control of its own, so it becomes focusable and a keyboard user can
+ *  scroll it — the case that would otherwise be unreachable. */
+export const ScrollingTextOnlyBody: Story = {
+  args: {
+    title: "Terms of service",
+    footer: <Button>Accept</Button>,
+    children: (
+      <div style={{ display: "grid", gap: "1rem" }}>
+        {Array.from({ length: 24 }, (_, i) => (
+          <p key={i} style={{ margin: 0 }}>
+            {i + 1}. Each party shall retain the records described in this
+            section for the period required by the applicable retention policy,
+            and shall make them available on reasonable notice.
+          </p>
+        ))}
+      </div>
+    ),
+  },
+};
+
+/** A long body that does contain controls: it scrolls, but the controls are
+ *  already reachable, so no extra tab stop is added. */
+export const ScrollingBodyWithControls: Story = {
+  args: {
+    title: "Choose files",
+    footer: <Button>Add selected</Button>,
+    children: (
+      <div style={{ display: "grid", gap: "0.75rem" }}>
+        {Array.from({ length: 20 }, (_, i) => (
+          <label key={i} style={{ display: "flex", gap: "0.5rem" }}>
+            <input type="checkbox" />
+            report-{String(i + 1).padStart(2, "0")}.pdf
+          </label>
+        ))}
+      </div>
+    ),
+  },
+};
+
+/** Backdrop and Escape dismissal disabled — the footer is the only way out,
+ *  for a step that must not be abandoned half-done. */
+export const NotDismissable: Story = {
+  args: {
+    title: "Finishing upload",
+    disableBackdropClose: true,
+    disableEscapeClose: true,
+    footer: <Button>Done</Button>,
+    children: <Body />,
+  },
+};
+
+/** Closed — nothing is rendered into the portal. */
+export const Closed: Story = {
+  args: { open: false, title: "Delete file", children: <Body /> },
+};

--- a/frontend/editor/src/core/ui/Modal.tsx
+++ b/frontend/editor/src/core/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { FocusTrap } from "@mantine/core";
 import { Button } from "@app/ui/Button";
@@ -22,6 +22,29 @@ export interface ModalProps {
   children?: ReactNode;
 }
 
+/**
+ * A body that scrolls but contains no control of its own (a terms document, a
+ * long receipt) is unreachable by keyboard, so it takes a tab stop of its own
+ * — but only while it actually overflows, so the ordinary modal full of
+ * buttons gains no stray stop.
+ */
+function useScrollableWhenOverflowing() {
+  const [node, setNode] = useState<HTMLElement | null>(null);
+  const [overflows, setOverflows] = useState(false);
+
+  useEffect(() => {
+    if (!node) return;
+    const measure = () => setOverflows(node.scrollHeight > node.clientHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    for (const child of Array.from(node.children)) observer.observe(child);
+    return () => observer.disconnect();
+  }, [node]);
+
+  return { ref: useCallback(setNode, []), overflows };
+}
+
 /** Tab focus trapping and restoration are delegated to Mantine's FocusTrap. */
 export function Modal({
   open,
@@ -37,6 +60,8 @@ export function Modal({
   children,
 }: ModalProps) {
   const titleId = useId();
+  const { ref: bodyRef, overflows: bodyOverflows } =
+    useScrollableWhenOverflowing();
 
   useEffect(() => {
     if (!open || disableEscapeClose) return;
@@ -119,7 +144,14 @@ export function Modal({
               />
             </header>
           )}
-          <div className="sui-modal__body">{children}</div>
+          <div
+            ref={bodyRef}
+            className="sui-modal__body"
+            tabIndex={bodyOverflows ? 0 : undefined}
+            role={bodyOverflows ? "group" : undefined}
+          >
+            {children}
+          </div>
           {footer && <footer className="sui-modal__footer">{footer}</footer>}
         </div>
       </FocusTrap>

--- a/frontend/editor/src/core/ui/NavItem.css
+++ b/frontend/editor/src/core/ui/NavItem.css
@@ -20,7 +20,7 @@
 }
 .sui-navitem.is-active {
   background: var(--c-primary-subtle);
-  color: var(--c-accent-fg);
+  color: var(--c-accent-text);
   font-weight: 500;
 }
 .sui-navitem.is-active:hover {
@@ -76,17 +76,17 @@
   background: var(--color-red);
 }
 .sui-navitem[data-accent="blue"] .sui-navitem__icon {
-  color: var(--c-primary);
+  color: var(--c-accent-text);
 }
 .sui-navitem[data-accent="purple"] .sui-navitem__icon {
-  color: var(--color-purple);
+  color: var(--color-purple-dark);
 }
 .sui-navitem[data-accent="green"] .sui-navitem__icon {
-  color: var(--color-green);
+  color: var(--color-green-dark);
 }
 .sui-navitem[data-accent="amber"] .sui-navitem__icon {
-  color: var(--color-amber);
+  color: var(--color-amber-dark);
 }
 .sui-navitem[data-accent="red"] .sui-navitem__icon {
-  color: var(--color-red);
+  color: var(--color-red-dark);
 }

--- a/frontend/editor/src/core/ui/PanelHeader.css
+++ b/frontend/editor/src/core/ui/PanelHeader.css
@@ -46,7 +46,7 @@ button.sui-panelhdr__bar:hover {
   height: 1.75rem;
   border-radius: 9999px;
   background: var(--mantine-color-blue-light);
-  color: var(--mantine-color-blue-filled);
+  color: var(--c-accent-text);
   flex-shrink: 0;
 }
 
@@ -154,15 +154,15 @@ button.sui-panelhdr__bar:hover {
     var(--mantine-color-blue-filled) 18%,
     transparent
   );
-  color: var(--mantine-color-blue-3, var(--mantine-color-blue-filled));
+  color: var(--c-accent-text);
 }
 
 /* Dark mode: the subtle gray close button is too dim against the dark rail —
    brighten it to a clearly-visible light grey (near-white on hover). */
 [data-mantine-color-scheme="dark"] .sui-panelhdr__close {
-  color: var(--mantine-color-gray-4);
+  color: var(--c-text-subtle);
 }
 
 [data-mantine-color-scheme="dark"] .sui-panelhdr__close:hover {
-  color: var(--mantine-color-gray-2);
+  color: var(--c-text-subtle);
 }

--- a/frontend/editor/src/core/ui/ProgressBar.stories.tsx
+++ b/frontend/editor/src/core/ui/ProgressBar.stories.tsx
@@ -6,7 +6,12 @@ const meta: Meta<typeof ProgressBar> = {
   component: ProgressBar,
   tags: ["autodocs"],
   parameters: { layout: "padded" },
-  args: { value: 0.5, height: 6, thresholded: false },
+  args: {
+    value: 0.5,
+    height: 6,
+    thresholded: false,
+    label: "Docs processed",
+  },
   argTypes: {
     value: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     height: { control: { type: "number" } },
@@ -42,7 +47,7 @@ export const ThresholdLadder: Story = {
           <span style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
             {Math.round(v * 100)}%
           </span>
-          <ProgressBar value={v} thresholded />
+          <ProgressBar value={v} thresholded label="Docs processed" />
         </div>
       ))}
     </div>

--- a/frontend/editor/src/core/ui/ProgressBar.tsx
+++ b/frontend/editor/src/core/ui/ProgressBar.tsx
@@ -10,8 +10,9 @@ export interface ProgressBarProps {
   /** Optional override colour (CSS gradient or solid). Disables threshold behaviour. */
   color?: string;
   className?: string;
-  /** Accessible label for screen readers. */
-  label?: string;
+  /** Accessible name — describe what is being measured ("Storage used"), since
+   *  the bar carries no visible text of its own. */
+  label: string;
 }
 
 function clamp01(n: number) {

--- a/frontend/editor/src/core/ui/Select.tsx
+++ b/frontend/editor/src/core/ui/Select.tsx
@@ -46,6 +46,7 @@ export interface SelectProps {
   id?: string;
   name?: string;
   "aria-label"?: string;
+  "aria-labelledby"?: string;
   "aria-invalid"?: boolean;
   "aria-describedby"?: string;
   required?: boolean;
@@ -74,6 +75,7 @@ type PassthroughProps = Omit<
     | "id"
     | "name"
     | "aria-label"
+    | "aria-labelledby"
     | "aria-describedby"
     | "required"
     | "disabled"
@@ -106,6 +108,7 @@ export function Select({
   id,
   name,
   "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
   "aria-invalid": ariaInvalid,
   "aria-describedby": ariaDescribedBy,
   required,
@@ -128,6 +131,7 @@ export function Select({
     id,
     name,
     "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledBy,
     "aria-describedby": ariaDescribedBy,
     required,
     disabled,

--- a/frontend/editor/src/core/ui/SettingsRow.tsx
+++ b/frontend/editor/src/core/ui/SettingsRow.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { cloneElement, isValidElement, useId, type ReactNode } from "react";
 import "@app/ui/SettingsRow.css";
 
 export interface SettingsRowProps {
@@ -23,17 +23,31 @@ export function SettingsRow({
   control,
   className,
 }: SettingsRowProps) {
+  const labelId = useId();
+  // The row's label is plain text beside the control, not a <label> for it, so
+  // the control is named by pointing back at it — unless the caller named it.
+  const namedControl =
+    isValidElement<{ "aria-label"?: string; "aria-labelledby"?: string }>(
+      control,
+    ) &&
+    !control.props["aria-label"] &&
+    !control.props["aria-labelledby"]
+      ? cloneElement(control, { "aria-labelledby": labelId })
+      : control;
+
   return (
     <div
       className={["sui-settingsrow", className ?? ""].filter(Boolean).join(" ")}
     >
       <div className="sui-settingsrow__text">
-        <span className="sui-settingsrow__label">{label}</span>
+        <span id={labelId} className="sui-settingsrow__label">
+          {label}
+        </span>
         {description && (
           <span className="sui-settingsrow__desc">{description}</span>
         )}
       </div>
-      <div className="sui-settingsrow__control">{control}</div>
+      <div className="sui-settingsrow__control">{namedControl}</div>
     </div>
   );
 }

--- a/frontend/editor/src/core/ui/StatTile.css
+++ b/frontend/editor/src/core/ui/StatTile.css
@@ -27,7 +27,7 @@
   color: var(--color-amber-dark);
 }
 .sui-stat__value--danger {
-  color: var(--color-red);
+  color: var(--color-red-dark);
 }
 
 /* Inline code in a value (masked keys, model ids, URLs) reads as mono meta. */

--- a/frontend/editor/src/core/ui/StatusBadge.css
+++ b/frontend/editor/src/core/ui/StatusBadge.css
@@ -68,7 +68,7 @@
   --sui-status-c: var(--color-red-dark);
 }
 .sui-status--info {
-  --sui-status-c: var(--c-primary-hover);
+  --sui-status-c: var(--c-accent-text);
 }
 .sui-status--purple {
   --sui-status-c: var(--color-purple-dark);

--- a/frontend/editor/src/core/ui/StepIndicator.tsx
+++ b/frontend/editor/src/core/ui/StepIndicator.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import "@app/ui/StepIndicator.css";
 
 export interface StepIndicatorProps {
@@ -20,6 +21,7 @@ export function StepIndicator({
   size = "md",
   className,
 }: StepIndicatorProps) {
+  const { t } = useTranslation();
   return (
     <div
       className={["sui-steps", `sui-steps--${size}`, className ?? ""]
@@ -29,6 +31,10 @@ export function StepIndicator({
       aria-valuemin={1}
       aria-valuemax={total}
       aria-valuenow={current}
+      aria-label={t("common.stepOf", "Step {{current}} of {{total}}", {
+        current,
+        total,
+      })}
     >
       {Array.from({ length: total }, (_, i) => {
         const step = i + 1;

--- a/frontend/editor/src/core/ui/Table.tsx
+++ b/frontend/editor/src/core/ui/Table.tsx
@@ -25,6 +25,14 @@ export interface TableProps<T> {
    * all rows interactive.
    */
   isRowInteractive?: (row: T) => boolean;
+  /**
+   * Set when every row already carries a control that performs {@link onRowClick}.
+   * Rows keep their pointer target but drop the button role and tab stop, so the
+   * in-row control is not nested inside another widget and the table keeps its
+   * row semantics. Keyboard and assistive-tech users reach the action through
+   * that control instead.
+   */
+  rowActionInCell?: boolean;
   /** Rendered in place of the body when there are no rows. */
   empty?: ReactNode;
   className?: string;
@@ -34,7 +42,7 @@ export interface TableProps<T> {
  * Minimal data table primitive. Columns own their own cell renderers, so the
  * table stays presentational — callers pre-sort/filter and pass the rows they
  * want shown. Rows become focusable buttons-in-disguise when `onRowClick` is
- * set.
+ * set, unless `rowActionInCell` says a control in the row already offers it.
  */
 export function Table<T>({
   columns,
@@ -42,6 +50,7 @@ export function Table<T>({
   rowKey,
   onRowClick,
   isRowInteractive,
+  rowActionInCell = false,
   empty,
   className,
 }: TableProps<T>) {
@@ -85,10 +94,12 @@ export function Table<T>({
                       : "sui-table__row"
                   }
                   onClick={rowInteractive ? () => onRowClick?.(row) : undefined}
-                  tabIndex={rowInteractive ? 0 : undefined}
-                  role={rowInteractive ? "button" : undefined}
+                  tabIndex={rowInteractive && !rowActionInCell ? 0 : undefined}
+                  role={
+                    rowInteractive && !rowActionInCell ? "button" : undefined
+                  }
                   onKeyDown={
-                    rowInteractive
+                    rowInteractive && !rowActionInCell
                       ? (e) => {
                           if (e.key === "Enter" || e.key === " ") {
                             e.preventDefault();

--- a/frontend/editor/src/core/ui/Tabs.css
+++ b/frontend/editor/src/core/ui/Tabs.css
@@ -42,7 +42,7 @@
   border-radius: var(--radius-pill);
 }
 .sui-tabs--pill .sui-tabs__tab.is-active {
-  color: var(--sui-tab-accent, var(--c-primary));
+  color: var(--sui-tab-accent, var(--c-accent-text));
   background: var(--c-primary-tint);
   border-color: var(--sui-tab-accent, var(--c-primary-border));
   font-weight: 500;
@@ -56,7 +56,7 @@
   margin-bottom: -1px;
 }
 .sui-tabs--underline .sui-tabs__tab.is-active {
-  color: var(--sui-tab-accent, var(--c-primary));
+  color: var(--sui-tab-accent, var(--c-accent-text));
   border-bottom-color: var(--sui-tab-accent, var(--c-primary));
   font-weight: 500;
 }

--- a/frontend/editor/src/core/ui/ToggleSwitch.tsx
+++ b/frontend/editor/src/core/ui/ToggleSwitch.tsx
@@ -6,6 +6,8 @@ export interface ToggleSwitchProps {
   onChange: (checked: boolean) => void;
   /** Accessible label associated to the control. */
   label?: string;
+  /** Names the switch from text rendered elsewhere (e.g. a SettingsRow label). */
+  "aria-labelledby"?: string;
   /** Optional helper text rendered next to the label. */
   description?: string;
   disabled?: boolean;
@@ -23,6 +25,7 @@ export function ToggleSwitch({
   checked,
   onChange,
   label,
+  "aria-labelledby": ariaLabelledBy,
   description,
   disabled,
   size = "md",
@@ -39,6 +42,7 @@ export function ToggleSwitch({
         id={controlId}
         type="checkbox"
         role="switch"
+        aria-labelledby={ariaLabelledBy}
         checked={checked}
         disabled={disabled}
         onChange={(e) => onChange(e.target.checked)}

--- a/frontend/editor/src/core/ui/accents.css
+++ b/frontend/editor/src/core/ui/accents.css
@@ -24,10 +24,14 @@
   --_tert-tint: var(--c-hover);
 }
 /* Danger is pinned to a fixed deep red (not the theme-lightened coral), so the
-   fill and the outline/text are the SAME red in both light and dark. */
+   fill and the outline/text are the SAME red in both light and dark.
+
+   The fill is red-600 rather than red-500 because white sits on it: red-500
+   gives 3.76:1, short of the 4.5:1 body text needs, while red-600 gives 4.85:1
+   and holds in either theme. */
 .sui-acc-danger {
-  --_solid: var(--p-red-500);
-  --_solid-hover: var(--p-red-600);
+  --_solid: var(--p-red-600);
+  --_solid-hover: color-mix(in srgb, var(--p-red-600) 85%, var(--p-black));
   --_on: #ffffff;
   --_text: var(--p-red-500);
   --_bd: color-mix(in srgb, var(--p-red-500) 45%, transparent);

--- a/frontend/editor/src/core/ui/accents.css
+++ b/frontend/editor/src/core/ui/accents.css
@@ -9,7 +9,8 @@
     var(--c-btn-inverse)
   );
   --_on: var(--c-btn-inverse);
-  --_text: var(--c-primary-hover);
+  /* Deeper than --c-primary-hover, which lands at 4.28:1 on the accent tint. */
+  --_text: var(--c-accent-text);
   --_bd: color-mix(in srgb, var(--c-primary) 38%, var(--c-surface));
   --_tint: color-mix(in srgb, var(--c-primary) 12%, transparent);
   --_solid-2: var(--c-btn-secondary);
@@ -24,30 +25,35 @@
   --_tert-tint: var(--c-hover);
 }
 /* Danger is pinned to a fixed deep red (not the theme-lightened coral), so the
-   fill and the outline/text are the SAME red in both light and dark.
-
-   The fill is red-600 rather than red-500 because white sits on it: red-500
-   gives 3.76:1, short of the 4.5:1 body text needs, while red-600 gives 4.85:1
-   and holds in either theme. */
+   fill and the outline/text are the SAME red in both light and dark. */
 .sui-acc-danger {
+  /* One step deeper than the base red so the white label on the filled
+     variant clears 4.5:1. */
   --_solid: var(--p-red-600);
-  --_solid-hover: color-mix(in srgb, var(--p-red-600) 85%, var(--p-black));
+  --_solid-hover: var(--p-red-700);
   --_on: #ffffff;
-  --_text: var(--p-red-500);
+  /* Theme-aware like the other accents: the mid red only clears 3.6:1 as text
+     on a light surface, so light mode needs the deeper shade while dark mode
+     needs the lighter one. */
+  --_text: var(--color-red-dark);
   --_bd: color-mix(in srgb, var(--p-red-500) 45%, transparent);
   --_tint: color-mix(in srgb, var(--p-red-500) 12%, transparent);
 }
 .sui-acc-success {
-  --_solid: var(--color-green);
-  --_solid-hover: var(--color-green-dark);
+  /* The base green is a tint/border colour; as a fill behind white text it
+     only reaches 2.3:1, so the solid variant uses the deeper shade. */
+  --_solid: var(--p-green-700);
+  --_solid-hover: var(--p-green-800);
   --_on: #ffffff;
   --_text: var(--color-green-dark);
   --_bd: var(--color-green-border);
   --_tint: color-mix(in srgb, var(--color-green) 12%, transparent);
 }
 .sui-acc-warning {
-  --_solid: var(--color-amber);
-  --_solid-hover: var(--color-amber-dark);
+  /* Deepened so the white label clears 4.5:1, matching how danger and success
+     resolve the same problem — every filled accent reads white-on-colour. */
+  --_solid: var(--p-amber-700);
+  --_solid-hover: var(--p-amber-800);
   --_on: #ffffff;
   --_text: var(--color-amber-dark);
   --_bd: var(--color-amber-border);
@@ -110,7 +116,9 @@
     var(--p-cyan-400) 100%
   );
   --_on: #ffffff;
-  --_text: var(--p-indigo-500);
+  /* The gradient's mid indigo is a fill colour; as text on the light surface
+     it only reaches 4.1:1 (3.6:1 on its own tint). */
+  --_text: var(--p-indigo-600);
   --_bd: var(--p-indigo-200);
   --_tint: color-mix(in srgb, var(--p-indigo-500) 10%, transparent);
 }

--- a/frontend/editor/src/desktop/components/SetupWizard/DesktopAuthLayout.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/DesktopAuthLayout.stories.tsx
@@ -1,0 +1,41 @@
+/**
+ * The frame every desktop setup-wizard screen sits in. It contributes the
+ * branding and centring; the screen itself is passed as children.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DesktopAuthLayout } from "@app/components/SetupWizard/DesktopAuthLayout";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof DesktopAuthLayout> = {
+  title: "Desktop/SetupWizard/DesktopAuthLayout",
+  component: DesktopAuthLayout,
+  parameters: { layout: "fullscreen" },
+  // The shell's wordmark resolves a logo variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DesktopAuthLayout>;
+
+export const Default: Story = {
+  args: { children: <p>Sign-in form goes here.</p> },
+};
+
+/** Taller content, where the frame has to scroll rather than clip. */
+export const TallContent: Story = {
+  args: {
+    children: (
+      <div style={{ display: "grid", gap: "1rem" }}>
+        {Array.from({ length: 12 }, (_, i) => (
+          <p key={i}>Setup step detail line {i + 1}</p>
+        ))}
+      </div>
+    ),
+  },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLink.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLink.stories.tsx
@@ -1,0 +1,21 @@
+/**
+ * The escape hatch at the bottom of the desktop sign-in screen, for people
+ * connecting to their own server rather than a Stirling account.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SelfHostedLink } from "@app/components/SetupWizard/SelfHostedLink";
+
+const meta: Meta<typeof SelfHostedLink> = {
+  title: "Desktop/SetupWizard/SelfHostedLink",
+  component: SelfHostedLink,
+  parameters: { layout: "centered" },
+  args: { onClick: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof SelfHostedLink>;
+
+export const Default: Story = {};
+
+/** Disabled while the wizard is mid-request. */
+export const Disabled: Story = { args: { disabled: true } };

--- a/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.stories.tsx
+++ b/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.stories.tsx
@@ -1,0 +1,46 @@
+/**
+ * The save-state dot on a desktop file thumbnail. Three states, decided from
+ * the file stub rather than a prop: never written to disk, written but with
+ * unsaved edits, and clean.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FileEditorStatusDot } from "@app/components/fileEditor/FileEditorStatusDot";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+function stub(overrides: Partial<StirlingFileStub>): StirlingFileStub {
+  return {
+    id: "story-file" as FileId,
+    name: "report.pdf",
+    type: "application/pdf",
+    size: 120_000,
+    lastModified: Date.parse("2026-03-14T09:30:00Z"),
+    isLeaf: true,
+    originalFileId: "story-file",
+    versionNumber: 1,
+    ...overrides,
+  } as StirlingFileStub;
+}
+
+const meta: Meta<typeof FileEditorStatusDot> = {
+  title: "Desktop/FileEditorStatusDot",
+  component: FileEditorStatusDot,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FileEditorStatusDot>;
+
+/** Held in memory only — nothing has been written to disk yet. */
+export const NotSaved: Story = {
+  args: { file: stub({ localFilePath: undefined }) },
+};
+
+/** On disk, but edited since. */
+export const UnsavedChanges: Story = {
+  args: { file: stub({ localFilePath: "/tmp/report.pdf", isDirty: true }) },
+};
+
+export const Saved: Story = {
+  args: { file: stub({ localFilePath: "/tmp/report.pdf", isDirty: false }) },
+};

--- a/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.tsx
+++ b/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.tsx
@@ -25,9 +25,12 @@ export function FileEditorStatusDot({ file }: FileEditorStatusDotProps) {
   return (
     <div className={styles.thumbBadgesRight}>
       <Tooltip label={label}>
+        {/* A bare span cannot carry aria-label; without a role the save state
+            is conveyed by colour alone and announced as nothing at all. */}
         <span
           className={styles.statusDot}
           style={{ backgroundColor: color }}
+          role="img"
           aria-label={label}
         />
       </Tooltip>

--- a/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.stories.tsx
+++ b/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * A div dressed as a disabled button. Mantine's `disabled` kills pointer events
+ * outright, which also kills the tooltip explaining *why* the control is
+ * unavailable — so this renders the disabled look by hand and keeps hover.
+ *
+ * Desktop-layer stories resolve `@app/*` against desktop → cloud → proprietary
+ * → core, matching the desktop build rather than the editor's order.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DisabledButtonWithTooltip } from "@app/components/shared/DisabledButtonWithTooltip";
+
+const meta: Meta<typeof DisabledButtonWithTooltip> = {
+  title: "Desktop/DisabledButtonWithTooltip",
+  component: DisabledButtonWithTooltip,
+  parameters: { layout: "padded" },
+  args: {
+    tooltip: "Sign in to use this tool",
+    children: "Convert to PDF/A",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DisabledButtonWithTooltip>;
+
+/** The tooltip only appears on hover, so the resting state is what is captured. */
+export const Default: Story = {};
+
+export const LongLabel: Story = {
+  args: { children: "Convert this document to an archival PDF/A-3b file" },
+};
+
+/** A long reason wraps inside the tooltip rather than widening it. */
+export const LongTooltip: Story = {
+  args: {
+    tooltip:
+      "This tool needs a desktop licence and an active connection to the cloud backend.",
+  },
+};
+
+/** In a narrow column the control still fills its container. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 200 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.tsx
+++ b/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.tsx
@@ -20,25 +20,39 @@ export function DisabledButtonWithTooltip({
   className,
   style,
 }: DisabledButtonWithTooltipProps) {
-  const [hovered, setHovered] = React.useState(false);
+  const [shown, setShown] = React.useState(false);
+  const tooltipId = React.useId();
   return (
     <div
       className="relative w-full"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={() => setShown(true)}
+      onMouseLeave={() => setShown(false)}
     >
+      {/* The point of this control is to look disabled while still explaining
+          why. That explanation has to reach a keyboard as well as a pointer, so
+          the element stays focusable and announces itself as a disabled button
+          described by its own tooltip. */}
       <div
         className={`locked-button${className ? ` ${className}` : ""}`}
         style={style}
+        role="button"
+        aria-disabled="true"
+        aria-describedby={tooltipId}
+        tabIndex={0}
+        onFocus={() => setShown(true)}
+        onBlur={() => setShown(false)}
       >
         {children}
       </div>
-      {hovered && (
-        <div className="locked-button-tooltip">
-          {tooltip}
-          <div className="locked-button-tooltip-arrow" />
-        </div>
-      )}
+      <div
+        id={tooltipId}
+        role="tooltip"
+        className="locked-button-tooltip"
+        style={shown ? undefined : { display: "none" }}
+      >
+        {tooltip}
+        <div className="locked-button-tooltip-arrow" />
+      </div>
     </div>
   );
 }

--- a/frontend/editor/src/proprietary/auth/ui/AuthShell.tsx
+++ b/frontend/editor/src/proprietary/auth/ui/AuthShell.tsx
@@ -15,7 +15,11 @@ export interface AuthShellProps {
 export function AuthShell({ children, footer }: AuthShellProps) {
   return (
     <div className={styles.authContainer}>
-      <div className={styles.authCard}>
+      {/* The card caps at 96vh and hides its scrollbar, so on a short viewport
+          it scrolls with nothing to grab. Focusable so a keyboard can scroll
+          it; the group role keeps it announced as one region rather than an
+          unlabelled interactive element. */}
+      <div className={styles.authCard} tabIndex={0} role="group">
         <div className={styles.authContent}>{children}</div>
       </div>
       {footer && (

--- a/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
+++ b/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
@@ -176,6 +176,7 @@ export const ProfilePictureCropper: React.FC<ProfilePictureCropperProps> = ({
             step={0.1}
             onChange={setZoom}
             disabled={processing}
+            thumbLabel={t("config.account.profilePicture.cropper.zoom", "Zoom")}
           />
         </Stack>
 

--- a/frontend/editor/src/saas/routes/login/MagicLinkForm.stories.tsx
+++ b/frontend/editor/src/saas/routes/login/MagicLinkForm.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Magic-link sign-in on the SaaS login screen. Collapsed it is a single link;
+ * expanded it becomes an email field and a send button, so the two states are
+ * really two different components sharing a prop.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import MagicLinkForm from "@app/routes/login/MagicLinkForm";
+
+const meta: Meta<typeof MagicLinkForm> = {
+  title: "SaaS/Login/MagicLinkForm",
+  component: MagicLinkForm,
+  parameters: { layout: "padded" },
+  args: {
+    showMagicLink: false,
+    magicLinkEmail: "",
+    setMagicLinkEmail: () => {},
+    setShowMagicLink: () => {},
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MagicLinkForm>;
+
+/** Collapsed — just the link that opens the form. */
+export const Collapsed: Story = {};
+
+export const Expanded: Story = { args: { showMagicLink: true } };
+
+export const WithEmail: Story = {
+  args: { showMagicLink: true, magicLinkEmail: "a.whitfield@example.com" },
+};
+
+/** Sending, which disables the field and the button together. */
+export const Submitting: Story = {
+  args: {
+    showMagicLink: true,
+    magicLinkEmail: "a.whitfield@example.com",
+    isSubmitting: true,
+  },
+};
+
+/** Typing for real, so the field and its clear/submit states track input. */
+export const Interactive: Story = {
+  render: function Interactive() {
+    const [open, setOpen] = useState(true);
+    const [email, setEmail] = useState("");
+    return (
+      <MagicLinkForm
+        showMagicLink={open}
+        magicLinkEmail={email}
+        setMagicLinkEmail={setEmail}
+        setShowMagicLink={setOpen}
+        onSubmit={() => {}}
+        isSubmitting={false}
+      />
+    );
+  },
+};


### PR DESCRIPTION
Coverage for the editor's own components, plus the defects the stories surfaced. **62 story files.**

Areas: viewer, tools, form fill, file manager, page editor, files page, shared components and the core UI kit.

## Defects fixed

- **SVG groups acting as buttons** in the measurement overlay — Clear all, the label-mode cycle and per-measurement delete had no role, no name, no tab stop. A keyboard user could draw measurements but not delete one.
- **Two stamp sliders ignored `disabled`** while their number fields honoured it, so two of three stayed draggable while the tool ran. A functional bug no a11y rule reports; it surfaced because isolating each variant put three near-identical blocks side by side.
- **Nested interactive controls** — the attachment row and add-file card were each a `role="button"` wrapping their own real buttons.
- **A collapsed panel** that set `aria-hidden` while its controls stayed in the tab order.
- **Unnamed controls**: row checkboxes, the page-number field, the zoom slider thumb.
- **Colour used as the only signal**: an Active badge at 4.05:1, and a badge whose `opacity: 0.75` cancelled the contrast fix beneath it.

## How the stories are built

Components here read context rather than props, so they mount **slices** — the fields each component actually reads — rather than provider trees. That keeps fixtures honest about dependencies, and a story that needed the tool registry would have said so.

Stories that rendered identically to their neighbours were deleted rather than kept for the count.

## Independence

Touches only `editor/src/core`. No file overlaps the proprietary, portal or desktop coverage PRs.