### PR TITLE
fix(sanitize): don't add empty /AA to the document catalog

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/SanitizeController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/SanitizeController.java
@@ -132,8 +132,11 @@ public class SanitizeController {
             catalog.setOpenAction(null);
         }
 
-        PDDocumentCatalogAdditionalActions catalogActions = catalog.getActions();
-        if (catalogActions != null) {
+        // getActions() creates an empty /AA in the catalog as a side effect when
+        // none exists (#7441), so only call it if /AA is already present.
+        COSDictionary aaDict = catalog.getCOSObject().getCOSDictionary(COSName.AA);
+        if (aaDict != null) {
+            PDDocumentCatalogAdditionalActions catalogActions = catalog.getActions();
             if (catalogActions.getWC() instanceof PDActionJavaScript) {
                 catalogActions.setWC(null);
             }

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/security/SanitizeControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/security/SanitizeControllerTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -202,6 +203,45 @@ class SanitizeControllerTest {
 
             ResponseEntity<Resource> response = sanitizeController.sanitizePDF(request);
             assertNotNull(response.getBody());
+        }
+
+        @Test
+        @DisplayName("Should not add an empty /AA dictionary to the catalog (#7441)")
+        void testDoesNotAddEmptyAAToCatalog() throws Exception {
+            try (PDDocument input = Loader.loadPDF(simplePdfBytes)) {
+                assertFalse(
+                        input.getDocumentCatalog().getCOSObject().containsKey(COSName.AA),
+                        "test setup: input PDF must start without /AA");
+            }
+
+            MockMultipartFile pdfFile =
+                    new MockMultipartFile(
+                            "fileInput",
+                            "test.pdf",
+                            MediaType.APPLICATION_PDF_VALUE,
+                            simplePdfBytes);
+
+            SanitizePdfRequest request = new SanitizePdfRequest();
+            request.setFileInput(pdfFile);
+            request.setRemoveJavaScript(true);
+            request.setRemoveEmbeddedFiles(true);
+            request.setRemoveXMPMetadata(false);
+            request.setRemoveMetadata(false);
+            request.setRemoveLinks(false);
+            request.setRemoveFonts(false);
+
+            when(pdfDocumentFactory.load(any(MultipartFile.class), anyBoolean()))
+                    .thenAnswer(inv -> Loader.loadPDF(simplePdfBytes));
+
+            ResponseEntity<Resource> response = sanitizeController.sanitizePDF(request);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+
+            byte[] sanitizedBytes = drainBody(response);
+            try (PDDocument sanitized = Loader.loadPDF(sanitizedBytes)) {
+                assertFalse(
+                        sanitized.getDocumentCatalog().getCOSObject().containsKey(COSName.AA),
+                        "sanitized catalog should not contain /AA");
+            }
         }
     }
 


### PR DESCRIPTION
# Description of Changes

The sanitize endpoint adds an empty `/AA` (additional actions) dictionary to the catalog of every PDF it processes, even documents that had no JavaScript to begin with.

Cause: `sanitizeJavaScript()` calls PDFBox's `PDDocumentCatalog#getActions()` unconditionally, and that getter creates the `/AA` entry as a side effect of being read. It also never returns null, so the existing null check was dead code. Fixed by checking the underlying `COSDictionary` for `/AA` before calling `getActions()`, same as the `/Names` handling earlier in the method.

Added a regression test that runs a clean PDF through the controller and checks the output catalog has no `/AA`. It fails on main and passes with the fix. Full backend suite passes locally.

Left out on purpose: removing a pre-existing `/AA` that ends up empty after its JS actions are nulled. Can do that in a follow-up if there's interest.

Closes #7441

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I ran the backend checks via gradlew (full :stirling-pdf:test plus spotlessCheck), no frontend changes
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
