### PR TITLE
chore(dependabot): refresh dependency update configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,7 @@ updates:
     directories:
       - /devTools
       - /frontend
+      - /testing/compose/mcp-client-check
     schedule:
       interval: "weekly"
     cooldown:
@@ -93,6 +94,13 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@typescript/*"
       vite:
         patterns:
           - "vite"
@@ -170,14 +178,6 @@ updates:
         patterns:
           - "tokio"
           - "tokio-*"
-
-  - package-ecosystem: pip
-    directory: /testing/cucumber
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    rebase-strategy: "auto"
 
   - package-ecosystem: "uv"
     directory: "/engine"


### PR DESCRIPTION
# Description of Changes

- Added `/testing/compose/mcp-client-check` to the existing Docker Compose dependency monitoring configuration so dependencies used by the MCP client check environment are covered by Dependabot.
- Added a `tanstack` dependency group matching `@tanstack/*` packages, allowing related TanStack updates to be reviewed together.
- Added a `typescript` dependency group covering both `typescript` and `@typescript/*` packages.
- Removed the obsolete `pip` Dependabot configuration for `/testing/cucumber`, as dependency management for this area has moved to the current `uv`-based setup.
- Kept the existing Dependabot scheduling, cooldown, grouping, and rebase strategy conventions unchanged where applicable.


---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
