### PR TITLE
Encrypted-at-rest badge on documents (P3A follow-up)

### DIFF
--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -7185,6 +7185,7 @@ beforeHelper = "header against your signing secret before trusting a payload. SD
 beforeSignature = "Verify the"
 
 [portal.documents]
+encryptedAtRest = "Encrypted"
 exportCsv = "Export CSV"
 search = "Search by filename, ID..."
 subtitle = "Every document your org has processed, with its full processing record. Content access is request-gated."

--- a/frontend/editor/src/portal/components/documents/EncryptedFileBadge.css
+++ b/frontend/editor/src/portal/components/documents/EncryptedFileBadge.css
@@ -1,0 +1,5 @@
+.portal-doc-encrypted {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}

--- a/frontend/editor/src/portal/components/documents/EncryptedFileBadge.stories.tsx
+++ b/frontend/editor/src/portal/components/documents/EncryptedFileBadge.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Card } from "@app/ui";
+import { EncryptedFileBadge } from "@portal/components/documents/EncryptedFileBadge";
+
+const meta: Meta<typeof EncryptedFileBadge> = {
+  title: "Portal/Documents/EncryptedFileBadge",
+  component: EncryptedFileBadge,
+  parameters: { layout: "padded" },
+};
+export default meta;
+type Story = StoryObj<typeof EncryptedFileBadge>;
+
+/** Shown in a file row, which is the only place it makes sense to judge it. */
+function FileRow({
+  name,
+  encryptionKeyId,
+}: {
+  name: string;
+  encryptionKeyId: string | null;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "1rem",
+        padding: "0.6rem 0",
+      }}
+    >
+      <span style={{ fontSize: "0.8125rem", fontWeight: 600 }}>{name}</span>
+      <EncryptedFileBadge encryptionKeyId={encryptionKeyId} />
+    </div>
+  );
+}
+
+/** Encrypted and plaintext files side by side in a deployment that uses the feature. */
+export const InFileList: Story = {
+  render: () => (
+    <div style={{ maxWidth: "36rem" }}>
+      <Card padding="loose">
+        <FileRow
+          name="Q3-board-pack.pdf"
+          encryptionKeyId="1f0b6a11-0000-4000-8000-000000000001"
+        />
+        <FileRow
+          name="signed-msa-acme.pdf"
+          encryptionKeyId="1f0b6a11-0000-4000-8000-000000000001"
+        />
+        <FileRow name="scratch-notes.pdf" encryptionKeyId={null} />
+      </Card>
+    </div>
+  ),
+};
+
+/** A deployment that never enabled encryption: no file has a key, so no markers. */
+export const FeatureUnused: Story = {
+  render: () => (
+    <div style={{ maxWidth: "36rem" }}>
+      <Card padding="loose">
+        <FileRow name="scratch-notes.pdf" encryptionKeyId={null} />
+        <FileRow name="draft-terms.pdf" encryptionKeyId={null} />
+      </Card>
+    </div>
+  ),
+};

--- a/frontend/editor/src/portal/components/documents/EncryptedFileBadge.tsx
+++ b/frontend/editor/src/portal/components/documents/EncryptedFileBadge.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from "react-i18next";
+import LockRounded from "@mui/icons-material/LockRounded";
+import { StatusBadge } from "@app/ui";
+import "@portal/components/documents/EncryptedFileBadge.css";
+
+export interface EncryptedFileBadgeProps {
+  /** `StoredFile.encryptionKeyId`. Null means the file is stored as plaintext. */
+  encryptionKeyId: string | null;
+}
+
+/**
+ * Marks a stored file as encrypted at rest. Carries a text label rather than
+ * relying on the padlock alone, so it is not colour or icon only.
+ *
+ * Renders nothing for a plaintext file, so a deployment that never enabled the
+ * feature shows no marker anywhere without the caller having to know that: the
+ * key id is the only input, which is what a file list actually has.
+ */
+export function EncryptedFileBadge({
+  encryptionKeyId,
+}: EncryptedFileBadgeProps) {
+  const { t } = useTranslation();
+  if (!encryptionKeyId) return null;
+
+  return (
+    <StatusBadge tone="success" size="sm" showDot={false}>
+      <span className="portal-doc-encrypted">
+        <LockRounded style={{ fontSize: "0.85rem" }} aria-hidden />
+        {t("portal.documents.encryptedAtRest")}
+      </span>
+    </StatusBadge>
+  );
+}


### PR DESCRIPTION
# Encrypted-at-rest badge on documents (P3A follow-up)

Split out of #7501. That PR built the operator surface for encryption at rest; this one is the user
-facing half: showing a person which of their files are encrypted, without asking an administrator.

The component was written in #7501 but never wired to anything, because no documents endpoint
returns `encryptionKeyId`. Shipping an unreachable component inside a PR whose description showed a
screenshot of it would have read as delivered, so it moved here instead.

## Status

**Draft.** The component and its stories are here. The API work and the wiring are not.

## User stories

**US-9. See which of my files are encrypted**

As a user, I want to see that my stored file is encrypted, so that I can tell a customer or an
auditor without asking an administrator.

- [x] Badge component driven by `StoredFile.encryptionKeyId`
- [x] The indicator has a text label, not colour or an icon alone
- [x] Absent, rather than showing "not encrypted", when a file has no key: a negative badge on every
      file in an install that does not use the feature is noise
- [ ] A documents endpoint returns `encryptionKeyId`. Nothing exposes it to the frontend today
- [ ] The badge is rendered on a documents surface
- [ ] The surface is covered by a test that asserts the badge appears for an encrypted file and not
      for a plaintext one

## Open questions

**Which surface?** `ReviewQueueTable` and `DocumentOverview` are both plausible. The badge belongs
wherever a file is identified, but putting it in a table costs a column, which may not be worth it
if most installs never enable encryption.

**Does it belong in My Files too?** That is editor territory rather than portal, and a second
consumer would argue for the badge living somewhere more shared than
`portal/components/documents/`.

## Test plan

- Storybook covers both states: a file list mixing encrypted and plaintext files, and an install
  that never enabled the feature
- Wiring is untested until the surface is chosen

## Related

- #7501 — the operator surface this splits from
- #7549 — publish the operator docs
