### PR TITLE
Change frontend CI to only run tests once

### DIFF
--- a/.github/workflows/frontend-validation.yml
+++ b/.github/workflows/frontend-validation.yml
@@ -1,8 +1,8 @@
 name: Frontend lint, type-check, and build
 
 # Reusable workflow called from build.yml when frontend / testing sources
-# change. Runs the consolidated `task frontend:check:all` (lint, types,
-# unit tests, build) and uploads the dist artifact for downstream jobs.
+# change. Runs `task frontend:check:all` and uploads the 
+# coverage + dist artifacts for downstream jobs.
 on:
   workflow_call:
 
@@ -105,16 +105,6 @@ jobs:
                 comment_id: existing.id,
               });
             }
-      - name: Vitest coverage
-        # Separate from `frontend:check:all` so the quality-gate run stays
-        # uninstrumented (faster signal) and coverage stays an informational
-        # follow-up. Continue-on-error keeps the workflow green even when
-        # a handful of test files refuse to import (e.g. missing icon
-        # specifiers) - the summary still gets posted with whatever
-        # vitest managed to instrument.
-        id: frontend-coverage
-        continue-on-error: true
-        run: task frontend:test:coverage
       - name: Install uv
         if: always()
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -457,8 +457,17 @@ tasks:
   test:editor:
     desc: "Run editor tests"
     deps: [prepare]
+    vars:
+      COVERAGE: '{{.COVERAGE | default .CI | default "false"}}'
     cmds:
-      - npx vitest run --root editor
+      - >
+        npx vitest run --root editor
+        {{if eq .COVERAGE "true"}}--coverage
+        --coverage.provider=v8
+        --coverage.reporter=text-summary
+        --coverage.reporter=json-summary
+        --coverage.reporter=html
+        --coverage.reportsDirectory=./coverage{{end}}
 
   test:watch:
     desc: "Run tests in watch mode"
@@ -468,24 +477,9 @@ tasks:
 
   test:coverage:
     desc: "Run tests with coverage (one-shot; CI-friendly)."
-    deps: [prepare]
     cmds:
-      # `vitest run` makes this CI-safe (the bare `vitest` form enters watch
-      # mode). Explicit reporter list because v8 + json-summary is what the
-      # coverage-summary.py helper consumes; html/text are kept for humans.
-      #
-      # reportsDirectory is pinned to ./coverage relative to vitest's root
-      # (--root editor), so output lands at frontend/editor/coverage/. The
-      # CI upload step reads from that path. An earlier attempt with
-      # `./editor/coverage` double-nested into frontend/editor/editor/coverage;
-      # pinning future-proofs against vitest changing the default.
-      - >
-        npx vitest run --root editor --coverage
-        --coverage.provider=v8
-        --coverage.reporter=text-summary
-        --coverage.reporter=json-summary
-        --coverage.reporter=html
-        --coverage.reportsDirectory=./coverage
+      - task: test:editor
+        vars: { COVERAGE: "true" }
 
   # ============================================================
   # Code Generation


### PR DESCRIPTION
# Description of Changes
Frontend CI is currently set to run `task frontend:check:all`, which runs the tests, and then manually runs them a second time with coverage enabled. This adds about 4 minutes onto the runtime of the frontend tests for no reason. This PR changes the `frontend:test` rule to respond to the `COVERAGE` and `CI` env vars to enable coverage analysis of the frontend tests if the setting tells them to.