### PR TITLE
build(deps): bump org.simplejavamail from 8.12.0 to 9.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     cooldown:
       default-days: 7
     rebase-strategy: "auto"
+    groups:
+      simple-java-mail:
+        patterns:
+          - "org.simplejavamail:simple-java-mail"
+          - "org.simplejavamail:outlook-module"
 
   - package-ecosystem: "docker"
     directories:

--- a/app/common/build.gradle
+++ b/app/common/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     api 'org.snakeyaml:snakeyaml-engine:3.0.1'
     api "org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3"
     // Simple Java Mail for EML/MSG parsing (replaces direct Angus Mail usage)
-    api 'org.simplejavamail:simple-java-mail:8.12.6'
-    api 'org.simplejavamail:outlook-module:8.12.6' // MSG file support
+    api 'org.simplejavamail:simple-java-mail:9.2.0'
+    api 'org.simplejavamail:outlook-module:9.2.0' // MSG file support
     api 'jakarta.mail:jakarta.mail-api:2.1.5'
     runtimeOnly 'org.eclipse.angus:angus-mail:2.0.5'
 

--- a/app/common/src/main/java/stirling/software/common/util/EmlParser.java
+++ b/app/common/src/main/java/stirling/software/common/util/EmlParser.java
@@ -194,7 +194,7 @@ public class EmlParser {
         }
         attachment.setFilename(filename);
 
-        String contentId = embedded ? stripCid(resourceName) : null;
+        String contentId = embedded ? stripCid(resource.getContentId()) : null;
         attachment.setContentId(contentId);
 
         String detectedContentType = EmlProcessingUtils.detectMimeType(filename, contentType);


### PR DESCRIPTION
Bump org.simplejavamail:simple-java-mail and outlook-module from 8.12.6 to 9.2.0 in app/common/build.gradle. Add a Dependabot group for the org.simplejavamail artifacts in .github/dependabot.yml so updates for those packages are grouped into a single PR.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
