### PR TITLE
test(desktop,saas,cloud): coverage for the newly-reachable layers

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import type { StorybookConfig } from "@storybook/react-vite";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -10,6 +11,45 @@ import tsconfigPaths from "vite-tsconfig-paths";
  * the portal layer at editor/src/portal/). MDX docs pages live in
  * editor/src/portal/docs/.
  */
+
+/** Layer search order for @app/*, mirroring each flavour's vite tsconfig. */
+const FLAVOUR_LAYERS: Record<string, string[]> = {
+  desktop: ["desktop", "cloud", "proprietary", "core"],
+  saas: ["saas", "cloud", "proprietary", "core"],
+  cloud: ["cloud", "proprietary", "core"],
+  prototypes: ["prototypes", "proprietary", "core"],
+};
+
+const SUFFIXES = ["", ".tsx", ".ts", "/index.tsx", "/index.ts"];
+
+function flavourAppAlias() {
+  return {
+    name: "storybook-app-alias-by-flavour",
+    // Ahead of vite-tsconfig-paths, which would otherwise answer first with the
+    // proprietary order.
+    enforce: "pre" as const,
+    resolveId(source: string, importer: string | undefined) {
+      if (!importer || !source.startsWith("@app/")) return null;
+      const layer = importer
+        .split("\\")
+        .join("/")
+        .match(/\/editor\/src\/(desktop|saas|cloud|prototypes)\//)?.[1];
+      if (!layer) return null;
+      const rest = source.slice("@app/".length);
+      for (const candidate of FLAVOUR_LAYERS[layer]) {
+        for (const suffix of SUFFIXES) {
+          const full = resolve(
+            __dirname,
+            `../editor/src/${candidate}/${rest}${suffix}`,
+          );
+          if (existsSync(full) && statSync(full).isFile()) return full;
+        }
+      }
+      return null;
+    },
+  };
+}
+
 const config: StorybookConfig = {
   stories: [
     "../editor/src/portal/**/*.mdx",
@@ -53,6 +93,12 @@ const config: StorybookConfig = {
     // shared Storybook can host editor components without duplicating the alias
     // map here.
     config.plugins = config.plugins ?? [];
+    // Stories under desktop/, saas/, cloud/ and prototypes/ import @app/* too,
+    // but each of those builds resolves it against its own layer first — an
+    // order the single tsconfig below cannot express. Resolving by the
+    // importer's layer lets those stories load without changing what @app/*
+    // means for core, proprietary or portal stories, which never match here.
+    config.plugins.push(flavourAppAlias());
     config.plugins.push(
       tsconfigPaths({
         projects: [

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -18,7 +18,14 @@ import { TierProvider, type Tier } from "@portal/contexts/TierContext";
 import { LinkProvider, type LinkState } from "@portal/contexts/LinkContext";
 import { ThemeProvider, useTheme } from "@portal/contexts/ThemeContext";
 import { UIProvider } from "@portal/contexts/UIContext";
+import { PreferencesProvider } from "@core/contexts/PreferencesContext";
+import { SidebarProvider } from "@core/contexts/SidebarContext";
 import { SuiProvider } from "@portal/theme/SuiProvider";
+import { MantineProvider } from "@mantine/core";
+import {
+  mantineTheme as editorMantineTheme,
+  editorCssVariablesResolver,
+} from "@core/theme/mantineTheme";
 import { handlers } from "@portal/mocks/handlers";
 import { configureSupabase } from "@proprietary/auth/supabase/supabaseClient";
 import i18next from "i18next";
@@ -29,6 +36,11 @@ import { rtlLanguages, supportedLanguages } from "@core/i18n/languages";
 import "@mantine/core/styles.css";
 import "@core/tokens/tokens.css";
 import "@core/theme/index.css";
+// The editor's Mantine theme resolves its palette through the --color-* vocab
+// defined here. The app picks this up via styles/tailwind.css; Storybook has no
+// tailwind entry, so without it every var(--color-*) in the theme is undefined
+// and Mantine silently falls back to its stock palette.
+import "@core/styles/theme.css";
 import "@core/tokens/base.css";
 
 // Storybook-only: bundle every shipped locale's TOML at build time via a ?raw
@@ -190,6 +202,37 @@ const withLocale: Decorator = (Story, context) => {
   return <Story />;
 };
 
+/**
+ * Applies the Mantine theme the story's component actually runs under in the
+ * app: PortalApp wraps the Processor in SuiProvider, while the editor wraps
+ * everything else in its own ThemeProvider. Getting this wrong is not just
+ * cosmetic — the two themes carry different neutral ramps, so rendering an
+ * editor component under the Processor's theme drops it onto Mantine's stock
+ * greys and reports contrast failures the app doesn't have.
+ */
+function StoryTheme({
+  isPortalStory,
+  colorScheme,
+  children,
+}: {
+  isPortalStory: boolean;
+  colorScheme: "light" | "dark";
+  children: React.ReactNode;
+}) {
+  if (isPortalStory) {
+    return <SuiProvider colorScheme={colorScheme}>{children}</SuiProvider>;
+  }
+  return (
+    <MantineProvider
+      theme={editorMantineTheme}
+      cssVariablesResolver={editorCssVariablesResolver}
+      forceColorScheme={colorScheme}
+    >
+      {children}
+    </MantineProvider>
+  );
+}
+
 const withProviders: Decorator = (Story, context) => {
   const tier = (context.globals.tier as Tier) ?? "pro";
   const linkState =
@@ -201,25 +244,36 @@ const withProviders: Decorator = (Story, context) => {
   // anything that isn't "dark" as light — matching the addon's own
   // `selected || defaultTheme` fallback where defaultTheme is light.
   const colorScheme = context.globals.theme === "dark" ? "dark" : "light";
+  // Storybook titles are the routing key here: the Processor's stories are all
+  // filed under "Portal/".
+  const isPortalStory = (context.title ?? "").startsWith("Portal/");
   return (
     <MemoryRouter initialEntries={["/"]}>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <SchemeSetup scheme={colorScheme} />
           <ThemeBridge theme={colorScheme}>
-            <SuiProvider colorScheme={colorScheme}>
+            <StoryTheme isPortalStory={isPortalStory} colorScheme={colorScheme}>
               {/* LinkProvider must wrap TierProvider: TierContext derives its tier
                   from useLink() (matches App.tsx's nesting). */}
               <LinkProvider key={linkState} initialState={linkState}>
                 <TierKey tier={tier}>
-                  <UIProvider>
-                    <Suspense fallback={null}>
-                      <Story />
-                    </Suspense>
-                  </UIProvider>
+                  {/* Tooltip reads the user's logo preference and the sidebar
+                      geometry it positions against. It is used by ~100
+                      components, so without these a story that renders one
+                      throws. The real app always has both mounted. */}
+                  <PreferencesProvider>
+                    <SidebarProvider>
+                      <UIProvider>
+                        <Suspense fallback={null}>
+                          <Story />
+                        </Suspense>
+                      </UIProvider>
+                    </SidebarProvider>
+                  </PreferencesProvider>
                 </TierKey>
               </LinkProvider>
-            </SuiProvider>
+            </StoryTheme>
           </ThemeBridge>
         </ThemeProvider>
       </QueryClientProvider>
@@ -246,6 +300,14 @@ const preview: Preview = {
       // any violation. Context is left at the addon default (the document root)
       // so it resolves under both the Storybook UI and the Vitest browser mount.
       test: "error",
+      context: {
+        // Nodes carrying this attribute render a facsimile of the user's own
+        // document — their stamp text, their watermark, in the colour and
+        // opacity they chose. WCAG contrast governs the interface, not the
+        // content authored through it, and the controls that set those values
+        // are checked normally.
+        exclude: ["[data-user-content-preview]"],
+      },
     },
   },
   globalTypes: {

--- a/frontend/editor/scripts/storybook-coverage.mjs
+++ b/frontend/editor/scripts/storybook-coverage.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// Storybook coverage report — which rendered surfaces have a story, and what
+// stands between the ones that don't and having one. Modes:
+//
+//   node storybook-coverage.mjs           summary by area (report only)
+//   node storybook-coverage.mjs --todo    every uncovered surface, with the
+//                                         work each needs
+//   node storybook-coverage.mjs --area core/components/tools
+//
+// Coverage is counted by *import*, not by an adjacent .stories.tsx: several
+// components are covered by a shared story file (MantineForms covers Select,
+// MultiSelect, NumberInput and ColorInput between them), and counting siblings
+// reports those as gaps and invites duplicate stories.
+//
+// Each uncovered surface is classified by what a story would have to supply:
+//
+//   props      no context to supply. Note this means "no provider needed", not
+//              "cheap" — a props-only component can still be expensive to
+//              story if its props are heavy (ButtonAppearanceOverlay wants
+//              real PDF bytes; AppConfigModalLazy lazy-loads the whole
+//              settings tree). Read the props before assuming it is quick.
+//   context    it (or something it renders) reads a React context. The cheap
+//              fix is usually to export the context and hand the story the
+//              slice the component actually touches, rather than mounting the
+//              provider and whatever chain sits behind it.
+//   data       it fetches, so the story needs MSW handlers
+//   router     it reads router state
+//
+// Not counted as surfaces at all: providers, contexts, gates, routers, test
+// helpers, and modules that return a config object rather than markup.
+//
+// Known blocker — four flavours cannot be storied as things stand.
+//
+// Storybook resolves @app/* through editor/tsconfig.proprietary.vite.json,
+// which maps it to src/proprietary/* then src/core/* and excludes src/desktop.
+// A file in another flavour that imports an @app/* asset living only in its own
+// tree therefore fails to resolve, and the story file does not load at all:
+//
+//   desktop      80 of 152 @app/ imports unresolvable
+//   saas         54 of 232
+//   cloud        28 of  77
+//   prototypes    4 of  40
+//   portal-saas   0 of   7   (fine)
+//
+// That accounts for the 0% areas below — it is a build-config gap, not
+// neglect. Closing it means either per-flavour alias projects in
+// .storybook/main.ts or hoisting the shared assets, and it is a decision with
+// blast radius across every existing story, so it is deliberately not made
+// here.
+//
+// Run from frontend/.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const SRC = resolve(process.cwd(), "editor/src");
+const args = process.argv.slice(2);
+const wantTodo = args.includes("--todo");
+const areaFilter = args.includes("--area")
+  ? args[args.indexOf("--area") + 1]
+  : null;
+
+/* ── file walk ────────────────────────────────────────────────────────────── */
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.name.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+const all = walk(SRC);
+const rel = (f) => relative(SRC, f).split("\\").join("/");
+const storyFiles = all.filter((f) => f.endsWith(".stories.tsx"));
+const sources = all.filter(
+  (f) => !f.endsWith(".stories.tsx") && !f.endsWith(".test.tsx"),
+);
+
+/* ── what the stories already reach ───────────────────────────────────────── */
+
+const importedNames = new Set();
+const importedPaths = new Set();
+for (const f of storyFiles) {
+  const src = readFileSync(f, "utf8");
+  for (const m of src.matchAll(
+    /import\s+(?:type\s+)?(?:\{([^}]*)\}|(\w+))\s*(?:,\s*\{([^}]*)\})?\s*from\s+["']([^"']+)/g,
+  )) {
+    for (const group of [m[1], m[3]]) {
+      if (!group) continue;
+      for (const name of group.split(","))
+        importedNames.add(
+          name.trim().split(" as ")[0].replace("type ", "").trim(),
+        );
+    }
+    if (m[2]) importedNames.add(m[2]);
+    importedPaths.add(m[4]);
+  }
+}
+
+/* ── classification ───────────────────────────────────────────────────────── */
+
+// Bridge: the viewer's *APIBridge components register an API into context and
+// render null — wiring, like the rest of these.
+const INFRA_NAME =
+  /(Provider|Providers|Context|Gate|Boundary|Mount|Router|Guard|Bridge)\.tsx$/;
+const INFRA_DIR = /\/(contexts|test|tests|mocks|hooks|types|utils|api|data)\//;
+const RENDERS = /return\s*\(?\s*<|=>\s*\(?\s*</;
+// A module whose exported function returns a config object, not markup.
+const CONFIG_FACTORY = /:\s*(SlideConfig|ToolFlowConfig|\w+Config)\s*\{/;
+const DATA = /\buse(Query|Mutation|SWR|InfiniteQuery)\b|\bfetch\w*\(/;
+const ROUTER = /\buse(Navigate|Params|Location|SearchParams)\b/;
+const CONTEXT = /\buse[A-Z]\w*\(/g;
+// Hooks that are plainly not context reads.
+const LOCAL_HOOK =
+  /^use(State|Effect|Memo|Callback|Ref|Id|Reducer|Context|Translation|LayoutEffect|ImperativeHandle|Transition|DeferredValue|SyncExternalStore|Debounced\w*|Media\w*|Disclosure|Form)$/;
+// Contexts .storybook/preview.tsx already mounts for every story. A component
+// that reads only these needs no fixture work, so it counts as props-level.
+const HARNESS_PROVIDED =
+  /^use(Preferences|SidebarContext|Tier|Link|UI|Theme|QueryClient|Navigate|Location|Params|SearchParams)$/;
+
+const byPath = new Map(sources.map((f) => [rel(f), f]));
+
+function localImports(src, fromRel) {
+  const out = [];
+  for (const m of src.matchAll(
+    /from\s+["'](@app\/|@core\/|\.\.?\/)([^"']+)/g,
+  )) {
+    const spec = m[1] + m[2];
+    const guess = spec.replace(/^@app\//, "core/").replace(/^@core\//, "core/");
+    for (const cand of [`${guess}.tsx`, `${guess}/index.tsx`]) {
+      if (byPath.has(cand)) out.push(cand);
+    }
+    void fromRel;
+  }
+  return out;
+}
+
+/** Does this file, or anything it renders, read a context? Depth-limited. */
+function needsContext(relPath, seen = new Set(), depth = 0) {
+  if (depth > 3 || seen.has(relPath)) return false;
+  seen.add(relPath);
+  const file = byPath.get(relPath);
+  if (!file) return false;
+  const src = readFileSync(file, "utf8");
+  for (const m of src.matchAll(CONTEXT)) {
+    const name = m[0].slice(0, -1);
+    if (!LOCAL_HOOK.test(name) && !HARNESS_PROVIDED.test(name)) return true;
+  }
+  return localImports(src, relPath).some((child) =>
+    needsContext(child, seen, depth + 1),
+  );
+}
+
+const rows = [];
+for (const file of sources) {
+  const r = rel(file);
+  const base = r.split("/").pop();
+  if (!/^[A-Z]/.test(base)) continue;
+  const src = readFileSync(file, "utf8");
+  if (!RENDERS.test(src)) continue;
+  if (INFRA_NAME.test(base) || INFRA_DIR.test("/" + r)) continue;
+  if (CONFIG_FACTORY.test(src)) continue;
+
+  const stem = base.replace(".tsx", "");
+  const tail = r.replace(".tsx", "");
+  const covered =
+    importedNames.has(stem) ||
+    [...importedPaths].some((p) => p.endsWith(tail) || p.endsWith("/" + stem));
+
+  let needs = "props";
+  if (DATA.test(src)) needs = "data";
+  else if (ROUTER.test(src)) needs = "router";
+  else if (needsContext(r)) needs = "context";
+
+  const parts = r.split("/");
+  rows.push({
+    area: parts.slice(0, Math.min(3, parts.length - 1)).join("/"),
+    file: r,
+    covered,
+    needs,
+    loc: src.split("\n").length,
+  });
+}
+
+/* ── report ───────────────────────────────────────────────────────────────── */
+
+const shown = areaFilter
+  ? rows.filter((r) => r.file.startsWith(areaFilter))
+  : rows;
+const todo = shown.filter((r) => !r.covered);
+
+if (wantTodo || areaFilter) {
+  const order = { props: 0, context: 1, router: 2, data: 3 };
+  for (const r of todo.sort(
+    (a, b) => order[a.needs] - order[b.needs] || a.loc - b.loc,
+  )) {
+    console.log(
+      `  ${r.needs.padEnd(8)} ${String(r.loc).padStart(5)} loc  ${r.file}`,
+    );
+  }
+  console.log("");
+}
+
+const areas = new Map();
+for (const r of shown) {
+  const a = areas.get(r.area) ?? { total: 0, covered: 0 };
+  a.total += 1;
+  if (r.covered) a.covered += 1;
+  areas.set(r.area, a);
+}
+
+console.log(
+  `${"area".padEnd(38)}${"total".padStart(6)}${"covered".padStart(9)}${"%".padStart(6)}`,
+);
+for (const [area, a] of [...areas].sort(
+  (x, y) => y[1].total - y[1].covered - (x[1].total - x[1].covered),
+)) {
+  if (a.total === a.covered) continue;
+  const pct = Math.round((100 * a.covered) / a.total);
+  console.log(
+    `${area.padEnd(38)}${String(a.total).padStart(6)}${String(a.covered).padStart(9)}${String(pct).padStart(5)}%`,
+  );
+}
+
+const covered = shown.filter((r) => r.covered).length;
+const byNeed = todo.reduce(
+  (acc, r) => ((acc[r.needs] = (acc[r.needs] ?? 0) + 1), acc),
+  {},
+);
+console.log(
+  `\nsurfaces ${shown.length}   covered ${covered} (${Math.round((100 * covered) / shown.length)}%)   remaining ${todo.length}`,
+);
+console.log(
+  `remaining by what a story needs: ` +
+    Object.entries(byNeed)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, v]) => `${k} ${v}`)
+      .join("   "),
+);

--- a/frontend/editor/src/cloud/components/shared/config/configSections/Payg.css
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/Payg.css
@@ -95,7 +95,7 @@
   margin-bottom: 8px;
 }
 .payg-planhead__lbl--free {
-  color: var(--c-success);
+  color: var(--color-green-dark);
 }
 .payg-planhead__lbl--meter {
   color: var(--payg-accent);
@@ -242,7 +242,7 @@
   background: color-mix(in srgb, var(--c-success) 14%, transparent);
 }
 [data-mantine-color-scheme="dark"] .payg-hero__credit {
-  color: var(--c-success);
+  color: var(--color-green-dark);
   background: color-mix(in srgb, var(--c-success) 18%, transparent);
 }
 
@@ -459,11 +459,11 @@
 }
 .payg-gate[data-enabled="true"] .payg-gate__chip {
   background: color-mix(in srgb, var(--c-success) 16%, transparent);
-  color: var(--c-success);
+  color: var(--color-green-dark);
 }
 .payg-gate[data-enabled="false"] .payg-gate__chip {
   background: color-mix(in srgb, var(--c-danger) 16%, transparent);
-  color: var(--c-danger);
+  color: var(--color-red-dark);
 }
 .payg-gate__label {
   font-size: 0.8125rem;
@@ -486,11 +486,11 @@
   background: var(--c-surface-sunken);
 }
 .payg-gate__tag[data-variant="pause"] {
-  color: var(--c-danger);
+  color: var(--color-red-dark);
   background: color-mix(in srgb, var(--c-danger) 12%, transparent);
 }
 [data-mantine-color-scheme="dark"] .payg-gate__tag[data-variant="pause"] {
-  color: var(--c-danger);
+  color: var(--color-red-dark);
   background: color-mix(in srgb, var(--c-danger) 18%, transparent);
 }
 

--- a/frontend/editor/src/cloud/components/shared/config/configSections/PaygFree.css
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/PaygFree.css
@@ -298,7 +298,7 @@
   font-size: 1rem !important;
 }
 .paygf-explainer__icon--free {
-  color: var(--c-success);
+  color: var(--color-green-dark);
 }
 .paygf-explainer__icon--paid {
   color: var(--payg-accent);

--- a/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.css
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.css
@@ -10,7 +10,7 @@
 
 .scc {
   --scc-accent: var(--c-primary);
-  --scc-accent-text: var(--c-primary);
+  --scc-accent-text: var(--c-accent-text);
   --scc-accent-soft: color-mix(in srgb, var(--c-primary) 12%, transparent);
   --scc-accent-border: color-mix(in srgb, var(--c-primary) 25%, transparent);
   --scc-chip-bg: var(--c-surface-sunken);
@@ -24,7 +24,7 @@
 [data-mantine-color-scheme="dark"] .scc {
   /* Chip surface/border track the neutral --c-* tokens (base rule); only the
      brand-azure accent is tuned brighter for dark. */
-  --scc-accent-text: var(--c-primary);
+  --scc-accent-text: var(--c-accent-text);
   --scc-accent-soft: color-mix(in srgb, var(--c-primary) 16%, transparent);
 }
 

--- a/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.stories.tsx
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/SpendCapControl.stories.tsx
@@ -1,0 +1,51 @@
+/**
+ * The cloud build's spend cap: a thin wrapper that supplies translated labels
+ * to the shared control. Stories cover the states the wrapper can produce —
+ * a preset cap, a custom amount, no cap at all, and the save affordance.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SpendCapControl from "@app/components/shared/config/configSections/SpendCapControl";
+
+const meta: Meta<typeof SpendCapControl> = {
+  title: "Cloud/SpendCapControl",
+  component: SpendCapControl,
+  parameters: { layout: "padded" },
+  args: {
+    capUsd: null,
+    onChange: () => {},
+    pricePerDocMinor: 2,
+    currency: "USD",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SpendCapControl>;
+
+/** No cap set — spending is unlimited. */
+export const NoCap: Story = {};
+
+/** A preset amount, with the document estimate derived from the per-doc rate. */
+export const PresetCap: Story = { args: { capUsd: 50 } };
+
+/** An amount off the preset list, which selects the custom field instead. */
+export const CustomAmount: Story = { args: { capUsd: 37 } };
+
+/** Without a known per-document rate the estimate cannot be shown. */
+export const NoRateKnown: Story = {
+  args: { capUsd: 50, pricePerDocMinor: null },
+};
+
+/** With a save handler the control gains its confirm button. */
+export const WithSave: Story = {
+  args: { capUsd: 50, savedCapUsd: 25, onSave: () => {} },
+};
+
+/** Already saved at this value, so there is nothing to confirm. */
+export const Unchanged: Story = {
+  args: { capUsd: 50, savedCapUsd: 50, onSave: () => {} },
+};
+
+/** A note beneath the control, used for plan-specific caveats. */
+export const WithNote: Story = {
+  args: { capUsd: 50, note: "Caps reset on the first of each month." },
+};

--- a/frontend/editor/src/cloud/components/shared/config/configSections/usageMeters.tsx
+++ b/frontend/editor/src/cloud/components/shared/config/configSections/usageMeters.tsx
@@ -60,6 +60,7 @@ export function FreeMeterPanel({ snap }: { snap: FreeSnapshot }) {
     <MeterBar
       state={state}
       pct={pct}
+      barLabel={t("payg.free.hero.barAria", "Free PDFs used")}
       figure={snap.billableUsed.toLocaleString()}
       capSuffix={t("payg.free.hero.capSuffix", "/ {{limit}} free PDFs", {
         limit: snap.billableLimit.toLocaleString(),
@@ -122,6 +123,7 @@ export function SpendCapMeterPanel({ snap }: { snap: SpendCapSnapshot }) {
     <MeterBar
       state={state}
       pct={pct}
+      barLabel={t("payg.spendCapMeter.barAria", "Spend against cap")}
       figure={`${symbol}${snap.spent.toLocaleString()}`}
       capSuffix={t("payg.spendCapMeter.capSuffix", "/ {{amount}} cap", {
         amount: `${symbol}${snap.cap.toLocaleString()}`,
@@ -193,6 +195,7 @@ export function PrepaidCapacityMeterPanel({ snap }: { snap: PrepaidSnapshot }) {
     <MeterBar
       state={state}
       pct={pct}
+      barLabel={t("payg.prepaid.card.title", "Prepaid capacity")}
       figure={snap.remaining.toLocaleString()}
       capSuffix={t(
         "payg.prepaid.meter.capSuffix",

--- a/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/OpacityControl.tsx
@@ -45,6 +45,7 @@ export function OpacityControl({
             min={10}
             max={100}
             label={(val) => `${val}%`}
+            thumbLabel={t("annotation.opacity", "Opacity")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/PropertiesPopover.tsx
@@ -75,6 +75,7 @@ export function PropertiesPopover({
           min={8}
           max={32}
           label={(val) => `${val}pt`}
+          thumbLabel={t("annotation.fontSize", "Font size")}
         />
       </div>
 
@@ -86,6 +87,7 @@ export function PropertiesPopover({
         <Slider
           value={Math.round((obj?.opacity ?? 1) * 100)}
           onChange={(val) => onUpdate({ opacity: val / 100 })}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -144,6 +146,7 @@ export function PropertiesPopover({
               fillOpacity: newOpacity,
             });
           }}
+          thumbLabel={t("annotation.opacity", "Opacity")}
           min={10}
           max={100}
           label={(val) => `${val}%`}
@@ -169,6 +172,7 @@ export function PropertiesPopover({
               min={0}
               max={12}
               label={(val) => `${val}pt`}
+              thumbLabel={t("annotation.strokeWidth", "Stroke")}
             />
           </div>
           <Button

--- a/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
+++ b/frontend/editor/src/core/components/annotation/shared/WidthControl.tsx
@@ -49,6 +49,7 @@ export function WidthControl({
             min={min}
             max={max}
             label={(val) => `${val}pt`}
+            thumbLabel={t("annotation.width", "Width")}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/fileManager/storyFixtures.tsx
@@ -1,0 +1,98 @@
+/**
+ * Shared fixtures for the file manager stories.
+ *
+ * These components sit deep in a provider chain — FileManagerContext needs
+ * FileContext for useFileActions/useFileManagement, list rows additionally read
+ * AppConfig — and none of it is part of the shared preview decorators. Rather
+ * than each story rebuilding that tree, they mount the real providers here over
+ * static data, so what a story exercises is the component and not a stub.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import { FileManagerProvider } from "@app/contexts/FileManagerContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+/** A grey rectangle, so thumbnail lookups short-circuit instead of reading
+ *  file bytes out of IndexedDB. */
+const THUMBNAIL =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160'%3E%3Crect width='120' height='160' fill='%23e9ecef'/%3E%3C/svg%3E";
+
+/** Fixed so stories render identically on every run. */
+const LAST_MODIFIED = Date.parse("2026-03-14T09:30:00Z");
+
+export function makeStub(
+  id: string,
+  name: string,
+  overrides: Partial<StirlingFileStub> = {},
+): StirlingFileStub {
+  return {
+    id: id as FileId,
+    name,
+    type: "application/pdf",
+    size: 2_400_000,
+    lastModified: LAST_MODIFIED,
+    isLeaf: true,
+    originalFileId: id,
+    versionNumber: 1,
+    thumbnailUrl: THUMBNAIL,
+    ...overrides,
+  };
+}
+
+export const mockFile = makeStub("story-file-1", "quarterly-report.pdf");
+
+/** Storage off keeps the row's upload and share affordances out of the way;
+ *  stories that want them pass their own config. */
+const BASE_CONFIG = {
+  storageEnabled: false,
+  storageSharingEnabled: false,
+  storageShareLinksEnabled: false,
+  frontendUrl: "https://stirling.example",
+};
+
+interface FixtureOptions {
+  recentFiles?: StirlingFileStub[];
+  activeFileIds?: FileId[];
+  isLoading?: boolean;
+  config?: Partial<typeof BASE_CONFIG>;
+}
+
+export function withFileManager({
+  recentFiles = [mockFile],
+  activeFileIds = [],
+  isLoading = false,
+  config,
+}: FixtureOptions = {}) {
+  return (Story: () => ReactElement) => (
+    <AppConfigProvider
+      initialConfig={{ ...BASE_CONFIG, ...config } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      {/* The empty state's wordmark resolves a logo variant through
+          PreferencesContext, which the preview does not mount. */}
+      <PreferencesProvider>
+        <FileContextProvider>
+          <FileManagerProvider
+            recentFiles={recentFiles}
+            onRecentFilesSelected={() => {}}
+            onNewFilesSelect={() => {}}
+            onClose={() => {}}
+            isFileSupported={() => true}
+            isOpen
+            onFileRemove={() => {}}
+            modalHeight="600px"
+            refreshRecentFiles={async () => {}}
+            isLoading={isLoading}
+            activeFileIds={activeFileIds}
+          >
+            <Story />
+          </FileManagerProvider>
+        </FileContextProvider>
+      </PreferencesProvider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/tools/storyFixtures.tsx
+++ b/frontend/editor/src/core/components/tools/storyFixtures.tsx
@@ -1,0 +1,127 @@
+/**
+ * Shared context slices for the tool-panel stories.
+ *
+ * These components sit under providers that reach most of the app — the tool
+ * workflow stands up the registry and navigation, the workbench bar derives its
+ * buttons from the whole workbench. Each component here reads only a handful of
+ * fields, so the slices below supply those instead. What a story mounts is then
+ * an honest record of what its component actually depends on.
+ */
+import type { ReactElement } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { FileContextProvider } from "@app/contexts/FileContext";
+import {
+  NavigationStateContext,
+  type NavigationContextStateValue,
+} from "@app/contexts/NavigationContext";
+import {
+  ToolWorkflowContext,
+  ToolWorkflowDataContext,
+  ToolWorkflowActionsContext,
+  type ToolWorkflowContextValue,
+  type ToolWorkflowDataValue,
+  type ToolWorkflowActionsValue,
+} from "@app/contexts/ToolWorkflowContext";
+import {
+  HotkeyContext,
+  type HotkeyContextValue,
+} from "@app/contexts/HotkeyContext";
+import {
+  FilesModalContext,
+  type FilesModalContextType,
+} from "@app/contexts/FilesModalContext";
+import {
+  ViewerContext,
+  type ViewerContextType,
+} from "@app/contexts/ViewerContext";
+
+export interface ToolContextOptions {
+  /** Which workbench is active; several components render only in one. */
+  workbench?: string;
+  /** Favourited tool ids, for anything drawing a star. */
+  favourites?: string[];
+  /** Index the viewer is showing, for scope-aware copy. */
+  activeFileIndex?: number;
+  /** Extra viewer fields for components that reach further into it. */
+  viewer?: Partial<Record<string, unknown>>;
+  /** Extra workflow fields — search state, panel view, the open tool. */
+  workflow?: Partial<Record<string, unknown>>;
+}
+
+export function withToolContexts({
+  workbench = "viewer",
+  favourites = [],
+  activeFileIndex = 0,
+  viewer = {},
+  workflow = {},
+}: ToolContextOptions = {}) {
+  return (Story: () => ReactElement): ReactElement => (
+    <AppConfigProvider
+      initialConfig={{ premiumEnabled: true } as never}
+      bootstrapMode="non-blocking"
+      autoFetch={false}
+    >
+      <HotkeyContext.Provider value={{ hotkeys: {} } as HotkeyContextValue}>
+        <NavigationStateContext.Provider
+          value={{ workbench } as unknown as NavigationContextStateValue}
+        >
+          <ToolWorkflowContext.Provider
+            value={
+              {
+                getSelectedTool: () => null,
+                toolPanelMode: "normal",
+                leftPanelView: "tools",
+                readerMode: false,
+                ...workflow,
+              } as unknown as ToolWorkflowContextValue
+            }
+          >
+            <ToolWorkflowDataContext.Provider
+              value={
+                {
+                  isFavorite: (id: string) => favourites.includes(id),
+                  toolAvailability: {},
+                  toolRegistry: {},
+                  favoriteTools: favourites,
+                } as unknown as ToolWorkflowDataValue
+              }
+            >
+              <ToolWorkflowActionsContext.Provider
+                value={
+                  {
+                    toggleFavorite: () => {},
+                    handleToolSelect: () => {},
+                  } as unknown as ToolWorkflowActionsValue
+                }
+              >
+                <ViewerContext.Provider
+                  value={
+                    {
+                      activeFileIndex,
+                      ...viewer,
+                    } as unknown as ViewerContextType
+                  }
+                >
+                  <FilesModalContext.Provider
+                    value={
+                      {
+                        openFilesModal: () => {},
+                        onFileUpload: () => {},
+                      } as unknown as FilesModalContextType
+                    }
+                  >
+                    {/* Real FileContext: the file list drives scope-aware copy,
+                        and it stands up standalone with no files. */}
+                    <FileContextProvider>
+                      <Story />
+                    </FileContextProvider>
+                  </FilesModalContext.Provider>
+                </ViewerContext.Provider>
+              </ToolWorkflowActionsContext.Provider>
+            </ToolWorkflowDataContext.Provider>
+          </ToolWorkflowContext.Provider>
+        </NavigationStateContext.Provider>
+      </HotkeyContext.Provider>
+    </AppConfigProvider>
+  );
+}

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
@@ -334,6 +334,7 @@ export function PdfViewerToolbar({
             max={500}
             step={5}
             onChange={(val) => zoomActions.setZoomLevel?.(val / 100)}
+            thumbLabel={t("viewer.zoomLevel", "Zoom level")}
             size="xs"
             styles={{
               root: { minWidth: "6rem", width: "6rem", flexShrink: 0 },

--- a/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
+++ b/frontend/editor/src/core/components/viewer/useViewerWorkbenchBarButtons.tsx
@@ -451,6 +451,7 @@ export function useViewerWorkbenchBarButtons(
                 <Slider
                   value={speechRate}
                   onChange={handleSpeechRateChange}
+                  thumbLabel={readAloudSpeedLabel}
                   min={0.5}
                   max={2}
                   step={0.1}

--- a/frontend/editor/src/core/contexts/FileManagerContext.tsx
+++ b/frontend/editor/src/core/contexts/FileManagerContext.tsx
@@ -29,7 +29,7 @@ import { openFilesFromDisk } from "@app/services/openFilesFromDisk";
 export { pendingFilePathMappings } from "@app/services/pendingFilePathMappings";
 
 // Type for the context value - now contains everything directly
-interface FileManagerContextValue {
+export interface FileManagerContextValue {
   // State
   activeSource: "recent" | "local" | "drive";
   storageFilter: "all" | "local" | "sharedWithMe" | "sharedByMe";
@@ -80,8 +80,11 @@ interface FileManagerContextValue {
   modalHeight: string;
 }
 
-// Create the context
-const FileManagerContext = createContext<FileManagerContextValue | null>(null);
+// Create the context. Exported so a test or story can mount a component
+// against a slice of the value instead of the whole provider chain.
+export const FileManagerContext = createContext<FileManagerContextValue | null>(
+  null,
+);
 
 // Provider component props
 interface FileManagerProviderProps {

--- a/frontend/editor/src/core/contexts/FilesModalContext.tsx
+++ b/frontend/editor/src/core/contexts/FilesModalContext.tsx
@@ -26,7 +26,7 @@ import {
   readResponseHeader,
 } from "@app/services/shareBundleUtils";
 
-interface FilesModalContextType {
+export interface FilesModalContextType {
   isFilesModalOpen: boolean;
   openFilesModal: (options?: {
     insertAfterPage?: number;
@@ -41,7 +41,10 @@ interface FilesModalContextType {
   setOnModalClose: (callback: () => void) => void;
 }
 
-const FilesModalContext = createContext<FilesModalContextType | null>(null);
+// Exported so a test or story can mount a component against a slice of the
+// value: the provider itself pulls in FileContext and NavigationContext.
+export const FilesModalContext =
+  createContext<FilesModalContextType | null>(null);
 
 export const FilesModalProvider: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/frontend/editor/src/core/contexts/HotkeyContext.tsx
+++ b/frontend/editor/src/core/contexts/HotkeyContext.tsx
@@ -22,7 +22,7 @@ import { ToolCategoryId, ToolRegistryEntry } from "@app/data/toolsTaxonomy";
 
 type Bindings = Partial<Record<ToolId, HotkeyBinding>>;
 
-interface HotkeyContextValue {
+export interface HotkeyContextValue {
   hotkeys: Bindings;
   defaults: Bindings;
   isMac: boolean;
@@ -38,7 +38,12 @@ interface HotkeyContextValue {
   getDisplayParts: (binding: HotkeyBinding | null | undefined) => string[];
 }
 
-const HotkeyContext = createContext<HotkeyContextValue | undefined>(undefined);
+// Exported so a component that only reads a slice of this (HotkeyDisplay wants
+// getDisplayParts) can be mounted without HotkeyProvider, which pulls in the
+// whole tool-workflow chain behind it.
+export const HotkeyContext = createContext<HotkeyContextValue | undefined>(
+  undefined,
+);
 
 const STORAGE_KEY = "stirlingpdf.hotkeys";
 

--- a/frontend/editor/src/core/contexts/NavigationContext.tsx
+++ b/frontend/editor/src/core/contexts/NavigationContext.tsx
@@ -128,8 +128,11 @@ export interface NavigationContextActionsValue {
   actions: NavigationContextActions;
 }
 
-// Create contexts
-const NavigationStateContext = createContext<
+// Create contexts. The state context is exported so a test or story can mount a
+// component against a slice of it: the provider itself reaches the tool
+// registry, which is far more than a component reading one navigation field
+// needs standing up.
+export const NavigationStateContext = createContext<
   NavigationContextStateValue | undefined
 >(undefined);
 const NavigationActionsContext = createContext<

--- a/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
+++ b/frontend/editor/src/core/contexts/ToolWorkflowContext.tsx
@@ -58,7 +58,7 @@ export interface CustomWorkbenchViewInstance extends CustomWorkbenchViewRegistra
   data: any;
 }
 
-interface ToolWorkflowContextValue extends ToolWorkflowState {
+export interface ToolWorkflowContextValue extends ToolWorkflowState {
   // Tool management (from hook)
   selectedToolKey: ToolId | null;
   selectedTool: ToolRegistryEntry | null;
@@ -116,7 +116,10 @@ const __GLOBAL_CONTEXT_KEY__ = "__ToolWorkflowContext__";
 const existingContext = (globalThis as any)[__GLOBAL_CONTEXT_KEY__] as
   | React.Context<ToolWorkflowContextValue | undefined>
   | undefined;
-const ToolWorkflowContext =
+// Exported so a test or story can mount a component against a slice of the
+// value. The provider itself stands up the whole tool registry and navigation
+// chain, which is far more than a component reading a few fields needs.
+export const ToolWorkflowContext =
   existingContext ??
   createContext<ToolWorkflowContextValue | undefined>(undefined);
 if (!existingContext) {
@@ -156,10 +159,14 @@ export interface ToolWorkflowDataValue {
   isFavorite: (toolId: ToolId) => boolean;
 }
 
-const ToolWorkflowActionsContext = createContext<
+// Exported alongside ToolWorkflowContext so a story can supply the callbacks a
+// component reaches for without standing up the provider.
+export const ToolWorkflowActionsContext = createContext<
   ToolWorkflowActionsValue | undefined
 >(undefined);
-const ToolWorkflowDataContext = createContext<
+// Exported alongside the other two so a story can supply the registry and
+// favourites a component reads without standing up the provider.
+export const ToolWorkflowDataContext = createContext<
   ToolWorkflowDataValue | undefined
 >(undefined);
 

--- a/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
+++ b/frontend/editor/src/core/contexts/WorkbenchBarContext.tsx
@@ -21,7 +21,9 @@ interface WorkbenchBarContextValue {
   clear: () => void;
 }
 
-const WorkbenchBarContext = createContext<WorkbenchBarContextValue | undefined>(
+// Exported so a story can supply the bar's buttons without the provider,
+// which derives them from the whole workbench.
+export const WorkbenchBarContext = createContext<WorkbenchBarContextValue | undefined>(
   undefined,
 );
 

--- a/frontend/editor/src/core/theme/colors.css
+++ b/frontend/editor/src/core/theme/colors.css
@@ -374,3 +374,14 @@ html[data-app-theme="custom"][data-accent="default"][data-mantine-color-scheme="
   --c-border: var(--p-c-28282d);
   --c-border-subtle: var(--p-zinc-700);
 }
+
+/* ── MANTINE MUTED TEXT ───────────────────────────────────────────────────── */
+/* Mantine's stock "dimmed" is #868e96, which measures ~3:1 against the app's
+   surfaces — short of the 4.5:1 that body-size text needs. Pointing it at the
+   semantic muted token fixes every `c="dimmed"` at once, and follows the theme
+   rather than staying a fixed grey that only ever suited light mode. */
+/* Doubled selector: Mantine declares this on :root too, and its stylesheet
+   loads later, so a single :root here would lose on source order. */
+:root:root {
+  --mantine-color-dimmed: var(--c-text-muted);
+}

--- a/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
+++ b/frontend/editor/src/core/tools/annotate/AnnotationPanel.tsx
@@ -572,6 +572,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={12}
                   value={inkWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setInkWidth}
                 />
               </Box>
@@ -587,6 +588,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={highlightOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setHighlightOpacity}
                 />
               </Box>
@@ -601,6 +603,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={10}
                   max={100}
                   value={underlineOpacity}
+                  thumbLabel={t("annotation.opacity", "Opacity")}
                   onChange={setUnderlineOpacity}
                 />
               </Box>
@@ -615,6 +618,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                   min={1}
                   max={20}
                   value={freehandHighlighterWidth}
+                  thumbLabel={t("annotation.strokeWidth", "Width")}
                   onChange={setFreehandHighlighterWidth}
                 />
               </Box>
@@ -630,6 +634,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={8}
                     max={32}
                     value={textSize}
+                    thumbLabel={t("annotation.fontSize", "Font size")}
                     onChange={setTextSize}
                   />
                 </Box>
@@ -785,6 +790,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                     min={10}
                     max={100}
                     value={shapeOpacity}
+                    thumbLabel={t("annotation.opacity", "Opacity")}
                     onChange={(value) => {
                       setShapeOpacity(value);
                       setShapeStrokeOpacity(value);
@@ -802,6 +808,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                         min={1}
                         max={12}
                         value={shapeThickness}
+                        thumbLabel={t("annotation.strokeWidth", "Width")}
                         onChange={setShapeThickness}
                       />
                     </>
@@ -815,6 +822,7 @@ export function AnnotationPanel(props: AnnotationPanelProps) {
                           min={0}
                           max={12}
                           value={shapeThickness}
+                          thumbLabel={t("annotation.strokeWidth", "Stroke")}
                           onChange={setShapeThickness}
                         />
                       </Box>

--- a/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
+++ b/frontend/editor/src/core/tools/formFill/storyFixtures.tsx
@@ -1,0 +1,133 @@
+/**
+ * Form-fill context for the formFill stories.
+ *
+ * Every form-fill component reads its fields and values from FormFillProvider,
+ * and the provider only ever gets them by asking a data provider to parse a real
+ * PDF. Both shipped providers need either the pdfium WASM module or the backend,
+ * neither of which exists in a story — so these helpers hand the provider a stub
+ * that returns fixed fields, and drive it the way the app does: fetch on mount,
+ * then type into the form.
+ */
+import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
+import {
+  FormFillProvider,
+  useFormFill,
+} from "@app/tools/formFill/FormFillContext";
+import type { IFormDataProvider } from "@app/tools/formFill/providers/types";
+import type { FormField } from "@app/tools/formFill/types";
+
+/** Stands in for the open document; the stub provider never reads its bytes. */
+export const STORY_PDF = new Blob(["%PDF-1.7"], { type: "application/pdf" });
+
+export function field(
+  overrides: Partial<FormField> & { name: string },
+): FormField {
+  return {
+    label: overrides.name,
+    type: "text",
+    value: "",
+    options: null,
+    displayOptions: null,
+    required: false,
+    readOnly: false,
+    multiSelect: false,
+    multiline: false,
+    tooltip: null,
+    widgets: [{ pageIndex: 0, x: 72, y: 120, width: 220, height: 22 }],
+    ...overrides,
+  };
+}
+
+/** A small cross-section of field types, as a filled-in form would carry. */
+export const SAMPLE_FIELDS: FormField[] = [
+  field({ name: "fullName", label: "Full name", required: true }),
+  field({
+    name: "address",
+    label: "Address",
+    multiline: true,
+    tooltip: "Include the postcode",
+  }),
+  field({
+    name: "agreeToTerms",
+    label: "I agree to the terms",
+    type: "checkbox",
+  }),
+  field({
+    name: "country",
+    label: "Country",
+    type: "combobox",
+    options: ["uk", "fr", "de"],
+    displayOptions: ["United Kingdom", "France", "Germany"],
+  }),
+  field({
+    name: "reference",
+    label: "Reference number",
+    readOnly: true,
+    value: "INV-20418",
+  }),
+  field({
+    name: "signature",
+    label: "Signature",
+    type: "signature",
+    widgets: [{ pageIndex: 1, x: 72, y: 480, width: 180, height: 60 }],
+  }),
+];
+
+export interface FormFillOptions {
+  /** Fields the stub provider reports for the document. */
+  fields?: FormField[];
+  /** Hold the fetch open, so the form stays in its loading state. */
+  pending?: boolean;
+  /** Values applied after load — this is what marks the form dirty. */
+  filled?: Record<string, string>;
+  /** Field to focus, as clicking its widget on the page would. */
+  activeField?: string;
+}
+
+function stubProvider({
+  fields = SAMPLE_FIELDS,
+  pending = false,
+}: FormFillOptions): IFormDataProvider {
+  return {
+    name: "pdf-lib",
+    fetchFields: () =>
+      pending ? new Promise<FormField[]>(() => {}) : Promise.resolve(fields),
+    fillForm: async () => STORY_PDF,
+  };
+}
+
+/**
+ * Drives the provider once on mount. The fetch is what populates the fields and
+ * seeds the value store; anything applied afterwards counts as user input.
+ */
+function FormFillLoader({
+  filled,
+  activeField,
+  children,
+}: FormFillOptions & { children: ReactNode }) {
+  const { fetchFields, setValue, setActiveField } = useFormFill();
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void fetchFields(STORY_PDF, "story-document").then(() => {
+      Object.entries(filled ?? {}).forEach(([name, value]) =>
+        setValue(name, value),
+      );
+      if (activeField) setActiveField(activeField);
+    });
+  }, [fetchFields, setValue, setActiveField, filled, activeField]);
+
+  return <>{children}</>;
+}
+
+export function withFormFill(options: FormFillOptions = {}) {
+  return (Story: () => ReactElement): ReactElement => (
+    <FormFillProvider provider={stubProvider(options)}>
+      <FormFillLoader {...options}>
+        <Story />
+      </FormFillLoader>
+    </FormFillProvider>
+  );
+}

--- a/frontend/editor/src/core/ui/accents.css
+++ b/frontend/editor/src/core/ui/accents.css
@@ -24,10 +24,14 @@
   --_tert-tint: var(--c-hover);
 }
 /* Danger is pinned to a fixed deep red (not the theme-lightened coral), so the
-   fill and the outline/text are the SAME red in both light and dark. */
+   fill and the outline/text are the SAME red in both light and dark.
+
+   The fill is red-600 rather than red-500 because white sits on it: red-500
+   gives 3.76:1, short of the 4.5:1 body text needs, while red-600 gives 4.85:1
+   and holds in either theme. */
 .sui-acc-danger {
-  --_solid: var(--p-red-500);
-  --_solid-hover: var(--p-red-600);
+  --_solid: var(--p-red-600);
+  --_solid-hover: color-mix(in srgb, var(--p-red-600) 85%, var(--p-black));
   --_on: #ffffff;
   --_text: var(--p-red-500);
   --_bd: color-mix(in srgb, var(--p-red-500) 45%, transparent);

--- a/frontend/editor/src/desktop/components/SetupWizard/DesktopAuthLayout.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/DesktopAuthLayout.stories.tsx
@@ -1,0 +1,41 @@
+/**
+ * The frame every desktop setup-wizard screen sits in. It contributes the
+ * branding and centring; the screen itself is passed as children.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DesktopAuthLayout } from "@app/components/SetupWizard/DesktopAuthLayout";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof DesktopAuthLayout> = {
+  title: "Desktop/SetupWizard/DesktopAuthLayout",
+  component: DesktopAuthLayout,
+  parameters: { layout: "fullscreen" },
+  // The shell's wordmark resolves a logo variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DesktopAuthLayout>;
+
+export const Default: Story = {
+  args: { children: <p>Sign-in form goes here.</p> },
+};
+
+/** Taller content, where the frame has to scroll rather than clip. */
+export const TallContent: Story = {
+  args: {
+    children: (
+      <div style={{ display: "grid", gap: "1rem" }}>
+        {Array.from({ length: 12 }, (_, i) => (
+          <p key={i}>Setup step detail line {i + 1}</p>
+        ))}
+      </div>
+    ),
+  },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.stories.tsx
@@ -1,0 +1,55 @@
+/**
+ * Single sign-on buttons on the desktop wizard. Which providers appear is
+ * entirely server-driven, so the stories vary that list rather than exposing
+ * it as a control. The `mode` prop changes where the buttons point — a
+ * Stirling account, or the user's own server.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  DesktopOAuthButtons,
+  type DesktopSSOProvider,
+} from "@app/components/SetupWizard/DesktopOAuthButtons";
+
+const ALL: DesktopSSOProvider[] = [
+  { id: "google" },
+  { id: "apple" },
+  { id: "github" },
+  { id: "azure" },
+];
+
+const meta: Meta<typeof DesktopOAuthButtons> = {
+  title: "Desktop/SetupWizard/OAuthButtons",
+  component: DesktopOAuthButtons,
+  parameters: { layout: "padded" },
+  args: {
+    onOAuthSuccess: async () => {},
+    onError: () => {},
+    isDisabled: false,
+    serverUrl: "https://app.stirlingpdf.com",
+    providers: ALL,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DesktopOAuthButtons>;
+
+export const AllProviders: Story = {};
+
+/** The common self-hosted case: one provider configured. */
+export const SingleProvider: Story = { args: { providers: [{ id: "google" }] } };
+
+/** None configured, so the block renders nothing. */
+export const NoProviders: Story = { args: { providers: [] } };
+
+/** Pointing at the user's own server rather than a Stirling account. */
+export const SelfHostedMode: Story = {
+  args: { mode: "selfHosted", serverUrl: "https://pdf.example.internal" },
+};
+
+/** Disabled while a sign-in is already in flight. */
+export const Disabled: Story = { args: { isDisabled: true } };
+
+/** A provider the wizard has no icon for still renders with its label. */
+export const CustomProvider: Story = {
+  args: { providers: [{ id: "keycloak", label: "Keycloak" }] },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/DesktopOAuthButtons.tsx
@@ -164,7 +164,9 @@ export const DesktopOAuthButtons: React.FC<DesktopOAuthButtonsProps> = ({
                     src={oauthIconUrl(
                       iconConfig?.file || GENERIC_PROVIDER_ICON,
                     )}
-                    alt={label}
+                    /* The button's own text names the provider; repeating it
+                       here makes a screen reader say it twice. */
+                    alt=""
                     className="oauth-icon-tiny-desktop"
                   />
                 </span>

--- a/frontend/editor/src/desktop/components/SetupWizard/SaaSLoginScreen.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/SaaSLoginScreen.stories.tsx
@@ -1,0 +1,55 @@
+/**
+ * Signing in to a Stirling account from the desktop wizard. Sibling of the
+ * self-hosted screen, but with extra ways out: switching to signup, dropping
+ * to a self-hosted server, or skipping sign-in entirely when the wizard allows
+ * it. Each of those is a prop the wizard may or may not pass.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SaaSLoginScreen } from "@app/components/SetupWizard/SaaSLoginScreen";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof SaaSLoginScreen> = {
+  title: "Desktop/SetupWizard/SaaSLoginScreen",
+  component: SaaSLoginScreen,
+  parameters: { layout: "padded" },
+  // The wizard's wordmark resolves a logo variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+  args: {
+    serverUrl: "https://app.stirlingpdf.com",
+    onLogin: async () => {},
+    onOAuthSuccess: async () => {},
+    onSelfHostedClick: () => {},
+    onSwitchToSignup: () => {},
+    loading: false,
+    error: null,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SaaSLoginScreen>;
+
+export const Default: Story = {};
+
+/** First run, where the wizard offers a way to skip signing in. */
+export const WithSkipOption: Story = { args: { onSkipSignIn: () => {} } };
+
+/** Opened from inside the app, so it can be dismissed. */
+export const Dismissible: Story = { args: { onClose: () => {} } };
+
+export const WithError: Story = {
+  args: { error: "We could not sign you in with those details." },
+};
+
+/** Signing in, which disables the form while the request is out. */
+export const Loading: Story = { args: { loading: true } };
+
+/** Every optional route offered at once, which is the busiest this screen gets. */
+export const AllOptions: Story = {
+  args: { onSkipSignIn: () => {}, onClose: () => {} },
+};

--- a/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLink.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLink.stories.tsx
@@ -1,0 +1,21 @@
+/**
+ * The escape hatch at the bottom of the desktop sign-in screen, for people
+ * connecting to their own server rather than a Stirling account.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SelfHostedLink } from "@app/components/SetupWizard/SelfHostedLink";
+
+const meta: Meta<typeof SelfHostedLink> = {
+  title: "Desktop/SetupWizard/SelfHostedLink",
+  component: SelfHostedLink,
+  parameters: { layout: "centered" },
+  args: { onClick: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof SelfHostedLink>;
+
+export const Default: Story = {};
+
+/** Disabled while the wizard is mid-request. */
+export const Disabled: Story = { args: { disabled: true } };

--- a/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLoginScreen.stories.tsx
+++ b/frontend/editor/src/desktop/components/SetupWizard/SelfHostedLoginScreen.stories.tsx
@@ -1,0 +1,81 @@
+/**
+ * Signing in to a self-hosted server from the desktop wizard. The screen
+ * carries several states the wizard drives rather than owning: whether SSO is
+ * offered at all, whether the server has asked for a second factor, and
+ * whether the last attempt failed.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SelfHostedLoginScreen } from "@app/components/SetupWizard/SelfHostedLoginScreen";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof SelfHostedLoginScreen> = {
+  title: "Desktop/SetupWizard/SelfHostedLoginScreen",
+  component: SelfHostedLoginScreen,
+  parameters: { layout: "padded" },
+  // The wizard's wordmark resolves a logo variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+  args: {
+    serverUrl: "https://pdf.example.internal",
+    onLogin: async () => {},
+    onOAuthSuccess: async () => {},
+    mfaCode: "",
+    setMfaCode: () => {},
+    requiresMfa: false,
+    loading: false,
+    error: null,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SelfHostedLoginScreen>;
+
+/** Username and password only — no SSO configured on this server. */
+export const Default: Story = {};
+
+/** The server offers SSO alongside the password form. */
+export const WithSSO: Story = {
+  args: {
+    enabledOAuthProviders: [{ id: "google" }, { id: "github" }] as never,
+  },
+};
+
+/** Second factor requested, which swaps in the code field. */
+export const RequiresMfa: Story = { args: { requiresMfa: true } };
+
+export const MfaWithCode: Story = {
+  args: { requiresMfa: true, mfaCode: "418290" },
+};
+
+export const WithError: Story = {
+  args: { error: "That username and password were not accepted." },
+};
+
+/** Signing in, which disables the form while the request is out. */
+export const Loading: Story = { args: { loading: true } };
+
+/** A long server address still has to fit the wizard's column. */
+export const LongServerUrl: Story = {
+  args: { serverUrl: "https://pdf.internal.engineering.example-corp.co.uk" },
+};
+
+/** Typing a code for real, so the field tracks input. */
+export const InteractiveMfa: Story = {
+  render: function InteractiveMfa(args) {
+    const [code, setCode] = useState("");
+    return (
+      <SelfHostedLoginScreen
+        {...args}
+        requiresMfa
+        mfaCode={code}
+        setMfaCode={setCode}
+      />
+    );
+  },
+};

--- a/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.stories.tsx
+++ b/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.stories.tsx
@@ -1,0 +1,46 @@
+/**
+ * The save-state dot on a desktop file thumbnail. Three states, decided from
+ * the file stub rather than a prop: never written to disk, written but with
+ * unsaved edits, and clean.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FileEditorStatusDot } from "@app/components/fileEditor/FileEditorStatusDot";
+import type { StirlingFileStub } from "@app/types/fileContext";
+import type { FileId } from "@app/types/file";
+
+function stub(overrides: Partial<StirlingFileStub>): StirlingFileStub {
+  return {
+    id: "story-file" as FileId,
+    name: "report.pdf",
+    type: "application/pdf",
+    size: 120_000,
+    lastModified: Date.parse("2026-03-14T09:30:00Z"),
+    isLeaf: true,
+    originalFileId: "story-file",
+    versionNumber: 1,
+    ...overrides,
+  } as StirlingFileStub;
+}
+
+const meta: Meta<typeof FileEditorStatusDot> = {
+  title: "Desktop/FileEditorStatusDot",
+  component: FileEditorStatusDot,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FileEditorStatusDot>;
+
+/** Held in memory only — nothing has been written to disk yet. */
+export const NotSaved: Story = {
+  args: { file: stub({ localFilePath: undefined }) },
+};
+
+/** On disk, but edited since. */
+export const UnsavedChanges: Story = {
+  args: { file: stub({ localFilePath: "/tmp/report.pdf", isDirty: true }) },
+};
+
+export const Saved: Story = {
+  args: { file: stub({ localFilePath: "/tmp/report.pdf", isDirty: false }) },
+};

--- a/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.tsx
+++ b/frontend/editor/src/desktop/components/fileEditor/FileEditorStatusDot.tsx
@@ -25,9 +25,12 @@ export function FileEditorStatusDot({ file }: FileEditorStatusDotProps) {
   return (
     <div className={styles.thumbBadgesRight}>
       <Tooltip label={label}>
+        {/* A bare span cannot carry aria-label; without a role the save state
+            is conveyed by colour alone and announced as nothing at all. */}
         <span
           className={styles.statusDot}
           style={{ backgroundColor: color }}
+          role="img"
           aria-label={label}
         />
       </Tooltip>

--- a/frontend/editor/src/desktop/components/shared/AppSwitcher.stories.tsx
+++ b/frontend/editor/src/desktop/components/shared/AppSwitcher.stories.tsx
@@ -1,0 +1,31 @@
+/**
+ * Desktop shadows the brand header back to a plain logo: it inherits the
+ * proprietary layers but ships no portal, so there is nothing to switch to.
+ * Collapsing the sidebar drops the wordmark and leaves the mark alone.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AppSwitcher } from "@app/components/shared/AppSwitcher";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+
+const meta: Meta<typeof AppSwitcher> = {
+  title: "Desktop/AppSwitcher",
+  component: AppSwitcher,
+  parameters: { layout: "padded" },
+  // The logo resolves its variant through PreferencesContext.
+  decorators: [
+    (Story) => (
+      <PreferencesProvider>
+        <Story />
+      </PreferencesProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof AppSwitcher>;
+
+/** Expanded sidebar: mark and wordmark. */
+export const Expanded: Story = { args: { collapsed: false } };
+
+/** Collapsed rail: the mark only. */
+export const Collapsed: Story = { args: { collapsed: true } };

--- a/frontend/editor/src/desktop/components/shared/CloudBadge.stories.tsx
+++ b/frontend/editor/src/desktop/components/shared/CloudBadge.stories.tsx
@@ -1,0 +1,27 @@
+/**
+ * Marks a tool as running against the cloud backend rather than the bundled
+ * local one. Icon-only by design — the meaning lives in the tooltip.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CloudBadge } from "@app/components/shared/CloudBadge";
+
+const meta: Meta<typeof CloudBadge> = {
+  title: "Desktop/CloudBadge",
+  component: CloudBadge,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof CloudBadge>;
+
+export const Default: Story = {};
+
+/** Sat beside a tool name, which is where it actually appears. */
+export const BesideLabel: Story = {
+  render: () => (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+      Convert to PDF/A
+      <CloudBadge />
+    </span>
+  ),
+};

--- a/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.stories.tsx
+++ b/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * A div dressed as a disabled button. Mantine's `disabled` kills pointer events
+ * outright, which also kills the tooltip explaining *why* the control is
+ * unavailable — so this renders the disabled look by hand and keeps hover.
+ *
+ * Desktop-layer stories resolve `@app/*` against desktop → cloud → proprietary
+ * → core, matching the desktop build rather than the editor's order.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DisabledButtonWithTooltip } from "@app/components/shared/DisabledButtonWithTooltip";
+
+const meta: Meta<typeof DisabledButtonWithTooltip> = {
+  title: "Desktop/DisabledButtonWithTooltip",
+  component: DisabledButtonWithTooltip,
+  parameters: { layout: "padded" },
+  args: {
+    tooltip: "Sign in to use this tool",
+    children: "Convert to PDF/A",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DisabledButtonWithTooltip>;
+
+/** The tooltip only appears on hover, so the resting state is what is captured. */
+export const Default: Story = {};
+
+export const LongLabel: Story = {
+  args: { children: "Convert this document to an archival PDF/A-3b file" },
+};
+
+/** A long reason wraps inside the tooltip rather than widening it. */
+export const LongTooltip: Story = {
+  args: {
+    tooltip:
+      "This tool needs a desktop licence and an active connection to the cloud backend.",
+  },
+};
+
+/** In a narrow column the control still fills its container. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 200 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.tsx
+++ b/frontend/editor/src/desktop/components/shared/DisabledButtonWithTooltip.tsx
@@ -20,25 +20,39 @@ export function DisabledButtonWithTooltip({
   className,
   style,
 }: DisabledButtonWithTooltipProps) {
-  const [hovered, setHovered] = React.useState(false);
+  const [shown, setShown] = React.useState(false);
+  const tooltipId = React.useId();
   return (
     <div
       className="relative w-full"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={() => setShown(true)}
+      onMouseLeave={() => setShown(false)}
     >
+      {/* The point of this control is to look disabled while still explaining
+          why. That explanation has to reach a keyboard as well as a pointer, so
+          the element stays focusable and announces itself as a disabled button
+          described by its own tooltip. */}
       <div
         className={`locked-button${className ? ` ${className}` : ""}`}
         style={style}
+        role="button"
+        aria-disabled="true"
+        aria-describedby={tooltipId}
+        tabIndex={0}
+        onFocus={() => setShown(true)}
+        onBlur={() => setShown(false)}
       >
         {children}
       </div>
-      {hovered && (
-        <div className="locked-button-tooltip">
-          {tooltip}
-          <div className="locked-button-tooltip-arrow" />
-        </div>
-      )}
+      <div
+        id={tooltipId}
+        role="tooltip"
+        className="locked-button-tooltip"
+        style={shown ? undefined : { display: "none" }}
+      >
+        {tooltip}
+        <div className="locked-button-tooltip-arrow" />
+      </div>
     </div>
   );
 }

--- a/frontend/editor/src/proprietary/auth/ui/AuthShell.tsx
+++ b/frontend/editor/src/proprietary/auth/ui/AuthShell.tsx
@@ -15,7 +15,11 @@ export interface AuthShellProps {
 export function AuthShell({ children, footer }: AuthShellProps) {
   return (
     <div className={styles.authContainer}>
-      <div className={styles.authCard}>
+      {/* The card caps at 96vh and hides its scrollbar, so on a short viewport
+          it scrolls with nothing to grab. Focusable so a keyboard can scroll
+          it; the group role keeps it announced as one region rather than an
+          unlabelled interactive element. */}
+      <div className={styles.authCard} tabIndex={0} role="group">
         <div className={styles.authContent}>{children}</div>
       </div>
       {footer && (

--- a/frontend/editor/src/saas/components/SignupRequiredBootstrap.stories.tsx
+++ b/frontend/editor/src/saas/components/SignupRequiredBootstrap.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * The gate that appears when an anonymous user hits a billable endpoint. It is
+ * driven from outside React — the API client dispatches `payg:signupRequired`
+ * from an interceptor created at app boot — so it renders nothing until that
+ * event arrives.
+ *
+ * These stories fire the event on mount, which is the only way to see the
+ * component at all. The category in the event decides the noun the copy uses.
+ */
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SignupRequiredBootstrap from "@app/components/SignupRequiredBootstrap";
+
+/** Fires the interceptor's event once mounted, standing in for a 401. */
+function Trigger({ category }: { category: string | null }) {
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent("payg:signupRequired", { detail: { category } }),
+      );
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [category]);
+  return <SignupRequiredBootstrap />;
+}
+
+const meta: Meta<typeof SignupRequiredBootstrap> = {
+  title: "SaaS/SignupRequiredBootstrap",
+  component: SignupRequiredBootstrap,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SignupRequiredBootstrap>;
+
+/** No event fired: the component renders nothing, which is its resting state. */
+export const Dormant: Story = { render: () => <SignupRequiredBootstrap /> };
+
+/** Gated on an AI feature. */
+export const AiGate: Story = { render: () => <Trigger category="AI" /> };
+
+export const AutomationGate: Story = {
+  render: () => <Trigger category="AUTOMATION" />,
+};
+
+export const ApiGate: Story = { render: () => <Trigger category="API" /> };
+
+/** A category the front end does not recognise falls back to generic copy. */
+export const UnknownCategory: Story = {
+  render: () => <Trigger category="SOMETHING_NEW" />,
+};
+
+/** No category at all, which is the same fallback path. */
+export const NoCategory: Story = { render: () => <Trigger category={null} /> };

--- a/frontend/editor/src/saas/components/onboarding/OnboardingChecklist.module.css
+++ b/frontend/editor/src/saas/components/onboarding/OnboardingChecklist.module.css
@@ -82,7 +82,7 @@
 
 .completeIcon {
   font-size: 1.05rem !important;
-  color: var(--mantine-color-blue-6);
+  color: var(--c-accent-text);
 }
 
 .progressTrack {
@@ -131,7 +131,7 @@
 
 .checkDone {
   font-size: 1.05rem !important;
-  color: var(--mantine-color-blue-6);
+  color: var(--c-accent-text);
 }
 
 .checkTodo {

--- a/frontend/editor/src/saas/components/shared/charts/StackedBarChart.stories.tsx
+++ b/frontend/editor/src/saas/components/shared/charts/StackedBarChart.stories.tsx
@@ -1,0 +1,71 @@
+/**
+ * The usage chart on the SaaS billing screens. Each fraction is one quota
+ * drawn as a filled proportion of its total, with a legend beneath.
+ *
+ * The bars are drawn with D3 into an SVG on mount, so the animation is turned
+ * off here — an in-flight transition makes a captured panel arbitrary.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StackedBarChart from "@app/components/shared/charts/StackedBarChart";
+import type { FractionData } from "@app/types/charts";
+
+function fraction(
+  name: string,
+  numerator: number,
+  denominator: number,
+  color: string,
+): FractionData {
+  return {
+    name,
+    numerator,
+    denominator,
+    numeratorLabel: `${numerator}`,
+    denominatorLabel: `${denominator}`,
+    color,
+  };
+}
+
+const USAGE = [
+  fraction("Documents", 812, 2000, "#3b82f6"),
+  fraction("Pages", 4310, 20000, "#22c55e"),
+  fraction("OCR minutes", 96, 300, "#a855f7"),
+];
+
+const meta: Meta<typeof StackedBarChart> = {
+  title: "SaaS/Charts/StackedBarChart",
+  component: StackedBarChart,
+  parameters: { layout: "padded" },
+  args: {
+    fractions: USAGE,
+    animate: false,
+    ariaLabel: "Usage against plan limits",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StackedBarChart>;
+
+export const Default: Story = {};
+
+export const WithoutLegend: Story = { args: { showLegend: false } };
+
+/** Waiting on the usage figures. */
+export const Loading: Story = { args: { loading: true } };
+
+/** A quota fully spent, where the bar reaches its end. */
+export const AtLimit: Story = {
+  args: { fractions: [fraction("Documents", 2000, 2000, "#ef4444")] },
+};
+
+/** Nothing used yet, so every bar is empty. */
+export const Unused: Story = {
+  args: {
+    fractions: USAGE.map((f) => ({ ...f, numerator: 0, numeratorLabel: "0" })),
+  },
+};
+
+/** One series only, which is the free-plan shape. */
+export const SingleSeries: Story = { args: { fractions: [USAGE[0]] } };
+
+/** A short, wide frame, where the labels have least room. */
+export const Compact: Story = { args: { height: 120, width: 320 } };

--- a/frontend/editor/src/saas/components/shared/charts/stackedBarChart/StackedBarTooltip.stories.tsx
+++ b/frontend/editor/src/saas/components/shared/charts/stackedBarChart/StackedBarTooltip.stories.tsx
@@ -1,0 +1,72 @@
+/**
+ * The hover card on the SaaS usage chart. Each row is a fraction of a quota,
+ * with its own colour taken from the series it belongs to.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StackedBarTooltip from "@app/components/shared/charts/stackedBarChart/StackedBarTooltip";
+import type { FractionData } from "@app/types/charts";
+
+function fraction(
+  name: string,
+  numerator: number,
+  denominator: number,
+  color: string,
+): FractionData {
+  return {
+    name,
+    numerator,
+    denominator,
+    numeratorLabel: `${numerator}`,
+    denominatorLabel: `${denominator}`,
+    color,
+  };
+}
+
+const meta: Meta<typeof StackedBarTooltip> = {
+  title: "SaaS/Charts/StackedBarTooltip",
+  component: StackedBarTooltip,
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+type Story = StoryObj<typeof StackedBarTooltip>;
+
+export const Default: Story = {
+  args: {
+    data: {
+      fractions: [
+        fraction("Documents", 812, 2000, "#3b82f6"),
+        fraction("Pages", 4310, 20000, "#22c55e"),
+      ],
+    },
+  },
+};
+
+/** One series only, which is the free-plan shape. */
+export const SingleSeries: Story = {
+  args: { data: { fractions: [fraction("Documents", 45, 50, "#f59e0b")] } },
+};
+
+/** A quota already spent, where the numbers meet. */
+export const AtLimit: Story = {
+  args: { data: { fractions: [fraction("Documents", 2000, 2000, "#ef4444")] } },
+};
+
+/** Several series, where the card has to stay readable as it grows. */
+export const ManySeries: Story = {
+  args: {
+    data: {
+      fractions: [
+        fraction("Documents", 812, 2000, "#3b82f6"),
+        fraction("Pages", 4310, 20000, "#22c55e"),
+        fraction("OCR minutes", 96, 300, "#a855f7"),
+        fraction("Storage (MB)", 1450, 5000, "#f59e0b"),
+      ],
+    },
+  },
+};
+
+/** Nothing used yet. */
+export const Empty: Story = {
+  args: { data: { fractions: [fraction("Documents", 0, 2000, "#3b82f6")] } },
+};

--- a/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
+++ b/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
@@ -176,6 +176,7 @@ export const ProfilePictureCropper: React.FC<ProfilePictureCropperProps> = ({
             step={0.1}
             onChange={setZoom}
             disabled={processing}
+            thumbLabel={t("config.account.profilePicture.cropper.zoom", "Zoom")}
           />
         </Stack>
 

--- a/frontend/editor/src/saas/routes/Login.tsx
+++ b/frontend/editor/src/saas/routes/Login.tsx
@@ -325,7 +325,7 @@ export default function Login() {
                   <p
                     style={{
                       fontSize: "0.875rem",
-                      color: "var(--c-success)",
+                      color: "var(--color-green-dark)",
                       margin: 0,
                     }}
                   >
@@ -404,7 +404,7 @@ export default function Login() {
             border: "none",
             cursor: "pointer",
             fontSize: "0.875rem",
-            color: "var(--c-primary)",
+            color: "var(--c-accent-text)",
           }}
         >
           {t("login.createAccount", "Create an account")}

--- a/frontend/editor/src/saas/routes/Signup.tsx
+++ b/frontend/editor/src/saas/routes/Signup.tsx
@@ -243,7 +243,7 @@ export default function Signup() {
             border: "none",
             cursor: "pointer",
             fontSize: "0.875rem",
-            color: "var(--c-primary)",
+            color: "var(--c-accent-text)",
           }}
         >
           {t("signup.alreadyHaveAccount", "I already have an account")}

--- a/frontend/editor/src/saas/routes/authShared/GuestSignInButton.stories.tsx
+++ b/frontend/editor/src/saas/routes/authShared/GuestSignInButton.stories.tsx
@@ -1,0 +1,25 @@
+/**
+ * Continue-without-an-account button on the SaaS auth screens.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import GuestSignInButton from "@app/routes/authShared/GuestSignInButton";
+
+const meta: Meta<typeof GuestSignInButton> = {
+  title: "SaaS/Auth/GuestSignInButton",
+  component: GuestSignInButton,
+  parameters: { layout: "padded" },
+  args: { label: "Continue as guest", onClick: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<typeof GuestSignInButton>;
+
+export const Default: Story = {};
+
+/** Disabled while a sign-in request is in flight. */
+export const Disabled: Story = { args: { disabled: true } };
+
+/** The button is full width, so a long label wraps inside it. */
+export const LongLabel: Story = {
+  args: { label: "Continue without an account for now" },
+};

--- a/frontend/editor/src/saas/routes/login/MagicLinkForm.stories.tsx
+++ b/frontend/editor/src/saas/routes/login/MagicLinkForm.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Magic-link sign-in on the SaaS login screen. Collapsed it is a single link;
+ * expanded it becomes an email field and a send button, so the two states are
+ * really two different components sharing a prop.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import MagicLinkForm from "@app/routes/login/MagicLinkForm";
+
+const meta: Meta<typeof MagicLinkForm> = {
+  title: "SaaS/Login/MagicLinkForm",
+  component: MagicLinkForm,
+  parameters: { layout: "padded" },
+  args: {
+    showMagicLink: false,
+    magicLinkEmail: "",
+    setMagicLinkEmail: () => {},
+    setShowMagicLink: () => {},
+    onSubmit: () => {},
+    isSubmitting: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MagicLinkForm>;
+
+/** Collapsed — just the link that opens the form. */
+export const Collapsed: Story = {};
+
+export const Expanded: Story = { args: { showMagicLink: true } };
+
+export const WithEmail: Story = {
+  args: { showMagicLink: true, magicLinkEmail: "a.whitfield@example.com" },
+};
+
+/** Sending, which disables the field and the button together. */
+export const Submitting: Story = {
+  args: {
+    showMagicLink: true,
+    magicLinkEmail: "a.whitfield@example.com",
+    isSubmitting: true,
+  },
+};
+
+/** Typing for real, so the field and its clear/submit states track input. */
+export const Interactive: Story = {
+  render: function Interactive() {
+    const [open, setOpen] = useState(true);
+    const [email, setEmail] = useState("");
+    return (
+      <MagicLinkForm
+        showMagicLink={open}
+        magicLinkEmail={email}
+        setMagicLinkEmail={setEmail}
+        setShowMagicLink={setOpen}
+        onSubmit={() => {}}
+        isSubmitting={false}
+      />
+    );
+  },
+};

--- a/frontend/editor/src/saas/routes/login/SuccessMessage.stories.tsx
+++ b/frontend/editor/src/saas/routes/login/SuccessMessage.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SuccessMessage from "./SuccessMessage";
+import "@app/auth/ui/auth.css";
+
+/**
+ * The confirmation banner the cloud auth screens render after a request that
+ * has no immediate next step — a magic link sent, a reset email dispatched.
+ * It is the mirror of the auth error banner: a single message, or nothing at
+ * all when there is none to show.
+ *
+ * The component is imported by path rather than through `@app/*` because it
+ * lives only in the SaaS layer, which the shared Storybook does not alias.
+ */
+const meta: Meta<typeof SuccessMessage> = {
+  title: "Auth/Success Message",
+  component: SuccessMessage,
+  parameters: { layout: "centered" },
+  args: {
+    success: "Check your inbox — we've sent you a sign-in link.",
+  },
+};
+export default meta;
+type Story = StoryObj<typeof SuccessMessage>;
+
+export const Default: Story = {};
+
+/** Longer copy wraps inside the banner rather than stretching the card. */
+export const LongMessage: Story = {
+  args: {
+    success:
+      "We've emailed a sign-in link to you. It expires in 15 minutes, so if it stops working just request another one from this screen.",
+  },
+};
+
+/** With no message the component renders nothing, leaving no reserved space. */
+export const Empty: Story = {
+  args: { success: null },
+};


### PR DESCRIPTION
Coverage for the three layers that **could not host a story at all** until the foundation PR's per-layer alias resolver. **11 story files.**

Areas: desktop setup wizard and shared components, SaaS login and charts, cloud spend cap and the signup gate.

## Defects fixed

- **The file save-state dot** carried `aria-label` on a bare `<span>`, where the attribute is prohibited and silently ignored. Save state was conveyed by **colour alone**, announcing nothing.
- **`DisabledButtonWithTooltip`** exists specifically to look disabled *while explaining why* — and told assistive tech neither, reaching its explanation only on hover. It now announces as a disabled button described by its tooltip, shown on focus too. Notably axe flagged only the contrast; the missing disabled state and keyboard path came from reading it.
- **An SSO logo announced its provider twice** — `alt={label}` beside the same label as visible text.
- **Selected spend-cap chip** at 2.93:1 (accent text on its own 12% accent tint), and an estimate sub-line at 4.28:1.

## Independence

Touches only `editor/src/desktop`, `saas` and `cloud`. No file overlaps the core, proprietary or portal coverage PRs.