### PR TITLE
Stop a blocked IndexedDB upgrade from hanging the file library

### DIFF
--- a/frontend/editor/src/core/components/shared/FileSelectorPicker.tsx
+++ b/frontend/editor/src/core/components/shared/FileSelectorPicker.tsx
@@ -201,13 +201,27 @@ export function FileSelectorPicker({
     setSortDir(lsGet(LS_SORT_DIR, "desc", ["asc", "desc"]));
   }, [isOpen]);
 
-  // Load saved files when the saved tab is active and the picker is open
+  // Load saved files when the saved tab is active and the picker is open.
+  // Cancellable: storage reads can be slow or reject, and outlive the popover.
   useEffect(() => {
     if (activeTab !== "saved" || !isOpen) return;
+    let cancelled = false;
     setSavedLoading(true);
     loadRecentFiles()
-      .then(setSavedStubs)
-      .finally(() => setSavedLoading(false));
+      .then((stubs) => {
+        if (!cancelled) setSavedStubs(stubs);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) setSavedStubs([]);
+        console.warn("Failed to load saved files for the picker:", error);
+      })
+      .finally(() => {
+        if (!cancelled) setSavedLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      setSavedLoading(false);
+    };
   }, [activeTab, isOpen, loadRecentFiles]);
 
   const workbenchIdSet = useMemo(
@@ -541,7 +555,9 @@ export function FileSelectorPicker({
           </div>
 
           <ScrollArea h={260} className={styles.list}>
-            {savedLoading ? (
+            {/* Workbench renders from memory, so a stuck storage read must not
+                spin it too. */}
+            {savedLoading && activeTab === "saved" ? (
               <div className={styles.emptyState}>
                 <Loader size="sm" />
               </div>

--- a/frontend/editor/src/core/components/shared/FileSidebar.tsx
+++ b/frontend/editor/src/core/components/shared/FileSidebar.tsx
@@ -306,32 +306,45 @@ const FileSidebar = forwardRef<HTMLDivElement, FileSidebarProps>(
     const storageEnabled = config?.storageEnabled === true && !isAnonymous;
 
     const refreshStubs = useCallback(async () => {
-      // Leaf files from IDB - same source as the file selection modal.
-      const stubs = await indexedDB.loadLeafMetadata();
-      const idbIds = new Set(stubs.map((s) => s.id as string));
+      // `stubsLoaded` gates the spinner, so the `finally` below must set it on
+      // every path - callers never await this, so a rejection goes nowhere.
+      let stubs: StirlingFileStub[] = [];
+      try {
+        // Leaf files from IDB - same source as the file selection modal.
+        stubs = await indexedDB.loadLeafMetadata();
+      } catch (error) {
+        // Carry on with the in-memory workbench files: an unreadable library
+        // should cost the user their history, not the file they're working on.
+        console.error("Failed to read the file library from storage:", error);
+      }
 
-      // Also include workbench files not yet flushed to IDB.
-      const pendingStubs = state.files.ids
-        .map((id) => state.files.byId[id])
-        .filter(
-          (stub): stub is NonNullable<typeof stub> =>
-            !!stub && stub.isLeaf !== false && !idbIds.has(stub.id as string),
+      try {
+        const idbIds = new Set(stubs.map((s) => s.id as string));
+
+        // Also include workbench files not yet flushed to IDB.
+        const pendingStubs = state.files.ids
+          .map((id) => state.files.byId[id])
+          .filter(
+            (stub): stub is NonNullable<typeof stub> =>
+              !!stub && stub.isLeaf !== false && !idbIds.has(stub.id as string),
+          );
+
+        const allStubs = [...stubs, ...pendingStubs];
+        // A version swap briefly lists both the old leaf (IDB) and its replacement (workbench); two stubs for one lineage collide on the row key and corrupt React reconciliation, so drop any stub another names as its parent.
+        const superseded = new Set(
+          allStubs.map((s) => s.parentFileId as string | undefined),
         );
-
-      const allStubs = [...stubs, ...pendingStubs];
-      // A version swap briefly lists both the old leaf (IDB) and its replacement (workbench); two stubs for one lineage collide on the row key and corrupt React reconciliation, so drop any stub another names as its parent.
-      const superseded = new Set(
-        allStubs.map((s) => s.parentFileId as string | undefined),
-      );
-      const currentStubs = allStubs.filter(
-        (s) => !superseded.has(s.id as string),
-      );
-      setAllFileStubs(
-        currentStubs.sort(
-          (a, b) => (b.lastModified ?? 0) - (a.lastModified ?? 0),
-        ),
-      );
-      setStubsLoaded(true);
+        const currentStubs = allStubs.filter(
+          (s) => !superseded.has(s.id as string),
+        );
+        setAllFileStubs(
+          currentStubs.sort(
+            (a, b) => (b.lastModified ?? 0) - (a.lastModified ?? 0),
+          ),
+        );
+      } finally {
+        setStubsLoaded(true);
+      }
     }, [indexedDB, state.files.ids, state.files.byId]);
 
     // Refresh on mount, workbench changes, or external IndexedDB writes —

--- a/frontend/editor/src/core/services/indexedDBManager.blocked.test.ts
+++ b/frontend/editor/src/core/services/indexedDBManager.blocked.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import "fake-indexeddb/auto";
+import { expectConsole } from "@app/tests/failOnConsole";
+
+import { indexedDBManager } from "@app/services/indexedDBManager";
+
+/** Regression tests for the "spins forever" bug. Both directions: we yield our
+ *  connection to another tab's upgrade, and we fail rather than hang on theirs. */
+
+/** A database per test: these leave connections and version histories behind,
+ *  and would otherwise block each other for the reason under test. */
+function freshDb(name: string, version: number) {
+  return {
+    name: `blocked-guard-${name}`,
+    version,
+    stores: [{ name: "items", keyPath: "id" }],
+  };
+}
+
+/** A raw connection that ignores `versionchange`, like an older build. */
+function holdConnectionIgnoringVersionChange(
+  name: string,
+  version: number,
+): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(name, version);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains("items")) {
+        db.createObjectStore("items", { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  indexedDBManager.closeAllDatabases();
+});
+
+describe("openDatabase — another connection is in the way", () => {
+  test("rejects with an actionable error instead of hanging forever", async () => {
+    expectConsole.warn(/blocked by another open connection/);
+
+    const db = freshDb("hangs", 2);
+    // A connection at v1 that never yields, so our v2 open is blocked.
+    const squatter = await holdConnectionIgnoringVersionChange(db.name, 1);
+
+    vi.useFakeTimers();
+    const open = indexedDBManager.openDatabase(db);
+    // Surface the rejection to the assertion, not to the process.
+    const settled = open.then(
+      () => "resolved" as const,
+      (error: Error) => error,
+    );
+
+    // The block alone must not settle it - the squatter could still close.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await Promise.resolve();
+
+    // ...but it must not wait indefinitely either.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const outcome = await settled;
+    expect(outcome).toBeInstanceOf(Error);
+    expect((outcome as Error).message).toMatch(/another tab/i);
+
+    squatter.close();
+  });
+
+  test("a later open succeeds once the blocker is gone", async () => {
+    const config = freshDb("unblocked", 3);
+    const squatter = await holdConnectionIgnoringVersionChange(config.name, 1);
+    // Closed before the upgrade is requested, so it is never blocked.
+    squatter.close();
+
+    const db = await indexedDBManager.openDatabase(config);
+    expect(db.version).toBe(3);
+  });
+});
+
+describe("openDatabase — we are in someone else's way", () => {
+  test("closes our connection when another tab needs to upgrade", async () => {
+    expectConsole.warn(/Another tab is upgrading/);
+
+    const config = freshDb("yields", 4);
+    const db = await indexedDBManager.openDatabase(config);
+    expect(db.version).toBe(4);
+
+    // Our `versionchange` handler must close, or this open stays blocked.
+    const upgraded = await new Promise<IDBDatabase | "blocked">((resolve) => {
+      const request = indexedDB.open(config.name, 5);
+      request.onblocked = () => resolve("blocked");
+      request.onupgradeneeded = () => {
+        const upgrading = request.result;
+        if (!upgrading.objectStoreNames.contains("items")) {
+          upgrading.createObjectStore("items", { keyPath: "id" });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+    });
+
+    expect(upgraded).not.toBe("blocked");
+    (upgraded as IDBDatabase).close();
+  });
+
+  test("forgets the closed handle so the next open reconnects", async () => {
+    expectConsole.warn(/Another tab is upgrading/);
+    const config = freshDb("reconnects", 6);
+    const first = await indexedDBManager.openDatabase(config);
+
+    // Drive the same path the other tab's upgrade would.
+    first.onversionchange?.(
+      new Event("versionchange") as IDBVersionChangeEvent,
+    );
+
+    // A cached-but-closed handle is worse than none - every read then fails.
+    const second = await indexedDBManager.openDatabase(config);
+    expect(second).not.toBe(first);
+    expect(() => second.transaction("items", "readonly")).not.toThrow();
+  });
+});

--- a/frontend/editor/src/core/services/indexedDBManager.ts
+++ b/frontend/editor/src/core/services/indexedDBManager.ts
@@ -21,6 +21,9 @@ export interface DatabaseConfig {
 
 class IndexedDBManager {
   private static instance: IndexedDBManager;
+  /** Grace period after `blocked`: long enough for a well-behaved tab to close
+   *  its connection, short enough to answer someone watching a spinner. */
+  private static readonly BLOCKED_GRACE_MS = 10_000;
   private databases = new Map<string, IDBDatabase>();
   private initPromises = new Map<string, Promise<IDBDatabase>>();
 
@@ -47,6 +50,24 @@ class IndexedDBManager {
       return existingPromise;
     }
 
+    // Register BEFORE the first await or the check above is dead: boot-time
+    // callers all open their own, and only the first ever receives `blocked`.
+    const initPromise = this.initialiseDatabase(config);
+    this.initPromises.set(config.name, initPromise);
+
+    try {
+      const db = await initPromise;
+      this.databases.set(config.name, db);
+      return db;
+    } catch (error) {
+      this.initPromises.delete(config.name);
+      throw error;
+    }
+  }
+
+  private async initialiseDatabase(
+    config: DatabaseConfig,
+  ): Promise<IDBDatabase> {
     // SaaS lineage shipped a v6 and a v7 of stirling-pdf-files whose
     // upgrade paths corrupted records (separate cursor walks racing in
     // one versionchange transaction). The SaaS build wipes those
@@ -65,17 +86,46 @@ class IndexedDBManager {
       }
     }
 
-    const initPromise = this.performDatabaseInit(config);
-    this.initPromises.set(config.name, initPromise);
+    return this.performDatabaseInit(config);
+  }
 
-    try {
-      const db = await initPromise;
-      this.databases.set(config.name, db);
-      return db;
-    } catch (error) {
-      this.initPromises.delete(config.name);
-      throw error;
-    }
+  /** Drop our cached handle + in-flight promise so the next open starts clean. */
+  private forgetDatabase(name: string): void {
+    this.databases.delete(name);
+    this.initPromises.delete(name);
+  }
+
+  /** Make a blocked open/delete fail loudly instead of hanging. Rejecting does
+   *  not cancel the request, so check `gaveUp()` and close what still arrives. */
+  private blockedGuard(
+    // `deleteDatabase` returns an IDBOpenDBRequest too, so both call sites fit.
+    request: IDBOpenDBRequest,
+    config: Pick<DatabaseConfig, "name">,
+    reject: (reason: Error) => void,
+  ): { settle: () => void; gaveUp: () => boolean } {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let gaveUp = false;
+    request.onblocked = () => {
+      console.warn(
+        `${config.name} is blocked by another open connection (another tab?). ` +
+          `Waiting ${IndexedDBManager.BLOCKED_GRACE_MS}ms for it to close.`,
+      );
+      timer = setTimeout(() => {
+        gaveUp = true;
+        reject(
+          new Error(
+            `Timed out opening ${config.name}: another tab is holding it at an ` +
+              `older version. Close Stirling PDF's other tabs and reload.`,
+          ),
+        );
+      }, IndexedDBManager.BLOCKED_GRACE_MS);
+    };
+    return {
+      settle: () => {
+        if (timer !== undefined) clearTimeout(timer);
+      },
+      gaveUp: () => gaveUp,
+    };
   }
 
   private performDatabaseInit(config: DatabaseConfig): Promise<IDBDatabase> {
@@ -83,20 +133,46 @@ class IndexedDBManager {
       console.log(`Opening IndexedDB: ${config.name} v${config.version}`);
       const request = indexedDB.open(config.name, config.version);
 
+      // A blocked upgrade fires `blocked` and then nothing at all - no success,
+      // no error - so without this the promise never settles.
+      const { settle, gaveUp } = this.blockedGuard(request, config, reject);
+
       request.onerror = () => {
+        settle();
         console.error(`Failed to open ${config.name}:`, request.error);
         reject(request.error);
       };
 
       request.onsuccess = () => {
+        settle();
         const db = request.result;
+
+        // Blocker gone, but we already rejected: holding this would block the
+        // next upgrade in turn.
+        if (gaveUp()) {
+          console.warn(
+            `${config.name} opened after we gave up waiting; closing the orphaned connection.`,
+          );
+          db.close();
+          return;
+        }
+
         console.log(`Successfully opened ${config.name}`);
+
+        // Yield to another tab's upgrade, or a release that bumps the version
+        // bricks every open tab until the user closes them.
+        db.onversionchange = () => {
+          console.warn(
+            `Another tab is upgrading ${config.name}; closing this connection so it can proceed.`,
+          );
+          this.forgetDatabase(config.name);
+          db.close();
+        };
 
         // Set up close handler to clean up our references
         db.onclose = () => {
           console.log(`Database ${config.name} closed`);
-          this.databases.delete(config.name);
-          this.initPromises.delete(config.name);
+          this.forgetDatabase(config.name);
         };
 
         resolve(db);
@@ -303,8 +379,7 @@ class IndexedDBManager {
     const db = this.databases.get(name);
     if (db) {
       db.close();
-      this.databases.delete(name);
-      this.initPromises.delete(name);
+      this.forgetDatabase(name);
     }
   }
 
@@ -330,8 +405,22 @@ class IndexedDBManager {
     return new Promise((resolve, reject) => {
       const deleteRequest = indexedDB.deleteDatabase(name);
 
-      deleteRequest.onerror = () => reject(deleteRequest.error);
+      // Deletes block like upgrades do, and this one is awaited on the files
+      // open path, so a blocked delete would hang the whole storage layer.
+      const { settle, gaveUp } = this.blockedGuard(
+        deleteRequest,
+        { name },
+        reject,
+      );
+
+      deleteRequest.onerror = () => {
+        settle();
+        reject(deleteRequest.error);
+      };
       deleteRequest.onsuccess = () => {
+        settle();
+        // Caller has moved on; don't resolve an already-rejected promise.
+        if (gaveUp()) return;
         console.log(`Deleted database: ${name}`);
         resolve();
       };

--- a/frontend/editor/src/core/tests/helpers/api-stubs.ts
+++ b/frontend/editor/src/core/tests/helpers/api-stubs.ts
@@ -131,6 +131,9 @@ export interface MockAppApiOptions {
   languages?: string[];
   /** Default locale. */
   defaultLocale?: string;
+  /** Advertise server-side storage. Off by default - a spec that stubs or
+   *  blocks `/api/v1/storage/files` must set this or the route is never hit. */
+  storageEnabled?: boolean;
   /** Merge overrides into the endpoint availability map. */
   endpointsAvailability?: Record<string, { enabled: boolean }>;
   /** Backend probe status. Set to `"DOWN"` to exercise offline-mode UI. */
@@ -156,6 +159,7 @@ export async function mockAppApis(
     },
     languages = ["en-US"],
     defaultLocale = "en-US",
+    storageEnabled = false,
     endpointsAvailability = {},
     backendStatus = "UP",
   } = opts;
@@ -173,6 +177,7 @@ export async function mockAppApis(
         isAdmin,
         languages,
         defaultLocale,
+        storageEnabled,
       },
     }),
   );

--- a/frontend/editor/src/core/tests/stubbed/file-library-resilience.spec.ts
+++ b/frontend/editor/src/core/tests/stubbed/file-library-resilience.spec.ts
@@ -1,0 +1,140 @@
+/** The sidebar and file pickers must reach a resting state even when storage
+ *  can't be read. Blocks the database for real, then asserts the UI recovers. */
+
+import path from "path";
+import { test, expect } from "@app/tests/helpers/stub-test-base";
+
+const SAMPLE_PDF = path.join(
+  import.meta.dirname,
+  "../test-fixtures/sample.pdf",
+);
+
+/** The app opens `stirling-pdf-files` at this version; block it from below. */
+const BLOCKING_VERSION = 8;
+
+/** Park a connection on an older version and never yield it, the way a tab
+ *  running an older build does, so the app's upgrade can't proceed. */
+async function blockTheFilesDatabase(page: import("@playwright/test").Page) {
+  await page.addInitScript((version: number) => {
+    const request = indexedDB.open("stirling-pdf-files", version);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains("files")) {
+        db.createObjectStore("files", { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => {
+      // Deliberately NO onversionchange handler: hold the database open.
+      (window as unknown as { __blocker?: IDBDatabase }).__blocker =
+        request.result;
+    };
+  }, BLOCKING_VERSION);
+}
+
+/** Closing the context is NOT enough: WebKit keeps origin databases between
+ *  contexts, so a stray v8 makes a random later spec fail. */
+async function unblockTheFilesDatabase(page: import("@playwright/test").Page) {
+  await page.evaluate(async () => {
+    const holder = window as unknown as { __blocker?: IDBDatabase };
+    holder.__blocker?.close();
+    holder.__blocker = undefined;
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase("stirling-pdf-files");
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    });
+  });
+}
+
+test.use({ autoGoto: false });
+
+test("the sidebar stops loading even when the file library is unreadable", async ({
+  page,
+}) => {
+  // Allow for the manager's blocked-upgrade grace period plus app boot.
+  test.setTimeout(120_000);
+
+  const warnings: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "warning" || message.type() === "error") {
+      warnings.push(message.text());
+    }
+  });
+
+  await blockTheFilesDatabase(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  try {
+    // Storage is not on the critical path for rendering the workbench.
+    await page.waitForSelector('[data-tour="tool-button-compare"]', {
+      timeout: 60_000,
+    });
+
+    // The spinner is the whole bug: it must clear once the manager gives up.
+    await expect(page.locator(".file-sidebar-loading")).toHaveCount(0, {
+      timeout: 60_000,
+    });
+
+    // The reason must be discoverable - a silent console made the original
+    // report impossible to diagnose.
+    expect(
+      warnings.some((text) => /blocked by another open connection/i.test(text)),
+      `expected a blocked-database warning, got: ${JSON.stringify(warnings)}`,
+    ).toBe(true);
+  } finally {
+    await unblockTheFilesDatabase(page);
+  }
+});
+
+// `loadRecentFiles` only fetches `/api/v1/storage/files` when app-config
+// advertises `storageEnabled`; without it the route below is never requested.
+test.describe("with server-side storage enabled", () => {
+  test.use({ stubOptions: { storageEnabled: true } });
+
+  test("the picker's Workbench tab lists files while saved files are still loading", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    // Hold the saved-files read open so the picker stays stuck all test.
+    let sawSavedFilesRequest = false;
+    await page.route("**/api/v1/storage/files", async () => {
+      sawSavedFilesRequest = true;
+      await new Promise(() => {
+        /* never responds */
+      });
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector('[data-tour="tool-button-compare"]', {
+      timeout: 60_000,
+    });
+
+    // Put a file in the workbench so the Workbench tab has something to show.
+    await page.getByTestId("files-button").click();
+    await page.locator('[data-testid="file-input"]').setInputFiles(SAMPLE_PDF);
+    await expect(page.locator(".file-sidebar-file-item").first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.locator('[data-tour="tool-button-compare"]').first().click();
+    await page.getByTestId("compare-slot-base-add").click();
+
+    // The picker must actually be stuck, or the rest proves nothing.
+    const picker = page.locator(".mantine-Popover-dropdown");
+    await expect(picker).toBeVisible({ timeout: 30_000 });
+    await expect
+      .poll(() => sawSavedFilesRequest, { timeout: 30_000 })
+      .toBe(true);
+
+    // Workbench lists from memory, so a stuck read must not hide it. Scope to
+    // the popover: the sidebar row behind it matches the same locator.
+    await picker
+      .getByRole("button", { name: "Workbench", exact: true })
+      .click();
+    await expect(
+      picker.getByRole("button", { name: /sample\.pdf/ }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});


### PR DESCRIPTION
# Description of Changes

Split out of #7366, which was chasing a Safari report. These fixes are **engine-agnostic** — they were found via the same symptom, not the same cause, so they belong on their own evidence.

## The bug

A version upgrade blocked by another connection fires `blocked` and then **nothing at all** — no `success`, no `error` — until that connection goes away. The open promise never settled, so every awaiting caller hung: the file sidebar and the tool file pickers spun forever, **with nothing in the console**. That silence is why this was reported as unreproducible.

Any user with a second tab on an older build hits it, on every browser.

## The root cause was the dedupe, not the missing guard

`openDatabase` checked `initPromises` for an in-flight open, then registered its own promise **after** an `await` (the SaaS v6/v7 corruption wipe). A map written after a yield point can't dedupe callers racing into it in the same tick, so every context that opened the files database during boot got **its own connection** — and per spec only the first request ever receives `blocked`. The event landed on one arbitrary request while the rest sat there.

Registration is now hoisted above everything async. One connection per database per tab, and `blocked` reliably reaches the request that exists. Notably this only affected `stirling-pdf-files`: it's the one config with an `await` before registration, and it's the one the sidebar depends on.

## The rest

- **`blockedGuard`.** Warn on `blocked`, wait out a grace period, then reject with something the user can act on. Rejecting does **not** cancel the request, so a connection that arrives after we gave up is closed rather than held — otherwise we become the next tab's blocker. Reused for `deleteDatabase`, which blocks the same way and is awaited on the files open path, so a blocked delete would have hung the whole storage layer.
- **`onversionchange`** closes and forgets our connection, so a release that bumps the schema version no longer bricks every open tab. Forget-before-close matters: a cached-but-closed handle is worse than none, because every transaction on it throws.
- **The sidebar and the saved-files picker reach a resting state.** `refreshStubs` sets its loaded flag in a `finally` — callers never await it, so a rejection went nowhere and the spinner was permanent. On failure it carries on with the in-memory workbench files: an unreadable library should cost the user their history, not the file they're working on. The picker's spinner is now scoped to the tab that's actually loading, so a stuck storage read can't spin the memory-backed Workbench tab.

## Tests

- `indexedDBManager.blocked.test.ts` covers **both directions**: we fail rather than hang on someone else's upgrade (asserting both halves of the grace period — still pending early, rejected at the deadline), and we yield ours to theirs and reconnect afterwards. The yield test is behavioural: it opens a raw higher version and fails if that open reports `blocked`.
- `file-library-resilience.spec.ts` doesn't mock the failure — it **reproduces** it. An init script parks a connection on an older version and never yields, then the spec asserts the workbench still renders, the sidebar spinner clears, and the reason reaches the console. Cleanup deletes the database explicitly, because WebKit keeps origin databases between browser contexts and a stray version would fail an unrelated later spec.

## Verification

- `task frontend:check` green: typecheck, oxlint, theme lint, stylelint, prettier, 214 test files / 1836 tests.
- Both new test files verified to fail against the unfixed code.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] My changes generate no new warnings
