### PR TITLE
fix(build): ensure `./gradlew clean` removes stale SaaS build artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,12 @@ bootJar {
     enabled = false
 }
 
+// :saas is only included for SaaS builds, but a default-flavor clean must still remove artifacts
+// left behind by an earlier SaaS build.
+tasks.named('clean') {
+    delete layout.projectDirectory.dir('app/saas/build')
+}
+
 // Configure main class for the root project
 springBoot {
     mainClass = 'stirling.software.SPDF.SPDFApplication'


### PR DESCRIPTION
### Motivation
- `./gradlew clean` on the default/proprietary flavor did not remove `app/saas/build` left behind by earlier SaaS builds, causing stale artifacts to persist across flavors.

### Description
- Add a `clean` hook in `build.gradle` that deletes `app/saas/build` (`tasks.named('clean') { delete layout.projectDirectory.dir('app/saas/build') }`) so the root `clean` always removes SaaS artifacts even when `:saas` is not included.

### Testing
- Created `app/saas/build/clean-regression-marker`, ran `./gradlew clean`, and verified the `app/saas/build` directory was deleted (success).
- Ran `./gradlew spotlessCheck test`; Spotless checks passed but the full test run reported environment-dependent unit test failures unrelated to this change (8 failures), and `task backend:check` could not be executed because the `task` CLI is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b0a9aac888325aa78e05c953355dc)