### PR TITLE
Fix a11y violations in nightlies and improve a11y config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,9 +135,9 @@ jobs:
     secrets: inherit
 
   # Required (in all-checks-passed). Scans the stories a branch touches in both
-  # light and dark; a NEW axe violation in either theme blocks the merge. The
-  # whole-suite sweep (nightly.yml) still covers regressions a change ripples
-  # into stories it doesn't touch.
+  # light and dark; an axe violation in either theme blocks the merge. The
+  # whole-suite sweep (nightly.yml) still covers stories a change affects without
+  # touching them directly.
   frontend-a11y:
     if: needs.files-changed.outputs.frontend == 'true'
     needs: [files-changed]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,9 +134,10 @@ jobs:
     uses: ./.github/workflows/frontend-validation.yml
     secrets: inherit
 
-  # Advisory: deliberately NOT in all-checks-passed. It reports on the stories a
-  # branch touches so a regression is visible in review, but a browser scan is
-  # too new here to block merges on. Promote it once its pass/fail proves stable.
+  # Required (in all-checks-passed). Scans the stories a branch touches in both
+  # light and dark; a NEW axe violation in either theme blocks the merge. The
+  # whole-suite sweep (nightly.yml) still covers regressions a change ripples
+  # into stories it doesn't touch.
   frontend-a11y:
     if: needs.files-changed.outputs.frontend == 'true'
     needs: [files-changed]
@@ -290,6 +291,7 @@ jobs:
       - db-migration-test
       - check-generateOpenApiDocs
       - frontend-validation
+      - frontend-a11y
       - playwright-e2e
       - playwright-e2e-live
       - playwright-e2e-enterprise
@@ -316,6 +318,7 @@ jobs:
             db-migration-test=${{ needs.db-migration-test.result }}
             check-generateOpenApiDocs=${{ needs.check-generateOpenApiDocs.result }}
             frontend-validation=${{ needs.frontend-validation.result }}
+            frontend-a11y=${{ needs.frontend-a11y.result }}
             playwright-e2e=${{ needs.playwright-e2e.result }}
             playwright-e2e-live=${{ needs.playwright-e2e-live.result }}
             playwright-e2e-enterprise=${{ needs.playwright-e2e-enterprise.result }}

--- a/.github/workflows/frontend-a11y.yml
+++ b/.github/workflows/frontend-a11y.yml
@@ -3,9 +3,8 @@ name: Frontend a11y regression gate
 # Reusable workflow called from build.yml when frontend sources change.
 #
 # Scans the stories this branch touches in real Chromium and runs axe against
-# each. Existing violations are grandfathered in .storybook/a11y-baseline.json;
-# the check fails on a NEW violation — a story breaking a rule it wasn't already
-# breaking — or on a story that fails to render at all.
+# each; the check fails on any axe violation, or on a story that fails to render
+# at all.
 #
 # Only changed stories, because a full sweep is ~30 minutes: far too slow to sit
 # in front of every merge. The whole suite is scanned nightly instead

--- a/.github/workflows/frontend-a11y.yml
+++ b/.github/workflows/frontend-a11y.yml
@@ -10,10 +10,6 @@ name: Frontend a11y regression gate
 # Only changed stories, because a full sweep is ~30 minutes: far too slow to sit
 # in front of every merge. The whole suite is scanned nightly instead
 # (nightly.yml), which catches anything a branch didn't touch.
-#
-# Advisory for now: this is not in build.yml's all-checks-passed list, so a
-# failure reports without blocking. Promote it once a few weeks of runs show the
-# pass/fail is stable.
 on:
   workflow_call:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,10 +59,14 @@ jobs:
   # the story itself — a shared component, a theme token — still surfaces within
   # a day.
   a11y-all-stories:
-    name: a11y (every story, light + dark)
+    name: a11y (every story)
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [light, dark]
     runs-on: ubuntu-latest
-    # Two full sweeps (one per theme), each ~30 minutes of browser time.
-    timeout-minutes: 120
+    # One full sweep (~30 minutes of browser time).
+    timeout-minutes: 60
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -82,14 +86,14 @@ jobs:
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
-      - name: a11y gate (every story, light + dark)
-        run: task frontend:storybook:a11y
+      - name: a11y gate (every story, ${{ matrix.theme }})
+        run: task frontend:storybook:a11y:${{ matrix.theme }}
 
       - name: Upload scan reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: a11y-scan-nightly-${{ github.run_id }}
+          name: a11y-scan-nightly-${{ matrix.theme }}-${{ github.run_id }}
           path: frontend/.a11y-scan/
           retention-days: 14
           if-no-files-found: ignore

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -210,14 +210,25 @@ tasks:
       #   task frontend:storybook:test -- Button
       - npx vitest run --config .storybook/vitest.config.ts {{.CLI_ARGS}}
 
-  storybook:a11y:
-    desc: "a11y regression gate over every story, light and dark: fail only on NEW axe violations"
+  storybook:a11y:light:
+    desc: "a11y gate over every story in light mode"
     deps: [prepare, storybook:browser]
     cmds:
-      - node .storybook/a11y-scan.mjs
+      - node .storybook/a11y-scan.mjs {{.CLI_ARGS}}
       - node .storybook/a11y-check.mjs --in .a11y-scan --manifest .a11y-scan/manifest.txt
-      - SCAN_THEME=dark node .storybook/a11y-scan.mjs
+
+  storybook:a11y:dark:
+    desc: "a11y gate over every story in dark mode"
+    deps: [prepare, storybook:browser]
+    cmds:
+      - SCAN_THEME=dark node .storybook/a11y-scan.mjs {{.CLI_ARGS}}
       - node .storybook/a11y-check.mjs --in .a11y-scan --manifest .a11y-scan/manifest.txt --baseline .storybook/a11y-baseline.dark.json
+
+  storybook:a11y:
+    desc: "a11y gate over every story, light and dark"
+    cmds:
+      - task: storybook:a11y:light
+      - task: storybook:a11y:dark
 
   storybook:a11y:changed:
     desc: "a11y gate over the stories this branch affects (default base origin/main)"
@@ -233,7 +244,6 @@ tasks:
 
       Pass a base ref through CLI_ARGS, e.g.
         task frontend:storybook:a11y:changed -- origin/release
-    deps: [prepare, storybook:browser]
     vars:
       BASE: '{{.CLI_ARGS | default "origin/main"}}'
       CHANGED:
@@ -244,10 +254,10 @@ tasks:
             echo "a11y: no story files affected vs {{.BASE}} — nothing to check"
             exit 0
           fi
-          node .storybook/a11y-scan.mjs {{.CHANGED}}
-          node .storybook/a11y-check.mjs --in .a11y-scan --manifest .a11y-scan/manifest.txt
-          SCAN_THEME=dark node .storybook/a11y-scan.mjs {{.CHANGED}}
-          node .storybook/a11y-check.mjs --in .a11y-scan --manifest .a11y-scan/manifest.txt --baseline .storybook/a11y-baseline.dark.json
+          rc=0
+          task frontend:storybook:a11y:light -- {{.CHANGED}} || rc=1
+          task frontend:storybook:a11y:dark -- {{.CHANGED}} || rc=1
+          exit $rc
 
   storybook:a11y:record:
     desc: "Re-record both a11y baselines (run after intentionally fixing/adding violations)"

--- a/frontend/editor/src/core/components/filesPage/VersionTimeline.tsx
+++ b/frontend/editor/src/core/components/filesPage/VersionTimeline.tsx
@@ -219,7 +219,20 @@ export function VersionTimeline({
                     align="center"
                     style={{ flex: 1, minWidth: 0, flexWrap: "nowrap" }}
                   >
-                    <Badge size="xs" variant={isActive ? "filled" : "light"}>
+                    <Badge
+                      size="xs"
+                      variant={isActive ? "filled" : "light"}
+                      styles={
+                        isActive
+                          ? {
+                              root: {
+                                backgroundColor: "var(--c-accent-solid)",
+                              },
+                              label: { color: "var(--c-text-on-primary)" },
+                            }
+                          : undefined
+                      }
+                    >
                       v{v.versionNumber ?? 1}
                     </Badge>
                     <Text


### PR DESCRIPTION
# Description of Changes
This fixes the a11y violations that are currently failing in the nightlies in dark mode. Now that we're down to 0 baseline, we can require the a11y tests to pass in PRs before they merge, so I've changed that, and I've also made it so that the nightly will report failures in both light and dark mode instead of just light mode if that fails.

<img width="2560" height="838" alt="image" src="https://github.com/user-attachments/assets/b0322182-f6ff-4dea-9a1c-5a6c9c9c5439" />