### PR TITLE
Encryption at rest: revoked-key UX, migration control, key-list paging (P3A follow-ups)

### DIFF
--- a/devGuide/STORAGE_ENCRYPTION_AT_REST.md
+++ b/devGuide/STORAGE_ENCRYPTION_AT_REST.md
@@ -195,6 +195,21 @@ account.
 The same information is on the Storage tab under Infrastructure in the admin UI, which is the
 surface most operators should use.
 
+## Known limitations
+
+Being addressed; this section goes away as they are.
+
+- **A revoked key reads as a generic failure to the person holding the file.** The API answers 403
+  with "Access to this file has been revoked", but no user-facing surface distinguishes that from an
+  ordinary permissions error, so the user cannot tell that an administrator did this deliberately
+  and that asking them can undo it.
+- **The migration cannot be stopped, and its pacing is fixed.** `PAGE_SIZE` and the pause between
+  pages are constants in `StorageEncryptionMigrationService`, so a run cannot be slowed on a busy
+  server or sped up on an idle one, and the only way to end one early is to switch encryption off,
+  which ends it as `FAILED`.
+- **`/status` returns every key row.** There is no paging, so an install with a key per team returns
+  the whole table on every poll of the admin UI.
+
 ## What this protects against
 
 Stolen disks, database dumps, exposed object-storage buckets, decommissioned media, and platform

--- a/frontend/editor/src/core/services/httpErrorHandler.ts
+++ b/frontend/editor/src/core/services/httpErrorHandler.ts
@@ -1,6 +1,10 @@
 // frontend/editor/src/core/services/httpErrorHandler.ts
 import { alert } from "@app/components/toast";
 import {
+  isStorageKeyRevoked,
+  STORAGE_KEY_REVOKED_DETAIL,
+} from "@app/services/storageKeyRevoked";
+import {
   broadcastErroredFiles,
   extractErrorFileIds,
   normalizeAxiosErrorData,
@@ -85,6 +89,13 @@ export async function handleHttpError(error: unknown): Promise<boolean> {
   const skipAuthRedirect = axiosError?.config?.skipAuthRedirect === true;
   // Check if this error should skip the global toast (component will handle it)
   if (axiosError?.config?.suppressErrorToast === true) {
+    // ...except a revoked encryption key. Every caller that reads a stored file
+    // suppresses this toast and reports its own generic failure, which tells the
+    // user what did not happen but never that an administrator did it on purpose
+    // and can undo it. Explain it here rather than in each of those callers.
+    if (await isStorageKeyRevoked(axiosError)) {
+      showSpecialErrorToast(STORAGE_KEY_REVOKED_DETAIL, { status: 403 });
+    }
     return false; // Don't show global toast, but continue rejection
   }
 

--- a/frontend/editor/src/core/services/specialErrorToasts.ts
+++ b/frontend/editor/src/core/services/specialErrorToasts.ts
@@ -1,5 +1,6 @@
 import i18n from "i18next";
 import { alert } from "@app/components/toast";
+import { STORAGE_KEY_REVOKED_PATTERN } from "@app/services/storageKeyRevoked";
 
 interface ErrorToastMapping {
   regex: RegExp;
@@ -20,6 +21,16 @@ const MAPPINGS: ErrorToastMapping[] = [
       /the pdf document is passworded and either the password was not provided or was incorrect/i,
     i18nKey: "errors.incorrectPasswordProvided",
     defaultMessage: "The PDF password is incorrect or not provided.",
+  },
+  {
+    // Storage encryption kill switch. Matches the detail from
+    // StorageEncryptionErrors.revoked, which both My Files and workflow reads
+    // answer with. A permissions 403 does not match, so it still falls through
+    // to the generic message.
+    regex: STORAGE_KEY_REVOKED_PATTERN,
+    i18nKey: "errors.storageKeyRevoked",
+    defaultMessage:
+      "An administrator has revoked access to files stored under this encryption key. This is reversible: ask an administrator to restore the key.",
   },
 ];
 

--- a/frontend/editor/src/core/services/storageKeyRevoked.test.ts
+++ b/frontend/editor/src/core/services/storageKeyRevoked.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { isStorageKeyRevoked } from "@app/services/storageKeyRevoked";
+
+/** The backend's wording, from StorageEncryptionErrors.revoked. */
+const DETAIL =
+  "Access to this file has been revoked (its encryption key is disabled)";
+
+function axiosError(status: number, data: unknown) {
+  return { response: { status, data } };
+}
+
+/** Stands in for the Blob axios hands back when responseType is "blob". */
+function blobBody(text: string) {
+  return { text: () => Promise.resolve(text) };
+}
+
+describe("isStorageKeyRevoked", () => {
+  it("recognises the revocation detail in a JSON body", async () => {
+    await expect(
+      isStorageKeyRevoked(axiosError(403, { detail: DETAIL })),
+    ).resolves.toBe(true);
+  });
+
+  it("recognises it in a plain-text body", async () => {
+    await expect(isStorageKeyRevoked(axiosError(403, DETAIL))).resolves.toBe(
+      true,
+    );
+  });
+
+  // The file endpoints request blobs, so this is the shape that actually
+  // arrives when someone opens a file under a revoked key.
+  it("reads a blob body before matching", async () => {
+    await expect(
+      isStorageKeyRevoked(
+        axiosError(403, blobBody(JSON.stringify({ detail: DETAIL }))),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("leaves an ordinary permissions 403 alone", async () => {
+    await expect(
+      isStorageKeyRevoked(
+        axiosError(403, {
+          detail: "You do not have permission to view this file",
+        }),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("ignores other statuses carrying the same words", async () => {
+    await expect(isStorageKeyRevoked(axiosError(500, DETAIL))).resolves.toBe(
+      false,
+    );
+  });
+
+  it("does not throw on a body it cannot read", async () => {
+    const unreadable = {
+      response: {
+        status: 403,
+        data: {
+          text: () => Promise.reject(new Error("stream already consumed")),
+        },
+      },
+    };
+    await expect(isStorageKeyRevoked(unreadable)).resolves.toBe(false);
+  });
+
+  it("returns false for an error with no response at all", async () => {
+    await expect(isStorageKeyRevoked(new Error("network"))).resolves.toBe(
+      false,
+    );
+  });
+});

--- a/frontend/editor/src/core/services/storageKeyRevoked.ts
+++ b/frontend/editor/src/core/services/storageKeyRevoked.ts
@@ -1,0 +1,56 @@
+import { normalizeAxiosErrorData } from "@app/services/errorUtils";
+
+/**
+ * The storage-encryption kill switch, as it reaches the browser.
+ *
+ * Revoking a scope's key makes reads of everything stored under it answer 403
+ * with a distinctive detail (see `StorageEncryptionErrors.revoked`), from both
+ * My Files and workflow document reads. It is a deliberate, reversible policy
+ * state rather than a permissions failure, and it reads as a generic error
+ * unless callers tell the two apart.
+ */
+
+/**
+ * The detail the backend sends. Passing this to `showSpecialErrorToast` reuses
+ * the one copy of the message rather than writing it a second time.
+ */
+export const STORAGE_KEY_REVOKED_DETAIL =
+  "Access to this file has been revoked (its encryption key is disabled)";
+
+/** Matches the backend's revocation detail. Shared so the toast table and the
+ *  call sites that suppress that toast cannot drift apart. */
+export const STORAGE_KEY_REVOKED_PATTERN =
+  /access to this file has been revoked/i;
+
+/**
+ * True when a failed request was refused because the file's encryption key is
+ * revoked. False for an ordinary permissions 403, which is a different problem
+ * with a different remedy.
+ *
+ * Async because the file endpoints request blobs, so the error body arrives as
+ * a Blob and has to be read before it can be matched.
+ */
+export async function isStorageKeyRevoked(error: unknown): Promise<boolean> {
+  const response = (error as { response?: { status?: number; data?: unknown } })
+    ?.response;
+  if (response?.status !== 403) return false;
+
+  let body: unknown;
+  try {
+    body = await normalizeAxiosErrorData(response.data);
+  } catch {
+    return false;
+  }
+  if (body === undefined) return false;
+
+  const text = typeof body === "string" ? body : safeStringify(body);
+  return text !== null && STORAGE_KEY_REVOKED_PATTERN.test(text);
+}
+
+function safeStringify(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
# Encryption at rest: revoked-key UX, migration control, key-list paging (P3A follow-ups)

Three items deferred out of #7501, bundled because they are all small and all in the same subsystem.
Stacked on #7501, so review that first; this shows only the delta.

The commit here documents the three gaps in the runbook. Each story below deletes its bullet from
that section as it lands.

## Status

**Draft.** Scope, stories and implementation plan agreed; build not started.

## User stories

**US-10. Understand why a file will not open**

As a user whose team's key has been revoked, I want a clear message rather than a generic error, so
that I raise the right request with the right person.

- [ ] A 403 from a revoked key renders as "access to this file has been revoked" wording, not a
      generic failure toast
- [ ] Distinguished from a permissions 403. The backend already makes this possible: revocation
      answers with "Access to this file has been revoked (its encryption key is disabled)" from
      `StorageEncryptionErrors.revoked`, while a permissions failure does not
- [ ] Applies to both My Files and workflow document reads, which P2 made consistent
- [ ] Says that it is reversible by an administrator, so the user asks for the right thing

Note: this is the only story here that a non-administrator ever sees, and it is the one most likely
to generate a support ticket if left alone.

**US-11. Stop a migration I should not have started**

As an administrator, I want to stop a running migration and control how hard it works, so that a
long job on a busy server is not something I have to wait out.

- [ ] `POST /migrate/cancel` ends a run, leaving already-encrypted files encrypted
- [ ] The run reports a distinct terminal state for cancelled, not `FAILED`. `FAILED` currently
      means "encryption was switched off mid-run", and conflating the two would make the panel's
      message wrong
- [ ] Page size and inter-page pause are configurable rather than the `PAGE_SIZE` and pause
      constants in `StorageEncryptionMigrationService`
- [ ] The panel gets a Stop control while a run is going
- [ ] Cancelling is safe to do repeatedly, and cancelling an already-finished run is not an error

**US-12. Keep `/status` cheap on a large install**

As an operator of an install with many teams, I want the status endpoint to stay small, so that the
admin UI polling it does not pull the whole key table each time.

- [ ] `/status` pages its key list
- [ ] The panel pages with it, rather than rendering whatever the first page happens to be
- [ ] `pendingRotationRows` stays a database count. It is already counted rather than derived from
      the key list, so it does not become wrong when the list is a page
- [ ] Existing callers of `/status` keep working, or the change is called out as breaking

## Implementation plan

Ordered by risk to #7501, which is under review: US-10 touches nothing it owns, US-11 adds to the
contract, US-12 changes it. Each stage is independently reviewable and shippable.

### Stage 1 — US-10, the revoked-key message

Smallest, and the only story a non-administrator ever sees.

The backend already answers a revoked read with 403 and a distinctive detail
(`StorageEncryptionErrors.revoked`: "Access to this file has been revoked (its encryption key is
disabled)"). The frontend has a central matcher for exactly this: `specialErrorToasts.ts` holds a
`MAPPINGS` table of `{ regex, i18nKey, defaultMessage }` consulted by `httpErrorHandler.ts` before
it falls back to a generic toast.

- Add one entry matching the revocation detail, with copy that says an administrator did this
  deliberately and can undo it. A permissions 403 does not match the pattern, so it still falls
  through to the generic message — that is US-10's "distinguished from a permissions 403".
- Handle the call sites that opt out of the global toast with `suppressErrorToast: true` and render
  their own error: the My Files download in `FileManagerContext`, plus `FileSelectorPicker`,
  `FilesModalContext` and `fileSyncService`. Each needs the same distinction locally.
- Add the `en-US` key. Covered by a unit test on the matcher and one on a suppressing call site.

### Stage 2 — US-11, cancel and pacing

**Cancel.** `migratePages` already returns a terminal `State` from inside the per-file loop — that
is how "encryption switched off mid-run" ends a run — so cancellation slots into the same place.

- `Run` gains an `AtomicBoolean cancelled`; the per-file loop checks it and returns the new state.
- `cancel()` reads `currentRun` and sets the flag. Idempotent: cancelling a finished or absent run
  is a no-op, not an error, so a double click cannot produce a 409.
- `POST /migrate/cancel` on `StorageEncryptionAdminController`, and a `migration.cancelled` audit
  event carrying the counts at the point it stopped.

**A distinct terminal state.** Cancelled must not reuse `FAILED`. `FAILED` currently means
"encryption was switched off mid-run", and the panel's failure copy says exactly that — reusing it
would tell an operator who pressed Stop to go and re-enable a flag they never touched. So:
`State.CANCELLED` on the enum, `"CANCELLED"` on the frontend `MigrationState`, a `STATE_TONE`
entry, and its own copy.

**Pacing.** `PAGE_SIZE` and `PAUSE_BETWEEN_PAGES_MS` are constants in the service. Move them to
`storage.encryption.migration.pageSize` / `pauseMs` under a new nested `Migration` class in
`ApplicationProperties.Storage.Encryption`, keeping today's values (25 / 200ms) as defaults and
clamping to a sane range rather than trusting the file.

**UI.** A Stop control while a run is `RUNNING`, using the existing confirmation pattern — the
start dialog currently promises there is no stop control, and that sentence comes out when this
lands. The devGuide bullet goes with it.

### Stage 3 — US-12, key-list paging

Last, because it is the only stage that changes a response shape #7501 already consumes, so it is
the one most likely to churn against review feedback.

- `/status` takes `page` and `size`; `keys` becomes a page rather than `findAll(Sort.by(...))`.
- `pendingRotationRows` stays a database count and is already written that way, so it keeps
  reporting the whole table when `keys` is one page.
- The panel pages with it rather than rendering whatever the first page holds.
- Decide and document whether the shape change is breaking for any other caller of `/status`.

## Decisions taken in this plan

- **Cancelled is its own state, not `FAILED`.** Different cause, different remedy, different copy.
- **Cancel is idempotent.** A stop button that can 409 on a double click is worse than one that
  quietly does nothing the second time.
- **Pacing is configuration, not an API parameter.** It is an operator's tuning knob for their
  server, not a per-run choice, and it belongs where the rest of the encryption settings live.
- **Paging goes last** so it lands after #7501 settles.

## Open question

Cluster behaviour is unresolved and is not blocked by any of the above. The migration guard is
per-node, so a cancel reaches only the node running the job. Stage 2 should either say so in the UI
or refuse when clustering is on. Flagging rather than deciding here.

## Why bundle them

All three touch `StorageEncryptionAdminController`, the migration service, or
`portal/api/storageEncryption.ts`. Three separate PRs would conflict with each other for no benefit.

## Test plan

- Cancel: a run that is cancelled mid-flight leaves the already-encrypted files encrypted and
  reports the cancelled state, and cancelling twice is not an error
- Paging: a status call with more key rows than one page returns a page, and `pendingRotationRows`
  still counts the whole table
- Revoked read: a component test that a 403 carrying the revocation detail renders the revoked
  wording, and a plain 403 does not

## Related

- #7501 — the operator surface these were deferred from
- #7550 — the encrypted badge, split out of the same PR
- #7549 — publish the operator docs

