### PR TITLE
Drop environment from CI jobs that do not deploy

### DIFF
--- a/.github/workflows/PR-Auto-Deploy-V2.yml
+++ b/.github/workflows/PR-Auto-Deploy-V2.yml
@@ -462,7 +462,6 @@ jobs:
             });
 
   cleanup-v2-deployment:
-    environment: pr-preview
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/PR-Demo-cleanup.yml
+++ b/.github/workflows/PR-Demo-cleanup.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   cleanup:
-    environment: pr-preview
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -20,7 +20,6 @@ permissions:
 
 jobs:
   build:
-    environment: ci-unsigned
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
           filters: .github/config/.files.yaml
 
   gradle-cache-prime:
-    environment: ci-unsigned
     name: Prime shared Gradle cache
     needs: [files-changed]
     runs-on: ubuntu-latest

--- a/.github/workflows/check-licence.yml
+++ b/.github/workflows/check-licence.yml
@@ -10,7 +10,6 @@ permissions:
 
 jobs:
   check-licence:
-    environment: ci-unsigned
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/check-openapi.yml
+++ b/.github/workflows/check-openapi.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   check-generate-openapi-docs:
-    environment: ci-unsigned
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/db-migration-test.yml
+++ b/.github/workflows/db-migration-test.yml
@@ -13,7 +13,6 @@ permissions:
 
 jobs:
   migration-test:
-    environment: ci-unsigned
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/docker-compose-tests.yml
+++ b/.github/workflows/docker-compose-tests.yml
@@ -17,7 +17,6 @@ permissions:
 
 jobs:
   docker-compose-tests:
-    environment: ci-unsigned
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   playwright-e2e-live:
-    environment: ci-unsigned
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/frontend-backend-licenses-update.yml
+++ b/.github/workflows/frontend-backend-licenses-update.yml
@@ -42,8 +42,6 @@ jobs:
           filters: .github/config/.files.yaml
 
   generate-frontend-license-report:
-    # ci-bot, not bot-identity: this job runs on PRs too, and bot-identity is main-only.
-    environment: ci-bot
     if: needs.files-changed.outputs.licenses-frontend == 'true'
     name: Generate Frontend License Report
     needs: files-changed
@@ -318,8 +316,6 @@ jobs:
           GH_TOKEN: ${{ steps.setup-bot.outputs.token }}
 
   generate-backend-license-report:
-    # ci-bot, not bot-identity: this job runs on PRs too, and bot-identity is main-only.
-    environment: ci-bot
     if: needs.files-changed.outputs.licenses-backend == 'true'
     needs: files-changed
     name: Generate Backend License Report

--- a/.github/workflows/multiOSReleases.yml
+++ b/.github/workflows/multiOSReleases.yml
@@ -38,7 +38,6 @@ permissions:
 
 jobs:
   determine-matrix:
-    environment: ci-unsigned
     if: ${{ vars.CI_PROFILE != 'lite' }}
     runs-on: ubuntu-latest
     outputs:
@@ -119,7 +118,6 @@ jobs:
         env:
           INPUT_PLATFORM: ${{ github.event.inputs.platform }}
   build-jars:
-    environment: ci-unsigned
     needs: determine-matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,7 +127,6 @@ jobs:
   # Runs the @nightly tag (conversion scenarios) plus a 10-shard concurrency run
   # of every other feature.
   cucumber-nightly:
-    environment: ci-unsigned
     name: Cucumber (nightly scenarios + full concurrency)
     runs-on: ubuntu-latest
     # Fork pull requests get no MAVEN_* secrets, so the image build cannot work.

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -57,9 +57,7 @@ permissions:
 
 jobs:
   determine-matrix:
-    # Only probes APPLE_CERTIFICATE for presence, so it stays on the unrestricted
-    # signing environment - release-signing would block every PR run.
-    environment: ci-signing
+    # No environment: only probes APPLE_CERTIFICATE, which is a repo-level secret.
     if: ${{ vars.CI_PROFILE != 'lite' }}
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -37,7 +37,6 @@ jobs:
   # spring-security=true matrix entry if `task backend:build` and
   # `task backend:build:ci` produce equivalent JARs (verify before wiring).
   test-build-docker-images:
-    environment: ci-unsigned
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why

Any job that declares `environment:` makes GitHub create a **deployment record**, which renders as "deployed to X" boxes in the PR timeline. There is no setting to suppress them, so the only fix is to stop declaring environments on jobs that are not actually deploying anything.

`build.yml` fans out into ~8 reusable workflows that each declared `environment: ci-unsigned`, so a single PR produced 8 deployment notices (see #7547). 84 of the last 100 deployments on this repo were `ci-unsigned`.

Two things make those declarations not worth the noise:

- `ci-unsigned`, `ci-signing` and `ci-bot` all have no protection rules and no branch policy, so access to their secrets is identical to a repo-level secret for anyone who can push a workflow. They guard against accident, not attack.
- `MAVEN_PUBLIC_URL` is not set at repo, org, environment or variable level, so `settings.gradle` skips the custom-maven block entirely and `MAVEN_USER` / `MAVEN_PASSWORD` are never read. Most of the `ci-unsigned` jobs were scoping secrets the build ignores. Both are also still present at repo level.

## What changed

Removed `environment:` from 15 jobs across 14 workflows that do not deploy and hold no environment-only secret:

- `ci-unsigned` on the MAVEN-only jobs: backend-build, build (gradle-cache-prime), check-licence, check-openapi, db-migration-test, docker-compose-tests, e2e-live, nightly, test-build-docker, multiOSReleases (determine-matrix + build-jars)
- `ci-bot` on both license-report jobs: `GH_APP_ID` and `GH_APP_PRIVATE_KEY` are repo-level
- `ci-signing` on tauri-build `determine-matrix`: it only probes `APPLE_CERTIFICATE`, which is repo-level
- `pr-preview` on the two PR teardown jobs: they only use org-level `NEW_VPS_*`, and tearing down is not a deployment

## What was deliberately kept

- `build-enterprise` keeps `ci-unsigned` - `PREMIUM_KEY_ENTERPRISE` exists only in that environment
- `tauri-build` `build` keeps its conditional environment - `TAURI_SIGNING_PRIVATE_KEY` and the `VITE_*` secrets are environment-only, and `release-signing` is the reviewer gate on main
- `sync-portal-docs` and `sync_files_v2` keep `bot-identity` - it does not deploy, but its `[main]` branch policy is what stops any branch acting as the GitHub App
- All real publish/deploy paths keep theirs: `package-publish`, `docker-publish`, `docker-base-publish`, `release-signing`, and the two `pr-preview` deploy jobs

## Testing

All 47 workflow files parse, and all 78 jobs still resolve a `runs-on` or `uses`. No backend, frontend or engine files are touched.