### PR TITLE
Pair a self-hosted server with a code instead of an in-browser login

### DIFF
--- a/.taskfiles/backend.yml
+++ b/.taskfiles/backend.yml
@@ -58,14 +58,17 @@ tasks:
         platforms: [linux, darwin]
 
   dev:saas:
-    desc: "Start backend in SaaS flavor against Supabase"
+    desc: "Start backend in SaaS flavor against Supabase (PROFILES=dev|staging|'')"
     # `dotenv:` reads from the root Taskfile's directory (".") because this
     # subtaskfile is included with `dir: .`.
     dotenv: ['app/.env.saas.local', 'app/.env.saas']
     ignore_error: true
     vars:
       PORT: '{{.PORT | default "8080"}}'
-      # Override to "" to run the pure `saas` profile against your own SAAS_DB_*.
+      # dev     = the Supabase preview branch of the SaaS PR you are testing. Set
+      #           SAAS_DEV_PROJECT_REF; it changes as PRs come and go.
+      # staging = pinned to the long-lived v3 project. Always there.
+      # ""      = the pure `saas` profile against your own SAAS_DB_*.
       PROFILES: '{{.PROFILES | default "dev"}}'
       AIENGINE_URL: '{{.AIENGINE_URL | default ""}}'
       AIENGINE_ENABLED: '{{.AIENGINE_ENABLED | default "false"}}'

--- a/app/.env.saas
+++ b/app/.env.saas
@@ -7,9 +7,28 @@
 # takes precedence over what's defined here.
 #
 # DO NOT commit `.env.saas.local`. Only `.env.saas` is checked in.
+#
+# ---------------------------------------------------------------------------
+# THREE ENVIRONMENTS, ONE PATTERN
+#
+# Each one derives its Supabase URLs, JWT issuer and JWKS from a single project
+# ref, so pointing at a different project is one variable, not five.
+#
+#   prod     no profile          SAAS_DB_*          the live project
+#   staging  PROFILES=staging    SAAS_STAGING_DB_*  pinned to v3, always there
+#   dev      PROFILES=dev        SAAS_DEV_*         follows a SaaS PR's preview
+#                                                   branch, so it changes often
+#
+#   task backend:dev:saas                      # dev (the default)
+#   task backend:dev:saas PROFILES=staging     # staging
+#   task backend:dev:saas PROFILES=            # prod-shaped, against SAAS_DB_*
+#
+# Use staging when you want somewhere stable to reproduce something or share a
+# link. Use dev when you are testing an open SaaS PR, because the PR's preview
+# branch is the only place its migrations have been applied.
 ###############################################################################
 
-# ---------- Supabase project ----------
+# ---------- Supabase project (prod / no-profile) ----------
 # Project reference (the subdomain part of <ref>.supabase.co). Required.
 # Set in .env.saas.local.
 SAAS_DB_PROJECT_REF=
@@ -17,18 +36,47 @@ SAAS_DB_PROJECT_REF=
 # Edge function secret used by billing/license rollup calls. Set in .env.saas.local.
 SUPABASE_EDGE_FUNCTION_SECRET=
 
-# ---------- Database (saas profile) ----------
-# Direct JDBC URL to the Supabase Postgres. Required when running the plain
-# `saas` profile (i.e. without `--spring.profiles.include=dev`).
+# ---------- Database (no profile) ----------
+# Direct JDBC URL to the Supabase Postgres. Required when running without
+# `--spring.profiles.include=...`.
 # Example: jdbc:postgresql://db.<project-ref>.supabase.co:5432/postgres
 SAAS_DB_URL=
 SAAS_DB_USERNAME=postgres
 SAAS_DB_PASSWORD=
 
-# ---------- Database (dev profile overrides) ----------
-# Used when `--spring.profiles.include=dev` is active. The dev profile
-# defaults the URL/username to the shared dev Supabase project, but the
-# password must still be provided in .env.saas.local.
-SAAS_DEV_DB_URL=
+# ---------- staging profile ----------
+# Pinned to the v3 project in application-staging.properties, so the ref, URLs
+# and meter endpoint are already set. Only the password is needed, in
+# .env.saas.local. Override the URL only for a different host (e.g. the pooler).
+#
+# These also serve as the dev profile's fallback: with no SAAS_DEV_PROJECT_REF
+# set, dev runs against staging and warns loudly at startup.
+#
+# NB the entries below are commented rather than left blank. A dotenv line with an
+# empty value still SETS the variable, and Spring's ${VAR:default} only uses the
+# default when the variable is absent, not when it is empty. Leaving these blank
+# would resolve them to "" and defeat the fallback.
+SAAS_STAGING_PROJECT_REF=qacaivhsjtftfwtgjvva
+# SAAS_STAGING_PUBLISHABLE_KEY=
+SAAS_STAGING_DB_URL=
+SAAS_STAGING_DB_USERNAME=postgres
+SAAS_STAGING_DB_PASSWORD=
+
+# ---------- dev profile ----------
+# SAAS_DEV_PROJECT_REF is the SaaS PR's Supabase preview branch ref, taken from
+# that PR's "Supabase Preview" check. The dev profile derives the Supabase URL,
+# JWT issuer, JWKS, meter endpoint and (unless overridden) the database host from
+# it, so this one value follows a different PR.
+#
+# Leave it blank and dev falls back to staging, saying so at startup. That keeps a
+# checkout with no PR in flight bootable, but do not leave it blank while testing
+# a SaaS PR: staging will not have that PR's migrations.
+#
+# A preview branch has its OWN database password and API keys; the parent
+# project's will not authenticate. Both live in .env.saas.local.
+# Commented, not blank: see the note above. Set these in .env.saas.local.
+# SAAS_DEV_PROJECT_REF=
+# SAAS_DEV_PUBLISHABLE_KEY=
+# SAAS_DEV_DB_URL=
 SAAS_DEV_DB_USERNAME=postgres
-SAAS_DEV_DB_PASSWORD=
+# SAAS_DEV_DB_PASSWORD=

--- a/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/AccountLinkClient.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/AccountLinkClient.java
@@ -146,6 +146,96 @@ public class AccountLinkClient {
         return new RegisterResult(deviceId, deviceSecret, teamId);
     }
 
+    /** What a successful {@link #pairStart} returns; {@code deviceCode} never leaves the server. */
+    public record PairStartResult(
+            String userCode,
+            String deviceCode,
+            String verificationUri,
+            long expiresInSeconds,
+            int intervalSeconds) {}
+
+    /**
+     * Outcome of one {@link #pairPoll}. {@code credential} is non-null only when {@code status} is
+     * {@code approved}, and SaaS returns it exactly once per pairing.
+     */
+    public record PairPollResult(String status, RegisterResult credential) {}
+
+    /**
+     * Starts a device-grant pairing. Unauthenticated: an unlinked instance has no credential yet,
+     * and the returned device code is what authorises its subsequent polling.
+     */
+    public PairStartResult pairStart(String instanceName, String version) throws IOException {
+        ObjectNode payload = mapper.createObjectNode();
+        if (instanceName != null && !instanceName.isBlank()) {
+            payload.put("name", instanceName);
+        }
+        if (version != null && !version.isBlank()) {
+            payload.put("version", version);
+        }
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(uri("/api/v1/pair/start"))
+                        .header("Content-Type", "application/json")
+                        .header("Accept", "application/json")
+                        .timeout(timeout())
+                        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+                        .build();
+
+        HttpResponse<String> response = send(request);
+        if (response.statusCode() / 100 != 2) {
+            throw new UpstreamException(response.statusCode(), response.body());
+        }
+        JsonNode root = mapper.readTree(response.body());
+        String userCode = text(root, "userCode");
+        String deviceCode = text(root, "deviceCode");
+        if (userCode == null || deviceCode == null) {
+            throw new IOException("SaaS pair/start response missing userCode/deviceCode");
+        }
+        return new PairStartResult(
+                userCode,
+                deviceCode,
+                text(root, "verificationUri"),
+                root.hasNonNull("expiresInSeconds") ? root.get("expiresInSeconds").asLong() : 0L,
+                root.hasNonNull("intervalSeconds") ? root.get("intervalSeconds").asInt() : 5);
+    }
+
+    /**
+     * Polls a pairing. SaaS answers 200 with a status for every non-exceptional case, including
+     * "still waiting", so only transport and genuine server faults raise here.
+     */
+    public PairPollResult pairPoll(String deviceCode) throws IOException {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("deviceCode", deviceCode);
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(uri("/api/v1/pair/poll"))
+                        .header("Content-Type", "application/json")
+                        .header("Accept", "application/json")
+                        .timeout(timeout())
+                        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+                        .build();
+
+        HttpResponse<String> response = send(request);
+        if (response.statusCode() / 100 != 2) {
+            throw new UpstreamException(response.statusCode(), response.body());
+        }
+        JsonNode root = mapper.readTree(response.body());
+        String status = text(root, "status");
+        if (status == null) {
+            throw new IOException("SaaS pair/poll response missing status");
+        }
+        if (!"approved".equals(status)) {
+            return new PairPollResult(status, null);
+        }
+        String deviceId = text(root, "deviceId");
+        String deviceSecret = text(root, "deviceSecret");
+        if (deviceId == null || deviceSecret == null) {
+            throw new IOException("SaaS pair/poll approved without a credential");
+        }
+        Long teamId = root.hasNonNull("teamId") ? root.get("teamId").asLong() : null;
+        return new PairPollResult(status, new RegisterResult(deviceId, deviceSecret, teamId));
+    }
+
     /**
      * Revokes this instance's own credential on the SaaS side, authenticated by that credential.
      * Best-effort: returns {@code false} if SaaS is unreachable or rejects, so the caller (local

--- a/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/AccountLinkController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/AccountLinkController.java
@@ -42,16 +42,61 @@ public class AccountLinkController {
 
     private final AccountLinkService service;
     private final LocalUsageService localUsageService;
+    private final PairingService pairingService;
     // Present only when metering is on (its own flag); absent → /sync-now reports 409.
     private final ObjectProvider<UsageSyncService> syncServiceProvider;
 
     public AccountLinkController(
             AccountLinkService service,
             LocalUsageService localUsageService,
+            PairingService pairingService,
             ObjectProvider<UsageSyncService> syncServiceProvider) {
         this.service = service;
         this.localUsageService = localUsageService;
+        this.pairingService = pairingService;
         this.syncServiceProvider = syncServiceProvider;
+    }
+
+    /** Optional label for this server, shown to the leader who approves the pairing. */
+    public record PairStartRequest(String name) {}
+
+    /**
+     * Starts a device-grant pairing and returns the code to display. The device code stays on the
+     * server; the response carries only what the admin needs to read out.
+     */
+    @PostMapping("/pair/start")
+    public ResponseEntity<?> pairStart(@RequestBody(required = false) PairStartRequest req) {
+        try {
+            return ResponseEntity.ok(pairingService.start(req != null ? req.name() : null));
+        } catch (AccountLinkClient.UpstreamException e) {
+            log.warn("Pairing start rejected upstream: HTTP {}", e.status());
+            HttpStatus status =
+                    e.status() == HttpStatus.TOO_MANY_REQUESTS.value()
+                            ? HttpStatus.TOO_MANY_REQUESTS
+                            : HttpStatus.BAD_GATEWAY;
+            return ResponseEntity.status(status)
+                    .body(java.util.Map.of("error", "PAIR_START_FAILED"));
+        } catch (IOException e) {
+            // Don't echo the message: a DNS/TLS failure can carry the configured SaaS host.
+            log.warn("Pairing start failed (transport): {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                    .body(java.util.Map.of("error", "PAIR_START_FAILED"));
+        }
+    }
+
+    /**
+     * Advances the pairing, polling SaaS at most once per advertised interval. The portal calls
+     * this on a timer while the code is on screen.
+     */
+    @GetMapping("/pair/status")
+    public ResponseEntity<PairingService.PairingView> pairStatus() {
+        return ResponseEntity.ok(pairingService.advance());
+    }
+
+    @PostMapping("/pair/cancel")
+    public ResponseEntity<Void> pairCancel() {
+        pairingService.cancel();
+        return ResponseEntity.noContent().build();
     }
 
     /** {@code supabaseJwt} is the admin's short-lived token the portal already holds. */

--- a/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/PairingService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/PairingService.java
@@ -1,0 +1,178 @@
+package stirling.software.proprietary.accountlink;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Instance side of device-grant pairing (RFC 8628).
+ *
+ * <p>Starts a pairing, shows the admin a code, and advances it by polling SaaS until a team leader
+ * approves. On approval the returned device credential is persisted exactly as the JWT path would
+ * have persisted it, so nothing downstream can tell how an instance was linked.
+ *
+ * <p>Polling is driven lazily by {@link #advance} rather than a scheduler. The interactive flow
+ * inherently requires the admin's browser to be open, so there is nothing to do in the background,
+ * and an abandoned pairing simply expires. The advertised interval is enforced against the shared
+ * state row, so several replicas polling at once cannot exceed it.
+ */
+@Slf4j
+@Service
+@Profile("!saas")
+@ConditionalOnProperty(name = "stirling.billing.account-link.enabled", havingValue = "true")
+public class PairingService {
+
+    private final AccountLinkClient client;
+    private final PairingStateRepository stateRepo;
+    private final DeviceCredentialStore credentialStore;
+    private final EntitlementCache entitlementCache;
+    private final String instanceVersion;
+
+    public PairingService(
+            AccountLinkClient client,
+            PairingStateRepository stateRepo,
+            DeviceCredentialStore credentialStore,
+            EntitlementCache entitlementCache,
+            @org.springframework.beans.factory.annotation.Value("${stirling.version:}")
+                    String instanceVersion) {
+        this.client = client;
+        this.stateRepo = stateRepo;
+        this.credentialStore = credentialStore;
+        this.entitlementCache = entitlementCache;
+        this.instanceVersion = instanceVersion;
+    }
+
+    /**
+     * What the portal renders. {@code phase} is one of idle, waiting, linked, expired, denied. The
+     * device code is deliberately absent: only the code the human types is ever exposed.
+     */
+    public record PairingView(
+            String phase,
+            String userCode,
+            String verificationUri,
+            String expiresAt,
+            int intervalSeconds) {
+
+        static PairingView idle() {
+            return new PairingView("idle", null, null, null, 0);
+        }
+    }
+
+    /**
+     * Begins a pairing, replacing any previous one. Restarting is the correct response to an
+     * abandoned or expired code, and the old pairing is left to expire on the SaaS side.
+     */
+    @Transactional
+    public PairingView start(String instanceName) throws IOException {
+        AccountLinkClient.PairStartResult result = client.pairStart(instanceName, instanceVersion);
+        LocalDateTime now = LocalDateTime.now();
+
+        PairingState state = stateRepo.findState().orElseGet(PairingState::new);
+        state.setId(PairingState.SINGLETON_ID);
+        state.setUserCode(result.userCode());
+        state.setDeviceCode(result.deviceCode());
+        state.setVerificationUri(result.verificationUri());
+        state.setIntervalSeconds(Math.max(1, result.intervalSeconds()));
+        state.setStartedAt(now);
+        state.setExpiresAt(now.plusSeconds(Math.max(1, result.expiresInSeconds())));
+        state.setLastPolledAt(null);
+        stateRepo.save(state);
+
+        log.info("Pairing: awaiting approval of code {}", result.userCode());
+        return view("waiting", state);
+    }
+
+    /**
+     * Advances the current pairing, polling SaaS at most once per advertised interval. Returns the
+     * phase the portal should render.
+     */
+    @Transactional
+    public PairingView advance() {
+        if (credentialStore.isLinked()) {
+            return new PairingView("linked", null, null, null, 0);
+        }
+        Optional<PairingState> found = stateRepo.findState();
+        if (found.isEmpty()) {
+            return PairingView.idle();
+        }
+        PairingState state = found.get();
+        LocalDateTime now = LocalDateTime.now();
+        if (state.isExpired(now)) {
+            return view("expired", state);
+        }
+
+        LocalDateTime last = state.getLastPolledAt();
+        if (last != null && last.plusSeconds(state.getIntervalSeconds()).isAfter(now)) {
+            return view("waiting", state);
+        }
+        state.setLastPolledAt(now);
+        stateRepo.save(state);
+
+        AccountLinkClient.PairPollResult poll;
+        try {
+            poll = client.pairPoll(state.getDeviceCode());
+        } catch (IOException e) {
+            // Transport or upstream fault. Stay waiting rather than tearing the pairing down: the
+            // admin may still be mid-approval and the next poll can succeed.
+            log.debug("Pairing: poll failed, still waiting: {}", e.getMessage());
+            return view("waiting", state);
+        }
+
+        switch (poll.status()) {
+            case "approved" -> {
+                AccountLinkClient.RegisterResult cred = poll.credential();
+                credentialStore.save(cred.deviceId(), cred.deviceSecret(), cred.teamId());
+                stateRepo.delete(state);
+                entitlementCache.invalidate();
+                log.info("Pairing: linked to team {}", cred.teamId());
+                return new PairingView("linked", null, null, null, 0);
+            }
+            case "denied" -> {
+                stateRepo.delete(state);
+                log.info("Pairing: approval was declined");
+                return new PairingView("denied", null, null, null, 0);
+            }
+            case "expired", "unknown" -> {
+                stateRepo.delete(state);
+                return new PairingView("expired", null, null, null, 0);
+            }
+            default -> {
+                return view("waiting", state);
+            }
+        }
+    }
+
+    /** Current pairing without contacting SaaS, for a cheap read. */
+    @Transactional(readOnly = true)
+    public PairingView current() {
+        if (credentialStore.isLinked()) {
+            return new PairingView("linked", null, null, null, 0);
+        }
+        return stateRepo
+                .findState()
+                .map(s -> view(s.isExpired(LocalDateTime.now()) ? "expired" : "waiting", s))
+                .orElseGet(PairingView::idle);
+    }
+
+    /** Abandons the in-flight pairing. The SaaS row is left to expire. */
+    @Transactional
+    public void cancel() {
+        stateRepo.findState().ifPresent(stateRepo::delete);
+    }
+
+    private static PairingView view(String phase, PairingState state) {
+        return new PairingView(
+                phase,
+                state.getUserCode(),
+                state.getVerificationUri(),
+                state.getExpiresAt() != null ? state.getExpiresAt().toString() : null,
+                state.getIntervalSeconds());
+    }
+}

--- a/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/PairingState.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/PairingState.java
@@ -1,0 +1,69 @@
+package stirling.software.proprietary.accountlink;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * The pairing this instance currently has in flight (device grant, RFC 8628).
+ *
+ * <p>Singleton, like {@link DeviceCredential}: one instance pairs to one team at a time. It lives
+ * in the database rather than in memory for a specific reason. On a multi-replica deployment the
+ * admin's browser reaches an arbitrary pod through the ingress, so pod-local state would mean a
+ * refresh landing on a different pod shows no pairing, or starts a second one with a different
+ * code. A shared row makes any pod able to render and advance the same pairing.
+ *
+ * <p>{@code deviceCode} is held in plaintext because it is what we must present on every poll, the
+ * same posture as the device secret this pairing goes on to produce.
+ */
+@Entity
+@Table(name = "account_link_pairing_state")
+@NoArgsConstructor
+@Getter
+@Setter
+public class PairingState implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final Long SINGLETON_ID = 1L;
+
+    @Id
+    @Column(name = "id")
+    private Long id = SINGLETON_ID;
+
+    /** Display form of the code the admin types, e.g. {@code WXYZ-4821}. */
+    @Column(name = "user_code", nullable = false, length = 16)
+    private String userCode;
+
+    /** The bearer secret for polling. Never rendered. */
+    @Column(name = "device_code", nullable = false, length = 128)
+    private String deviceCode;
+
+    @Column(name = "verification_uri", nullable = false, length = 256)
+    private String verificationUri;
+
+    @Column(name = "interval_seconds", nullable = false)
+    private int intervalSeconds;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    /** Enforces the advertised poll interval without needing a scheduler. */
+    @Column(name = "last_polled_at")
+    private LocalDateTime lastPolledAt;
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt != null && now.isAfter(expiresAt);
+    }
+}

--- a/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/PairingStateRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/PairingStateRepository.java
@@ -1,0 +1,15 @@
+package stirling.software.proprietary.accountlink;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PairingStateRepository extends JpaRepository<PairingState, Long> {
+
+    /** The singleton in-flight pairing, if one is running. */
+    default Optional<PairingState> findState() {
+        return findById(PairingState.SINGLETON_ID);
+    }
+}

--- a/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/AccountLinkClientTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/AccountLinkClientTest.java
@@ -259,4 +259,115 @@ class AccountLinkClientTest {
                 client.reportUsage(
                         "dev-1", "sec-1", 1L, LocalDateTime.of(2026, 6, 1, 0, 0), 1, 0, 0));
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairStartParsesBothCodesAndSendsNoCredential() throws Exception {
+        HttpResponse<String> resp =
+                response(
+                        201,
+                        "{\"userCode\":\"WXYZ-4821\",\"deviceCode\":\"dc-1\","
+                                + "\"verificationUri\":\"https://s/link\",\"expiresInSeconds\":600,"
+                                + "\"intervalSeconds\":5}");
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        when(httpClient.send(captor.capture(), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(resp);
+
+        AccountLinkClient.PairStartResult result = client.pairStart("pdf-prod-01", "1.4.2");
+
+        assertEquals("WXYZ-4821", result.userCode());
+        assertEquals("dc-1", result.deviceCode());
+        assertEquals("https://s/link", result.verificationUri());
+        assertEquals(600L, result.expiresInSeconds());
+        assertEquals(5, result.intervalSeconds());
+
+        HttpRequest sent = captor.getValue();
+        assertEquals("https://saas.example.com/api/v1/pair/start", sent.uri().toString());
+        // An unlinked instance has no credential to present, and must not imply otherwise.
+        assertNull(sent.headers().firstValue("X-Device-Id").orElse(null));
+        assertNull(sent.headers().firstValue("X-Device-Secret").orElse(null));
+        assertNull(sent.headers().firstValue("Authorization").orElse(null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairStartFallsBackToADefaultIntervalWhenSaasOmitsIt() throws Exception {
+        HttpResponse<String> resp =
+                response(201, "{\"userCode\":\"AAAA2222\",\"deviceCode\":\"dc\"}");
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(resp);
+
+        assertEquals(5, client.pairStart(null, null).intervalSeconds());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairStartRejectsAResponseMissingEitherCode() throws Exception {
+        HttpResponse<String> resp = response(201, "{\"userCode\":\"AAAA2222\"}");
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(resp);
+
+        assertThrows(java.io.IOException.class, () -> client.pairStart("x", "1.0"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairStartSurfacesTheUpstreamStatus() throws Exception {
+        HttpResponse<String> resp = response(429, "{}");
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(resp);
+
+        AccountLinkClient.UpstreamException ex =
+                assertThrows(
+                        AccountLinkClient.UpstreamException.class,
+                        () -> client.pairStart("x", "1.0"));
+        // The controller maps 429 through rather than flattening it to a 502.
+        assertEquals(429, ex.status());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairPollReturnsTheStatusWithoutACredentialWhileWaiting() throws Exception {
+        HttpResponse<String> resp = response(200, "{\"status\":\"pending\"}");
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(resp);
+
+        AccountLinkClient.PairPollResult result = client.pairPoll("dc-1");
+
+        assertEquals("pending", result.status());
+        assertNull(result.credential());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairPollParsesTheCredentialOnApproval() throws Exception {
+        HttpResponse<String> resp =
+                response(
+                        200,
+                        "{\"status\":\"approved\",\"deviceId\":\"dev-9\","
+                                + "\"deviceSecret\":\"sec-9\",\"teamId\":7}");
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(resp);
+
+        AccountLinkClient.PairPollResult result = client.pairPoll("dc-1");
+
+        assertNotNull(result.credential());
+        assertEquals("dev-9", result.credential().deviceId());
+        assertEquals("sec-9", result.credential().deviceSecret());
+        assertEquals(7L, result.credential().teamId());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairPollRejectsAnApprovalWithNoCredential() throws Exception {
+        // Better to fail loudly than to store a half-credential and fail every later call.
+        HttpResponse<String> resp = response(200, "{\"status\":\"approved\"}");
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(resp);
+
+        assertThrows(java.io.IOException.class, () -> client.pairPoll("dc-1"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void pairPollRejectsAResponseWithNoStatus() throws Exception {
+        HttpResponse<String> resp = response(200, "{}");
+        when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(resp);
+
+        assertThrows(java.io.IOException.class, () -> client.pairPoll("dc-1"));
+    }
 }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/AccountLinkControllerTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/AccountLinkControllerTest.java
@@ -35,7 +35,11 @@ class AccountLinkControllerTest {
         syncService = mock(UsageSyncService.class);
         syncProvider = mock(ObjectProvider.class);
         controller =
-                new AccountLinkController(service, mock(LocalUsageService.class), syncProvider);
+                new AccountLinkController(
+                        service,
+                        mock(LocalUsageService.class),
+                        mock(PairingService.class),
+                        syncProvider);
     }
 
     @Test

--- a/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/PairingServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/PairingServiceTest.java
@@ -1,0 +1,155 @@
+package stirling.software.proprietary.accountlink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PairingServiceTest {
+
+    @Mock private AccountLinkClient client;
+    @Mock private PairingStateRepository stateRepo;
+    @Mock private DeviceCredentialStore credentialStore;
+    @Mock private EntitlementCache entitlementCache;
+
+    private PairingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PairingService(client, stateRepo, credentialStore, entitlementCache, "1.4.2");
+        when(stateRepo.save(any(PairingState.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(stateRepo.findState()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void start_persistsTheDeviceCodeButOnlyExposesTheUserCode() throws IOException {
+        when(client.pairStart("pdf-prod-01", "1.4.2"))
+                .thenReturn(
+                        new AccountLinkClient.PairStartResult(
+                                "WXYZ-4821", "secret-device-code", "https://x/link", 600, 5));
+
+        PairingService.PairingView view = service.start("pdf-prod-01");
+
+        assertThat(view.phase()).isEqualTo("waiting");
+        assertThat(view.userCode()).isEqualTo("WXYZ-4821");
+        assertThat(view.verificationUri()).isEqualTo("https://x/link");
+        // The view is what reaches the browser, so the polling secret must not be on it.
+        assertThat(view.toString()).doesNotContain("secret-device-code");
+
+        org.mockito.ArgumentCaptor<PairingState> saved =
+                org.mockito.ArgumentCaptor.forClass(PairingState.class);
+        verify(stateRepo).save(saved.capture());
+        assertThat(saved.getValue().getDeviceCode()).isEqualTo("secret-device-code");
+        assertThat(saved.getValue().getId()).isEqualTo(PairingState.SINGLETON_ID);
+    }
+
+    @Test
+    void advance_storesTheCredentialAndClearsStateOnApproval() throws IOException {
+        PairingState state = waiting();
+        when(stateRepo.findState()).thenReturn(Optional.of(state));
+        when(client.pairPoll("secret-device-code"))
+                .thenReturn(
+                        new AccountLinkClient.PairPollResult(
+                                "approved",
+                                new AccountLinkClient.RegisterResult("device-id", "secret", 7L)));
+
+        PairingService.PairingView view = service.advance();
+
+        assertThat(view.phase()).isEqualTo("linked");
+        verify(credentialStore).save("device-id", "secret", 7L);
+        verify(stateRepo).delete(state);
+        verify(entitlementCache).invalidate();
+    }
+
+    @Test
+    void advance_respectsTheAdvertisedInterval() throws IOException {
+        PairingState state = waiting();
+        state.setLastPolledAt(LocalDateTime.now());
+        when(stateRepo.findState()).thenReturn(Optional.of(state));
+
+        assertThat(service.advance().phase()).isEqualTo("waiting");
+        // Several replicas can call this at once, so the shared row is what keeps us inside the
+        // interval SaaS asked for.
+        verify(client, never()).pairPoll(anyString());
+    }
+
+    @Test
+    void advance_keepsWaitingWhenTheUpstreamPollFails() throws IOException {
+        PairingState state = waiting();
+        when(stateRepo.findState()).thenReturn(Optional.of(state));
+        when(client.pairPoll(anyString())).thenThrow(new IOException("connect timed out"));
+
+        // A dropped poll must not tear down a pairing the admin may be mid-approval on.
+        assertThat(service.advance().phase()).isEqualTo("waiting");
+        verify(stateRepo, never()).delete(any(PairingState.class));
+        verify(credentialStore, never()).save(anyString(), anyString(), any());
+    }
+
+    @Test
+    void advance_deniedAndExpiredClearTheStateWithoutLinking() throws IOException {
+        PairingState denied = waiting();
+        when(stateRepo.findState()).thenReturn(Optional.of(denied));
+        when(client.pairPoll(anyString()))
+                .thenReturn(new AccountLinkClient.PairPollResult("denied", null));
+        assertThat(service.advance().phase()).isEqualTo("denied");
+
+        PairingState unknown = waiting();
+        when(stateRepo.findState()).thenReturn(Optional.of(unknown));
+        when(client.pairPoll(anyString()))
+                .thenReturn(new AccountLinkClient.PairPollResult("unknown", null));
+        assertThat(service.advance().phase()).isEqualTo("expired");
+
+        verify(credentialStore, never()).save(anyString(), anyString(), any());
+    }
+
+    @Test
+    void advance_reportsExpiryLocallyWithoutCallingSaas() throws IOException {
+        PairingState state = waiting();
+        state.setExpiresAt(LocalDateTime.now().minusSeconds(1));
+        when(stateRepo.findState()).thenReturn(Optional.of(state));
+
+        assertThat(service.advance().phase()).isEqualTo("expired");
+        verify(client, never()).pairPoll(anyString());
+    }
+
+    @Test
+    void advance_shortCircuitsOnceLinked() throws IOException {
+        when(credentialStore.isLinked()).thenReturn(true);
+
+        assertThat(service.advance().phase()).isEqualTo("linked");
+        verify(client, never()).pairPoll(anyString());
+    }
+
+    @Test
+    void advance_idleWhenNothingIsInFlight() {
+        assertThat(service.advance().phase()).isEqualTo("idle");
+    }
+
+    private static PairingState waiting() {
+        PairingState state = new PairingState();
+        state.setId(PairingState.SINGLETON_ID);
+        state.setUserCode("WXYZ-4821");
+        state.setDeviceCode("secret-device-code");
+        state.setVerificationUri("https://x/link");
+        state.setIntervalSeconds(5);
+        state.setStartedAt(LocalDateTime.now().minusSeconds(30));
+        state.setExpiresAt(LocalDateTime.now().plusMinutes(9));
+        return state;
+    }
+}

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/AccountLinkController.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/AccountLinkController.java
@@ -19,13 +19,6 @@ import io.swagger.v3.oas.annotations.Hidden;
 
 import lombok.extern.slf4j.Slf4j;
 
-import stirling.software.common.model.enumeration.TeamRole;
-import stirling.software.proprietary.model.TeamMembership;
-import stirling.software.proprietary.security.database.repository.UserRepository;
-import stirling.software.proprietary.security.model.User;
-import stirling.software.proprietary.security.repository.TeamMembershipRepository;
-import stirling.software.saas.util.AuthenticationUtils;
-
 /**
  * Account-link registration surface (combined-billing "Mode A").
  *
@@ -47,16 +40,12 @@ import stirling.software.saas.util.AuthenticationUtils;
 public class AccountLinkController {
 
     private final AccountLinkService service;
-    private final TeamMembershipRepository memberRepo;
-    private final UserRepository userRepository;
+    private final LeaderTeamResolver leaderTeamResolver;
 
     public AccountLinkController(
-            AccountLinkService service,
-            TeamMembershipRepository memberRepo,
-            UserRepository userRepository) {
+            AccountLinkService service, LeaderTeamResolver leaderTeamResolver) {
         this.service = service;
-        this.memberRepo = memberRepo;
-        this.userRepository = userRepository;
+        this.leaderTeamResolver = leaderTeamResolver;
     }
 
     /** Optional display name for the instance (hostname / label). */
@@ -78,7 +67,7 @@ public class AccountLinkController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<RegisterResponse> register(
             @RequestBody(required = false) RegisterRequest req, Authentication auth) {
-        LeaderTeam lt = resolveLeaderTeam(auth);
+        LeaderTeamResolver.LeaderTeam lt = resolveLeaderTeam(auth);
         if (lt.error() != null) {
             return ResponseEntity.status(lt.error()).build();
         }
@@ -98,7 +87,7 @@ public class AccountLinkController {
     @GetMapping("/instances")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<InstanceRow>> list(Authentication auth) {
-        LeaderTeam lt = resolveLeaderTeam(auth);
+        LeaderTeamResolver.LeaderTeam lt = resolveLeaderTeam(auth);
         if (lt.error() != null) {
             return ResponseEntity.status(lt.error()).build();
         }
@@ -124,7 +113,7 @@ public class AccountLinkController {
     @PostMapping("/instances/{instanceId}/revoke")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> revoke(@PathVariable Long instanceId, Authentication auth) {
-        LeaderTeam lt = resolveLeaderTeam(auth);
+        LeaderTeamResolver.LeaderTeam lt = resolveLeaderTeam(auth);
         if (lt.error() != null) {
             return ResponseEntity.status(lt.error()).build();
         }
@@ -132,30 +121,8 @@ public class AccountLinkController {
         return ok ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
     }
 
-    // ---------------------------------------------------------------------------------------
-    // Helpers — team always derived from the caller; instance linking is a leader (billing) action.
-    // ---------------------------------------------------------------------------------------
-
-    /**
-     * Resolved caller team, or an {@code error} status to return (teamId/userId null when error).
-     */
-    private record LeaderTeam(Long teamId, Long userId, HttpStatus error) {}
-
-    private LeaderTeam resolveLeaderTeam(Authentication auth) {
-        User user;
-        try {
-            user = AuthenticationUtils.getCurrentUser(auth, userRepository);
-        } catch (SecurityException e) {
-            return new LeaderTeam(null, null, HttpStatus.UNAUTHORIZED);
-        }
-        List<TeamMembership> rows = memberRepo.findPrimaryMembership(user.getId());
-        if (rows.isEmpty()) {
-            return new LeaderTeam(null, null, HttpStatus.FORBIDDEN);
-        }
-        TeamMembership m = rows.get(0);
-        if (m.getRole() != TeamRole.LEADER) {
-            return new LeaderTeam(null, null, HttpStatus.FORBIDDEN);
-        }
-        return new LeaderTeam(m.getTeam().getId(), user.getId(), null);
+    /** Delegates to the shared rule so the register and pairing paths cannot diverge. */
+    private LeaderTeamResolver.LeaderTeam resolveLeaderTeam(Authentication auth) {
+        return leaderTeamResolver.resolve(auth);
     }
 }

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/LeaderTeamResolver.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/LeaderTeamResolver.java
@@ -1,0 +1,59 @@
+package stirling.software.saas.accountlink;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import stirling.software.common.model.enumeration.TeamRole;
+import stirling.software.proprietary.model.TeamMembership;
+import stirling.software.proprietary.security.database.repository.UserRepository;
+import stirling.software.proprietary.security.model.User;
+import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+import stirling.software.saas.util.AuthenticationUtils;
+
+/**
+ * Resolves the caller's team and asserts they lead it.
+ *
+ * <p>Binding an instance to a team is a billing action, so both the JWT register path and the
+ * pairing approval path must agree on who is allowed to do it. Shared rather than duplicated
+ * precisely because it is an authorization rule: two copies could drift and one of them would be
+ * wrong.
+ */
+@Component
+@Profile("saas")
+@ConditionalOnProperty(name = "stirling.billing.account-link.enabled", havingValue = "true")
+public class LeaderTeamResolver {
+
+    private final TeamMembershipRepository memberRepo;
+    private final UserRepository userRepository;
+
+    public LeaderTeamResolver(TeamMembershipRepository memberRepo, UserRepository userRepository) {
+        this.memberRepo = memberRepo;
+        this.userRepository = userRepository;
+    }
+
+    /** Resolved caller team, or an {@code error} status to return (ids null when error). */
+    public record LeaderTeam(Long teamId, Long userId, HttpStatus error) {}
+
+    public LeaderTeam resolve(Authentication auth) {
+        User user;
+        try {
+            user = AuthenticationUtils.getCurrentUser(auth, userRepository);
+        } catch (SecurityException e) {
+            return new LeaderTeam(null, null, HttpStatus.UNAUTHORIZED);
+        }
+        List<TeamMembership> rows = memberRepo.findPrimaryMembership(user.getId());
+        if (rows.isEmpty()) {
+            return new LeaderTeam(null, null, HttpStatus.FORBIDDEN);
+        }
+        TeamMembership m = rows.get(0);
+        if (m.getRole() != TeamRole.LEADER) {
+            return new LeaderTeam(null, null, HttpStatus.FORBIDDEN);
+        }
+        return new LeaderTeam(m.getTeam().getId(), user.getId(), null);
+    }
+}

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/PairingController.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/PairingController.java
@@ -1,0 +1,213 @@
+package stirling.software.saas.accountlink;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Pairing-code surface for linking a self-hosted instance (RFC 8628 device grant).
+ *
+ * <p>Two unauthenticated endpoints for the instance ({@code /start}, {@code /poll}) and three for
+ * the admin on our own site ({@code /lookup}, {@code /approve}, {@code /deny}). The instance side
+ * is unauthenticated by design: the instance has no account, and the device code it receives from
+ * {@code /start} is the bearer secret that authorises its own polling.
+ *
+ * <p>Gated behind {@code stirling.billing.account-link.enabled}: off means the beans are absent and
+ * every path here 404s, so the {@code permitAll} entries in the security chain lead nowhere.
+ */
+@Slf4j
+@Hidden
+@RestController
+@RequestMapping("/api/v1/pair")
+@Profile("saas")
+@ConditionalOnProperty(name = "stirling.billing.account-link.enabled", havingValue = "true")
+public class PairingController {
+
+    private final PairingService service;
+    private final LeaderTeamResolver leaderTeamResolver;
+    private final String verificationUri;
+
+    public PairingController(
+            PairingService service,
+            LeaderTeamResolver leaderTeamResolver,
+            @Value(
+                            "${stirling.billing.account-link.pairing.verification-uri:https://stirling.com/link}")
+                    String verificationUri) {
+        this.service = service;
+        this.leaderTeamResolver = leaderTeamResolver;
+        this.verificationUri = verificationUri;
+    }
+
+    /** Instance-supplied hints shown on the approval screen. Both optional and both untrusted. */
+    public record StartRequest(String name, String version) {}
+
+    public record StartResponse(
+            String userCode,
+            String deviceCode,
+            String verificationUri,
+            long expiresInSeconds,
+            int intervalSeconds) {}
+
+    public record PollRequest(String deviceCode) {}
+
+    /**
+     * {@code status} is one of pending, approved, denied, expired, slow_down, unknown. Credential
+     * fields are populated only on approved, and only on the first such poll.
+     */
+    public record PollResponse(
+            String status,
+            String deviceId,
+            String deviceSecret,
+            Long teamId,
+            int intervalSeconds) {}
+
+    public record PendingResponse(
+            String userCode,
+            String name,
+            String version,
+            String address,
+            String requestedAt,
+            String expiresAt) {}
+
+    public record ApproveRequest(String code, String name) {}
+
+    public record CodeRequest(String code) {}
+
+    // -------------------------------------------------------------------------------------------
+    // Instance side, unauthenticated
+    // -------------------------------------------------------------------------------------------
+
+    @PostMapping("/start")
+    public ResponseEntity<StartResponse> start(
+            @RequestBody(required = false) StartRequest req, HttpServletRequest http) {
+        String name = req != null ? req.name() : null;
+        String version = req != null ? req.version() : null;
+        PairingService.StartResult result;
+        try {
+            result = service.start(name, version, clientIp(http));
+        } catch (PairingService.TooManyRequestsException e) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
+        }
+        long expiresIn =
+                Math.max(0, ChronoUnit.SECONDS.between(LocalDateTime.now(), result.expiresAt()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(
+                        new StartResponse(
+                                PairingService.forDisplay(result.userCode()),
+                                result.deviceCode(),
+                                verificationUri,
+                                expiresIn,
+                                result.intervalSeconds()));
+    }
+
+    /**
+     * Always 200 with a status, rather than the RFC's error-coded 400s. The instance treats this as
+     * a state read and has no use for the distinction, and a 200 keeps a routine "still waiting"
+     * out of upstream error logs.
+     */
+    @PostMapping("/poll")
+    public ResponseEntity<PollResponse> poll(@RequestBody(required = false) PollRequest req) {
+        PairingService.PollResult result = service.poll(req != null ? req.deviceCode() : null);
+        String status = result.outcome().name().toLowerCase(java.util.Locale.ROOT);
+        if (result.outcome() != PairingService.PollOutcome.APPROVED) {
+            return ResponseEntity.ok(
+                    new PollResponse(status, null, null, null, PairingService.INTERVAL_SECONDS));
+        }
+        return ResponseEntity.ok(
+                new PollResponse(
+                        status,
+                        result.credential().deviceId(),
+                        result.credential().deviceSecret(),
+                        result.teamId(),
+                        PairingService.INTERVAL_SECONDS));
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Admin side, on our own origin, team leaders only
+    // -------------------------------------------------------------------------------------------
+
+    @GetMapping("/lookup")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<PendingResponse> lookup(
+            @RequestParam("code") String code, Authentication auth) {
+        LeaderTeamResolver.LeaderTeam lt = leaderTeamResolver.resolve(auth);
+        if (lt.error() != null) {
+            return ResponseEntity.status(lt.error()).build();
+        }
+        Optional<PairingService.PendingView> pending = service.lookup(code);
+        return pending.map(
+                        p ->
+                                ResponseEntity.ok(
+                                        new PendingResponse(
+                                                PairingService.forDisplay(p.userCode()),
+                                                p.instanceLabel(),
+                                                p.instanceVersion(),
+                                                p.requesterIp(),
+                                                p.createdAt() != null
+                                                        ? p.createdAt().toString()
+                                                        : null,
+                                                p.expiresAt() != null
+                                                        ? p.expiresAt().toString()
+                                                        : null)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/approve")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> approve(@RequestBody ApproveRequest req, Authentication auth) {
+        LeaderTeamResolver.LeaderTeam lt = leaderTeamResolver.resolve(auth);
+        if (lt.error() != null) {
+            return ResponseEntity.status(lt.error()).build();
+        }
+        boolean ok = service.approve(req.code(), lt.teamId(), lt.userId(), req.name());
+        return ok ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/deny")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deny(@RequestBody CodeRequest req, Authentication auth) {
+        LeaderTeamResolver.LeaderTeam lt = leaderTeamResolver.resolve(auth);
+        if (lt.error() != null) {
+            return ResponseEntity.status(lt.error()).build();
+        }
+        boolean ok = service.deny(req.code());
+        return ok ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    /**
+     * Best guess at the caller's address, shown on the approval screen and used as rate-limit
+     * input.
+     *
+     * <p>Hint only. The first {@code X-Forwarded-For} hop is client-set, so it is both spoofable
+     * and a weak rate-limit key. It earns its place by helping a leader recognise their own server;
+     * the controls that actually matter are the short code lifetime, leader-only approval, and the
+     * approval screen itself.
+     */
+    private static String clientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/PairingController.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/PairingController.java
@@ -43,19 +43,61 @@ import lombok.extern.slf4j.Slf4j;
 @ConditionalOnProperty(name = "stirling.billing.account-link.enabled", havingValue = "true")
 public class PairingController {
 
+    /** Path of the approval page, appended to whichever base URL we resolve. */
+    static final String LINK_PATH = "/link";
+
     private final PairingService service;
     private final LeaderTeamResolver leaderTeamResolver;
-    private final String verificationUri;
+    private final String configuredBaseUrl;
 
     public PairingController(
             PairingService service,
             LeaderTeamResolver leaderTeamResolver,
-            @Value(
-                            "${stirling.billing.account-link.pairing.verification-uri:https://stirling.com/link}")
-                    String verificationUri) {
+            @Value("${stirling.billing.account-link.pairing.base-url:}") String configuredBaseUrl) {
         this.service = service;
         this.leaderTeamResolver = leaderTeamResolver;
-        this.verificationUri = verificationUri;
+        this.configuredBaseUrl = configuredBaseUrl;
+    }
+
+    /**
+     * Where the admin goes to approve: our own base URL plus {@value #LINK_PATH}.
+     *
+     * <p>Left unset, this is derived from the request that reached us, which is right by
+     * construction because the approval page is served by this same app. Hard-coding a default host
+     * would silently point staging and self-hosted-cloud deployments at production, and any guess
+     * also has to get the context path right. An operator can still pin it with {@code
+     * stirling.billing.account-link.pairing.base-url} when the API and the web app are not on the
+     * same origin.
+     *
+     * <p>The derived form trusts the forwarded host, which is client-controlled. That is fine here:
+     * the value is only ever echoed back to the caller that supplied it, so a spoofed host misleads
+     * nobody but the spoofer.
+     */
+    private String verificationUri(HttpServletRequest request) {
+        if (configuredBaseUrl != null && !configuredBaseUrl.isBlank()) {
+            return configuredBaseUrl.strip().replaceAll("/+$", "") + LINK_PATH;
+        }
+        String forwardedHost = firstHeaderValue(request, "X-Forwarded-Host");
+        String host = forwardedHost != null ? forwardedHost : request.getHeader("Host");
+        String scheme =
+                firstNonBlank(firstHeaderValue(request, "X-Forwarded-Proto"), request.getScheme());
+        if (host == null || host.isBlank()) {
+            host = request.getServerName();
+        }
+        String contextPath = request.getContextPath() == null ? "" : request.getContextPath();
+        return scheme + "://" + host + contextPath + LINK_PATH;
+    }
+
+    private static String firstHeaderValue(HttpServletRequest request, String name) {
+        String value = request.getHeader(name);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.split(",")[0].trim();
+    }
+
+    private static String firstNonBlank(String a, String b) {
+        return a != null && !a.isBlank() ? a : b;
     }
 
     /** Instance-supplied hints shown on the approval screen. Both optional and both untrusted. */
@@ -115,7 +157,7 @@ public class PairingController {
                         new StartResponse(
                                 PairingService.forDisplay(result.userCode()),
                                 result.deviceCode(),
-                                verificationUri,
+                                verificationUri(http),
                                 expiresIn,
                                 result.intervalSeconds()));
     }

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/PairingController.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/PairingController.java
@@ -6,7 +6,9 @@ import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -60,14 +62,15 @@ public class PairingController {
     }
 
     /**
-     * Where the admin goes to approve: our own base URL plus {@value #LINK_PATH}.
+     * Where the admin goes to approve: the SaaS <b>web app's</b> base URL plus {@value #LINK_PATH}.
      *
-     * <p>Left unset, this is derived from the request that reached us, which is right by
-     * construction because the approval page is served by this same app. Hard-coding a default host
-     * would silently point staging and self-hosted-cloud deployments at production, and any guess
-     * also has to get the context path right. An operator can still pin it with {@code
-     * stirling.billing.account-link.pairing.base-url} when the API and the web app are not on the
-     * same origin.
+     * <p>This must be the origin that serves the SPA, because {@code /link} is a frontend route. In
+     * a deployment where one JAR serves both the API and the SPA they are the same host, so the
+     * request-derived fallback below is correct. Where they are split — a separate API host, or
+     * local dev with a Vite server on another port — deriving gives an API origin that renders
+     * nothing, so {@code stirling.billing.account-link.pairing.base-url} has to be set. That is why
+     * an unset value warns at startup rather than failing quietly: the symptom is a blank page at
+     * the end of the flow, which is a long way from the cause.
      *
      * <p>The derived form trusts the forwarded host, which is client-controlled. That is fine here:
      * the value is only ever echoed back to the caller that supplied it, so a spoofed host misleads
@@ -98,6 +101,30 @@ public class PairingController {
 
     private static String firstNonBlank(String a, String b) {
         return a != null && !a.isBlank() ? a : b;
+    }
+
+    /**
+     * Warns when the approval URL will be guessed from the request rather than configured.
+     *
+     * <p>Guessing is right only where the API and the SPA share an origin. Anywhere else the admin
+     * is handed an API host that renders nothing, and the flow dead-ends on a blank page with no
+     * hint as to why. Cheap to say so at boot; expensive to work out from the symptom.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void warnIfApprovalUrlIsGuessed() {
+        if (configuredBaseUrl != null && !configuredBaseUrl.isBlank()) {
+            log.info("Pairing: approval URL base is {}", configuredBaseUrl.strip());
+            return;
+        }
+        log.warn(
+                """
+                Pairing: stirling.billing.account-link.pairing.base-url is not set, so the approval \
+                URL will be derived from each incoming request.
+                  - Correct only if this app also serves the web UI on the same origin.
+                  - If the API and the SPA are on different hosts (a split deployment, or local dev \
+                with a separate Vite server), the admin will be sent to an origin with no /link \
+                page and the pairing will dead-end on a blank screen.\
+                """);
     }
 
     /** Instance-supplied hints shown on the approval screen. Both optional and both untrusted. */

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/PairingRequest.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/PairingRequest.java
@@ -1,0 +1,110 @@
+package stirling.software.saas.accountlink;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One in-flight pairing between a self-hosted instance and a SaaS team (OAuth device authorization
+ * grant, RFC 8628).
+ *
+ * <p>The instance starts a pairing unauthenticated and receives two values: a short {@code
+ * user_code} the admin types on our site, and a high-entropy {@code device_code} only the instance
+ * ever holds. We store the user code in the clear because it is useless on its own (approving
+ * requires an authenticated team leader) but keep only a SHA-256 hash of the device code, which is
+ * the real bearer secret.
+ *
+ * <p>Lifecycle: {@code PENDING} on start, {@code APPROVED} once a leader confirms it, {@code
+ * CONSUMED} when the instance polls and collects its device credential. Approval deliberately does
+ * not mint the credential; minting happens on the poll that presents the device code, so the secret
+ * is only ever delivered to the party that started the pairing. {@code DENIED} is a leader
+ * rejecting it. Expiry is by {@code expires_at} rather than a status, so a stale row reads as
+ * expired without needing a sweeper.
+ */
+@Entity
+@Table(name = "account_pairing_request")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PairingRequest {
+
+    public enum Status {
+        PENDING,
+        APPROVED,
+        CONSUMED,
+        DENIED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pairing_id")
+    private Long pairingId;
+
+    /** Normalised (upper case, no separator) code the admin types. Unique while it lives. */
+    @Column(name = "user_code", nullable = false, unique = true, length = 16)
+    private String userCode;
+
+    /** SHA-256 hex of the device code. The plaintext exists only on the instance. */
+    @Column(name = "device_code_hash", nullable = false, length = 64)
+    private String deviceCodeHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private Status status = Status.PENDING;
+
+    /** Set on approval; the team the instance will be bound to. */
+    @Column(name = "team_id")
+    private Long teamId;
+
+    @Column(name = "approved_by_user_id")
+    private Long approvedByUserId;
+
+    /**
+     * Instance-supplied label, shown on the approval screen so a leader knows what they approve.
+     */
+    @Column(name = "instance_label", length = 128)
+    private String instanceLabel;
+
+    @Column(name = "instance_version", length = 32)
+    private String instanceVersion;
+
+    /** Caller address as seen by us, shown on the approval screen and used for rate limiting. */
+    @Column(name = "requester_ip", length = 64)
+    private String requesterIp;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    /**
+     * Last poll, so an instance polling faster than the advertised interval can be told to slow.
+     */
+    @Column(name = "last_polled_at")
+    private LocalDateTime lastPolledAt;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @Column(name = "consumed_at")
+    private LocalDateTime consumedAt;
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt != null && now.isAfter(expiresAt);
+    }
+}

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/PairingRequestRepository.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/PairingRequestRepository.java
@@ -1,0 +1,30 @@
+package stirling.software.saas.accountlink;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+
+@Repository
+public interface PairingRequestRepository extends JpaRepository<PairingRequest, Long> {
+
+    Optional<PairingRequest> findByUserCode(String userCode);
+
+    /**
+     * Row-locked read for the poll path. Two pods of one deployment can present the same device
+     * code concurrently; without the lock both could pass the {@code APPROVED} check and mint two
+     * credentials for one pairing.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from PairingRequest p where p.deviceCodeHash = :hash")
+    Optional<PairingRequest> findByDeviceCodeHashForUpdate(@Param("hash") String hash);
+
+    /** Rate-limit input: how many pairings this address has started recently. */
+    long countByRequesterIpAndCreatedAtAfter(String requesterIp, LocalDateTime after);
+}

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/PairingService.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/PairingService.java
@@ -44,7 +44,10 @@ public class PairingService {
     /** Short enough that a leaked code is near-useless, long enough to walk to another device. */
     static final Duration LIFETIME = Duration.ofMinutes(10);
 
-    /** Advertised poll interval. Polling faster than this earns a SLOW_DOWN. */
+    /**
+     * Advertised poll interval. Polling the waiting loop faster than this earns a SLOW_DOWN; an
+     * already-approved pairing is always delivered immediately (see {@link #poll}).
+     */
     static final int INTERVAL_SECONDS = 5;
 
     /** Concurrent pairings one address may start within {@link #LIFETIME}. */
@@ -123,7 +126,8 @@ public class PairingService {
         request.setExpiresAt(now.plus(LIFETIME));
         repo.save(request);
 
-        log.info("Pairing: started {} for label {}", userCode, request.getInstanceLabel());
+        // The user code is a live secret while the pairing is open, so it stays out of the log.
+        log.info("Pairing: started for label {}", request.getInstanceLabel());
         return new StartResult(userCode, deviceCode, request.getExpiresAt(), INTERVAL_SECONDS);
     }
 
@@ -163,7 +167,7 @@ public class PairingService {
             request.setInstanceLabel(trim(name, 128));
         }
         repo.save(request);
-        log.info("Pairing: {} approved for team {}", request.getUserCode(), teamId);
+        log.info("Pairing: approved for team {}", teamId);
         return true;
     }
 
@@ -176,7 +180,7 @@ public class PairingService {
         PairingRequest request = found.get();
         request.setStatus(PairingRequest.Status.DENIED);
         repo.save(request);
-        log.info("Pairing: {} denied", request.getUserCode());
+        log.info("Pairing: declined");
         return true;
     }
 
@@ -209,11 +213,16 @@ public class PairingService {
         }
 
         LocalDateTime lastPolled = request.getLastPolledAt();
-        boolean tooFast =
-                lastPolled != null && lastPolled.plusSeconds(INTERVAL_SECONDS).isAfter(now);
         request.setLastPolledAt(now);
 
         if (request.getStatus() == PairingRequest.Status.PENDING) {
+            // The interval throttles the waiting loop, which is the only part that repeats. It is
+            // deliberately NOT applied to an approved pairing below: that is a one-shot terminal
+            // step, the credential is already sitting there, and delaying it would just make
+            // pairing feel slow. Nothing is protected by stalling it, since the CONSUMED flip plus
+            // the row lock already make minting happen exactly once.
+            boolean tooFast =
+                    lastPolled != null && lastPolled.plusSeconds(INTERVAL_SECONDS).isAfter(now);
             repo.save(request);
             return PollResult.of(tooFast ? PollOutcome.SLOW_DOWN : PollOutcome.PENDING);
         }
@@ -226,9 +235,9 @@ public class PairingService {
         request.setStatus(PairingRequest.Status.CONSUMED);
         request.setConsumedAt(now);
         repo.save(request);
+        // Don't log the user code: it is a live secret for as long as the pairing is open.
         log.info(
-                "Pairing: {} consumed, instance {} bound to team {}",
-                request.getUserCode(),
+                "Pairing: consumed, instance {} bound to team {}",
                 credential.instanceId(),
                 request.getTeamId());
         return new PollResult(PollOutcome.APPROVED, credential, request.getTeamId());

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/PairingService.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/PairingService.java
@@ -1,0 +1,294 @@
+package stirling.software.saas.accountlink;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Device-grant pairing between a self-hosted instance and a SaaS team (RFC 8628).
+ *
+ * <p>Replaces carrying an admin's Supabase JWT through the instance's browser. The instance starts
+ * a pairing and polls; the admin approves on our own site, where redirects and SSO already work.
+ * That is the whole point: a customer origin can never be on the Supabase redirect allow-list, so
+ * the human half of the flow has to happen somewhere we control.
+ *
+ * <p>Credential minting is delegated to {@link AccountLinkService#register}, so a paired instance
+ * is indistinguishable from one registered the old way and everything downstream (entitlement,
+ * metering, revocation) is untouched.
+ */
+@Slf4j
+@Service
+@Profile("saas")
+@ConditionalOnProperty(name = "stirling.billing.account-link.enabled", havingValue = "true")
+public class PairingService {
+
+    /**
+     * User-code alphabet with the ambiguous characters removed (no I, L, O, U, 0, 1) so a code read
+     * off one screen and typed on another cannot be mistyped into a different valid code.
+     */
+    private static final String ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789";
+
+    private static final int USER_CODE_LENGTH = 8;
+    private static final int DEVICE_CODE_BYTES = 32;
+
+    /** Short enough that a leaked code is near-useless, long enough to walk to another device. */
+    static final Duration LIFETIME = Duration.ofMinutes(10);
+
+    /** Advertised poll interval. Polling faster than this earns a SLOW_DOWN. */
+    static final int INTERVAL_SECONDS = 5;
+
+    /** Concurrent pairings one address may start within {@link #LIFETIME}. */
+    static final int MAX_STARTS_PER_IP = 5;
+
+    /** Attempts before we give up finding an unused user code (collisions are vanishingly rare). */
+    private static final int CODE_ATTEMPTS = 10;
+
+    private final PairingRequestRepository repo;
+    private final AccountLinkService accountLinkService;
+    private final SecureRandom random = new SecureRandom();
+
+    public PairingService(PairingRequestRepository repo, AccountLinkService accountLinkService) {
+        this.repo = repo;
+        this.accountLinkService = accountLinkService;
+    }
+
+    public record StartResult(
+            String userCode, String deviceCode, LocalDateTime expiresAt, int intervalSeconds) {}
+
+    /**
+     * What a leader is shown before approving. Deliberately specific: this is the phishing guard.
+     */
+    public record PendingView(
+            String userCode,
+            String instanceLabel,
+            String instanceVersion,
+            String requesterIp,
+            LocalDateTime createdAt,
+            LocalDateTime expiresAt) {}
+
+    public enum PollOutcome {
+        PENDING,
+        APPROVED,
+        DENIED,
+        EXPIRED,
+        SLOW_DOWN,
+        UNKNOWN
+    }
+
+    /** {@code credential} is populated only on {@link PollOutcome#APPROVED}, exactly once. */
+    public record PollResult(
+            PollOutcome outcome, AccountLinkService.RegisteredInstance credential, Long teamId) {
+
+        static PollResult of(PollOutcome outcome) {
+            return new PollResult(outcome, null, null);
+        }
+    }
+
+    /** Raised when an address starts more concurrent pairings than {@link #MAX_STARTS_PER_IP}. */
+    public static class TooManyRequestsException extends RuntimeException {
+        public TooManyRequestsException() {
+            super("Too many pairing requests from this address");
+        }
+    }
+
+    @Transactional
+    public StartResult start(String instanceLabel, String instanceVersion, String requesterIp) {
+        LocalDateTime now = LocalDateTime.now();
+        if (requesterIp != null
+                && repo.countByRequesterIpAndCreatedAtAfter(requesterIp, now.minus(LIFETIME))
+                        >= MAX_STARTS_PER_IP) {
+            throw new TooManyRequestsException();
+        }
+
+        String userCode = allocateUserCode();
+        String deviceCode = randomDeviceCode();
+
+        PairingRequest request = new PairingRequest();
+        request.setUserCode(userCode);
+        request.setDeviceCodeHash(AccountLinkService.sha256Hex(deviceCode));
+        request.setStatus(PairingRequest.Status.PENDING);
+        request.setInstanceLabel(trim(instanceLabel, 128));
+        request.setInstanceVersion(trim(instanceVersion, 32));
+        request.setRequesterIp(trim(requesterIp, 64));
+        request.setExpiresAt(now.plus(LIFETIME));
+        repo.save(request);
+
+        log.info("Pairing: started {} for label {}", userCode, request.getInstanceLabel());
+        return new StartResult(userCode, deviceCode, request.getExpiresAt(), INTERVAL_SECONDS);
+    }
+
+    /**
+     * The pending pairing behind a typed code, or empty when unknown, expired or already settled.
+     */
+    @Transactional(readOnly = true)
+    public Optional<PendingView> lookup(String typedCode) {
+        return findPending(typedCode)
+                .map(
+                        p ->
+                                new PendingView(
+                                        p.getUserCode(),
+                                        p.getInstanceLabel(),
+                                        p.getInstanceVersion(),
+                                        p.getRequesterIp(),
+                                        p.getCreatedAt(),
+                                        p.getExpiresAt()));
+    }
+
+    /**
+     * Binds a pending pairing to {@code teamId}. The caller must already have been checked for team
+     * leadership; the team is never taken from the request body.
+     */
+    @Transactional
+    public boolean approve(String typedCode, Long teamId, Long userId, String name) {
+        Optional<PairingRequest> found = findPending(typedCode);
+        if (found.isEmpty()) {
+            return false;
+        }
+        PairingRequest request = found.get();
+        request.setStatus(PairingRequest.Status.APPROVED);
+        request.setTeamId(teamId);
+        request.setApprovedByUserId(userId);
+        request.setApprovedAt(LocalDateTime.now());
+        if (name != null && !name.isBlank()) {
+            request.setInstanceLabel(trim(name, 128));
+        }
+        repo.save(request);
+        log.info("Pairing: {} approved for team {}", request.getUserCode(), teamId);
+        return true;
+    }
+
+    @Transactional
+    public boolean deny(String typedCode) {
+        Optional<PairingRequest> found = findPending(typedCode);
+        if (found.isEmpty()) {
+            return false;
+        }
+        PairingRequest request = found.get();
+        request.setStatus(PairingRequest.Status.DENIED);
+        repo.save(request);
+        log.info("Pairing: {} denied", request.getUserCode());
+        return true;
+    }
+
+    /**
+     * The instance's poll. Mints the device credential on the first poll after approval and marks
+     * the pairing consumed, so a replayed device code cannot mint a second credential.
+     */
+    @Transactional
+    public PollResult poll(String deviceCode) {
+        if (deviceCode == null || deviceCode.isBlank()) {
+            return PollResult.of(PollOutcome.UNKNOWN);
+        }
+        Optional<PairingRequest> found =
+                repo.findByDeviceCodeHashForUpdate(AccountLinkService.sha256Hex(deviceCode));
+        if (found.isEmpty()) {
+            return PollResult.of(PollOutcome.UNKNOWN);
+        }
+        PairingRequest request = found.get();
+        LocalDateTime now = LocalDateTime.now();
+
+        // Consumed is terminal and must never mint again, even before the expiry passes.
+        if (request.getStatus() == PairingRequest.Status.CONSUMED) {
+            return PollResult.of(PollOutcome.UNKNOWN);
+        }
+        if (request.getStatus() == PairingRequest.Status.DENIED) {
+            return PollResult.of(PollOutcome.DENIED);
+        }
+        if (request.isExpired(now)) {
+            return PollResult.of(PollOutcome.EXPIRED);
+        }
+
+        LocalDateTime lastPolled = request.getLastPolledAt();
+        boolean tooFast =
+                lastPolled != null && lastPolled.plusSeconds(INTERVAL_SECONDS).isAfter(now);
+        request.setLastPolledAt(now);
+
+        if (request.getStatus() == PairingRequest.Status.PENDING) {
+            repo.save(request);
+            return PollResult.of(tooFast ? PollOutcome.SLOW_DOWN : PollOutcome.PENDING);
+        }
+
+        AccountLinkService.RegisteredInstance credential =
+                accountLinkService.register(
+                        request.getTeamId(),
+                        request.getApprovedByUserId(),
+                        request.getInstanceLabel());
+        request.setStatus(PairingRequest.Status.CONSUMED);
+        request.setConsumedAt(now);
+        repo.save(request);
+        log.info(
+                "Pairing: {} consumed, instance {} bound to team {}",
+                request.getUserCode(),
+                credential.instanceId(),
+                request.getTeamId());
+        return new PollResult(PollOutcome.APPROVED, credential, request.getTeamId());
+    }
+
+    /** Accepts what a human typed: any case, with or without the display separator. */
+    static String normalise(String typedCode) {
+        if (typedCode == null) {
+            return "";
+        }
+        return typedCode.replaceAll("[^A-Za-z0-9]", "").toUpperCase(Locale.ROOT);
+    }
+
+    /** Groups a stored code for display, e.g. {@code WXYZ4821} to {@code WXYZ-4821}. */
+    static String forDisplay(String userCode) {
+        if (userCode == null || userCode.length() != USER_CODE_LENGTH) {
+            return userCode;
+        }
+        return userCode.substring(0, 4) + "-" + userCode.substring(4);
+    }
+
+    private Optional<PairingRequest> findPending(String typedCode) {
+        String normalised = normalise(typedCode);
+        if (normalised.isEmpty()) {
+            return Optional.empty();
+        }
+        return repo.findByUserCode(normalised)
+                .filter(p -> p.getStatus() == PairingRequest.Status.PENDING)
+                .filter(p -> !p.isExpired(LocalDateTime.now()));
+    }
+
+    private String allocateUserCode() {
+        for (int attempt = 0; attempt < CODE_ATTEMPTS; attempt++) {
+            String candidate = randomUserCode();
+            if (repo.findByUserCode(candidate).isEmpty()) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("Could not allocate a free pairing code");
+    }
+
+    private String randomUserCode() {
+        StringBuilder sb = new StringBuilder(USER_CODE_LENGTH);
+        for (int i = 0; i < USER_CODE_LENGTH; i++) {
+            sb.append(ALPHABET.charAt(random.nextInt(ALPHABET.length())));
+        }
+        return sb.toString();
+    }
+
+    private String randomDeviceCode() {
+        byte[] buf = new byte[DEVICE_CODE_BYTES];
+        random.nextBytes(buf);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+    }
+
+    private static String trim(String value, int max) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String stripped = value.strip();
+        return stripped.length() <= max ? stripped : stripped.substring(0, max);
+    }
+}

--- a/app/saas/src/main/java/stirling/software/saas/config/DevProfileProjectNotice.java
+++ b/app/saas/src/main/java/stirling/software/saas/config/DevProfileProjectNotice.java
@@ -1,0 +1,60 @@
+package stirling.software.saas.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Says which Supabase project the {@code dev} profile actually ended up on.
+ *
+ * <p>The dev profile follows a SaaS PR's preview branch via {@code SAAS_DEV_PROJECT_REF}, and falls
+ * back to staging when that is unset so a checkout with no PR in flight still boots. The fallback
+ * is the reason this exists: running against staging while you believe you are on a PR branch looks
+ * exactly like the PR working, right up until a migration the PR added is missing and you get
+ * {@code relation ... does not exist}. Worth a loud line at startup rather than a silent surprise
+ * several requests later.
+ *
+ * <p>Logged on {@link ApplicationReadyEvent} so it lands at the end of the boot output where it can
+ * be seen, not buried in the middle of bean initialisation.
+ */
+@Slf4j
+@Component
+@Profile("dev")
+public class DevProfileProjectNotice {
+
+    private final String requestedRef;
+    private final String resolvedRef;
+
+    public DevProfileProjectNotice(
+            @Value("${SAAS_DEV_PROJECT_REF:}") String requestedRef,
+            @Value("${app.supabase.project-ref:}") String resolvedRef) {
+        this.requestedRef = requestedRef;
+        this.resolvedRef = resolvedRef;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void announceProject() {
+        if (requestedRef != null && !requestedRef.isBlank()) {
+            log.info(
+                    "SaaS dev profile: using Supabase preview branch {} (SAAS_DEV_PROJECT_REF).",
+                    resolvedRef);
+            return;
+        }
+        log.warn(
+                """
+                SaaS dev profile: SAAS_DEV_PROJECT_REF is not set, so this is running against \
+                STAGING ({}), not a PR preview branch.
+                  - Fine if you meant staging; prefer PROFILES=staging to say so explicitly.
+                  - NOT fine if you are testing a SaaS PR: staging will be missing that PR's \
+                migrations, which shows up as "relation ... does not exist".
+                  - To follow a PR, set SAAS_DEV_PROJECT_REF (plus that branch's \
+                SAAS_DEV_DB_PASSWORD and SAAS_DEV_PUBLISHABLE_KEY) in app/.env.saas.local. The ref \
+                is on the SaaS PR's "Supabase Preview" check.\
+                """,
+                resolvedRef);
+    }
+}

--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
@@ -288,6 +288,10 @@ public class SupabaseSecurityConfig {
                         : List.of(
                                 "http://localhost:3000",
                                 "http://localhost:5173",
+                                // The saas-flavour frontend dev server. 5173 is taken by the
+                                // self-hosted editor when both run together, which is the normal
+                                // setup for anything spanning instance and cloud.
+                                "http://localhost:5174",
                                 "http://localhost:8080",
                                 "https://stirling.com",
                                 "https://app.stirling.com",

--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
@@ -105,6 +105,13 @@ public class SupabaseSecurityConfig {
                                         .permitAll()
                                         .requestMatchers("/actuator/health", "/api/v1/config/**")
                                         .permitAll()
+                                        // Device-grant pairing: an unlinked instance has no
+                                        // account, so it cannot authenticate here. The device code
+                                        // returned by /start is the bearer secret that authorises
+                                        // its own /poll. Approval stays authenticated and
+                                        // leader-only. Both 404 unless account-link is enabled.
+                                        .requestMatchers("/api/v1/pair/start", "/api/v1/pair/poll")
+                                        .permitAll()
                                         .requestMatchers(
                                                 req ->
                                                         RequestUriUtils.isStaticResource(

--- a/app/saas/src/main/resources/application-dev.properties
+++ b/app/saas/src/main/resources/application-dev.properties
@@ -1,16 +1,54 @@
-# SaaS dev profile. Points at the dev Supabase project.
+# SaaS dev profile. Follows the Supabase preview branch of whichever SaaS PR you are working on.
+#
 # Boot: java -jar stirling-pdf.jar --spring.profiles.include=dev
+#   or: task backend:dev:saas PROFILES=dev   (dev is the task default)
+#
+# Unlike `staging`, this profile is deliberately NOT pinned to a project. Each SaaS PR gets its own
+# Supabase preview branch with its own ref, its own database and its own API keys, and that branch
+# is where the PR's migrations have actually been applied. So switching which PR you are testing is
+# one variable: SAAS_DEV_PROJECT_REF. Everything else is derived from it, the same way the prod
+# `saas` profile derives from SAAS_DB_PROJECT_REF.
+#
+# Want a stable, shared environment that will still be there next week? Use `staging`.
+#
+# With no SAAS_DEV_PROJECT_REF set, this profile falls back to staging and says so at startup.
+
 spring.config.import=optional:classpath:application-dev-local.properties
 
-app.supabase.project-ref=qacaivhsjtftfwtgjvva
+# ---------- Schema ----------
+# Let Hibernate reconcile the entity tables so a freshly created preview branch heals itself.
+#
+# A branch is built from the Supabase migrations, and those cover the SaaS-owned tables but not the
+# ~28 tables inherited from the self-hosted app (policies, stored_files, api_keys, the account-link
+# ones and so on). Those have only ever been created by ddl-auto, which is why a branch that has
+# never had the app booted against it comes up missing them.
+#
+# Safe here and only here: a preview branch is disposable, and `update` only ever adds. staging and
+# prod are NOT on this path (staging pins `none`; both already have the tables), so this must stay a
+# dev-profile setting rather than a global env var.
+spring.jpa.hibernate.ddl-auto=update
 
-stirling.supabase.url=https://qacaivhsjtftfwtgjvva.supabase.co
-stirling.supabase.publishable-key=sb_publishable_nIM8y-9ARPE7EzQwAQHKMg_40fCN6kY # gitleaks:allow
+# The preview branch ref (the <ref> in <ref>.supabase.co), from the SaaS PR's "Supabase Preview"
+# check. When it is not set, this falls back to the staging project rather than refusing to boot,
+# so a checkout with no PR in flight still runs. DevProfileProjectNotice logs a loud WARN when that
+# happens, because silently running against staging while you believe you are on a PR branch is the
+# one outcome worth shouting about.
+app.supabase.project-ref=${SAAS_DEV_PROJECT_REF:${SAAS_STAGING_PROJECT_REF:qacaivhsjtftfwtgjvva}}
 
-spring.datasource.url=${SAAS_DEV_DB_URL:jdbc:postgresql://db.qacaivhsjtftfwtgjvva.supabase.co:5432/postgres?ApplicationName=stirling-consolidation-${user.name}}
+# Everything below derives from the resolved ref above, so it follows the fallback too.
+stirling.supabase.url=https://${app.supabase.project-ref}.supabase.co
+# Per-branch and not derivable, so it has to be supplied. Dashboard > Settings > API.
+# Falls back to the staging key so the fallback is coherent rather than half-applied.
+stirling.supabase.publishable-key=${SAAS_DEV_PUBLISHABLE_KEY:${SAAS_STAGING_PUBLISHABLE_KEY:sb_publishable_nIM8y-9ARPE7EzQwAQHKMg_40fCN6kY}}
+
+# Host is derived from the resolved ref. Override the whole URL if the branch needs the pooler host
+# instead of the direct one, or if you want different connection parameters.
+spring.datasource.url=${SAAS_DEV_DB_URL:jdbc:postgresql://db.${app.supabase.project-ref}.supabase.co:5432/postgres?ApplicationName=stirling-dev-${user.name}}
 spring.datasource.username=${SAAS_DEV_DB_USERNAME:postgres}
 # Password not committed; export SAAS_DEV_DB_PASSWORD or pass --spring.datasource.password=...
-spring.datasource.password=${SAAS_DEV_DB_PASSWORD:}
+# NB a preview branch has its own password: the parent project's will not authenticate. Falls back
+# to the staging password so the staging fallback actually connects.
+spring.datasource.password=${SAAS_DEV_DB_PASSWORD:${SAAS_STAGING_DB_PASSWORD:}}
 
 # Conservative dev pool sizing.
 spring.datasource.hikari.maximum-pool-size=2
@@ -18,7 +56,7 @@ spring.datasource.hikari.minimum-idle=1
 spring.datasource.hikari.idle-timeout=60000
 spring.datasource.hikari.max-lifetime=1800000
 spring.datasource.hikari.keepalive-time=300000
-spring.datasource.hikari.data-source-properties.ApplicationName=stirling-consolidation-${user.name}
+spring.datasource.hikari.data-source-properties.ApplicationName=stirling-dev-${user.name}
 
 logging.level.stirling.software.saas=DEBUG
 logging.level.org.springframework.security.oauth2.jwt=WARN
@@ -29,4 +67,4 @@ logging.level.org.springframework.security.oauth2.server.resource=WARN
 # shared secret the team-invitation flow uses — no service-role key in the Java env).
 # Blank secret → the meter service no-ops with a WARN, so the app still boots.
 # The billing portal is NOT here — the FE calls create-customer-portal-session directly.
-payg.meter.endpoint=https://qacaivhsjtftfwtgjvva.supabase.co/functions/v1/meter-payg-units
+payg.meter.endpoint=https://${app.supabase.project-ref}.supabase.co/functions/v1/meter-payg-units

--- a/app/saas/src/main/resources/application-staging.properties
+++ b/app/saas/src/main/resources/application-staging.properties
@@ -1,0 +1,47 @@
+# SaaS staging profile. The long-lived shared environment on the v3 Supabase project.
+#
+# Boot: java -jar stirling-pdf.jar --spring.profiles.include=staging
+#   or: task backend:dev:saas PROFILES=staging
+#
+# Staging is PINNED to one project on purpose. It is the environment you can rely on being there
+# tomorrow: shared data, shared teams, stable URLs to paste into a ticket. Use it when you want to
+# reproduce something or hand a link to someone else.
+#
+# For work on an open SaaS PR use the `dev` profile instead, which follows that PR's Supabase
+# preview branch and therefore changes as PRs come and go.
+
+spring.config.import=optional:classpath:application-staging-local.properties
+
+# ---------- Schema ----------
+# Pinned OFF, and stated rather than inherited. Staging's schema is shared and already populated;
+# application-saas.properties defaults to `update`, so without this line staging would quietly pick
+# it up and Hibernate could start reconciling tables that RLS policies depend on.
+spring.jpa.hibernate.ddl-auto=none
+
+app.supabase.project-ref=qacaivhsjtftfwtgjvva
+
+stirling.supabase.url=https://qacaivhsjtftfwtgjvva.supabase.co
+stirling.supabase.publishable-key=sb_publishable_nIM8y-9ARPE7EzQwAQHKMg_40fCN6kY # gitleaks:allow
+
+spring.datasource.url=${SAAS_STAGING_DB_URL:jdbc:postgresql://db.qacaivhsjtftfwtgjvva.supabase.co:5432/postgres?ApplicationName=stirling-staging-${user.name}}
+spring.datasource.username=${SAAS_STAGING_DB_USERNAME:postgres}
+# Password not committed; export SAAS_STAGING_DB_PASSWORD or pass --spring.datasource.password=...
+spring.datasource.password=${SAAS_STAGING_DB_PASSWORD:}
+
+# Conservative pool sizing: this is a shared project, so don't hold connections others need.
+spring.datasource.hikari.maximum-pool-size=2
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.idle-timeout=60000
+spring.datasource.hikari.max-lifetime=1800000
+spring.datasource.hikari.keepalive-time=300000
+spring.datasource.hikari.data-source-properties.ApplicationName=stirling-staging-${user.name}
+
+logging.level.stirling.software.saas=DEBUG
+logging.level.org.springframework.security.oauth2.jwt=WARN
+logging.level.org.springframework.security.oauth2.server.resource=WARN
+
+# Supabase meter edge fn the Java backend calls (server-to-server, on job close).
+# URL is not a secret; auth rides the existing SUPABASE_EDGE_FUNCTION_SECRET (same
+# shared secret the team-invitation flow uses — no service-role key in the Java env).
+# Blank secret → the meter service no-ops with a WARN, so the app still boots.
+payg.meter.endpoint=https://qacaivhsjtftfwtgjvva.supabase.co/functions/v1/meter-payg-units

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/AccountLinkControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/AccountLinkControllerTest.java
@@ -44,7 +44,11 @@ class AccountLinkControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new AccountLinkController(service, memberRepo, userRepository);
+        // Real resolver over mocked repositories: the leader ladder moved into
+        // LeaderTeamResolver, and these cases are still the tests that cover it.
+        controller =
+                new AccountLinkController(
+                        service, new LeaderTeamResolver(memberRepo, userRepository));
         auth =
                 new AnonymousAuthenticationToken(
                         "k", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_USER")));

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/PairingControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/PairingControllerTest.java
@@ -45,8 +45,6 @@ import stirling.software.saas.util.AuthenticationUtils;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class PairingControllerTest {
 
-    private static final String VERIFY_URI = "https://stirling.example/link";
-
     @Mock private PairingService service;
     @Mock private TeamMembershipRepository memberRepo;
     @Mock private UserRepository userRepository;
@@ -62,7 +60,7 @@ class PairingControllerTest {
         caller = mockUser(42L);
         controller =
                 new PairingController(
-                        service, new LeaderTeamResolver(memberRepo, userRepository), VERIFY_URI);
+                        service, new LeaderTeamResolver(memberRepo, userRepository), "");
         auth =
                 new AnonymousAuthenticationToken(
                         "k", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_USER")));
@@ -90,7 +88,7 @@ class PairingControllerTest {
         // Grouped for reading aloud, which is the only thing this value is for.
         assertThat(body.userCode()).isEqualTo("WXYZ-4821");
         assertThat(body.deviceCode()).isEqualTo("device-code");
-        assertThat(body.verificationUri()).isEqualTo(VERIFY_URI);
+        assertThat(body.verificationUri()).isEqualTo("https://saas.example.test/link");
         assertThat(body.expiresInSeconds()).isPositive();
     }
 
@@ -165,6 +163,44 @@ class PairingControllerTest {
                 .thenReturn(PairingService.PollResult.of(PairingService.PollOutcome.UNKNOWN));
 
         assertThat(controller.poll(null).getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void start_derivesTheApprovalUrlFromTheRequestIncludingAnyContextPath() {
+        when(service.start(any(), any(), any()))
+                .thenReturn(
+                        new PairingService.StartResult(
+                                "AAAA2222", "d", LocalDateTime.now().plusMinutes(10), 5));
+        HttpServletRequest req = request("10.0.0.1", null);
+        // Behind a TLS-terminating proxy the scheme and host arrive as forwarded headers, and the
+        // app may be mounted under a subpath. Guessing a host would point staging at production.
+        when(req.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(req.getHeader("X-Forwarded-Host")).thenReturn("app.stirling.test, internal");
+        when(req.getContextPath()).thenReturn("/app");
+
+        assertThat(controller.start(null, req).getBody())
+                .isNotNull()
+                .extracting(PairingController.StartResponse::verificationUri)
+                .isEqualTo("https://app.stirling.test/app/link");
+    }
+
+    @Test
+    void start_prefersAConfiguredBaseUrlOverTheRequest() {
+        PairingController pinned =
+                new PairingController(
+                        service,
+                        new LeaderTeamResolver(memberRepo, userRepository),
+                        "https://pinned.example/base/");
+        when(service.start(any(), any(), any()))
+                .thenReturn(
+                        new PairingService.StartResult(
+                                "AAAA2222", "d", LocalDateTime.now().plusMinutes(10), 5));
+
+        assertThat(pinned.start(null, request("10.0.0.1", null)).getBody())
+                .isNotNull()
+                .extracting(PairingController.StartResponse::verificationUri)
+                // Trailing slash trimmed, so an operator cannot produce a double slash.
+                .isEqualTo("https://pinned.example/base/link");
     }
 
     // ---------------------------------------------------------------------------------------
@@ -331,10 +367,13 @@ class PairingControllerTest {
         return membership;
     }
 
-    private static HttpServletRequest request(String remoteAddr, String forwarded) {
+    private static HttpServletRequest request(String remoteAddr, String forwardedFor) {
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getRemoteAddr()).thenReturn(remoteAddr);
-        when(req.getHeader("X-Forwarded-For")).thenReturn(forwarded);
+        when(req.getHeader("X-Forwarded-For")).thenReturn(forwardedFor);
+        when(req.getHeader("Host")).thenReturn("saas.example.test");
+        when(req.getScheme()).thenReturn("https");
+        when(req.getContextPath()).thenReturn("");
         return req;
     }
 }

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/PairingControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/PairingControllerTest.java
@@ -1,0 +1,340 @@
+package stirling.software.saas.accountlink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import stirling.software.common.model.enumeration.TeamRole;
+import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.model.TeamMembership;
+import stirling.software.proprietary.security.database.repository.UserRepository;
+import stirling.software.proprietary.security.model.User;
+import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+import stirling.software.saas.util.AuthenticationUtils;
+
+/**
+ * The pairing surface's auth boundary: {@code /start} and {@code /poll} are open to an instance
+ * with no account, while lookup, approve and deny are authenticated and leader-only. Mirrors {@link
+ * AccountLinkControllerTest}'s static mock of {@link AuthenticationUtils} and runs the real {@link
+ * LeaderTeamResolver} over mocked repositories.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PairingControllerTest {
+
+    private static final String VERIFY_URI = "https://stirling.example/link";
+
+    @Mock private PairingService service;
+    @Mock private TeamMembershipRepository memberRepo;
+    @Mock private UserRepository userRepository;
+
+    private PairingController controller;
+    private Authentication auth;
+    private User caller;
+
+    @BeforeEach
+    void setUp() {
+        // Built here, never inside a when(...) argument: stubbing a mock while another stubbing
+        // is still open trips Mockito's unfinished-stubbing check.
+        caller = mockUser(42L);
+        controller =
+                new PairingController(
+                        service, new LeaderTeamResolver(memberRepo, userRepository), VERIFY_URI);
+        auth =
+                new AnonymousAuthenticationToken(
+                        "k", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Instance side: no account, so no authentication
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    void start_returnsTheDisplayCodeAndTheVerificationUri() {
+        when(service.start(anyString(), anyString(), anyString()))
+                .thenReturn(
+                        new PairingService.StartResult(
+                                "WXYZ4821", "device-code", LocalDateTime.now().plusMinutes(10), 5));
+
+        ResponseEntity<PairingController.StartResponse> resp =
+                controller.start(
+                        new PairingController.StartRequest("pdf-prod-01", "1.4.2"),
+                        request("203.0.113.44", null));
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        PairingController.StartResponse body = resp.getBody();
+        assertThat(body).isNotNull();
+        // Grouped for reading aloud, which is the only thing this value is for.
+        assertThat(body.userCode()).isEqualTo("WXYZ-4821");
+        assertThat(body.deviceCode()).isEqualTo("device-code");
+        assertThat(body.verificationUri()).isEqualTo(VERIFY_URI);
+        assertThat(body.expiresInSeconds()).isPositive();
+    }
+
+    @Test
+    void start_prefersTheForwardedAddressOverTheSocketPeer() {
+        when(service.start(any(), any(), anyString()))
+                .thenReturn(
+                        new PairingService.StartResult(
+                                "AAAA2222", "d", LocalDateTime.now().plusMinutes(10), 5));
+
+        controller.start(null, request("10.0.0.1", "203.0.113.44, 70.41.3.18"));
+
+        org.mockito.ArgumentCaptor<String> ip = org.mockito.ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(service).start(any(), any(), ip.capture());
+        assertThat(ip.getValue()).isEqualTo("203.0.113.44");
+    }
+
+    @Test
+    void start_mapsTheRateLimitTo429() {
+        when(service.start(any(), any(), any()))
+                .thenThrow(new PairingService.TooManyRequestsException());
+
+        assertThat(controller.start(null, request("10.0.0.1", null)).getStatusCode())
+                .isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    @Test
+    void poll_carriesTheCredentialOnlyOnApproval() {
+        when(service.poll("device-code"))
+                .thenReturn(
+                        new PairingService.PollResult(
+                                PairingService.PollOutcome.APPROVED,
+                                new AccountLinkService.RegisteredInstance(
+                                        1L, "dev-1", "sec-1", "pdf-prod-01"),
+                                7L));
+
+        PairingController.PollResponse body =
+                controller.poll(new PairingController.PollRequest("device-code")).getBody();
+
+        assertThat(body).isNotNull();
+        assertThat(body.status()).isEqualTo("approved");
+        assertThat(body.deviceSecret()).isEqualTo("sec-1");
+        assertThat(body.teamId()).isEqualTo(7L);
+    }
+
+    @Test
+    void poll_nonApprovedOutcomesCarryNoSecretAndStill200() {
+        for (PairingService.PollOutcome outcome :
+                List.of(
+                        PairingService.PollOutcome.PENDING,
+                        PairingService.PollOutcome.SLOW_DOWN,
+                        PairingService.PollOutcome.DENIED,
+                        PairingService.PollOutcome.EXPIRED,
+                        PairingService.PollOutcome.UNKNOWN)) {
+            when(service.poll(any())).thenReturn(PairingService.PollResult.of(outcome));
+
+            ResponseEntity<PairingController.PollResponse> resp =
+                    controller.poll(new PairingController.PollRequest("d"));
+
+            // A routine "still waiting" is not an error, so it must not be a 4xx.
+            assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(resp.getBody()).isNotNull();
+            assertThat(resp.getBody().status()).isEqualTo(outcome.name().toLowerCase());
+            assertThat(resp.getBody().deviceSecret()).isNull();
+            assertThat(resp.getBody().deviceId()).isNull();
+        }
+    }
+
+    @Test
+    void poll_toleratesAnEmptyBody() {
+        when(service.poll(null))
+                .thenReturn(PairingService.PollResult.of(PairingService.PollOutcome.UNKNOWN));
+
+        assertThat(controller.poll(null).getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Admin side: the leader ladder
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    void lookup_unauthenticated_returns401() {
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
+                    .thenThrow(new SecurityException("not authenticated"));
+
+            assertThat(controller.lookup("WXYZ-4821", auth).getStatusCode())
+                    .isEqualTo(HttpStatus.UNAUTHORIZED);
+            verifyNoInteractions(service);
+        }
+    }
+
+    @Test
+    void lookup_nonLeader_returns403() {
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
+                    .thenReturn(caller);
+            when(memberRepo.findPrimaryMembership(42L))
+                    .thenReturn(List.of(membership(9L, TeamRole.MEMBER)));
+
+            assertThat(controller.lookup("WXYZ-4821", auth).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
+            verifyNoInteractions(service);
+        }
+    }
+
+    @Test
+    void lookup_leader_returnsTheFactsAnApproverChecks() {
+        when(service.lookup("WXYZ-4821"))
+                .thenReturn(
+                        Optional.of(
+                                new PairingService.PendingView(
+                                        "WXYZ4821",
+                                        "pdf-prod-01",
+                                        "1.4.2",
+                                        "203.0.113.44",
+                                        LocalDateTime.now(),
+                                        LocalDateTime.now().plusMinutes(9))));
+
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            asLeader(mocked);
+
+            PairingController.PendingResponse body = controller.lookup("WXYZ-4821", auth).getBody();
+
+            assertThat(body).isNotNull();
+            assertThat(body.name()).isEqualTo("pdf-prod-01");
+            assertThat(body.address()).isEqualTo("203.0.113.44");
+            assertThat(body.version()).isEqualTo("1.4.2");
+            assertThat(body.userCode()).isEqualTo("WXYZ-4821");
+        }
+    }
+
+    @Test
+    void lookup_unknownCode_returns404() {
+        when(service.lookup(anyString())).thenReturn(Optional.empty());
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            asLeader(mocked);
+
+            assertThat(controller.lookup("NOPE", auth).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @Test
+    void approve_usesTheCallersTeamNeverTheRequestBody() {
+        when(service.approve(anyString(), anyLong(), anyLong(), any())).thenReturn(true);
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            asLeader(mocked);
+
+            ResponseEntity<Void> resp =
+                    controller.approve(
+                            new PairingController.ApproveRequest("WXYZ-4821", "renamed"), auth);
+
+            assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            // The team comes from the resolved membership (11), so a body cannot target another.
+            org.mockito.Mockito.verify(service).approve("WXYZ-4821", 11L, 42L, "renamed");
+        }
+    }
+
+    @Test
+    void approve_nonLeader_returns403AndTouchesNothing() {
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
+                    .thenReturn(caller);
+            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of());
+
+            assertThat(
+                            controller
+                                    .approve(
+                                            new PairingController.ApproveRequest("WXYZ-4821", null),
+                                            auth)
+                                    .getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
+            verifyNoInteractions(service);
+        }
+    }
+
+    @Test
+    void approve_unknownCode_returns404() {
+        when(service.approve(anyString(), anyLong(), anyLong(), any())).thenReturn(false);
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            asLeader(mocked);
+
+            assertThat(
+                            controller
+                                    .approve(
+                                            new PairingController.ApproveRequest("NOPE", null),
+                                            auth)
+                                    .getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @Test
+    void deny_leaderOnly() {
+        when(service.deny(anyString())).thenReturn(true);
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            asLeader(mocked);
+            assertThat(
+                            controller
+                                    .deny(new PairingController.CodeRequest("WXYZ-4821"), auth)
+                                    .getStatusCode())
+                    .isEqualTo(HttpStatus.NO_CONTENT);
+        }
+
+        try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
+            mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
+                    .thenThrow(new SecurityException("no"));
+            assertThat(
+                            controller
+                                    .deny(new PairingController.CodeRequest("WXYZ-4821"), auth)
+                                    .getStatusCode())
+                    .isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+
+    private void asLeader(org.mockito.MockedStatic<AuthenticationUtils> mocked) {
+        mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
+                .thenReturn(caller);
+        when(memberRepo.findPrimaryMembership(42L))
+                .thenReturn(List.of(membership(11L, TeamRole.LEADER)));
+    }
+
+    private static User mockUser(Long id) {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(id);
+        return user;
+    }
+
+    private static TeamMembership membership(Long teamId, TeamRole role) {
+        Team team = new Team();
+        team.setId(teamId);
+        TeamMembership membership = new TeamMembership();
+        membership.setTeam(team);
+        membership.setRole(role);
+        return membership;
+    }
+
+    private static HttpServletRequest request(String remoteAddr, String forwarded) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRemoteAddr()).thenReturn(remoteAddr);
+        when(req.getHeader("X-Forwarded-For")).thenReturn(forwarded);
+        return req;
+    }
+}

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/PairingServiceTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/PairingServiceTest.java
@@ -129,6 +129,27 @@ class PairingServiceTest {
     }
 
     @Test
+    void poll_approvedIsDeliveredEvenWhenThePollIsEarly() {
+        // Intentional, and pinned so it is not "fixed" later: the interval throttles the waiting
+        // loop, not the one-shot handover. Stalling an approved pairing would only make linking
+        // feel slow, and minting is already exactly-once via the CONSUMED flip and the row lock.
+        PairingRequest row = pending("WXYZ4821");
+        row.setStatus(PairingRequest.Status.APPROVED);
+        row.setTeamId(TEAM);
+        row.setApprovedByUserId(USER);
+        row.setLastPolledAt(LocalDateTime.now());
+        when(repo.findByDeviceCodeHashForUpdate(anyString())).thenReturn(Optional.of(row));
+        when(accountLinkService.register(TEAM, USER, "pdf-prod-01"))
+                .thenReturn(
+                        new AccountLinkService.RegisteredInstance(1L, "device-id", "secret", null));
+
+        PairingService.PollResult result = service.poll("device-code");
+
+        assertThat(result.outcome()).isEqualTo(PairingService.PollOutcome.APPROVED);
+        assertThat(result.credential().deviceSecret()).isEqualTo("secret");
+    }
+
+    @Test
     void poll_approvedMintsOnceAndThenRefusesAReplay() {
         PairingRequest row = pending("WXYZ4821");
         row.setStatus(PairingRequest.Status.APPROVED);

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/PairingServiceTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/PairingServiceTest.java
@@ -1,0 +1,206 @@
+package stirling.software.saas.accountlink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PairingServiceTest {
+
+    private static final Long TEAM = 7L;
+    private static final Long USER = 42L;
+
+    @Mock private PairingRequestRepository repo;
+    @Mock private AccountLinkService accountLinkService;
+
+    private PairingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PairingService(repo, accountLinkService);
+        when(repo.findByUserCode(anyString())).thenReturn(Optional.empty());
+        when(repo.save(any(PairingRequest.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void start_mintsCodesAndStoresOnlyTheDeviceCodeHash() {
+        PairingService.StartResult result = service.start("pdf-prod-01", "1.4.2", "203.0.113.44");
+
+        assertThat(result.userCode()).hasSize(8);
+        // The alphabet deliberately excludes characters that are easy to confuse when a code is
+        // read off one screen and typed on another.
+        assertThat(result.userCode())
+                .doesNotContainAnyWhitespaces()
+                .matches("[A-HJ-KM-NP-TV-Z2-9]+");
+        assertThat(result.deviceCode()).isNotBlank().isNotEqualTo(result.userCode());
+
+        ArgumentCaptor<PairingRequest> saved = ArgumentCaptor.forClass(PairingRequest.class);
+        verify(repo).save(saved.capture());
+        PairingRequest row = saved.getValue();
+        assertThat(row.getDeviceCodeHash())
+                .isEqualTo(AccountLinkService.sha256Hex(result.deviceCode()))
+                .isNotEqualTo(result.deviceCode());
+        assertThat(row.getStatus()).isEqualTo(PairingRequest.Status.PENDING);
+        assertThat(row.getInstanceLabel()).isEqualTo("pdf-prod-01");
+        assertThat(row.getTeamId()).isNull();
+    }
+
+    @Test
+    void start_refusesWhenOneAddressHasTooManyInFlight() {
+        when(repo.countByRequesterIpAndCreatedAtAfter(eq("203.0.113.44"), any()))
+                .thenReturn((long) PairingService.MAX_STARTS_PER_IP);
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+                PairingService.TooManyRequestsException.class,
+                () -> service.start("x", "1.0", "203.0.113.44"));
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void approve_bindsTheTeamButDoesNotMintYet() {
+        PairingRequest row = pending("WXYZ4821");
+        when(repo.findByUserCode("WXYZ4821")).thenReturn(Optional.of(row));
+
+        assertThat(service.approve("wxyz-4821", TEAM, USER, "renamed")).isTrue();
+
+        assertThat(row.getStatus()).isEqualTo(PairingRequest.Status.APPROVED);
+        assertThat(row.getTeamId()).isEqualTo(TEAM);
+        assertThat(row.getApprovedByUserId()).isEqualTo(USER);
+        assertThat(row.getInstanceLabel()).isEqualTo("renamed");
+        // Minting happens on the poll that presents the device code, so the secret only ever
+        // reaches the party that started the pairing.
+        verify(accountLinkService, never()).register(anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    void approve_acceptsAnyCasingAndSeparator() {
+        PairingRequest row = pending("WXYZ4821");
+        when(repo.findByUserCode("WXYZ4821")).thenReturn(Optional.of(row));
+
+        assertThat(service.approve(" wxyz 4821 ", TEAM, USER, null)).isTrue();
+    }
+
+    @Test
+    void approve_rejectsAnExpiredCode() {
+        PairingRequest row = pending("WXYZ4821");
+        row.setExpiresAt(LocalDateTime.now().minusMinutes(1));
+        when(repo.findByUserCode("WXYZ4821")).thenReturn(Optional.of(row));
+
+        assertThat(service.approve("WXYZ4821", TEAM, USER, null)).isFalse();
+        assertThat(row.getStatus()).isEqualTo(PairingRequest.Status.PENDING);
+    }
+
+    @Test
+    void poll_pendingStaysPending() {
+        PairingRequest row = pending("WXYZ4821");
+        when(repo.findByDeviceCodeHashForUpdate(anyString())).thenReturn(Optional.of(row));
+
+        assertThat(service.poll("device-code").outcome())
+                .isEqualTo(PairingService.PollOutcome.PENDING);
+        verify(accountLinkService, never()).register(anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    void poll_tooSoonAsksTheInstanceToSlowDown() {
+        PairingRequest row = pending("WXYZ4821");
+        row.setLastPolledAt(LocalDateTime.now());
+        when(repo.findByDeviceCodeHashForUpdate(anyString())).thenReturn(Optional.of(row));
+
+        assertThat(service.poll("device-code").outcome())
+                .isEqualTo(PairingService.PollOutcome.SLOW_DOWN);
+    }
+
+    @Test
+    void poll_approvedMintsOnceAndThenRefusesAReplay() {
+        PairingRequest row = pending("WXYZ4821");
+        row.setStatus(PairingRequest.Status.APPROVED);
+        row.setTeamId(TEAM);
+        row.setApprovedByUserId(USER);
+        when(repo.findByDeviceCodeHashForUpdate(anyString())).thenReturn(Optional.of(row));
+        when(accountLinkService.register(TEAM, USER, "pdf-prod-01"))
+                .thenReturn(
+                        new AccountLinkService.RegisteredInstance(1L, "device-id", "secret", null));
+
+        PairingService.PollResult first = service.poll("device-code");
+        assertThat(first.outcome()).isEqualTo(PairingService.PollOutcome.APPROVED);
+        assertThat(first.credential().deviceSecret()).isEqualTo("secret");
+        assertThat(first.teamId()).isEqualTo(TEAM);
+        assertThat(row.getStatus()).isEqualTo(PairingRequest.Status.CONSUMED);
+
+        // A replayed device code must not mint a second credential for one pairing.
+        PairingService.PollResult replay = service.poll("device-code");
+        assertThat(replay.outcome()).isEqualTo(PairingService.PollOutcome.UNKNOWN);
+        assertThat(replay.credential()).isNull();
+        verify(accountLinkService).register(TEAM, USER, "pdf-prod-01");
+    }
+
+    @Test
+    void poll_deniedAndExpiredAndUnknownNeverMint() {
+        PairingRequest denied = pending("AAAA1111");
+        denied.setStatus(PairingRequest.Status.DENIED);
+        when(repo.findByDeviceCodeHashForUpdate(anyString())).thenReturn(Optional.of(denied));
+        assertThat(service.poll("d").outcome()).isEqualTo(PairingService.PollOutcome.DENIED);
+
+        PairingRequest expired = pending("BBBB2222");
+        expired.setStatus(PairingRequest.Status.APPROVED);
+        expired.setExpiresAt(LocalDateTime.now().minusSeconds(1));
+        when(repo.findByDeviceCodeHashForUpdate(anyString())).thenReturn(Optional.of(expired));
+        assertThat(service.poll("d").outcome()).isEqualTo(PairingService.PollOutcome.EXPIRED);
+
+        when(repo.findByDeviceCodeHashForUpdate(anyString())).thenReturn(Optional.empty());
+        assertThat(service.poll("d").outcome()).isEqualTo(PairingService.PollOutcome.UNKNOWN);
+        assertThat(service.poll(null).outcome()).isEqualTo(PairingService.PollOutcome.UNKNOWN);
+
+        verify(accountLinkService, never()).register(anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    void lookup_exposesTheFactsAnApproverNeedsAndNoSecret() {
+        PairingRequest row = pending("WXYZ4821");
+        when(repo.findByUserCode("WXYZ4821")).thenReturn(Optional.of(row));
+
+        PairingService.PendingView view = service.lookup("WXYZ-4821").orElseThrow();
+
+        assertThat(view.instanceLabel()).isEqualTo("pdf-prod-01");
+        assertThat(view.instanceVersion()).isEqualTo("1.4.2");
+        assertThat(view.requesterIp()).isEqualTo("203.0.113.44");
+        assertThat(view.userCode()).isEqualTo("WXYZ4821");
+    }
+
+    @Test
+    void forDisplay_groupsTheCodeForReadingAloud() {
+        assertThat(PairingService.forDisplay("WXYZ4821")).isEqualTo("WXYZ-4821");
+        assertThat(PairingService.forDisplay(null)).isNull();
+        assertThat(PairingService.forDisplay("SHORT")).isEqualTo("SHORT");
+    }
+
+    private static PairingRequest pending(String userCode) {
+        PairingRequest row = new PairingRequest();
+        row.setUserCode(userCode);
+        row.setDeviceCodeHash("hash");
+        row.setStatus(PairingRequest.Status.PENDING);
+        row.setInstanceLabel("pdf-prod-01");
+        row.setInstanceVersion("1.4.2");
+        row.setRequesterIp("203.0.113.44");
+        row.setExpiresAt(LocalDateTime.now().plusMinutes(10));
+        return row;
+    }
+}

--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -5508,6 +5508,39 @@ title = "Page Ranges"
 bullet1 = "<strong>all</strong> → selects all pages"
 title = "Special Keywords"
 
+[pair.confirm]
+address = "Address"
+approve = "Pair server"
+code = "Code"
+decline = "Decline"
+name = "Name"
+sub = "Check these details match the server you are connecting. If they do not, decline."
+title = "Pair this server?"
+unknown = "Unknown"
+unnamed = "Not set"
+version = "Version"
+
+[pair.declined]
+sub = "Nothing was connected. If you did not expect this code, someone may have sent it to you by mistake."
+title = "Pairing declined"
+
+[pair.done]
+sub = "You can close this page. The server picks up the connection within a few seconds."
+title = "Server paired"
+
+[pair.entry]
+label = "Pairing code"
+sub = "From the screen on the server you are connecting."
+submit = "Continue"
+title = "Enter your pairing code"
+
+[pair.error]
+failed = "That did not go through. Only a team owner can pair a server."
+notFound = "That code is not valid. It may have expired, or already been used. Ask the server for a new one."
+
+[pair.meta]
+title = "Pair a server"
+
 [payg.activity]
 docs = "docs"
 empty = "No billable activity yet this period."
@@ -6316,17 +6349,42 @@ minutesAgo_other = "{{count}}m ago"
 never = "never"
 
 [portal.accountLink.modal]
-linkSubtitle = "Sign in to the account this server should bill against."
-linkTitle = "Link your Stirling account"
-reauthSubtitle = "Your session expired — sign back in to your Stirling account. Your instance stays linked."
+pairSubtitle = "Connect this server to your Stirling account to unlock teams, the processor, pipelines and policies."
+pairTitle = "Pair this server"
+reauthSubtitle = "Your session expired. Sign back in to your Stirling account; this server stays linked."
 reauthTitle = "Sign in again"
 simulateSignIn = "Simulate sign-in (dev)"
 
 [portal.accountLink.modal.loginNotConfigured]
-after = "to enable in-app linking against the hosted Stirling account."
+after = "to enable in-app sign-in against the hosted Stirling account."
 and = "and"
 before = "Set"
 title = "SaaS login not configured"
+
+[portal.accountLink.pairing]
+codeLabel = "Your pairing code"
+lead = "Open this address on any device and enter the code below."
+leaderHint = "A team owner has to approve it. They will be shown this server's name and address so they can check it is yours."
+newCode = "Get a new code"
+retry = "Try again"
+waiting = "Waiting for approval on the Stirling site."
+waitingWithExpiry = "Waiting for approval. Expires in {{countdown}}."
+
+[portal.accountLink.pairing.denied]
+body = "Someone declined this pairing on the Stirling site. Generate a new code if that was not intended."
+title = "Pairing declined"
+
+[portal.accountLink.pairing.error]
+body = "This server could not start a pairing. Check its outbound network access, then try again."
+title = "Could not reach Stirling"
+
+[portal.accountLink.pairing.expired]
+body = "Pairing codes are short lived. Generate a new one to try again."
+title = "Code expired"
+
+[portal.accountLink.pairing.linked]
+body = "This server is now connected to your Stirling account."
+title = "Server paired"
 
 [portal.accountLink.panel]
 instancesSub = "Every self-hosted instance registered to this org. Revoke a credential to immediately cut off its unattended access."

--- a/frontend/editor/src/portal/PortalProviders.tsx
+++ b/frontend/editor/src/portal/PortalProviders.tsx
@@ -22,11 +22,19 @@ function LinkModalHost() {
   const link = useAccountLinkContext();
   // "reauth" only refreshes the browser SaaS session for attended reads — the
   // sign-in already applied it to the Supabase client, so we just signal a
-  // refetch. It must NOT call completeLink (that re-registers → duplicate row).
-  const onLinked =
-    linkModalMode === "reauth"
-      ? () => markSaasSessionChanged()
-      : (session: SupabaseLoginSession) => link.completeLink(session);
+  // refetch. It must NOT re-register (that would mint a duplicate credential).
+  //
+  // Linking now pairs with a code, which stores the credential on the server
+  // before the modal ever hears about it, so there is no session to hand over
+  // and nothing to register: we only re-read the resulting status.
+  const onLinked = (session?: SupabaseLoginSession) => {
+    if (linkModalMode === "reauth") {
+      markSaasSessionChanged();
+      return;
+    }
+    void link.refreshStatus();
+    void session;
+  };
   return (
     <LinkAccountModal
       open={linkModalOpen}

--- a/frontend/editor/src/portal/api/link.ts
+++ b/frontend/editor/src/portal/api/link.ts
@@ -118,6 +118,53 @@ export async function triggerLocalSync(): Promise<void> {
 }
 
 /**
+ * The in-flight device-grant pairing for THIS instance
+ * (GET /api/v1/account-link/pair/status).
+ *
+ * `phase` drives what the modal renders:
+ *   idle    — nothing started yet
+ *   waiting — a code is live; show it and keep polling
+ *   linked  — approved and the credential is stored; we are done
+ *   denied  — a leader declined it
+ *   expired — the code timed out; offer a restart
+ *
+ * The device code never appears here. Only `userCode` is meant for human eyes.
+ */
+export interface PairingView {
+  phase: "idle" | "waiting" | "linked" | "denied" | "expired";
+  userCode: string | null;
+  verificationUri: string | null;
+  /** ISO timestamp the code stops working. */
+  expiresAt: string | null;
+  /** Seconds SaaS asks us to wait between polls. */
+  intervalSeconds: number;
+}
+
+/**
+ * Start pairing this instance. The local backend calls SaaS, keeps the device
+ * code server-side, and returns only the code the admin reads out.
+ */
+export async function startPairing(name?: string): Promise<PairingView> {
+  return apiClient.local.json<PairingView>(`${BASE}/pair/start`, {
+    method: "POST",
+    body: name ? { name } : {},
+  });
+}
+
+/**
+ * Advance the pairing. The local backend rate-limits its own upstream polling to
+ * the interval SaaS advertised, so calling this on a short timer is safe.
+ */
+export async function fetchPairingStatus(): Promise<PairingView> {
+  return apiClient.local.json<PairingView>(`${BASE}/pair/status`);
+}
+
+/** Abandon the in-flight pairing. The SaaS-side request is left to expire. */
+export async function cancelPairing(): Promise<void> {
+  await apiClient.local.json<void>(`${BASE}/pair/cancel`, { method: "POST" });
+}
+
+/**
  * Every linked instance for the team — SaaS-direct call with the admin's
  * Supabase JWT (no longer takes an accessToken parameter; the saas client
  * resolves the live session itself).

--- a/frontend/editor/src/portal/components/account-link/LinkAccountCard.stories.tsx
+++ b/frontend/editor/src/portal/components/account-link/LinkAccountCard.stories.tsx
@@ -10,6 +10,7 @@ const base: UseAccountLink = {
   phase: "idle",
   error: null,
   completeLink: async () => {},
+  refreshStatus: async () => {},
   unlink: async () => {},
 };
 

--- a/frontend/editor/src/portal/components/account-link/LinkAccountModal.stories.tsx
+++ b/frontend/editor/src/portal/components/account-link/LinkAccountModal.stories.tsx
@@ -14,10 +14,17 @@ const meta: Meta<typeof LinkAccountModal> = {
 export default meta;
 type Story = StoryObj<typeof LinkAccountModal>;
 
-/** Default "link" mode — sign in to register this instance against a Stirling account. */
+/**
+ * Default "link" mode: the server shows a pairing code and waits for a team owner
+ * to approve it. Driven by the MSW pair handlers, which settle on linked after a
+ * couple of polls, so this story moves on its own.
+ */
 export const Default: Story = {};
 
-/** "reauth" mode — an already-linked instance's session expired and needs a fresh sign-in. */
+/**
+ * "reauth" mode: the instance is already linked and only the browser's SaaS
+ * session lapsed, so this one keeps the in-app sign-in rather than pairing again.
+ */
 export const Reauth: Story = {
   args: { mode: "reauth" },
 };

--- a/frontend/editor/src/portal/components/account-link/LinkAccountModal.tsx
+++ b/frontend/editor/src/portal/components/account-link/LinkAccountModal.tsx
@@ -13,27 +13,39 @@ import {
   PENDING_LINK_KEY,
   SAAS_OAUTH_PROVIDERS,
 } from "@portal/auth/saasSupabase";
+import { PairingPanel } from "@portal/components/account-link/PairingPanel";
 
 interface Props {
   open: boolean;
   onClose: () => void;
   /**
-   * "link" registers this instance against the signed-in account; "reauth" only
-   * refreshes an expired SaaS session (the instance is already linked). The mode
-   * is persisted across the OAuth redirect so the SSO-return handler doesn't
-   * re-register on a reauth.
+   * "link" pairs this instance to a Stirling team with a device-grant code;
+   * "reauth" only refreshes an expired SaaS session for attended reads (the
+   * instance stays linked), which still needs an in-browser sign-in because it
+   * is a browser session we are renewing, not a server credential.
    */
   mode?: "link" | "reauth";
-  /** Called with the SaaS session after a successful sign-in. */
-  onLinked: (session: SupabaseLoginSession) => void | Promise<void>;
+  /**
+   * Called once the instance is linked. Carries the refreshed SaaS session on the
+   * reauth path; pairing produces no browser session, so it is called with no
+   * argument there.
+   */
+  onLinked: (session?: SupabaseLoginSession) => void | Promise<void>;
 }
 
 /**
- * In-app account-link login. Signs the admin in to their Stirling (SaaS) account
- * via the shared Supabase login (SSO + email/password), then hands the resulting
- * session to the caller to register this instance. No popup; the device secret
- * never reaches the browser. SSO redirects away and is finished by useAccountLink
- * on return.
+ * Connect this server to a Stirling account.
+ *
+ * <p>Linking uses a pairing code (device grant): the server displays a short code
+ * and the admin approves it on the Stirling site from any device. That indirection
+ * is not decoration. A self-hosted instance runs on an origin the identity
+ * provider will never have on its redirect allow-list, so an in-browser sign-in
+ * here cannot complete SSO or a sign-up confirmation. Moving the human half of
+ * the flow to our own origin is the only thing that makes those work, and it also
+ * covers servers with no browser at all.
+ *
+ * <p>Re-auth is the exception and keeps the in-browser Supabase login: there we
+ * genuinely want a session in this browser, and the admin already has an account.
  */
 export function LinkAccountModal({
   open,
@@ -42,15 +54,14 @@ export function LinkAccountModal({
   onLinked,
 }: Props) {
   const { t } = useTranslation();
-  useEffect(() => {
-    if (open) ensureSaasSupabase();
-  }, [open]);
-
   const reauth = mode === "reauth";
+
+  useEffect(() => {
+    if (open && reauth) ensureSaasSupabase();
+  }, [open, reauth]);
+
   const login = useSupabaseLogin({
     providers: SAAS_OAUTH_PROVIDERS,
-    // Return to the current page after SSO; the SSO-return handler in
-    // useAccountLink reads the persisted mode so it links vs. only refreshes.
     redirectTo: window.location.href,
     onBeforeOAuth: () => sessionStorage.setItem(PENDING_LINK_KEY, mode),
     onSuccess: async (session) => {
@@ -67,24 +78,29 @@ export function LinkAccountModal({
       title={
         reauth
           ? t("portal.accountLink.modal.reauthTitle", "Sign in again")
-          : t(
-              "portal.accountLink.modal.linkTitle",
-              "Link your Stirling account",
-            )
+          : t("portal.accountLink.modal.pairTitle", "Pair this server")
       }
       subtitle={
         reauth
           ? t(
               "portal.accountLink.modal.reauthSubtitle",
-              "Your session expired — sign back in to your Stirling account. Your instance stays linked.",
+              "Your session expired. Sign back in to your Stirling account; this server stays linked.",
             )
           : t(
-              "portal.accountLink.modal.linkSubtitle",
-              "Sign in to the account this server should bill against.",
+              "portal.accountLink.modal.pairSubtitle",
+              "Connect this server to your Stirling account to unlock teams, the processor, pipelines and policies.",
             )
       }
     >
-      {isSaasSupabaseConfigured ? (
+      {!reauth ? (
+        <PairingPanel
+          active={open}
+          onLinked={() => {
+            void onLinked();
+            onClose();
+          }}
+        />
+      ) : isSaasSupabaseConfigured ? (
         <SupabaseLoginForm state={login} />
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
@@ -101,7 +117,7 @@ export function LinkAccountModal({
             <code>VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY</code>{" "}
             {t(
               "portal.accountLink.modal.loginNotConfigured.after",
-              "to enable in-app linking against the hosted Stirling account.",
+              "to enable in-app sign-in against the hosted Stirling account.",
             )}
           </Banner>
           {import.meta.env.DEV && (

--- a/frontend/editor/src/portal/components/account-link/PairingPanel.css
+++ b/frontend/editor/src/portal/components/account-link/PairingPanel.css
@@ -1,0 +1,55 @@
+/* Device-grant pairing panel. Deliberately plain: the code is the only thing
+   that should draw the eye, so nothing else competes with it. */
+
+.portal-pairing {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.portal-pairing__lead {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--c-text-muted);
+}
+
+.portal-pairing__uri {
+  margin: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.875rem;
+  color: var(--c-text);
+}
+
+.portal-pairing__code {
+  margin: 0;
+  padding: 0.875rem 0.5rem;
+  text-align: center;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 1.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--c-text);
+  background: var(--c-surface-sunken);
+  border: 1px solid var(--c-border);
+  border-radius: 0.375rem;
+  /* The admin reads this off one screen and types it on another, so it has to
+     survive being selected, copied and squinted at. */
+  user-select: all;
+}
+
+.portal-pairing__wait {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--c-text-subtle);
+}
+
+.portal-pairing__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--c-text-subtle);
+}
+
+.portal-pairing__actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/editor/src/portal/components/account-link/PairingPanel.css
+++ b/frontend/editor/src/portal/components/account-link/PairingPanel.css
@@ -14,10 +14,23 @@
 }
 
 .portal-pairing__uri {
+  /* Now an <a>. Body colour rather than --c-primary: this is 0.875rem mono text, and
+     --c-primary (and its --c-accent-fg alias) only reaches ~3.1:1 on the light
+     surface, which the a11y gate rejects for text this size. The underline carries
+     the affordance instead of colour, so it does not depend on hue at all. */
+  display: block;
   margin: 0;
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.875rem;
   color: var(--c-text);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  overflow-wrap: anywhere;
+}
+
+.portal-pairing__uri:hover,
+.portal-pairing__uri:focus-visible {
+  text-decoration-thickness: 2px;
 }
 
 .portal-pairing__code {

--- a/frontend/editor/src/portal/components/account-link/PairingPanel.css
+++ b/frontend/editor/src/portal/components/account-link/PairingPanel.css
@@ -37,16 +37,19 @@
   user-select: all;
 }
 
+/* --c-text-muted, not --c-text-subtle: subtle is 3.59:1 on the dark surface and
+   fails AA. Both of these carry information the admin needs while they wait, so
+   neither can be decorative-faint. */
 .portal-pairing__wait {
   margin: 0;
   font-size: 0.8125rem;
-  color: var(--c-text-subtle);
+  color: var(--c-text-muted);
 }
 
 .portal-pairing__hint {
   margin: 0;
   font-size: 0.75rem;
-  color: var(--c-text-subtle);
+  color: var(--c-text-muted);
 }
 
 .portal-pairing__actions {

--- a/frontend/editor/src/portal/components/account-link/PairingPanel.tsx
+++ b/frontend/editor/src/portal/components/account-link/PairingPanel.tsx
@@ -1,0 +1,157 @@
+import { useTranslation } from "react-i18next";
+import { Banner, Button, Skeleton } from "@app/ui";
+import { usePairing } from "@portal/hooks/usePairing";
+import "@portal/components/account-link/PairingPanel.css";
+
+interface Props {
+  /** Only polls while true, so a closed dialog costs nothing. */
+  active: boolean;
+  /** Fired once the pairing is approved and the credential is stored. */
+  onLinked: () => void | Promise<void>;
+}
+
+function formatCountdown(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Shows the pairing code for this server and waits for a team leader to approve
+ * it (device grant, RFC 8628).
+ *
+ * <p>This is what replaces signing in to Stirling on the server itself. The admin
+ * can approve from any device, which is the only way SSO and sign-up can work:
+ * a customer's own origin can never be on the identity provider's redirect
+ * allow-list, so the human half of the flow has to happen on our site.
+ */
+export function PairingPanel({ active, onLinked }: Props) {
+  const { t } = useTranslation();
+  const { view, secondsLeft, starting, error, restart } = usePairing(
+    active,
+    onLinked,
+  );
+
+  if (error) {
+    return (
+      <div className="portal-pairing">
+        <Banner
+          tone="danger"
+          title={t(
+            "portal.accountLink.pairing.error.title",
+            "Could not reach Stirling",
+          )}
+        >
+          {t(
+            "portal.accountLink.pairing.error.body",
+            "This server could not start a pairing. Check its outbound network access, then try again.",
+          )}
+        </Banner>
+        <div className="portal-pairing__actions">
+          <Button variant="primary" onClick={() => void restart()}>
+            {t("portal.accountLink.pairing.retry", "Try again")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (starting || !view || view.phase === "idle") {
+    return (
+      <div className="portal-pairing">
+        <Skeleton height="3.5rem" />
+        <Skeleton height="1rem" width="12rem" />
+      </div>
+    );
+  }
+
+  if (view.phase === "expired" || view.phase === "denied") {
+    const expired = view.phase === "expired";
+    return (
+      <div className="portal-pairing">
+        <Banner
+          tone="warning"
+          title={
+            expired
+              ? t("portal.accountLink.pairing.expired.title", "Code expired")
+              : t("portal.accountLink.pairing.denied.title", "Pairing declined")
+          }
+        >
+          {expired
+            ? t(
+                "portal.accountLink.pairing.expired.body",
+                "Pairing codes are short lived. Generate a new one to try again.",
+              )
+            : t(
+                "portal.accountLink.pairing.denied.body",
+                "Someone declined this pairing on the Stirling site. Generate a new code if that was not intended.",
+              )}
+        </Banner>
+        <div className="portal-pairing__actions">
+          <Button variant="primary" onClick={() => void restart()}>
+            {t("portal.accountLink.pairing.newCode", "Get a new code")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (view.phase === "linked") {
+    return (
+      <div className="portal-pairing">
+        <Banner
+          tone="success"
+          title={t("portal.accountLink.pairing.linked.title", "Server paired")}
+        >
+          {t(
+            "portal.accountLink.pairing.linked.body",
+            "This server is now connected to your Stirling account.",
+          )}
+        </Banner>
+      </div>
+    );
+  }
+
+  return (
+    <div className="portal-pairing">
+      <p className="portal-pairing__lead">
+        {t(
+          "portal.accountLink.pairing.lead",
+          "Open this address on any device and enter the code below.",
+        )}
+      </p>
+
+      <p className="portal-pairing__uri">{view.verificationUri}</p>
+
+      <p
+        className="portal-pairing__code"
+        aria-label={t(
+          "portal.accountLink.pairing.codeLabel",
+          "Your pairing code",
+        )}
+      >
+        {view.userCode}
+      </p>
+
+      <p className="portal-pairing__wait" role="status">
+        {secondsLeft != null
+          ? t(
+              "portal.accountLink.pairing.waitingWithExpiry",
+              "Waiting for approval. Expires in {{countdown}}.",
+              { countdown: formatCountdown(secondsLeft) },
+            )
+          : t(
+              "portal.accountLink.pairing.waiting",
+              "Waiting for approval on the Stirling site.",
+            )}
+      </p>
+
+      <p className="portal-pairing__hint">
+        {t(
+          "portal.accountLink.pairing.leaderHint",
+          "A team owner has to approve it. They will be shown this server's name and address so they can check it is yours.",
+        )}
+      </p>
+    </div>
+  );
+}

--- a/frontend/editor/src/portal/components/account-link/PairingPanel.tsx
+++ b/frontend/editor/src/portal/components/account-link/PairingPanel.tsx
@@ -1,19 +1,11 @@
-import { useTranslation } from "react-i18next";
-import { Banner, Button, Skeleton } from "@app/ui";
 import { usePairing } from "@portal/hooks/usePairing";
-import "@portal/components/account-link/PairingPanel.css";
+import { PairingPanelView } from "@portal/components/account-link/PairingPanelView";
 
 interface Props {
   /** Only polls while true, so a closed dialog costs nothing. */
   active: boolean;
   /** Fired once the pairing is approved and the credential is stored. */
   onLinked: () => void | Promise<void>;
-}
-
-function formatCountdown(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
 }
 
 /**
@@ -24,134 +16,23 @@ function formatCountdown(seconds: number): string {
  * can approve from any device, which is the only way SSO and sign-up can work:
  * a customer's own origin can never be on the identity provider's redirect
  * allow-list, so the human half of the flow has to happen on our site.
+ *
+ * <p>Data only. {@link PairingPanelView} draws it, so every state stays reachable
+ * from Storybook without a network.
  */
 export function PairingPanel({ active, onLinked }: Props) {
-  const { t } = useTranslation();
   const { view, secondsLeft, starting, error, restart } = usePairing(
     active,
     onLinked,
   );
 
-  if (error) {
-    return (
-      <div className="portal-pairing">
-        <Banner
-          tone="danger"
-          title={t(
-            "portal.accountLink.pairing.error.title",
-            "Could not reach Stirling",
-          )}
-        >
-          {t(
-            "portal.accountLink.pairing.error.body",
-            "This server could not start a pairing. Check its outbound network access, then try again.",
-          )}
-        </Banner>
-        <div className="portal-pairing__actions">
-          <Button variant="primary" onClick={() => void restart()}>
-            {t("portal.accountLink.pairing.retry", "Try again")}
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  if (starting || !view || view.phase === "idle") {
-    return (
-      <div className="portal-pairing">
-        <Skeleton height="3.5rem" />
-        <Skeleton height="1rem" width="12rem" />
-      </div>
-    );
-  }
-
-  if (view.phase === "expired" || view.phase === "denied") {
-    const expired = view.phase === "expired";
-    return (
-      <div className="portal-pairing">
-        <Banner
-          tone="warning"
-          title={
-            expired
-              ? t("portal.accountLink.pairing.expired.title", "Code expired")
-              : t("portal.accountLink.pairing.denied.title", "Pairing declined")
-          }
-        >
-          {expired
-            ? t(
-                "portal.accountLink.pairing.expired.body",
-                "Pairing codes are short lived. Generate a new one to try again.",
-              )
-            : t(
-                "portal.accountLink.pairing.denied.body",
-                "Someone declined this pairing on the Stirling site. Generate a new code if that was not intended.",
-              )}
-        </Banner>
-        <div className="portal-pairing__actions">
-          <Button variant="primary" onClick={() => void restart()}>
-            {t("portal.accountLink.pairing.newCode", "Get a new code")}
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  if (view.phase === "linked") {
-    return (
-      <div className="portal-pairing">
-        <Banner
-          tone="success"
-          title={t("portal.accountLink.pairing.linked.title", "Server paired")}
-        >
-          {t(
-            "portal.accountLink.pairing.linked.body",
-            "This server is now connected to your Stirling account.",
-          )}
-        </Banner>
-      </div>
-    );
-  }
-
   return (
-    <div className="portal-pairing">
-      <p className="portal-pairing__lead">
-        {t(
-          "portal.accountLink.pairing.lead",
-          "Open this address on any device and enter the code below.",
-        )}
-      </p>
-
-      <p className="portal-pairing__uri">{view.verificationUri}</p>
-
-      <p
-        className="portal-pairing__code"
-        aria-label={t(
-          "portal.accountLink.pairing.codeLabel",
-          "Your pairing code",
-        )}
-      >
-        {view.userCode}
-      </p>
-
-      <p className="portal-pairing__wait" role="status">
-        {secondsLeft != null
-          ? t(
-              "portal.accountLink.pairing.waitingWithExpiry",
-              "Waiting for approval. Expires in {{countdown}}.",
-              { countdown: formatCountdown(secondsLeft) },
-            )
-          : t(
-              "portal.accountLink.pairing.waiting",
-              "Waiting for approval on the Stirling site.",
-            )}
-      </p>
-
-      <p className="portal-pairing__hint">
-        {t(
-          "portal.accountLink.pairing.leaderHint",
-          "A team owner has to approve it. They will be shown this server's name and address so they can check it is yours.",
-        )}
-      </p>
-    </div>
+    <PairingPanelView
+      view={view}
+      secondsLeft={secondsLeft}
+      loading={starting}
+      error={error}
+      onRetry={() => void restart()}
+    />
   );
 }

--- a/frontend/editor/src/portal/components/account-link/PairingPanelView.stories.tsx
+++ b/frontend/editor/src/portal/components/account-link/PairingPanelView.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { PairingView } from "@portal/api/link";
+import { PairingPanelView } from "@portal/components/account-link/PairingPanelView";
+
+/**
+ * Every state of the pairing panel (device grant, RFC 8628). The panel is pure,
+ * so these are props only: no network, no waiting out a real ten minute code.
+ */
+const meta: Meta<typeof PairingPanelView> = {
+  title: "Portal/AccountLink/PairingPanelView",
+  component: PairingPanelView,
+  parameters: { layout: "padded" },
+  args: {
+    view: null,
+    secondsLeft: null,
+    loading: false,
+    error: null,
+    onRetry: () => {},
+  },
+};
+export default meta;
+type Story = StoryObj<typeof PairingPanelView>;
+
+const waiting: PairingView = {
+  phase: "waiting",
+  userCode: "WXYZ-4821",
+  verificationUri: "https://stirling.com/link",
+  expiresAt: null,
+  intervalSeconds: 5,
+};
+
+/** The main state: a live code, on screen, waiting for a team owner to approve. */
+export const Waiting: Story = {
+  args: { view: waiting, secondsLeft: 587 },
+};
+
+/** Late in the code's life, so the countdown is the thing drawing the eye. */
+export const AboutToExpire: Story = {
+  args: { view: waiting, secondsLeft: 24 },
+};
+
+/**
+ * The instance has a code but no expiry yet, which happens if SaaS omitted the
+ * lifetime. The wait line falls back to prose rather than rendering "null".
+ */
+export const WaitingWithoutCountdown: Story = {
+  args: { view: waiting, secondsLeft: null },
+};
+
+/** First status read still in flight. */
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+/** Nobody approved in time. The only way out is a fresh code. */
+export const Expired: Story = {
+  args: {
+    view: { ...waiting, phase: "expired", userCode: null },
+    secondsLeft: 0,
+  },
+};
+
+/** Someone actively declined it on the Stirling site, which is worth saying plainly. */
+export const Declined: Story = {
+  args: { view: { ...waiting, phase: "denied", userCode: null } },
+};
+
+/** Approved: the credential is already stored server-side by this point. */
+export const Linked: Story = {
+  args: { view: { ...waiting, phase: "linked", userCode: null } },
+};
+
+/** The instance could not reach Stirling at all, usually egress rules. */
+export const CannotReachStirling: Story = {
+  args: { error: "Bad Gateway" },
+};

--- a/frontend/editor/src/portal/components/account-link/PairingPanelView.test.tsx
+++ b/frontend/editor/src/portal/components/account-link/PairingPanelView.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import type { PairingView } from "@portal/api/link";
+import { PairingPanelView } from "@portal/components/account-link/PairingPanelView";
+
+/**
+ * The approval link is the one part of this panel with logic behind it: it has to be
+ * a real link, open away from this tab, and carry the code so the admin does not
+ * retype eight characters on another device.
+ */
+const waiting = (over: Partial<PairingView> = {}): PairingView => ({
+  phase: "waiting",
+  userCode: "WXYZ-4821",
+  verificationUri: "https://stirling.com/link",
+  expiresAt: null,
+  intervalSeconds: 5,
+  ...over,
+});
+
+const renderView = (view: PairingView | null) =>
+  render(
+    <MantineProvider>
+      <PairingPanelView
+        view={view}
+        secondsLeft={587}
+        loading={false}
+        error={null}
+        onRetry={() => {}}
+      />
+    </MantineProvider>,
+  );
+
+describe("PairingPanelView approval link", () => {
+  it("is a link that opens away from this tab, with the code prefilled", () => {
+    renderView(waiting());
+
+    const link = screen.getByRole("link", {
+      name: "https://stirling.com/link",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://stirling.com/link?code=WXYZ-4821",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    // Without noreferrer the opened page gets a handle on this one.
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("adds the code to a URI that already has a query", () => {
+    renderView(
+      waiting({ verificationUri: "https://stirling.com/app/link?ref=x" }),
+    );
+
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "https://stirling.com/app/link?ref=x&code=WXYZ-4821",
+    );
+  });
+
+  it("still renders a followable link when the URI cannot be parsed", () => {
+    renderView(waiting({ verificationUri: "not-a-url" }));
+
+    // Better a plain link the admin can read than a mangled one, or none.
+    expect(screen.getByRole("link")).toHaveAttribute("href", "not-a-url");
+  });
+
+  it("keeps the code on screen as well as in the link", () => {
+    renderView(waiting());
+
+    // The admin may be approving on a phone, where this tab is no use to them.
+    expect(screen.getByLabelText(/pairing code/i)).toHaveTextContent(
+      "WXYZ-4821",
+    );
+  });
+
+  it("renders no link when there is no verification URI", () => {
+    renderView(waiting({ verificationUri: null }));
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/editor/src/portal/components/account-link/PairingPanelView.tsx
+++ b/frontend/editor/src/portal/components/account-link/PairingPanelView.tsx
@@ -20,6 +20,25 @@ function formatCountdown(seconds: number): string {
 }
 
 /**
+ * The approval URL with the code prefilled.
+ *
+ * <p>Built with URL rather than string concatenation so a verification URI that
+ * already carries a query or a path (a deployment under a subpath, say) gains the
+ * parameter instead of ending up with two question marks. A URI we cannot parse
+ * is returned untouched: a plain link the admin can still follow beats a dead one.
+ */
+function approvalHref(uri: string, userCode: string | null): string {
+  if (!userCode) return uri;
+  try {
+    const url = new URL(uri);
+    url.searchParams.set("code", userCode);
+    return url.toString();
+  } catch {
+    return uri;
+  }
+}
+
+/**
  * Presentation for the pairing panel. Pure: every state is reachable by props
  * alone, so Storybook and the a11y scan cover the whole flow without mocking a
  * network or waiting out a countdown. {@link PairingPanel} supplies the data.
@@ -122,7 +141,20 @@ export function PairingPanelView({
         )}
       </p>
 
-      <p className="portal-pairing__uri">{view.verificationUri}</p>
+      {/* A real link, opened in a new tab with the code already in the query, so the
+          common case is one click rather than reading a URL across to another window
+          and typing eight characters. The code stays on screen because the admin may
+          be approving on a phone, where this tab is no help. */}
+      {view.verificationUri ? (
+        <a
+          className="portal-pairing__uri"
+          href={approvalHref(view.verificationUri, view.userCode)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {view.verificationUri}
+        </a>
+      ) : null}
 
       <p
         className="portal-pairing__code"

--- a/frontend/editor/src/portal/components/account-link/PairingPanelView.tsx
+++ b/frontend/editor/src/portal/components/account-link/PairingPanelView.tsx
@@ -1,0 +1,158 @@
+import { useTranslation } from "react-i18next";
+import { Banner, Button, Skeleton } from "@app/ui";
+import type { PairingView } from "@portal/api/link";
+import "@portal/components/account-link/PairingPanel.css";
+
+export interface PairingPanelViewProps {
+  /** Null while the first status read is in flight. */
+  view: PairingView | null;
+  /** Seconds until the code stops working; null when there is no live code. */
+  secondsLeft: number | null;
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}
+
+function formatCountdown(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Presentation for the pairing panel. Pure: every state is reachable by props
+ * alone, so Storybook and the a11y scan cover the whole flow without mocking a
+ * network or waiting out a countdown. {@link PairingPanel} supplies the data.
+ */
+export function PairingPanelView({
+  view,
+  secondsLeft,
+  loading,
+  error,
+  onRetry,
+}: PairingPanelViewProps) {
+  const { t } = useTranslation();
+
+  if (error) {
+    return (
+      <div className="portal-pairing">
+        <Banner
+          tone="danger"
+          title={t(
+            "portal.accountLink.pairing.error.title",
+            "Could not reach Stirling",
+          )}
+        >
+          {t(
+            "portal.accountLink.pairing.error.body",
+            "This server could not start a pairing. Check its outbound network access, then try again.",
+          )}
+        </Banner>
+        <div className="portal-pairing__actions">
+          <Button variant="primary" onClick={onRetry}>
+            {t("portal.accountLink.pairing.retry", "Try again")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading || !view || view.phase === "idle") {
+    return (
+      <div className="portal-pairing">
+        <Skeleton height="3.5rem" />
+        <Skeleton height="1rem" width="12rem" />
+      </div>
+    );
+  }
+
+  if (view.phase === "expired" || view.phase === "denied") {
+    const expired = view.phase === "expired";
+    return (
+      <div className="portal-pairing">
+        <Banner
+          tone="warning"
+          title={
+            expired
+              ? t("portal.accountLink.pairing.expired.title", "Code expired")
+              : t("portal.accountLink.pairing.denied.title", "Pairing declined")
+          }
+        >
+          {expired
+            ? t(
+                "portal.accountLink.pairing.expired.body",
+                "Pairing codes are short lived. Generate a new one to try again.",
+              )
+            : t(
+                "portal.accountLink.pairing.denied.body",
+                "Someone declined this pairing on the Stirling site. Generate a new code if that was not intended.",
+              )}
+        </Banner>
+        <div className="portal-pairing__actions">
+          <Button variant="primary" onClick={onRetry}>
+            {t("portal.accountLink.pairing.newCode", "Get a new code")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (view.phase === "linked") {
+    return (
+      <div className="portal-pairing">
+        <Banner
+          tone="success"
+          title={t("portal.accountLink.pairing.linked.title", "Server paired")}
+        >
+          {t(
+            "portal.accountLink.pairing.linked.body",
+            "This server is now connected to your Stirling account.",
+          )}
+        </Banner>
+      </div>
+    );
+  }
+
+  return (
+    <div className="portal-pairing">
+      <p className="portal-pairing__lead">
+        {t(
+          "portal.accountLink.pairing.lead",
+          "Open this address on any device and enter the code below.",
+        )}
+      </p>
+
+      <p className="portal-pairing__uri">{view.verificationUri}</p>
+
+      <p
+        className="portal-pairing__code"
+        aria-label={t(
+          "portal.accountLink.pairing.codeLabel",
+          "Your pairing code",
+        )}
+      >
+        {view.userCode}
+      </p>
+
+      <p className="portal-pairing__wait" role="status">
+        {secondsLeft != null
+          ? t(
+              "portal.accountLink.pairing.waitingWithExpiry",
+              "Waiting for approval. Expires in {{countdown}}.",
+              { countdown: formatCountdown(secondsLeft) },
+            )
+          : t(
+              "portal.accountLink.pairing.waiting",
+              "Waiting for approval on the Stirling site.",
+            )}
+      </p>
+
+      <p className="portal-pairing__hint">
+        {t(
+          "portal.accountLink.pairing.leaderHint",
+          "A team owner has to approve it. They will be shown this server's name and address so they can check it is yours.",
+        )}
+      </p>
+    </div>
+  );
+}

--- a/frontend/editor/src/portal/hooks/useAccountLink.ts
+++ b/frontend/editor/src/portal/hooks/useAccountLink.ts
@@ -40,6 +40,12 @@ export interface UseAccountLink {
   error: string | null;
   /** Finish linking THIS instance with a SaaS session minted by the login modal. */
   completeLink: (session: SupabaseLoginSession, name?: string) => Promise<void>;
+  /**
+   * Re-read the link status from the local backend. The pairing flow stores the
+   * credential server-side before the browser is told anything, so there is no
+   * session to hand over: the UI just asks what the state is now.
+   */
+  refreshStatus: () => Promise<void>;
   /** Unlink this instance. */
   unlink: () => Promise<void>;
 }
@@ -71,27 +77,23 @@ export function useAccountLink(): UseAccountLink {
     [applyLinkFacts],
   );
 
+  const refreshStatus = useCallback(async () => {
+    try {
+      const next = await fetchStatus();
+      setStatus(next);
+      // A linked instance is at least linked-free; subscription comes from the wallet.
+      if (next.linked) applyLinkFacts(true, false);
+    } catch {
+      // Status endpoint absent (flag off) / unreachable → treat as not linked.
+      // Don't surface an error for the expected flag-off case.
+      setStatus({ linked: false, name: null });
+    }
+  }, [applyLinkFacts]);
+
   // Read the current link status on mount.
   useEffect(() => {
-    let cancelled = false;
-    void fetchStatus()
-      .then((s) => {
-        if (!cancelled) {
-          setStatus(s);
-          // A linked instance is at least linked-free; subscription comes from the wallet.
-          if (s.linked) applyLinkFacts(true, false);
-        }
-      })
-      .catch(() => {
-        // Status endpoint absent (flag off) / unreachable → leave status null,
-        // which renders as "Not linked". Don't surface an error or leak an
-        // unhandled rejection for the expected flag-off case.
-        if (!cancelled) setStatus({ linked: false, name: null });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [applyLinkFacts]);
+    void refreshStatus();
+  }, [refreshStatus]);
 
   // SSO return: an SSO sign-in we kicked off has redirected back and the SaaS
   // session is now in the shared Supabase client. The pending marker carries the
@@ -137,6 +139,7 @@ export function useAccountLink(): UseAccountLink {
     phase,
     error,
     completeLink,
+    refreshStatus,
     unlink,
   };
 }

--- a/frontend/editor/src/portal/hooks/usePairing.test.tsx
+++ b/frontend/editor/src/portal/hooks/usePairing.test.tsx
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import type { PairingView } from "@portal/api/link";
+
+/**
+ * The pairing loop has three properties worth pinning, because all three are easy
+ * to regress and none is obvious from reading the hook:
+ *
+ *   1. It adopts a pairing another replica already started rather than replacing
+ *      it, which is the whole reason the state lives in the shared database.
+ *   2. It fires `onLinked` exactly once, since the caller uses it to close the
+ *      dialog and refresh link state.
+ *   3. A failed poll leaves the pairing alone instead of surfacing an error.
+ */
+const { startPairing, fetchPairingStatus, cancelPairing } = vi.hoisted(() => ({
+  startPairing: vi.fn(),
+  fetchPairingStatus: vi.fn(),
+  cancelPairing: vi.fn(),
+}));
+
+vi.mock("@portal/api/link", () => ({
+  startPairing,
+  fetchPairingStatus,
+  cancelPairing,
+}));
+
+import { usePairing } from "@portal/hooks/usePairing";
+
+const waitingView = (over: Partial<PairingView> = {}): PairingView => ({
+  phase: "waiting",
+  userCode: "WXYZ-4821",
+  verificationUri: "https://s/link",
+  expiresAt: new Date(Date.now() + 600_000).toISOString(),
+  intervalSeconds: 5,
+  ...over,
+});
+
+const idleView: PairingView = {
+  phase: "idle",
+  userCode: null,
+  verificationUri: null,
+  expiresAt: null,
+  intervalSeconds: 0,
+};
+
+let seen: ReturnType<typeof usePairing> | null = null;
+
+// Mount inside act so the hook's async mount effect settles before we assert,
+// rather than resolving between render() and the first waitFor.
+const mount = async (onLinked?: () => void) => {
+  await act(async () => {
+    render(<Probe onLinked={onLinked} />);
+  });
+};
+
+function Probe({ onLinked }: { onLinked?: () => void }) {
+  seen = usePairing(true, onLinked);
+  return null;
+}
+
+describe("usePairing", () => {
+  beforeEach(() => {
+    seen = null;
+    startPairing.mockReset();
+    fetchPairingStatus.mockReset();
+    cancelPairing.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("adopts a pairing another replica already started", async () => {
+    fetchPairingStatus.mockResolvedValue(waitingView());
+
+    await mount();
+
+    await waitFor(() => expect(seen?.view?.phase).toBe("waiting"));
+    expect(seen?.view?.userCode).toBe("WXYZ-4821");
+    // Starting a second pairing would hand the admin a code the other pod is not
+    // waiting on, and would strand the first.
+    expect(startPairing).not.toHaveBeenCalled();
+  });
+
+  it("starts one when nothing is in flight", async () => {
+    fetchPairingStatus.mockResolvedValue(idleView);
+    startPairing.mockResolvedValue(waitingView({ userCode: "AAAA-2222" }));
+
+    await mount();
+
+    await waitFor(() => expect(startPairing).toHaveBeenCalledTimes(1));
+    expect(seen?.view?.userCode).toBe("AAAA-2222");
+  });
+
+  it("restarts rather than adopting an expired pairing", async () => {
+    fetchPairingStatus.mockResolvedValue({ ...idleView, phase: "expired" });
+    startPairing.mockResolvedValue(waitingView());
+
+    await mount();
+
+    await waitFor(() => expect(startPairing).toHaveBeenCalledTimes(1));
+  });
+
+  it("fires onLinked once, not on every later render", async () => {
+    fetchPairingStatus.mockResolvedValue({ ...idleView, phase: "linked" });
+    const onLinked = vi.fn();
+
+    await mount(onLinked);
+
+    await waitFor(() => expect(seen?.view?.phase).toBe("linked"));
+    expect(onLinked).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces an error when the pairing cannot be started", async () => {
+    fetchPairingStatus.mockResolvedValue(idleView);
+    startPairing.mockRejectedValue(new Error("Bad Gateway"));
+
+    await mount();
+
+    await waitFor(() => expect(seen?.error).toBe("Bad Gateway"));
+  });
+
+  it("keeps waiting when a poll fails mid-pairing", async () => {
+    vi.useFakeTimers();
+    fetchPairingStatus.mockResolvedValueOnce(waitingView());
+    await mount();
+    await vi.waitFor(() => expect(seen?.view?.phase).toBe("waiting"));
+
+    // A dropped poll must not clear the code the admin is currently typing in.
+    fetchPairingStatus.mockRejectedValue(new Error("network"));
+    await act(() => vi.advanceTimersByTimeAsync(7000));
+
+    expect(seen?.view?.phase).toBe("waiting");
+    expect(seen?.error).toBeNull();
+  });
+
+  it("does not poll faster than the advertised interval", async () => {
+    vi.useFakeTimers();
+    fetchPairingStatus.mockResolvedValue(waitingView({ intervalSeconds: 5 }));
+    await mount();
+    await vi.waitFor(() => expect(seen?.view?.phase).toBe("waiting"));
+
+    const afterAdopt = fetchPairingStatus.mock.calls.length;
+    await act(() => vi.advanceTimersByTimeAsync(4000));
+    expect(fetchPairingStatus.mock.calls.length).toBe(afterAdopt);
+
+    await act(() => vi.advanceTimersByTimeAsync(2000));
+    expect(fetchPairingStatus.mock.calls.length).toBeGreaterThan(afterAdopt);
+  });
+});

--- a/frontend/editor/src/portal/hooks/usePairing.ts
+++ b/frontend/editor/src/portal/hooks/usePairing.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  cancelPairing,
+  fetchPairingStatus,
+  startPairing,
+  type PairingView,
+} from "@portal/api/link";
+
+/**
+ * Drives the device-grant pairing shown in the connect modal.
+ *
+ * <p>One second-ticking timer does two jobs: it keeps the "expires in" display
+ * honest and it advances the pairing whenever the interval SaaS asked for has
+ * elapsed. The local backend also enforces that interval upstream, so a fast
+ * client here cannot hammer SaaS.
+ *
+ * <p>Polling stops the moment the phase is terminal. `linked` fires `onLinked`
+ * exactly once, guarded by a ref, because the caller uses it to refresh link
+ * state and close the dialog.
+ */
+
+const MIN_INTERVAL_SECONDS = 3;
+
+export interface UsePairing {
+  view: PairingView | null;
+  /** Seconds until the code stops working; null when there is no live code. */
+  secondsLeft: number | null;
+  /** True while a start request is in flight. */
+  starting: boolean;
+  error: string | null;
+  /** Begin (or restart) a pairing. */
+  restart: () => Promise<void>;
+  /** Abandon the pairing and clear local state. */
+  abandon: () => Promise<void>;
+}
+
+function secondsUntil(expiresAt: string | null): number | null {
+  if (!expiresAt) return null;
+  const ms = new Date(expiresAt).getTime() - Date.now();
+  return Number.isNaN(ms) ? null : Math.max(0, Math.floor(ms / 1000));
+}
+
+export function usePairing(
+  active: boolean,
+  onLinked?: () => void | Promise<void>,
+): UsePairing {
+  const [view, setView] = useState<PairingView | null>(null);
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mounted = useRef(true);
+  const linkedFired = useRef(false);
+  const lastPolled = useRef(0);
+  const busy = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const apply = useCallback(
+    (next: PairingView) => {
+      if (!mounted.current) return;
+      setView(next);
+      setSecondsLeft(secondsUntil(next.expiresAt));
+      if (next.phase === "linked" && !linkedFired.current) {
+        linkedFired.current = true;
+        void onLinked?.();
+      }
+    },
+    [onLinked],
+  );
+
+  const restart = useCallback(async () => {
+    setStarting(true);
+    setError(null);
+    try {
+      apply(await startPairing());
+      lastPolled.current = Date.now();
+    } catch (e) {
+      if (mounted.current) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      if (mounted.current) setStarting(false);
+    }
+  }, [apply]);
+
+  const abandon = useCallback(async () => {
+    try {
+      await cancelPairing();
+    } catch {
+      // Abandoning is best effort; the SaaS-side request expires on its own.
+    }
+    if (mounted.current) {
+      setView(null);
+      setSecondsLeft(null);
+    }
+  }, []);
+
+  // On open: adopt whatever pairing this deployment already has in flight (any
+  // replica may have started it) and only begin a new one when there is none.
+  useEffect(() => {
+    if (!active) return;
+    linkedFired.current = false;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const current = await fetchPairingStatus();
+        if (cancelled) return;
+        if (current.phase === "waiting" || current.phase === "linked") {
+          apply(current);
+          lastPolled.current = Date.now();
+        } else {
+          await restart();
+        }
+      } catch (e) {
+        if (!cancelled && mounted.current) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [active, apply, restart]);
+
+  useEffect(() => {
+    if (!active || view?.phase !== "waiting") return;
+    const intervalMs =
+      Math.max(MIN_INTERVAL_SECONDS, view.intervalSeconds || 0) * 1000;
+
+    const tick = setInterval(() => {
+      setSecondsLeft(secondsUntil(view.expiresAt));
+      if (busy.current || Date.now() - lastPolled.current < intervalMs) return;
+      busy.current = true;
+      lastPolled.current = Date.now();
+      void fetchPairingStatus()
+        .then(apply)
+        .catch(() => {
+          // A dropped poll is not worth surfacing: the next tick retries, and
+          // the phase only changes when SaaS says so.
+        })
+        .finally(() => {
+          busy.current = false;
+        });
+    }, 1000);
+    return () => clearInterval(tick);
+  }, [
+    active,
+    view?.phase,
+    view?.expiresAt,
+    view?.intervalSeconds,
+    apply,
+    view,
+  ]);
+
+  return { view, secondsLeft, starting, error, restart, abandon };
+}

--- a/frontend/editor/src/portal/hooks/usePairing.ts
+++ b/frontend/editor/src/portal/hooks/usePairing.ts
@@ -128,13 +128,19 @@ export function usePairing(
     };
   }, [active, apply, restart]);
 
+  // Read the fields out first so the timer depends on the values it actually uses.
+  // Depending on `view` itself would tear down and rebuild the interval on every
+  // poll response, since each one is a new object.
+  const phase = view?.phase;
+  const expiresAt = view?.expiresAt ?? null;
+  const intervalSeconds = view?.intervalSeconds ?? 0;
+
   useEffect(() => {
-    if (!active || view?.phase !== "waiting") return;
-    const intervalMs =
-      Math.max(MIN_INTERVAL_SECONDS, view.intervalSeconds || 0) * 1000;
+    if (!active || phase !== "waiting") return;
+    const intervalMs = Math.max(MIN_INTERVAL_SECONDS, intervalSeconds) * 1000;
 
     const tick = setInterval(() => {
-      setSecondsLeft(secondsUntil(view.expiresAt));
+      setSecondsLeft(secondsUntil(expiresAt));
       if (busy.current || Date.now() - lastPolled.current < intervalMs) return;
       busy.current = true;
       lastPolled.current = Date.now();
@@ -149,14 +155,7 @@ export function usePairing(
         });
     }, 1000);
     return () => clearInterval(tick);
-  }, [
-    active,
-    view?.phase,
-    view?.expiresAt,
-    view?.intervalSeconds,
-    apply,
-    view,
-  ]);
+  }, [active, phase, expiresAt, intervalSeconds, apply]);
 
   return { view, secondsLeft, starting, error, restart, abandon };
 }

--- a/frontend/editor/src/portal/mocks/handlers/link.ts
+++ b/frontend/editor/src/portal/mocks/handlers/link.ts
@@ -1,11 +1,14 @@
 import { http, HttpResponse, delay } from "msw";
 import type { LinkInstanceRequest } from "@portal/api/link";
 import {
+  cancelPairingMock,
   getLocalStatus,
   getLocalUsage,
   linkLocal,
   listInstances,
+  pairingStatusMock,
   revokeInstance,
+  startPairingMock,
   unlinkLocal,
 } from "@portal/mocks/link";
 
@@ -47,6 +50,26 @@ export const linkHandlers = [
     await delay(120);
     // Clear local link state, then 204 (no body) to match the real backend.
     unlinkLocal();
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // Device-grant pairing. start hands back the code the admin reads out; status
+  // advances it and settles on linked after a couple of polls, standing in for
+  // someone approving on another device. The device code never crosses the wire
+  // to the browser, matching the real contract.
+  http.post("/api/v1/account-link/pair/start", async () => {
+    await delay(120);
+    return HttpResponse.json(startPairingMock());
+  }),
+
+  http.get("/api/v1/account-link/pair/status", async () => {
+    await delay(120);
+    return HttpResponse.json(pairingStatusMock());
+  }),
+
+  http.post("/api/v1/account-link/pair/cancel", async () => {
+    await delay(120);
+    cancelPairingMock();
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/frontend/editor/src/portal/mocks/link.ts
+++ b/frontend/editor/src/portal/mocks/link.ts
@@ -22,6 +22,7 @@ import type {
   LinkStatus,
   LinkedInstanceRow,
   LocalUsage,
+  PairingView,
 } from "@portal/api/link";
 
 /* ──────────────────────────────────────────────────────────────────────── */
@@ -73,6 +74,8 @@ let store: LinkedInstanceRow[] = seedInstances();
 let nextId = 1004;
 let localStatus: LinkStatus = { linked: false, name: null };
 let localUsage: LocalUsage = seedLocalUsage();
+let pairing: PairingView | null = null;
+let pollsUntilApproved = 0;
 
 /** Resets the mock store + local link status to seed state (Storybook / tests). */
 export function resetLinkStore(): void {
@@ -80,6 +83,54 @@ export function resetLinkStore(): void {
   nextId = 1004;
   localStatus = { linked: false, name: null };
   localUsage = seedLocalUsage();
+  pairing = null;
+  pollsUntilApproved = 0;
+}
+
+/* ──────────────────────────────────────────────────────────────────────── */
+/*  Pairing (device grant) — start hands back a code, polling settles it     */
+/* ──────────────────────────────────────────────────────────────────────── */
+
+const IDLE_PAIRING: PairingView = {
+  phase: "idle",
+  userCode: null,
+  verificationUri: null,
+  expiresAt: null,
+  intervalSeconds: 0,
+};
+
+/** Starts a pairing. Approves itself after a couple of polls so the mock settles
+ *  on its own, the way a real admin approving on another device would. */
+export function startPairingMock(): PairingView {
+  pollsUntilApproved = 2;
+  pairing = {
+    phase: "waiting",
+    userCode: "WXYZ-4821",
+    verificationUri: "https://stirling.com/link",
+    expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    intervalSeconds: 5,
+  };
+  return { ...pairing };
+}
+
+/** Advances the mock pairing. Mirrors the real endpoint: linked once approved. */
+export function pairingStatusMock(): PairingView {
+  if (localStatus.linked) {
+    return { ...IDLE_PAIRING, phase: "linked" };
+  }
+  if (!pairing) return { ...IDLE_PAIRING };
+  if (pollsUntilApproved > 0) {
+    pollsUntilApproved -= 1;
+    return { ...pairing };
+  }
+  linkLocal("pdf-prod-01");
+  pairing = null;
+  return { ...IDLE_PAIRING, phase: "linked" };
+}
+
+export function cancelPairingMock(): void {
+  pairing = null;
+  pollsUntilApproved = 0;
 }
 
 /** Current instance-local unsynced usage (GET /api/v1/account-link/usage). */

--- a/frontend/editor/src/saas/App.tsx
+++ b/frontend/editor/src/saas/App.tsx
@@ -15,6 +15,7 @@ import Signup from "@app/routes/Signup";
 import AuthCallback from "@app/routes/AuthCallback";
 import ResetPassword from "@app/routes/ResetPassword";
 import OAuthConsent from "@app/routes/OAuthConsent";
+import PairDevice from "@app/routes/PairDevice";
 import ShareLinkPage from "@app/routes/ShareLinkPage";
 import { getAdminRouteExtensions } from "@app/routes/adminRouteExtensions";
 import OnboardingBootstrap from "@app/components/OnboardingBootstrap";
@@ -103,6 +104,11 @@ export default function App() {
                   <Route path="/auth/callback" element={<AuthCallback />} />
                   <Route path="/auth/reset" element={<ResetPassword />} />
                   <Route path="/oauth/consent" element={<OAuthConsent />} />
+                  {/* Where a self-hosted server's pairing code is approved. It
+                      has to be on this origin: the identity provider will only
+                      redirect to allow-listed URLs, so a customer's own
+                      hostname can never complete a sign-in round trip. */}
+                  <Route path="/link" element={<PairDevice />} />
                   {/* Shared-file links. Team invites are NOT routed here: on
                       SaaS they are accepted in-app via the Supabase team
                       invitation banner, not the Spring password-based

--- a/frontend/editor/src/saas/routes/PairDevice.css
+++ b/frontend/editor/src/saas/routes/PairDevice.css
@@ -1,0 +1,68 @@
+/* Approval page for a server pairing request. Plain on purpose: the facts the
+   approver has to check are the content, so nothing decorative sits near them. */
+
+.pair-device {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pair-device__title {
+  margin: 0;
+  font-size: 1.375rem;
+  font-weight: 600;
+}
+
+.pair-device__sub {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--c-text-muted);
+}
+
+.pair-device__label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--c-text-subtle);
+}
+
+.pair-device__input {
+  width: 100%;
+  margin-bottom: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 1.125rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--c-text);
+  background: var(--c-input-bg);
+  border: 1px solid var(--c-border-strong);
+  border-radius: 0.375rem;
+}
+
+.pair-device__facts {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.375rem 1rem;
+  margin: 0;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--c-border);
+  border-bottom: 1px solid var(--c-border);
+  font-size: 0.875rem;
+}
+
+.pair-device__facts dt {
+  color: var(--c-text-subtle);
+}
+
+.pair-device__facts dd {
+  margin: 0;
+  text-align: right;
+  word-break: break-all;
+}
+
+.pair-device__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/frontend/editor/src/saas/routes/PairDevice.tsx
+++ b/frontend/editor/src/saas/routes/PairDevice.tsx
@@ -6,23 +6,12 @@ import { useTranslation } from "@app/hooks/useTranslation";
 import { useDocumentMeta } from "@app/hooks/useDocumentMeta";
 import { withBasePath } from "@app/constants/app";
 import AuthLayout from "@app/routes/authShared/AuthLayout";
-import ErrorMessage from "@app/auth/ui/ErrorMessage";
-import { Button } from "@app/ui/Button";
-import "@app/auth/ui/auth.css";
+import {
+  PairDeviceView,
+  type PairPhase,
+  type PendingPairing,
+} from "@app/routes/PairDeviceView";
 import "@app/routes/authShared/saas-auth.css";
-import "@app/routes/PairDevice.css";
-
-/** Shape of GET /api/v1/pair/lookup. All display-only, and all instance-supplied. */
-interface PendingPairing {
-  userCode: string;
-  name: string | null;
-  version: string | null;
-  address: string | null;
-  requestedAt: string | null;
-  expiresAt: string | null;
-}
-
-type Phase = "entry" | "confirm" | "done" | "declined";
 
 /**
  * Approve a self-hosted server's pairing request (device grant, RFC 8628).
@@ -37,6 +26,8 @@ type Phase = "entry" | "confirm" | "done" | "declined";
  * are phishable: an attacker can start a pairing on their own server and talk
  * someone into approving the code. So we show what is actually being paired and
  * let the approver walk away.
+ *
+ * <p>Data only. {@link PairDeviceView} draws it.
  */
 export default function PairDevice() {
   const { t } = useTranslation();
@@ -46,7 +37,7 @@ export default function PairDevice() {
 
   const [code, setCode] = useState(params.get("code") ?? "");
   const [pending, setPending] = useState<PendingPairing | null>(null);
-  const [phase, setPhase] = useState<Phase>("entry");
+  const [phase, setPhase] = useState<PairPhase>("entry");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -122,123 +113,16 @@ export default function PairDevice() {
 
   return (
     <AuthLayout>
-      <div className="pair-device">
-        {phase === "entry" && (
-          <>
-            <h1 className="pair-device__title">
-              {t("pair.entry.title", "Enter your pairing code")}
-            </h1>
-            <p className="pair-device__sub">
-              {t(
-                "pair.entry.sub",
-                "From the screen on the server you are connecting.",
-              )}
-            </p>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                void lookup(code);
-              }}
-            >
-              <label className="pair-device__label" htmlFor="pair-code">
-                {t("pair.entry.label", "Pairing code")}
-              </label>
-              <input
-                id="pair-code"
-                className="pair-device__input"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                placeholder="WXYZ-4821"
-                autoComplete="off"
-                autoCapitalize="characters"
-                spellCheck={false}
-                aria-describedby={error ? "pair-error" : undefined}
-              />
-              {error && (
-                <div id="pair-error">
-                  <ErrorMessage error={error} />
-                </div>
-              )}
-              <Button
-                type="submit"
-                variant="primary"
-                disabled={busy || code.trim().length === 0}
-              >
-                {t("pair.entry.submit", "Continue")}
-              </Button>
-            </form>
-          </>
-        )}
-
-        {phase === "confirm" && pending && (
-          <>
-            <h1 className="pair-device__title">
-              {t("pair.confirm.title", "Pair this server?")}
-            </h1>
-            <p className="pair-device__sub">
-              {t(
-                "pair.confirm.sub",
-                "Check these details match the server you are connecting. If they do not, decline.",
-              )}
-            </p>
-            <dl className="pair-device__facts">
-              <dt>{t("pair.confirm.name", "Name")}</dt>
-              <dd>{pending.name ?? t("pair.confirm.unnamed", "Not set")}</dd>
-              <dt>{t("pair.confirm.address", "Address")}</dt>
-              <dd>{pending.address ?? t("pair.confirm.unknown", "Unknown")}</dd>
-              <dt>{t("pair.confirm.version", "Version")}</dt>
-              <dd>{pending.version ?? t("pair.confirm.unknown", "Unknown")}</dd>
-              <dt>{t("pair.confirm.code", "Code")}</dt>
-              <dd>{pending.userCode}</dd>
-            </dl>
-            {error && <ErrorMessage error={error} />}
-            <div className="pair-device__actions">
-              <Button
-                variant="secondary"
-                disabled={busy}
-                onClick={() => void decide(false)}
-              >
-                {t("pair.confirm.decline", "Decline")}
-              </Button>
-              <Button
-                variant="primary"
-                disabled={busy}
-                onClick={() => void decide(true)}
-              >
-                {t("pair.confirm.approve", "Pair server")}
-              </Button>
-            </div>
-          </>
-        )}
-
-        {phase === "done" && (
-          <>
-            <h1 className="pair-device__title">
-              {t("pair.done.title", "Server paired")}
-            </h1>
-            <p className="pair-device__sub">
-              {t(
-                "pair.done.sub",
-                "You can close this page. The server picks up the connection within a few seconds.",
-              )}
-            </p>
-          </>
-        )}
-
-        {phase === "declined" && (
-          <>
-            <h1 className="pair-device__title">
-              {t("pair.declined.title", "Pairing declined")}
-            </h1>
-            <p className="pair-device__sub">
-              {t(
-                "pair.declined.sub",
-                "Nothing was connected. If you did not expect this code, someone may have sent it to you by mistake.",
-              )}
-            </p>
-          </>
-        )}
-      </div>
+      <PairDeviceView
+        phase={phase}
+        code={code}
+        pending={pending}
+        busy={busy}
+        error={error}
+        onCodeChange={setCode}
+        onSubmitCode={() => void lookup(code)}
+        onDecide={(approve) => void decide(approve)}
+      />
     </AuthLayout>
   );
 }

--- a/frontend/editor/src/saas/routes/PairDevice.tsx
+++ b/frontend/editor/src/saas/routes/PairDevice.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import apiClient from "@app/services/apiClient";
+import { useAuth } from "@app/auth/UseSession";
+import { useTranslation } from "@app/hooks/useTranslation";
+import { useDocumentMeta } from "@app/hooks/useDocumentMeta";
+import { withBasePath } from "@app/constants/app";
+import AuthLayout from "@app/routes/authShared/AuthLayout";
+import ErrorMessage from "@app/auth/ui/ErrorMessage";
+import { Button } from "@app/ui/Button";
+import "@app/auth/ui/auth.css";
+import "@app/routes/authShared/saas-auth.css";
+import "@app/routes/PairDevice.css";
+
+/** Shape of GET /api/v1/pair/lookup. All display-only, and all instance-supplied. */
+interface PendingPairing {
+  userCode: string;
+  name: string | null;
+  version: string | null;
+  address: string | null;
+  requestedAt: string | null;
+  expiresAt: string | null;
+}
+
+type Phase = "entry" | "confirm" | "done" | "declined";
+
+/**
+ * Approve a self-hosted server's pairing request (device grant, RFC 8628).
+ *
+ * <p>This page exists because a self-hosted instance cannot complete an identity
+ * round trip on its own origin: the provider will only redirect to allow-listed
+ * URLs, and a customer's hostname can never be on that list. Doing the human half
+ * here, on an origin we control, is what lets SSO and sign-up work at all, and it
+ * covers headless servers that have no browser.
+ *
+ * <p>The confirmation step is the security control, not a formality. Device grants
+ * are phishable: an attacker can start a pairing on their own server and talk
+ * someone into approving the code. So we show what is actually being paired and
+ * let the approver walk away.
+ */
+export default function PairDevice() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { session, loading } = useAuth();
+  const [params] = useSearchParams();
+
+  const [code, setCode] = useState(params.get("code") ?? "");
+  const [pending, setPending] = useState<PendingPairing | null>(null);
+  const [phase, setPhase] = useState<Phase>("entry");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useDocumentMeta({
+    title: t("pair.meta.title", "Pair a server"),
+  });
+
+  // Signed-out visitors are sent to log in and returned here with the code
+  // preserved, so a code pasted from a server survives the detour.
+  useEffect(() => {
+    if (loading || session) return;
+    const next = `/link${code ? `?code=${encodeURIComponent(code)}` : ""}`;
+    navigate(`/login?next=${encodeURIComponent(withBasePath(next))}`, {
+      replace: true,
+    });
+  }, [loading, session, code, navigate]);
+
+  const lookup = useCallback(
+    async (typed: string) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const res = await apiClient.get<PendingPairing>("/api/v1/pair/lookup", {
+          params: { code: typed },
+        });
+        setPending(res.data);
+        setPhase("confirm");
+      } catch {
+        // 404 covers unknown, expired and already-settled codes alike. Telling
+        // them apart would help someone probing for live codes more than it
+        // would help the admin.
+        setError(
+          t(
+            "pair.error.notFound",
+            "That code is not valid. It may have expired, or already been used. Ask the server for a new one.",
+          ),
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [t],
+  );
+
+  const decide = useCallback(
+    async (approve: boolean) => {
+      if (!pending) return;
+      setBusy(true);
+      setError(null);
+      try {
+        await apiClient.post(
+          approve ? "/api/v1/pair/approve" : "/api/v1/pair/deny",
+          approve
+            ? { code: pending.userCode, name: pending.name }
+            : { code: pending.userCode },
+        );
+        setPhase(approve ? "done" : "declined");
+      } catch {
+        setError(
+          t(
+            "pair.error.failed",
+            "That did not go through. Only a team owner can pair a server.",
+          ),
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [pending, t],
+  );
+
+  if (loading || !session) return null;
+
+  return (
+    <AuthLayout>
+      <div className="pair-device">
+        {phase === "entry" && (
+          <>
+            <h1 className="pair-device__title">
+              {t("pair.entry.title", "Enter your pairing code")}
+            </h1>
+            <p className="pair-device__sub">
+              {t(
+                "pair.entry.sub",
+                "From the screen on the server you are connecting.",
+              )}
+            </p>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                void lookup(code);
+              }}
+            >
+              <label className="pair-device__label" htmlFor="pair-code">
+                {t("pair.entry.label", "Pairing code")}
+              </label>
+              <input
+                id="pair-code"
+                className="pair-device__input"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="WXYZ-4821"
+                autoComplete="off"
+                autoCapitalize="characters"
+                spellCheck={false}
+                aria-describedby={error ? "pair-error" : undefined}
+              />
+              {error && (
+                <div id="pair-error">
+                  <ErrorMessage error={error} />
+                </div>
+              )}
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={busy || code.trim().length === 0}
+              >
+                {t("pair.entry.submit", "Continue")}
+              </Button>
+            </form>
+          </>
+        )}
+
+        {phase === "confirm" && pending && (
+          <>
+            <h1 className="pair-device__title">
+              {t("pair.confirm.title", "Pair this server?")}
+            </h1>
+            <p className="pair-device__sub">
+              {t(
+                "pair.confirm.sub",
+                "Check these details match the server you are connecting. If they do not, decline.",
+              )}
+            </p>
+            <dl className="pair-device__facts">
+              <dt>{t("pair.confirm.name", "Name")}</dt>
+              <dd>{pending.name ?? t("pair.confirm.unnamed", "Not set")}</dd>
+              <dt>{t("pair.confirm.address", "Address")}</dt>
+              <dd>{pending.address ?? t("pair.confirm.unknown", "Unknown")}</dd>
+              <dt>{t("pair.confirm.version", "Version")}</dt>
+              <dd>{pending.version ?? t("pair.confirm.unknown", "Unknown")}</dd>
+              <dt>{t("pair.confirm.code", "Code")}</dt>
+              <dd>{pending.userCode}</dd>
+            </dl>
+            {error && <ErrorMessage error={error} />}
+            <div className="pair-device__actions">
+              <Button
+                variant="secondary"
+                disabled={busy}
+                onClick={() => void decide(false)}
+              >
+                {t("pair.confirm.decline", "Decline")}
+              </Button>
+              <Button
+                variant="primary"
+                disabled={busy}
+                onClick={() => void decide(true)}
+              >
+                {t("pair.confirm.approve", "Pair server")}
+              </Button>
+            </div>
+          </>
+        )}
+
+        {phase === "done" && (
+          <>
+            <h1 className="pair-device__title">
+              {t("pair.done.title", "Server paired")}
+            </h1>
+            <p className="pair-device__sub">
+              {t(
+                "pair.done.sub",
+                "You can close this page. The server picks up the connection within a few seconds.",
+              )}
+            </p>
+          </>
+        )}
+
+        {phase === "declined" && (
+          <>
+            <h1 className="pair-device__title">
+              {t("pair.declined.title", "Pairing declined")}
+            </h1>
+            <p className="pair-device__sub">
+              {t(
+                "pair.declined.sub",
+                "Nothing was connected. If you did not expect this code, someone may have sent it to you by mistake.",
+              )}
+            </p>
+          </>
+        )}
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/editor/src/saas/routes/PairDevice.tsx
+++ b/frontend/editor/src/saas/routes/PairDevice.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@app/auth/UseSession";
 import { useTranslation } from "@app/hooks/useTranslation";
 import { useDocumentMeta } from "@app/hooks/useDocumentMeta";
 import { withBasePath } from "@app/constants/app";
+import loginHeader from "@app/assets/brand/modern-logo/LoginLightModeHeader.svg";
 import AuthLayout from "@app/routes/authShared/AuthLayout";
 import {
   PairDeviceView,
@@ -113,6 +114,22 @@ export default function PairDevice() {
 
   return (
     <AuthLayout>
+      {/* Same header the sibling auth pages use: an admin arriving from a code on
+          another screen should be able to tell at a glance they are in the right
+          place, and on ours rather than somewhere that just looks like it. */}
+      <div className="auth-logo-block">
+        <img
+          src={loginHeader}
+          alt="Stirling PDF"
+          className="auth-logo-header auth-logo-header--light"
+        />
+        <img
+          src={withBasePath("/modern-logo/LoginDarkModeHeader.svg")}
+          alt="Stirling PDF"
+          className="auth-logo-header auth-logo-header--dark"
+        />
+      </div>
+
       <PairDeviceView
         phase={phase}
         code={code}

--- a/frontend/editor/src/saas/routes/PairDeviceView.test.tsx
+++ b/frontend/editor/src/saas/routes/PairDeviceView.test.tsx
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import userEvent from "@testing-library/user-event";
+import {
+  PairDeviceView,
+  type PairDeviceViewProps,
+  type PendingPairing,
+} from "@app/routes/PairDeviceView";
+
+/**
+ * The approval page is the security control in the pairing flow, so what it shows
+ * and when it lets you act are the things worth pinning. Device grants are
+ * phishable: the whole defence is that the approver can see what they are about to
+ * connect and can walk away.
+ *
+ * i18n is not initialised in the saas vitest project, so t() renders the key. These
+ * assert on keys, matching FreeLimitReachedModal.test.tsx. The instance-supplied
+ * values (name, address, version, code) are real data and assert as themselves.
+ */
+
+const pending: PendingPairing = {
+  userCode: "WXYZ-4821",
+  name: "pdf-prod-01",
+  version: "1.4.2",
+  address: "203.0.113.44",
+  requestedAt: null,
+  expiresAt: null,
+};
+
+const base = {
+  phase: "entry" as const,
+  code: "",
+  pending: null,
+  busy: false,
+  error: null,
+  onCodeChange: () => {},
+  onSubmitCode: () => {},
+  onDecide: () => {},
+};
+
+/** @app/ui/Button wraps Mantine, so it needs the provider (as FreeLimitReachedModal does). */
+function renderView(props: Partial<PairDeviceViewProps> = {}) {
+  const result = render(
+    <MantineProvider>
+      <PairDeviceView {...base} {...props} />
+    </MantineProvider>,
+  );
+  return {
+    ...result,
+    update: (next: Partial<PairDeviceViewProps>) =>
+      result.rerender(
+        <MantineProvider>
+          <PairDeviceView {...base} {...next} />
+        </MantineProvider>,
+      ),
+  };
+}
+
+describe("PairDeviceView", () => {
+  it("holds Continue until a code is typed", () => {
+    const { update } = renderView();
+    expect(
+      screen.getByRole("button", { name: "pair.entry.submit" }),
+    ).toBeDisabled();
+
+    // Whitespace is not a code.
+    update({ code: "   " });
+    expect(
+      screen.getByRole("button", { name: "pair.entry.submit" }),
+    ).toBeDisabled();
+
+    update({ code: "WXYZ-4821" });
+    expect(
+      screen.getByRole("button", { name: "pair.entry.submit" }),
+    ).toBeEnabled();
+  });
+
+  it("submits the typed code", async () => {
+    const onSubmitCode = vi.fn();
+    renderView({ code: "WXYZ-4821", onSubmitCode });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "pair.entry.submit" }),
+    );
+
+    expect(onSubmitCode).toHaveBeenCalledTimes(1);
+  });
+
+  it("names what is being paired so the approver can check it is theirs", () => {
+    renderView({ phase: "confirm", pending });
+
+    expect(screen.getByText("pdf-prod-01")).toBeInTheDocument();
+    expect(screen.getByText("203.0.113.44")).toBeInTheDocument();
+    expect(screen.getByText("1.4.2")).toBeInTheDocument();
+    expect(screen.getByText("WXYZ-4821")).toBeInTheDocument();
+  });
+
+  it("still renders the confirm step when the server sent no details", () => {
+    renderView({
+      phase: "confirm",
+      pending: { ...pending, name: null, version: null, address: null },
+    });
+
+    // Blanks must read as unknown rather than vanishing, so a bare request is
+    // visibly bare instead of looking like a well-described one.
+    expect(screen.getByText("pair.confirm.unnamed")).toBeInTheDocument();
+    expect(screen.getAllByText("pair.confirm.unknown")).toHaveLength(2);
+  });
+
+  it("offers declining as a peer of approving", async () => {
+    const onDecide = vi.fn();
+    renderView({ phase: "confirm", pending, onDecide });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "pair.confirm.decline" }),
+    );
+    expect(onDecide).toHaveBeenCalledWith(false);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "pair.confirm.approve" }),
+    );
+    expect(onDecide).toHaveBeenCalledWith(true);
+  });
+
+  it("holds both choices while a decision is in flight", () => {
+    renderView({ phase: "confirm", pending, busy: true });
+
+    expect(
+      screen.getByRole("button", { name: "pair.confirm.decline" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "pair.confirm.approve" }),
+    ).toBeDisabled();
+  });
+
+  it("shows the terminal steps", () => {
+    const { update } = renderView({ phase: "done" });
+    expect(screen.getByText("pair.done.title")).toBeInTheDocument();
+
+    update({ phase: "declined" });
+    expect(screen.getByText("pair.declined.title")).toBeInTheDocument();
+  });
+
+  it("renders nothing for confirm without a pairing to confirm", () => {
+    renderView({ phase: "confirm", pending: null });
+
+    expect(
+      screen.queryByRole("button", { name: "pair.confirm.approve" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/editor/src/saas/routes/PairDeviceView.tsx
+++ b/frontend/editor/src/saas/routes/PairDeviceView.tsx
@@ -1,0 +1,166 @@
+import { useTranslation } from "@app/hooks/useTranslation";
+import ErrorMessage from "@app/auth/ui/ErrorMessage";
+import { Button } from "@app/ui/Button";
+import "@app/auth/ui/auth.css";
+import "@app/routes/PairDevice.css";
+
+/** Shape of GET /api/v1/pair/lookup. All display-only, and all instance-supplied. */
+export interface PendingPairing {
+  userCode: string;
+  name: string | null;
+  version: string | null;
+  address: string | null;
+  requestedAt: string | null;
+  expiresAt: string | null;
+}
+
+export type PairPhase = "entry" | "confirm" | "done" | "declined";
+
+export interface PairDeviceViewProps {
+  phase: PairPhase;
+  code: string;
+  pending: PendingPairing | null;
+  busy: boolean;
+  error: string | null;
+  onCodeChange: (value: string) => void;
+  onSubmitCode: () => void;
+  onDecide: (approve: boolean) => void;
+}
+
+/**
+ * Presentation for the pairing approval page. Pure, so every step is reachable
+ * from props and the whole flow is covered by Storybook and the a11y scan without
+ * a session or a live pairing. {@link PairDevice} supplies the data.
+ */
+export function PairDeviceView({
+  phase,
+  code,
+  pending,
+  busy,
+  error,
+  onCodeChange,
+  onSubmitCode,
+  onDecide,
+}: PairDeviceViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="pair-device">
+      {phase === "entry" && (
+        <>
+          <h1 className="pair-device__title">
+            {t("pair.entry.title", "Enter your pairing code")}
+          </h1>
+          <p className="pair-device__sub">
+            {t(
+              "pair.entry.sub",
+              "From the screen on the server you are connecting.",
+            )}
+          </p>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSubmitCode();
+            }}
+          >
+            <label className="pair-device__label" htmlFor="pair-code">
+              {t("pair.entry.label", "Pairing code")}
+            </label>
+            <input
+              id="pair-code"
+              className="pair-device__input"
+              value={code}
+              onChange={(e) => onCodeChange(e.target.value)}
+              placeholder="WXYZ-4821"
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              aria-describedby={error ? "pair-error" : undefined}
+            />
+            {error && (
+              <div id="pair-error">
+                <ErrorMessage error={error} />
+              </div>
+            )}
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={busy || code.trim().length === 0}
+            >
+              {t("pair.entry.submit", "Continue")}
+            </Button>
+          </form>
+        </>
+      )}
+
+      {phase === "confirm" && pending && (
+        <>
+          <h1 className="pair-device__title">
+            {t("pair.confirm.title", "Pair this server?")}
+          </h1>
+          <p className="pair-device__sub">
+            {t(
+              "pair.confirm.sub",
+              "Check these details match the server you are connecting. If they do not, decline.",
+            )}
+          </p>
+          <dl className="pair-device__facts">
+            <dt>{t("pair.confirm.name", "Name")}</dt>
+            <dd>{pending.name ?? t("pair.confirm.unnamed", "Not set")}</dd>
+            <dt>{t("pair.confirm.address", "Address")}</dt>
+            <dd>{pending.address ?? t("pair.confirm.unknown", "Unknown")}</dd>
+            <dt>{t("pair.confirm.version", "Version")}</dt>
+            <dd>{pending.version ?? t("pair.confirm.unknown", "Unknown")}</dd>
+            <dt>{t("pair.confirm.code", "Code")}</dt>
+            <dd>{pending.userCode}</dd>
+          </dl>
+          {error && <ErrorMessage error={error} />}
+          <div className="pair-device__actions">
+            <Button
+              variant="secondary"
+              disabled={busy}
+              onClick={() => onDecide(false)}
+            >
+              {t("pair.confirm.decline", "Decline")}
+            </Button>
+            <Button
+              variant="primary"
+              disabled={busy}
+              onClick={() => onDecide(true)}
+            >
+              {t("pair.confirm.approve", "Pair server")}
+            </Button>
+          </div>
+        </>
+      )}
+
+      {phase === "done" && (
+        <>
+          <h1 className="pair-device__title">
+            {t("pair.done.title", "Server paired")}
+          </h1>
+          <p className="pair-device__sub">
+            {t(
+              "pair.done.sub",
+              "You can close this page. The server picks up the connection within a few seconds.",
+            )}
+          </p>
+        </>
+      )}
+
+      {phase === "declined" && (
+        <>
+          <h1 className="pair-device__title">
+            {t("pair.declined.title", "Pairing declined")}
+          </h1>
+          <p className="pair-device__sub">
+            {t(
+              "pair.declined.sub",
+              "Nothing was connected. If you did not expect this code, someone may have sent it to you by mistake.",
+            )}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Linking a self-hosted instance today needs an admin to sign in to Stirling **in a browser on the instance itself**. That cannot work for the cases that matter:

- **SSO never returns.** Supabase honours a `redirectTo` only when it is on the project's allow-list. A customer origin (`https://pdf.acme.internal`, `http://192.168.1.20:8080`) will never be on it, so the round trip completes on the SaaS site and the instance tab never receives a session. The link silently fails. Adding entries does not fix it: wildcards cover a domain we own, not the open set of customer hostnames.
- **Sign-up has the same problem.** The confirmation email redirects to the same Site URL.
- **Headless servers have no browser at all.**

This replaces that step with the OAuth device authorization grant (RFC 8628): the instance shows a short code, the admin approves it on our own origin from any device, and the instance polls until its credential is issued.

## What it does not change

Approval delegates to the existing `AccountLinkService.register`, so a paired instance is indistinguishable from one registered the old way. Entitlement, metering, revocation and the `linked_instance` table are untouched.

It removes surface rather than adding it: no Supabase client on the linking path, no SSO redirect allow-list, no `PENDING_LINK_KEY` round trip.

## Flow

| Step | Where |
|---|---|
| 1. `POST /api/v1/pair/start` returns a user code and a device code | instance, unauthenticated |
| 2. Instance shows the user code and starts polling | instance |
| 3. Admin opens `/link`, signs in, enters the code | our origin, so SSO works |
| 4. Admin approves after checking what is being paired | leader only |
| 5. `POST /api/v1/pair/poll` returns the credential, once | instance |

## Design notes worth reviewing

**Approval does not mint.** It binds the team; the credential is minted on the poll that presents the device code. So the secret only ever reaches the party that started the pairing, and the request flips to `CONSUMED` so a replayed device code cannot mint a second credential. There is a pessimistic row lock on that path because two pods can poll concurrently.

**The confirmation screen is a control, not a formality.** Device grants are phishable: an attacker can start a pairing on their own server and talk someone into approving the code. So the screen names the server, its address and version rather than asking a bare yes or no. Alongside that: leader-only approval, a 10 minute lifetime, and a per-address cap on concurrent pairings. The address is a hint (first `X-Forwarded-For` hop is client-set) and is commented as such.

**Pairing state is a database row, not memory.** On a multi-replica deployment the admin's browser reaches an arbitrary pod through the ingress. Pod-local state would mean a refresh landing elsewhere shows no pairing, or starts a second one with a different code. A shared singleton row lets any pod render and advance the same pairing. This also means pod recycling needs no special handling: `DeviceCredential` is already a singleton row in the shared database, so replacement pods just read it.

**No scheduler.** Polling is driven by the status endpoint and rate-limited against the shared row, so replicas cannot exceed the interval SaaS advertised and an abandoned pairing simply expires.

**`LeaderTeamResolver` is extracted** from `AccountLinkController` so the register and approval paths cannot drift on who may bind an instance to a team. That is an authorization rule, so a second copy would eventually be the wrong one. The existing controller tests now run the real resolver over mocked repositories, so its coverage moved with it.

**Re-auth keeps the in-browser Supabase login.** There we genuinely want a session in this browser and the admin already has an account, so the device grant would be the wrong tool.

## Deliberately deferred

The provisioned-credential path for GitOps, where the portal issues a credential to paste into cluster config and pods boot already paired. It needs no new SaaS logic (`RegisterResponse` already returns the secret) but it does require restating the "device secret never in the browser" invariant as a decision rather than letting it drift, so it belongs in its own change.

## Flag state

Unchanged. Everything here sits behind `stirling.billing.account-link.enabled`, off by default, so the beans are absent and every new path 404s. The two `permitAll` entries in the security chain therefore lead nowhere until the flag is on.

## Cross-repo

The new `account_pairing_request` table needs the Supabase migration in [Stirling-PDF-SaaS#323](https://github.com/Stirling-Tools/Stirling-PDF-SaaS/pull/323), which is a **prerequisite for running this flow** rather than a follow-up.

I originally wrote here that `ddl-auto=update` would create the table. That was wrong. SaaS environments run `ddl-auto=none`, because this schema is owned by the Supabase migrations and letting Hibernate near it fails anyway (it tries to shrink the RLS-policy-guarded `team_memberships.role` column). Confirmed against a live dev boot: Hibernate logs `No schema management actions found`, and the first `/pair/start` failed with `relation "stirling_pdf.account_pairing_request" does not exist`.

Still not a merge gate for *this* PR while the feature is dark, since nothing reaches the table until the flag is on. It is a gate on exercising the flow.

## Verification

- `:saas:test` and `:proprietary:test` accountlink: green, including a new test each side
- `spotlessCheck`, `:stirling-pdf:compileJava`: green
- `tsc` across the saas, portal and proprietary cascades: no errors in changed files
- `oxlint`, `stylelint`, `prettier`: clean
- portal vitest: 322 passing (3 pre-existing suite failures from a missing generated icon asset, unrelated)
- i18n audits: 46 passing, new keys added to `en-US` and the two orphaned ones retired

Not yet exercised end to end against a live SaaS backend with the flag on. That needs the manual runbook and is the obvious next step before anyone relies on it.


