### PR TITLE
fix(api): fix endpoint set concurrency and in-memory leaks

### DIFF
--- a/app/common/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
+++ b/app/common/src/main/java/stirling/software/SPDF/config/EndpointConfiguration.java
@@ -46,7 +46,7 @@ public class EndpointConfiguration {
     private final ApplicationProperties applicationProperties;
     @Getter private Map<String, Boolean> endpointStatuses = new ConcurrentHashMap<>();
     private Map<String, Set<String>> endpointGroups = new ConcurrentHashMap<>();
-    private Set<String> disabledGroups = new HashSet<>();
+    private Set<String> disabledGroups = ConcurrentHashMap.newKeySet();
     private Map<String, DisableReason> endpointDisableReasons = new ConcurrentHashMap<>();
     private Map<String, DisableReason> groupDisableReasons = new ConcurrentHashMap<>();
     private Map<String, Set<String>> endpointAlternatives = new ConcurrentHashMap<>();

--- a/app/core/src/main/java/stirling/software/SPDF/service/WeeklyActiveUsersService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/WeeklyActiveUsersService.java
@@ -4,7 +4,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +23,7 @@ public class WeeklyActiveUsersService {
     private final Map<String, Instant> activeBrowsers = new ConcurrentHashMap<>();
 
     // Track total unique browsers seen (overall)
-    private long totalUniqueBrowsers = 0;
+    private final AtomicLong totalUniqueBrowsers = new AtomicLong(0);
 
     // Application start time
     private final Instant startTime = Instant.now();
@@ -36,12 +38,12 @@ public class WeeklyActiveUsersService {
             return;
         }
 
-        boolean isNewBrowser = !activeBrowsers.containsKey(browserId);
-        activeBrowsers.put(browserId, Instant.now());
+        Instant now = Instant.now();
+        Instant previous = activeBrowsers.put(browserId, now);
 
-        if (isNewBrowser) {
-            totalUniqueBrowsers++;
-            log.debug("New browser recorded: {} (Total: {})", browserId, totalUniqueBrowsers);
+        if (previous == null) {
+            long total = totalUniqueBrowsers.incrementAndGet();
+            log.debug("New browser recorded: {} (Total: {})", browserId, total);
         }
     }
 
@@ -61,7 +63,7 @@ public class WeeklyActiveUsersService {
      * @return Total unique browsers count
      */
     public long getTotalUniqueBrowsers() {
-        return totalUniqueBrowsers;
+        return totalUniqueBrowsers.get();
     }
 
     /**
@@ -88,7 +90,8 @@ public class WeeklyActiveUsersService {
         activeBrowsers.entrySet().removeIf(entry -> entry.getValue().isBefore(sevenDaysAgo));
     }
 
-    /** Manual cleanup trigger (can be called by scheduled task if needed) */
+    /** Scheduled cleanup trigger running every hour */
+    @Scheduled(fixedRate = 3600000)
     public void performCleanup() {
         int sizeBefore = activeBrowsers.size();
         cleanupOldEntries();

--- a/app/saas/src/main/java/stirling/software/saas/service/RateLimitService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/RateLimitService.java
@@ -113,19 +113,13 @@ public class RateLimitService {
     public void cleanupExpiredBuckets() {
         long now = System.currentTimeMillis();
 
-        int hourlyRemoved =
-                (int)
-                        hourlyLimits.entrySet().stream()
-                                .filter(e -> e.getValue().getResetTime() < now)
-                                .peek(e -> hourlyLimits.remove(e.getKey()))
-                                .count();
+        int hourlyBefore = hourlyLimits.size();
+        hourlyLimits.entrySet().removeIf(e -> e.getValue().getResetTime() < now);
+        int hourlyRemoved = hourlyBefore - hourlyLimits.size();
 
-        int dailyRemoved =
-                (int)
-                        dailyLimits.entrySet().stream()
-                                .filter(e -> e.getValue().getResetTime() < now)
-                                .peek(e -> dailyLimits.remove(e.getKey()))
-                                .count();
+        int dailyBefore = dailyLimits.size();
+        dailyLimits.entrySet().removeIf(e -> e.getValue().getResetTime() < now);
+        int dailyRemoved = dailyBefore - dailyLimits.size();
 
         if (hourlyRemoved + dailyRemoved > 0) {
             log.debug(


### PR DESCRIPTION
# Description of Changes


Fix possible memory leaks. Moves manual resource management to more automated/library managed ways.

Changes:
* Refactored the rate limit bucket cleanup in `RateLimitService` to use `entrySet().removeIf` for both hourly and daily limits, improving clarity and efficiency. Now calculates the number of removed entries by comparing sizes before and after cleanup.
* Annotated the `performCleanup` method in `WeeklyActiveUsersService` with `@Scheduled(fixedRate = 3600000)` to automate cleanup every hour, instead of relying on manual or external triggers.
* Added imports for `AtomicLong` and `@Scheduled` in `WeeklyActiveUsersService` to support the new thread-safe counter and scheduled cleanup.

<!--
Please provide a summary of the changes, including:

- What was changed
- Why the change was made
- Any challenges encountered

Closes #(issue_number)
-->

---

## Checklist

### General

- [X] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [X] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [X] I have run `task check` to verify linters, typechecks, and tests pass
- [X] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
