### PR TITLE
deps: upgrade mwiede JSch to 2.28.6 and adapt SFTP password handling

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/policy/network/SftpFileClient.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/policy/network/SftpFileClient.java
@@ -65,7 +65,7 @@ final class SftpFileClient implements RemoteFileClient {
             }
             Session session = jsch.getSession(config.username(), config.host(), config.port());
             if (config.password() != null) {
-                session.setPassword(config.password());
+                session.setPassword(config.password().getBytes(StandardCharsets.UTF_8));
             }
             if (config.hostKeyFingerprint() != null) {
                 // Pinned key: only the configured fingerprint is ever accepted.

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     jpdfiumVersion = "1.0.4"
     jwtVersion = "0.13.0"
     awsSdkVersion = "2.44.12"
-    jschVersion = "0.2.23"
+    jschVersion = "2.28.6"
     commonsNetVersion = "3.11.1"
     smbjVersion = "0.14.0"
     tinkVersion = "1.23.0"


### PR DESCRIPTION
# Description of Changes

This PR replaces #7490 and upgrades `com.github.mwiede:jsch` from `0.2.23` to `2.28.6`.

In addition to the dependency bump from the original Dependabot PR, this PR includes the required compatibility adjustment for SFTP password authentication:

- Updated `jschVersion` in `build.gradle` from `0.2.23` to `2.28.6`.
- Updated `SftpFileClient` to pass the configured password to JSch as UTF-8 encoded bytes instead of using the `String` overload.
- Preserved the existing SFTP connection and host-key verification behavior.
- Addresses the API compatibility changes introduced by the newer JSch version that prevented the dependency upgrade from being used unchanged.

This supersedes #7490

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
