### PR TITLE
Group Storybook packages in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,10 @@ updates:
         patterns:
           - "@posthog/*"
           - "posthog-js"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
       supabase:
         patterns:
           - "@supabase/*"


### PR DESCRIPTION
### Motivation
- Group Storybook packages so Dependabot updates `storybook` and all `@storybook/*` packages together and reduce churn from many separate updates.

### Description
- Add a `storybook` group to the `npm` groups in `.github/dependabot.yml` with patterns `storybook` and `@storybook/*`.
- No other configuration changes were made.

### Testing
- Validated the new group patterns with `ruby -e 'require "yaml"; ...'`, which confirmed the `storybook` group and patterns and returned success.
- Ran `git diff --check` to ensure there are no whitespace or patch errors, which succeeded.
- Inspected the updated file with `nl -ba .github/dependabot.yml | sed -n '100,120p'` to confirm the inserted lines are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7afe74fe7083259900e8d9018f595c)