### PR TITLE
refactor(package): rename example classes and update package structure

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -22,7 +22,7 @@ frontend/editor/src/portal/components/docs/GettingStartedSection.tsx:generic-api
 
 # False positive: generic-api-key matches the Java type name "X509Certificate"
 # in a method signature (CreateSignatureBase.resolveSignatureAlgorithm) - not a secret.
-app/core/src/main/java/org/apache/pdfbox/examples/signature/CreateSignatureBase.java:generic-api-key:224
+app/core/src/main/java/stirling/software/SPDF/pdf/signature/CreateSignatureBase.java:generic-api-key:224
 
 # Supabase publishable key (public by design, RLS-protected) used as a CI fallback
 # default in the tauri-build workflow when the GitHub secret is unset - not a real secret.

--- a/app/common/src/main/java/stirling/software/common/service/CustomPDFDocumentFactory.java
+++ b/app/common/src/main/java/stirling/software/common/service/CustomPDFDocumentFactory.java
@@ -17,7 +17,6 @@ import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 
 import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.examples.util.DeletingRandomAccessFile;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
@@ -31,6 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.common.model.api.PDFFile;
+import stirling.software.common.util.DeletingRandomAccessFile;
 import stirling.software.common.util.ExceptionUtils;
 import stirling.software.common.util.TempFileManager;
 

--- a/app/common/src/main/java/stirling/software/common/util/DeletingRandomAccessFile.java
+++ b/app/common/src/main/java/stirling/software/common/util/DeletingRandomAccessFile.java
@@ -1,4 +1,4 @@
-package org.apache.pdfbox.examples.util;
+package stirling.software.common.util;
 
 import java.io.File;
 import java.io.IOException;

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
@@ -13,7 +13,6 @@ import java.util.Calendar;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.pdfbox.examples.signature.CreateSignatureBase;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -76,6 +75,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.SPDF.config.swagger.StandardPdfResponse;
 import stirling.software.SPDF.model.api.security.SignPDFWithCertRequest;
+import stirling.software.SPDF.pdf.signature.CreateSignatureBase;
 import stirling.software.SPDF.service.HardwareKeyStoreService;
 import stirling.software.common.annotations.AutoJobPostMapping;
 import stirling.software.common.enumeration.ResourceWeight;

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/CMSProcessableInputStream.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/CMSProcessableInputStream.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.pdfbox.examples.signature;
+package stirling.software.SPDF.pdf.signature;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/CreateSignatureBase.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/CreateSignatureBase.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.apache.pdfbox.examples.signature;
+package stirling.software.SPDF.pdf.signature;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TSAClient.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TSAClient.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.pdfbox.examples.signature;
+package stirling.software.SPDF.pdf.signature;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/ValidationTimeStamp.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/ValidationTimeStamp.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.pdfbox.examples.signature;
+package stirling.software.SPDF.pdf.signature;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/app/core/src/main/java/stirling/software/SPDF/utils/ConnectedInputStream.java
+++ b/app/core/src/main/java/stirling/software/SPDF/utils/ConnectedInputStream.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.pdfbox.examples.util;
+package stirling.software.SPDF.utils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/app/core/src/test/java/stirling/software/SPDF/pdf/signature/TSAClientTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/pdf/signature/TSAClientTest.java
@@ -1,4 +1,4 @@
-package org.apache.pdfbox.examples.signature;
+package stirling.software.SPDF.pdf.signature;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/app/core/src/test/java/stirling/software/SPDF/pdf/signature/ValidationTimeStampTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/pdf/signature/ValidationTimeStampTest.java
@@ -1,4 +1,4 @@
-package org.apache.pdfbox.examples.signature;
+package stirling.software.SPDF.pdf.signature;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/app/core/src/test/java/stirling/software/SPDF/utils/ConnectedInputStreamTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/utils/ConnectedInputStreamTest.java
@@ -1,4 +1,4 @@
-package org.apache.pdfbox.examples.util;
+package stirling.software.SPDF.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
# Description of Changes

Refactors a small set of previously vendored/derived PDFBox "example" classes into Stirling’s own package namespaces.



<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have run `task check` to verify linters, typechecks, and tests pass
- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
