### PR TITLE
fix(editor): PWA name respects configured appName

### DIFF
--- a/docs/residual-review-findings/feat-pwa-name-appname.md
+++ b/docs/residual-review-findings/feat-pwa-name-appname.md
@@ -1,7 +1,0 @@
-## Residual Review Findings
-
-Run context: LFG pipeline for issue #5492 (PWA name respects appName), plan `docs/plans/2026-08-10-pwa-name-appname.md`, branch `feat/pwa-name-appname`, review run `ce-code-review-pwa-name` (2026-08-10).
-
-- [P2] `frontend/editor/src/core/hooks/useManifestUrl.ts:168` — Test gap: HTTP non-OK manifest response (`!response.ok`) has no test. Filed as tracker ticket: https://github.com/Stirling-Tools/Stirling-PDF/issues/7419
-
-No `settled_conflict`-stamped findings were emitted by the review. No proceeded-and-flagged `settled_decision_conflicts` were returned by ce-work.

--- a/docs/residual-review-findings/feat-pwa-name-appname.md
+++ b/docs/residual-review-findings/feat-pwa-name-appname.md
@@ -1,0 +1,7 @@
+## Residual Review Findings
+
+Run context: LFG pipeline for issue #5492 (PWA name respects appName), plan `docs/plans/2026-08-10-pwa-name-appname.md`, branch `feat/pwa-name-appname`, review run `ce-code-review-pwa-name` (2026-08-10).
+
+- [P2] `frontend/editor/src/core/hooks/useManifestUrl.ts:168` — Test gap: HTTP non-OK manifest response (`!response.ok`) has no test. Filed as tracker ticket: https://github.com/Stirling-Tools/Stirling-PDF/issues/7419
+
+No `settled_conflict`-stamped findings were emitted by the review. No proceeded-and-flagged `settled_decision_conflicts` were returned by ce-work.

--- a/frontend/editor/src/core/components/AppProviders.tsx
+++ b/frontend/editor/src/core/components/AppProviders.tsx
@@ -33,6 +33,7 @@ import { usePosthogTracking } from "@app/hooks/usePosthogTracking";
 import { useScarfTracking } from "@app/hooks/useScarfTracking";
 import { useAppInitialization } from "@app/hooks/useAppInitialization";
 import { useLogoAssets } from "@app/hooks/useLogoAssets";
+import { useManifestUrl } from "@app/hooks/useManifestUrl";
 import AppConfigLoader from "@app/components/shared/AppConfigLoader";
 import { UpdateStartupPopup } from "@app/components/shared/UpdateStartupPopup";
 import { RedactionProvider } from "@app/contexts/RedactionContext";
@@ -58,7 +59,8 @@ function AppInitializer() {
 }
 
 function BrandingAssetManager() {
-  const { favicon, logo192, manifestHref } = useLogoAssets();
+  const { favicon, logo192 } = useLogoAssets();
+  const { manifestHref } = useManifestUrl();
 
   useEffect(() => {
     if (typeof document === "undefined") {

--- a/frontend/editor/src/core/hooks/useManifestUrl.test.tsx
+++ b/frontend/editor/src/core/hooks/useManifestUrl.test.tsx
@@ -1,0 +1,435 @@
+import {
+  describe,
+  expect,
+  test,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { AppConfigProvider } from "@app/contexts/AppConfigContext";
+import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import { TestQueryProvider } from "@app/tests/utils/TestQueryProvider";
+import { allowConsole } from "@app/tests/failOnConsole";
+import {
+  MAX_SHORT_NAME_CODE_POINTS,
+  resolveAppName,
+  truncateShortName,
+  mergeManifestName,
+  absolutizeManifestUrls,
+  useManifestUrl,
+  type StaticManifest,
+} from "@app/hooks/useManifestUrl";
+
+const MODERN_MANIFEST: StaticManifest = {
+  short_name: "Stirling PDF",
+  name: "Stirling PDF",
+  icons: [
+    {
+      src: "modern-logo/favicon.ico",
+      sizes: "64x64 32x32 24x24 16x16",
+      type: "image/x-icon",
+    },
+    { src: "modern-logo/logo192.png", type: "image/png", sizes: "192x192" },
+    { src: "modern-logo/logo512.png", type: "image/png", sizes: "512x512" },
+  ],
+  start_url: ".",
+  display: "standalone",
+  theme_color: "#000000",
+  background_color: "#ffffff",
+};
+
+const CLASSIC_MANIFEST: StaticManifest = {
+  ...MODERN_MANIFEST,
+  icons: [
+    {
+      src: "classic-logo/favicon.ico",
+      sizes: "64x64 32x32 24x24 16x16",
+      type: "image/x-icon",
+    },
+    { src: "classic-logo/logo192.png", type: "image/png", sizes: "192x192" },
+    { src: "classic-logo/logo512.png", type: "image/png", sizes: "512x512" },
+  ],
+};
+
+/** Test double so each scenario can set its own appName. */
+function ConfigHarness({
+  appName,
+  children,
+}: {
+  appName: string | null | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <TestQueryProvider>
+      <PreferencesProvider>
+        <AppConfigProvider
+          bootstrapMode="non-blocking"
+          autoFetch={false}
+          initialConfig={
+            appName == null
+              ? { enableLogin: false }
+              : { enableLogin: false, appNameNavbar: appName }
+          }
+        >
+          {children}
+        </AppConfigProvider>
+      </PreferencesProvider>
+    </TestQueryProvider>
+  );
+}
+
+function renderUseManifestUrl(options?: {
+  wrapper?: (props: { children: ReactNode }) => ReactNode;
+}) {
+  return renderHook(() => useManifestUrl(), options);
+}
+
+/**
+ * jsdom's Blob has no .text(); setupTests mocks Blob.prototype.arrayBuffer
+ * with a dummy buffer, so read the content through FileReader instead.
+ */
+function readBlobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+describe("resolveAppName", () => {
+  test("treats undefined, null, empty and whitespace-only as unset", () => {
+    expect(resolveAppName(undefined)).toBeNull();
+    expect(resolveAppName(null)).toBeNull();
+    expect(resolveAppName("")).toBeNull();
+    expect(resolveAppName("   ")).toBeNull();
+    expect(resolveAppName("\t\n ")).toBeNull();
+  });
+
+  test("returns the trimmed name when set", () => {
+    expect(resolveAppName("Acme Docs")).toBe("Acme Docs");
+    expect(resolveAppName("  Acme Docs  ")).toBe("Acme Docs");
+  });
+});
+
+describe("truncateShortName", () => {
+  test("keeps the full name when at most 12 code points (T4)", () => {
+    expect(truncateShortName("Acme Docs")).toBe("Acme Docs");
+    expect(truncateShortName("123456789012")).toBe("123456789012");
+  });
+
+  test("truncates to 11 code points plus ellipsis when longer (T3)", () => {
+    const long = "A Very Long Product Name That Exceeds Twelve";
+    const truncated = truncateShortName(long);
+    expect(truncated).toBe("A Very Long\u2026");
+    expect(Array.from(truncated).length).toBe(MAX_SHORT_NAME_CODE_POINTS);
+    expect(truncated.endsWith("\u2026")).toBe(true);
+  });
+
+  test("is surrogate-pair-safe for emoji / non-Latin names (T4b)", () => {
+    // 12 emoji: each is a surrogate pair; slicing code units would mojibake.
+    const twelveEmoji =
+      "\u{1F600}\u{1F601}\u{1F602}\u{1F603}\u{1F604}\u{1F605}\u{1F606}\u{1F607}\u{1F608}\u{1F609}\u{1F60A}\u{1F60B}";
+    expect(truncateShortName(twelveEmoji)).toBe(twelveEmoji);
+    const thirteenEmoji = twelveEmoji + "\u{1F60C}";
+    const truncated = truncateShortName(thirteenEmoji);
+    expect(Array.from(truncated).length).toBe(MAX_SHORT_NAME_CODE_POINTS);
+    expect(truncated.endsWith("\u2026")).toBe(true);
+    // No lone surrogate halves survive the truncation (the ellipsis itself is
+    // a single code unit and is expected).
+    for (const codePoint of Array.from(truncated)) {
+      const code = codePoint.codePointAt(0)!;
+      if (codePoint !== "\u2026") {
+        expect(code).toBeGreaterThan(0xffff);
+      }
+    }
+  });
+});
+
+describe("mergeManifestName", () => {
+  test("returns the static manifest unchanged when appName is unset (R2)", () => {
+    expect(mergeManifestName(MODERN_MANIFEST, null)).toBe(MODERN_MANIFEST);
+  });
+
+  test("merges name and truncated short_name when appName is set (R1/R5)", () => {
+    const merged = mergeManifestName(
+      MODERN_MANIFEST,
+      "A Very Long Product Name That Exceeds Twelve",
+    );
+    expect(merged.name).toBe("A Very Long Product Name That Exceeds Twelve");
+    expect(merged.short_name).toBe("A Very Long\u2026");
+    expect(merged.start_url).toBe(".");
+  });
+});
+
+describe("absolutizeManifestUrls", () => {
+  const ORIGIN = "https://pdf.example.com/";
+
+  test("rewrites start_url and every icon src to origin-absolute URLs (T6b)", () => {
+    const resolved = absolutizeManifestUrls(MODERN_MANIFEST, ORIGIN);
+    expect(resolved.start_url).toBe("https://pdf.example.com/");
+    for (const icon of resolved.icons ?? []) {
+      expect(icon.src).toMatch(/^https:\/\/pdf\.example\.com\//);
+      expect(icon.src).not.toMatch(/^(?!https?:)/);
+    }
+  });
+
+  test("rewrites scope and id when present", () => {
+    const withScopeAndId: StaticManifest = {
+      ...MODERN_MANIFEST,
+      scope: ".",
+      id: "./",
+    };
+    const resolved = absolutizeManifestUrls(withScopeAndId, ORIGIN);
+    expect(resolved.scope).toBe("https://pdf.example.com/");
+    expect(resolved.id).toBe("https://pdf.example.com/");
+  });
+
+  test("leaves already-absolute members untouched", () => {
+    const withAbsoluteIcons: StaticManifest = {
+      ...MODERN_MANIFEST,
+      start_url: "https://cdn.example.com/app",
+      icons: [{ src: "https://cdn.example.com/icon.png" }],
+    };
+    const resolved = absolutizeManifestUrls(withAbsoluteIcons, ORIGIN);
+    expect(resolved.start_url).toBe("https://cdn.example.com/app");
+    expect(resolved.icons?.[0]?.src).toBe("https://cdn.example.com/icon.png");
+  });
+});
+
+describe("useManifestUrl", () => {
+  let createObjectURLSpy: MockInstance<typeof URL.createObjectURL>;
+  let revokeObjectURLSpy: MockInstance<typeof URL.revokeObjectURL>;
+  beforeEach(() => {
+    createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockImplementation(
+        () => `blob:mock-${Math.random().toString(36).slice(2)}`,
+      );
+    revokeObjectURLSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const wrapperFor = (appName: string | null | undefined) => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ConfigHarness appName={appName}>{children}</ConfigHarness>
+    );
+    return wrapper;
+  };
+
+  test("T1: returns a blob URL and the blob manifest uses appName", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify(MODERN_MANIFEST)));
+
+    const { result } = renderUseManifestUrl({
+      wrapper: wrapperFor("Acme Docs"),
+    });
+
+    await waitFor(() => {
+      expect(result.current.manifestHref).toMatch(/^blob:/);
+    });
+
+    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
+    const text = await readBlobText(blob);
+    const manifest = JSON.parse(text) as StaticManifest;
+    expect(manifest.name).toBe("Acme Docs");
+    expect(manifest.short_name).toBe("Acme Docs");
+    // URL members must be origin-absolute in the produced blob (T6b).
+    expect(manifest.start_url).toMatch(/^https?:\/\//);
+    for (const icon of manifest.icons ?? []) {
+      expect(icon.src).toMatch(/^https?:\/\//);
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith("/manifest.json");
+  });
+
+  test("T2: static manifestHref returned unchanged when appName is unset", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify(MODERN_MANIFEST)));
+
+    for (const unset of [undefined, null, "", "   "]) {
+      const { result } = renderUseManifestUrl({ wrapper: wrapperFor(unset) });
+      expect(result.current.manifestHref).toBe("/manifest.json");
+      await act(async () => {});
+      // No blob is ever created, no fetch is issued.
+      expect(result.current.manifestHref).toBe("/manifest.json");
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
+  });
+
+  test("T3: short_name is first 11 code points + ellipsis when appName > 12", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(MODERN_MANIFEST)),
+    );
+
+    const { result } = renderUseManifestUrl({
+      wrapper: wrapperFor("A Very Long Product Name That Exceeds Twelve"),
+    });
+
+    await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
+    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
+    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    expect(manifest.name).toBe("A Very Long Product Name That Exceeds Twelve");
+    expect(manifest.short_name).toBe("A Very Long\u2026");
+    expect(Array.from(manifest.short_name!).length).toBe(
+      MAX_SHORT_NAME_CODE_POINTS,
+    );
+  });
+
+  test("T4: short_name is the full appName when at most 12 code points", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(MODERN_MANIFEST)),
+    );
+
+    const { result } = renderUseManifestUrl({
+      wrapper: wrapperFor("Acme Docs"),
+    });
+
+    await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
+    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
+    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    expect(manifest.short_name).toBe("Acme Docs");
+  });
+
+  test("T4b: surrogate-pair-safe truncation end-to-end", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(MODERN_MANIFEST)),
+    );
+
+    const longEmoji =
+      "\u{1F600}\u{1F601}\u{1F602}\u{1F603}\u{1F604}\u{1F605}\u{1F606}\u{1F607}\u{1F608}\u{1F609}\u{1F60A}\u{1F60B}\u{1F60C}";
+    const { result } = renderUseManifestUrl({ wrapper: wrapperFor(longEmoji) });
+
+    await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
+    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
+    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    expect(Array.from(manifest.short_name!).length).toBe(
+      MAX_SHORT_NAME_CODE_POINTS,
+    );
+    expect(manifest.short_name!.endsWith("\u2026")).toBe(true);
+  });
+
+  test("T5: changing appName revokes the previous blob URL", async () => {
+    // A Response body can only be read once; the hook re-fetches when appName
+    // changes, so each call must get a FRESH Response.
+    vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify(MODERN_MANIFEST))),
+    );
+
+    // Driver wrapper lets the test change the seeded appName between renders.
+    let setAppName: (value: string) => void = () => {};
+    const Driver = ({ children }: { children: ReactNode }) => {
+      const [appName, setter] = useState("First Name");
+      setAppName = setter;
+      return <ConfigHarness appName={appName}>{children}</ConfigHarness>;
+    };
+
+    const { result } = renderUseManifestUrl({ wrapper: Driver });
+    await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
+    const firstUrl = result.current.manifestHref;
+    expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      setAppName("Second Name");
+    });
+
+    await waitFor(() => {
+      expect(result.current.manifestHref).not.toBe(firstUrl);
+    });
+    await waitFor(() => {
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith(firstUrl);
+    });
+
+    // The new blob URL itself is not revoked.
+    const revocations = revokeObjectURLSpy.mock.calls.map((call) => call[0]);
+    expect(revocations).not.toContain(result.current.manifestHref);
+  });
+
+  test("T5b: unmount revokes the blob URL (no leaks)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(MODERN_MANIFEST)),
+    );
+
+    const { result, unmount } = renderUseManifestUrl({
+      wrapper: wrapperFor("Acme Docs"),
+    });
+    await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
+    const url = result.current.manifestHref;
+
+    unmount();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith(url);
+  });
+
+  test("T6: fetch failure falls back to the static manifestHref", async () => {
+    allowConsole.error(/\[useManifestUrl\] Failed to build runtime manifest/);
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+
+    const { result } = renderUseManifestUrl({
+      wrapper: wrapperFor("Acme Docs"),
+    });
+
+    await waitFor(() => {
+      expect(result.current.manifestHref).toBe("/manifest.json");
+    });
+    // No blob URL was ever created.
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
+    expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+  });
+
+  test("T9b: keeps the static manifestHref until the hook resolves", async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    vi.spyOn(globalThis, "fetch").mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const { result } = renderUseManifestUrl({
+      wrapper: wrapperFor("Acme Docs"),
+    });
+
+    // In flight: still the static manifest (no transient broken state).
+    expect(result.current.manifestHref).toBe("/manifest.json");
+
+    await act(async () => {
+      resolveFetch(new Response(JSON.stringify(MODERN_MANIFEST)));
+    });
+    await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
+  });
+
+  test("picks manifest-classic.json for the classic logo variant", async () => {
+    localStorage.setItem(
+      "stirlingpdf_preferences",
+      JSON.stringify({ logoVariant: "classic" }),
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify(CLASSIC_MANIFEST)));
+
+    const { result } = renderUseManifestUrl({
+      wrapper: wrapperFor("Acme Docs"),
+    });
+
+    await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
+    expect(fetchMock).toHaveBeenCalledWith("/manifest-classic.json");
+
+    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
+    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    expect(
+      manifest.icons?.some((icon) => icon.src?.includes("classic-logo")),
+    ).toBe(true);
+    localStorage.removeItem("stirlingpdf_preferences");
+  });
+});

--- a/frontend/editor/src/core/hooks/useManifestUrl.test.tsx
+++ b/frontend/editor/src/core/hooks/useManifestUrl.test.tsx
@@ -8,9 +8,12 @@ import {
   type MockInstance,
 } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { AppConfigProvider } from "@app/contexts/AppConfigContext";
-import { PreferencesProvider } from "@app/contexts/PreferencesContext";
+import {
+  PreferencesProvider,
+  usePreferences,
+} from "@app/contexts/PreferencesContext";
 import { TestQueryProvider } from "@app/tests/utils/TestQueryProvider";
 import { allowConsole } from "@app/tests/failOnConsole";
 import {
@@ -98,6 +101,14 @@ function readBlobText(blob: Blob): Promise<string> {
     reader.onerror = () => reject(reader.error);
     reader.readAsText(blob);
   });
+}
+
+/** Parse the most recently created blob as the merged manifest. */
+async function readBlobManifest(
+  createObjectURLSpy: MockInstance<typeof URL.createObjectURL>,
+): Promise<StaticManifest> {
+  const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
+  return JSON.parse(await readBlobText(blob)) as StaticManifest;
 }
 
 describe("resolveAppName", () => {
@@ -225,6 +236,34 @@ describe("useManifestUrl", () => {
     return wrapper;
   };
 
+  test("T6b: URL members are rewritten against the manifest URL, not the page URL (deep-link safe)", async () => {
+    // Page is on a deep route; the manifest lives at the app root. Members
+    // must resolve against the manifest's directory, not the deep link.
+    Object.defineProperty(window, "location", {
+      value: new URL("https://pdf.example.com/share/abc123"),
+      writable: true,
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(MODERN_MANIFEST)),
+    );
+
+    const { result } = renderUseManifestUrl({
+      wrapper: wrapperFor("Acme Docs"),
+    });
+
+    await waitFor(() => {
+      expect(result.current.manifestHref).toMatch(/^blob:/);
+    });
+
+    const manifest = await readBlobManifest(createObjectURLSpy);
+    // start_url "." resolves against the manifest URL (/manifest.json) -> app root.
+    expect(manifest.start_url).toBe("https://pdf.example.com/");
+    for (const icon of manifest.icons ?? []) {
+      expect(icon.src).toMatch(/^https:\/\/pdf\.example\.com\/modern-logo\//);
+      expect(icon.src).not.toContain("/share/");
+    }
+  });
+
   test("T1: returns a blob URL and the blob manifest uses appName", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -238,9 +277,7 @@ describe("useManifestUrl", () => {
       expect(result.current.manifestHref).toMatch(/^blob:/);
     });
 
-    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
-    const text = await readBlobText(blob);
-    const manifest = JSON.parse(text) as StaticManifest;
+    const manifest = await readBlobManifest(createObjectURLSpy);
     expect(manifest.name).toBe("Acme Docs");
     expect(manifest.short_name).toBe("Acme Docs");
     // URL members must be origin-absolute in the produced blob (T6b).
@@ -249,7 +286,9 @@ describe("useManifestUrl", () => {
       expect(icon.src).toMatch(/^https?:\/\//);
     }
 
-    expect(fetchMock).toHaveBeenCalledWith("/manifest.json");
+    expect(fetchMock).toHaveBeenCalledWith("/manifest.json", {
+      signal: expect.any(AbortSignal),
+    });
   });
 
   test("T2: static manifestHref returned unchanged when appName is unset", async () => {
@@ -279,8 +318,7 @@ describe("useManifestUrl", () => {
     });
 
     await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
-    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
-    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    const manifest = await readBlobManifest(createObjectURLSpy);
     expect(manifest.name).toBe("A Very Long Product Name That Exceeds Twelve");
     expect(manifest.short_name).toBe("A Very Long\u2026");
     expect(Array.from(manifest.short_name!).length).toBe(
@@ -298,8 +336,7 @@ describe("useManifestUrl", () => {
     });
 
     await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
-    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
-    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    const manifest = await readBlobManifest(createObjectURLSpy);
     expect(manifest.short_name).toBe("Acme Docs");
   });
 
@@ -313,8 +350,7 @@ describe("useManifestUrl", () => {
     const { result } = renderUseManifestUrl({ wrapper: wrapperFor(longEmoji) });
 
     await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
-    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
-    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    const manifest = await readBlobManifest(createObjectURLSpy);
     expect(Array.from(manifest.short_name!).length).toBe(
       MAX_SHORT_NAME_CODE_POINTS,
     );
@@ -410,26 +446,39 @@ describe("useManifestUrl", () => {
   });
 
   test("picks manifest-classic.json for the classic logo variant", async () => {
-    localStorage.setItem(
-      "stirlingpdf_preferences",
-      JSON.stringify({ logoVariant: "classic" }),
-    );
+    // Set the preference through the provider seam (a mount effect) rather
+    // than writing the raw storage key directly, matching production usage.
+    const ClassicWrapper = ({ children }: { children: ReactNode }) => {
+      const { updatePreference } = usePreferences();
+      useEffect(() => {
+        updatePreference("logoVariant", "classic");
+      }, [updatePreference]);
+      return <>{children}</>;
+    };
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify(CLASSIC_MANIFEST)));
+      .mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify(CLASSIC_MANIFEST))),
+      );
 
     const { result } = renderUseManifestUrl({
-      wrapper: wrapperFor("Acme Docs"),
+      // ClassicWrapper sits INSIDE ConfigHarness so usePreferences is
+      // available; its mount effect flips the variant before the hook reads it.
+      wrapper: (props) => (
+        <ConfigHarness appName="Acme Docs">
+          <ClassicWrapper>{props.children}</ClassicWrapper>
+        </ConfigHarness>
+      ),
     });
 
     await waitFor(() => expect(result.current.manifestHref).toMatch(/^blob:/));
-    expect(fetchMock).toHaveBeenCalledWith("/manifest-classic.json");
+    expect(fetchMock).toHaveBeenCalledWith("/manifest-classic.json", {
+      signal: expect.any(AbortSignal),
+    });
 
-    const blob = createObjectURLSpy.mock.calls.at(-1)?.[0] as Blob;
-    const manifest = JSON.parse(await readBlobText(blob)) as StaticManifest;
+    const manifest = await readBlobManifest(createObjectURLSpy);
     expect(
       manifest.icons?.some((icon) => icon.src?.includes("classic-logo")),
     ).toBe(true);
-    localStorage.removeItem("stirlingpdf_preferences");
   });
 });

--- a/frontend/editor/src/core/hooks/useManifestUrl.ts
+++ b/frontend/editor/src/core/hooks/useManifestUrl.ts
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from "react";
+import { useAppConfig } from "@app/contexts/AppConfigContext";
+import { useLogoAssets } from "@app/hooks/useLogoAssets";
+
+/**
+ * The served PWA manifest is a static JSON file (manifest.json /
+ * manifest-classic.json) that hardcodes "Stirling PDF". The installed PWA name
+ * must reflect the configured `ui.appNameNavbar` instead (issue #5492). The
+ * static files cannot interpolate runtime config, so the manifest is rebuilt at
+ * runtime: fetch the static file, merge `name`/`short_name` from the config,
+ * and inject the result as a blob URL into the existing <link rel="manifest">.
+ *
+ * URL-member rewriting is mandatory (KTD1): the static manifests use relative
+ * members (`"start_url": "."`, `"src": "modern-logo/logo192.png"`). The manifest
+ * spec resolves every URL member against the manifest URL; a blob URL has an
+ * opaque path, so relative references against it fail WHATWG URL parsing and the
+ * icons are dropped — which fails Chrome's installability check. Before creating
+ * the blob, rewrite `start_url`, every `icons[].src`, and (when present)
+ * `scope`/`id` to origin-absolute URLs resolved against `window.location`.
+ */
+
+/** PWA short names must stay within 12 code points (ellipsis included) per KTD3. */
+export const MAX_SHORT_NAME_CODE_POINTS = 12;
+
+export interface ManifestIcon {
+  src?: string;
+  sizes?: string;
+  type?: string;
+  purpose?: string;
+  [key: string]: unknown;
+}
+
+export interface StaticManifest {
+  name?: string;
+  short_name?: string;
+  start_url?: string;
+  scope?: string;
+  id?: string;
+  icons?: ManifestIcon[];
+  [key: string]: unknown;
+}
+
+/**
+ * Treat undefined / null / empty / whitespace-only as unset (KTD1/R2). Returns
+ * the trimmed name, or null when there is no usable configured name.
+ */
+export function resolveAppName(
+  value: string | null | undefined,
+): string | null {
+  if (value == null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Truncate a PWA short name to at most 12 code points, including the trailing
+ * ellipsis (KTD3): the first 11 code points + "…" when the name is longer.
+ * Surrogate-pair-safe: uses Array.from so astral characters (emoji, non-Latin)
+ * are never split.
+ */
+export function truncateShortName(name: string): string {
+  const codePoints = Array.from(name);
+  if (codePoints.length <= MAX_SHORT_NAME_CODE_POINTS) {
+    return name;
+  }
+  return `${codePoints
+    .slice(0, MAX_SHORT_NAME_CODE_POINTS - 1)
+    .join("")}\u2026`;
+}
+
+/** Resolve a manifest URL member against a base URL (KTD1). */
+export function resolveManifestUrl(
+  value: string | undefined,
+  base: string,
+): string | undefined {
+  if (typeof value !== "string" || value.trim() === "") {
+    return undefined;
+  }
+  return new URL(value, base).toString();
+}
+
+/** Merge the configured appName into the static manifest (KTD1/R2). */
+export function mergeManifestName(
+  manifest: StaticManifest,
+  appName: string | null,
+): StaticManifest {
+  if (appName == null) {
+    return manifest;
+  }
+  return {
+    ...manifest,
+    name: appName,
+    short_name: truncateShortName(appName),
+  };
+}
+
+/** Rewrite all URL members to origin-absolute URLs (KTD1). */
+export function absolutizeManifestUrls(
+  manifest: StaticManifest,
+  origin: string,
+): StaticManifest {
+  const next: StaticManifest = { ...manifest };
+  for (const key of ["start_url", "scope", "id"] as const) {
+    const resolved = resolveManifestUrl(next[key], origin);
+    if (resolved !== undefined) {
+      next[key] = resolved;
+    }
+  }
+  if (Array.isArray(next.icons)) {
+    next.icons = next.icons.map((icon) => {
+      if (typeof icon.src === "string" && icon.src.trim() !== "") {
+        return { ...icon, src: new URL(icon.src, origin).toString() };
+      }
+      return icon;
+    });
+  }
+  return next;
+}
+
+export interface UseManifestUrlResult {
+  /** The manifest URL for <link rel="manifest">: blob URL when a custom appName
+   *  is set, otherwise the static manifestHref. */
+  manifestHref: string;
+}
+
+/**
+ * Produces the runtime manifest URL reflecting the configured appName.
+ *
+ * - Reads the logo variant via `useLogoAssets().manifestHref` to pick
+ *   manifest.json vs manifest-classic.json.
+ * - Fetches the static manifest, merges `name`/`short_name` from
+ *   `AppConfig.appNameNavbar` (unset values fall back to the static ones), and
+ *   rewrites URL members to origin-absolute URLs.
+ * - Returns a blob URL. The previous blob URL is revoked only once its
+ *   successor exists (no transient broken manifest link) and on unmount (no
+ *   object-URL leaks).
+ * - Returns the static manifestHref unchanged on fetch failure (R7) and while
+ *   the fetch is in flight (T9b).
+ */
+export function useManifestUrl(): UseManifestUrlResult {
+  const { config } = useAppConfig();
+  const { manifestHref } = useLogoAssets();
+  const appName = resolveAppName(config?.appNameNavbar);
+
+  const [href, setHref] = useState(manifestHref);
+  const createdUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (appName == null) {
+      // No custom name: the static manifest is already correct (R2). Point back
+      // at the static href and release any runtime blob from a previous value.
+      if (createdUrlRef.current) {
+        URL.revokeObjectURL(createdUrlRef.current);
+        createdUrlRef.current = null;
+      }
+      setHref(manifestHref);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function buildManifestUrl() {
+      try {
+        const response = await fetch(manifestHref);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch manifest (HTTP ${response.status})`);
+        }
+        const staticManifest = (await response.json()) as StaticManifest;
+
+        const merged = mergeManifestName(staticManifest, appName);
+        const resolved = absolutizeManifestUrls(merged, window.location.href);
+        const blob = new Blob([JSON.stringify(resolved)], {
+          type: "application/manifest+json",
+        });
+        const newUrl = URL.createObjectURL(blob);
+
+        // Superseded by a newer run or unmounted: never leave a blob behind.
+        if (cancelled) {
+          URL.revokeObjectURL(newUrl);
+          return;
+        }
+
+        // Swap: release the previous runtime blob only once its successor
+        // exists, so the manifest link never points at a revoked URL.
+        if (createdUrlRef.current) {
+          URL.revokeObjectURL(createdUrlRef.current);
+        }
+        createdUrlRef.current = newUrl;
+        setHref(newUrl);
+      } catch (error) {
+        // Graceful degradation: keep serving the static manifest (R7).
+        console.error(
+          "[useManifestUrl] Failed to build runtime manifest:",
+          error,
+        );
+        if (!cancelled) {
+          setHref(manifestHref);
+        }
+      }
+    }
+
+    buildManifestUrl();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [manifestHref, appName]);
+
+  // Unmount-only cleanup: release the last runtime blob. The per-change swap
+  // above keeps at most one live blob at a time, so this never double-revokes.
+  useEffect(() => {
+    return () => {
+      if (createdUrlRef.current) {
+        URL.revokeObjectURL(createdUrlRef.current);
+        createdUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  return { manifestHref: href };
+}

--- a/frontend/editor/src/core/hooks/useManifestUrl.ts
+++ b/frontend/editor/src/core/hooks/useManifestUrl.ts
@@ -110,10 +110,8 @@ export function absolutizeManifestUrls(
   }
   if (Array.isArray(next.icons)) {
     next.icons = next.icons.map((icon) => {
-      if (typeof icon.src === "string" && icon.src.trim() !== "") {
-        return { ...icon, src: new URL(icon.src, origin).toString() };
-      }
-      return icon;
+      const resolved = resolveManifestUrl(icon.src, origin);
+      return resolved !== undefined ? { ...icon, src: resolved } : icon;
     });
   }
   return next;
@@ -160,17 +158,28 @@ export function useManifestUrl(): UseManifestUrlResult {
     }
 
     let cancelled = false;
+    const controller = new AbortController();
 
     async function buildManifestUrl() {
       try {
-        const response = await fetch(manifestHref);
+        const response = await fetch(manifestHref, {
+          signal: controller.signal,
+        });
         if (!response.ok) {
           throw new Error(`Failed to fetch manifest (HTTP ${response.status})`);
         }
         const staticManifest = (await response.json()) as StaticManifest;
 
         const merged = mergeManifestName(staticManifest, appName);
-        const resolved = absolutizeManifestUrls(merged, window.location.href);
+        // The manifest spec resolves URL members against the manifest URL,
+        // not the page URL. The static manifest lives at `${BASE_PATH}/`,
+        // so resolve against the manifest's own URL to stay correct on
+        // subpath deploys and deep-linked routes.
+        const manifestBase = new URL(manifestHref, window.location.origin);
+        const resolved = absolutizeManifestUrls(
+          merged,
+          manifestBase.toString(),
+        );
         const blob = new Blob([JSON.stringify(resolved)], {
           type: "application/manifest+json",
         });
@@ -190,14 +199,22 @@ export function useManifestUrl(): UseManifestUrlResult {
         createdUrlRef.current = newUrl;
         setHref(newUrl);
       } catch (error) {
-        // Graceful degradation: keep serving the static manifest (R7).
+        if (cancelled) {
+          // Teardown aborted the fetch (StrictMode double-mount, dep change,
+          // unmount): a normal transition, not a failure worth logging.
+          return;
+        }
+        // Graceful degradation: keep serving the static manifest (R7), and
+        // release the runtime blob it is replacing so none is orphaned.
+        if (createdUrlRef.current) {
+          URL.revokeObjectURL(createdUrlRef.current);
+          createdUrlRef.current = null;
+        }
         console.error(
           "[useManifestUrl] Failed to build runtime manifest:",
           error,
         );
-        if (!cancelled) {
-          setHref(manifestHref);
-        }
+        setHref(manifestHref);
       }
     }
 
@@ -205,6 +222,7 @@ export function useManifestUrl(): UseManifestUrlResult {
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [manifestHref, appName]);
 


### PR DESCRIPTION
# Description of Changes

The installed PWA name now follows the configured app name (`ui.appNameNavbar` / `APP_NAME`) instead of always showing "Stirling PDF". The browser tab already used the custom name; the web app manifest was the last hardcoded brand surface.

The manifest is rebuilt at runtime: the app fetches its static `manifest.json` (or `manifest-classic.json` for the classic logo), merges the configured app name into `name`/`short_name` (truncated to 12 code points including the ellipsis, surrogate-safe), and serves the result through a blob URL on the existing `<link rel="manifest">`. Because a blob URL cannot resolve relative references, URL members (`start_url`, `icons[].src`, `scope`, `id`) are rewritten to absolute URLs against the manifest's own location — correct on subpath deployments and deep-linked routes. The previous blob URL is revoked on change and unmount, and fetch failures degrade to the static manifest.

Closes Stirling-Tools/Stirling-PDF#5492

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

### Validation

- `npx vitest run --root editor` — 21/21 hook tests pass (new `useManifestUrl` suite covers the name merge, short-name truncation, URL absolutization, blob lifecycle, fetch-failure fallback, and logo-variant selection).
- `npx tsc --noEmit --project editor/src/core/tsconfig.json` — clean.
- `npx oxlint --config oxlint.config.ts --max-warnings=0` — clean.
- `npx vite build editor` — succeeds.
- Manual install check (Chrome, custom `APP_NAME`): install prompt appears and the installed name is the custom app name. PWA installability behavior is browser-dependent; the blob-URL manifest approach was validated for URL resolution but not exercised against every browser's install surface in this run.

Session-settled decisions carried from planning: runtime frontend manifest generation (user-approved, over a backend-templated manifest endpoint); merge config into the static manifest at runtime (user-directed, over build-time templating); short-name truncation to 12 code points including the ellipsis (user-directed, over no truncation).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
