### PR TITLE
ci(e2e): use Playwright container for stubbed matrix

### DIFF
--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -19,10 +19,6 @@ jobs:
     # avoiding three concurrent `playwright install --with-deps` runs.
     container:
       image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
-    # GitHub Actions overrides HOME inside the container. Playwright's
-    # browsers in the official image require the root home directory.
-    env:
-      HOME: /root
     strategy:
       # One browser breaking must not mask a failure in another - report all.
       fail-fast: false
@@ -55,6 +51,10 @@ jobs:
         run: task frontend:build
       - name: Run stubbed E2E tests (${{ matrix.browser }})
         env:
+          # The official Playwright image expects its browser runtime under
+          # the root home directory. Keep this scoped to Playwright so Docker
+          # and GitHub Actions continue using their normal HOME/config path.
+          HOME: /root
           PLAYWRIGHT_JSON_OUTPUT_FILE: ${{ github.workspace }}/frontend/playwright-report/results.json
           NPM_CONFIG_PREFER_OFFLINE: "true"
           NPM_CONFIG_FETCH_RETRIES: "5"

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -14,6 +14,11 @@ jobs:
   playwright-e2e:
     name: playwright-e2e (${{ matrix.browser }})
     runs-on: ubuntu-latest
+    # The image already contains the Playwright browsers and all Linux
+    # dependencies. This keeps the matrix for per-browser reporting while
+    # avoiding three concurrent `playwright install --with-deps` runs.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble@sha256:6446946a1d9fd62d9ae501312a2d76a43ee688542b21622056a372959b65d63d
     strategy:
       # One browser breaking must not mask a failure in another - report all.
       fail-fast: false
@@ -40,8 +45,8 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
-      - name: Install Playwright (${{ matrix.browser }})
-        run: task e2e:install -- ${{ matrix.browser }}
+      - name: Install frontend dependencies
+        run: task frontend:install
       - name: Build frontend (production bundle for vite preview)
         env:
           VITE_BUILD_FOR_PREVIEW: "1"

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
       - name: Install frontend dependencies
+        env:
+          NPM_CONFIG_PREFER_OFFLINE: "true"
+          NPM_CONFIG_FETCH_RETRIES: "5"
+          NPM_CONFIG_FETCH_RETRY_FACTOR: "2"
+          NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "1000"
+          NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "120000"
         run: task frontend:install
       - name: Build frontend (production bundle for vite preview)
         env:

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -18,7 +18,7 @@ jobs:
     # dependencies. This keeps the matrix for per-browser reporting while
     # avoiding three concurrent `playwright install --with-deps` runs.
     container:
-      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
+      image: mcr.microsoft.com/playwright:v1.58.2-noble@sha256:6446946a1d9fd62d9ae501312a2d76a43ee688542b21622056a372959b65d63d
     strategy:
       # One browser breaking must not mask a failure in another - report all.
       fail-fast: false

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -52,9 +52,10 @@ jobs:
       - name: Run stubbed E2E tests (${{ matrix.browser }})
         env:
           # The official Playwright image expects its browser runtime under
-          # the root home directory. Keep this scoped to Playwright so Docker
-          # and GitHub Actions continue using their normal HOME/config path.
+          # the root home directory. Keep this scoped to Playwright and use a
+          # neutral Docker config path so Docker does not read /root/.docker.
           HOME: /root
+          DOCKER_CONFIG: /tmp/playwright-docker-config
           PLAYWRIGHT_JSON_OUTPUT_FILE: ${{ github.workspace }}/frontend/playwright-report/results.json
           NPM_CONFIG_PREFER_OFFLINE: "true"
           NPM_CONFIG_FETCH_RETRIES: "5"

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -18,7 +18,11 @@ jobs:
     # dependencies. This keeps the matrix for per-browser reporting while
     # avoiding three concurrent `playwright install --with-deps` runs.
     container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble@sha256:6446946a1d9fd62d9ae501312a2d76a43ee688542b21622056a372959b65d63d
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
+    # GitHub Actions overrides HOME inside the container. Playwright's
+    # browsers in the official image require the root home directory.
+    env:
+      HOME: /root
     strategy:
       # One browser breaking must not mask a failure in another - report all.
       fail-fast: false

--- a/.github/workflows/e2e-stubbed.yml
+++ b/.github/workflows/e2e-stubbed.yml
@@ -45,14 +45,6 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
-      - name: Install frontend dependencies
-        env:
-          NPM_CONFIG_PREFER_OFFLINE: "true"
-          NPM_CONFIG_FETCH_RETRIES: "5"
-          NPM_CONFIG_FETCH_RETRY_FACTOR: "2"
-          NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "1000"
-          NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "120000"
-        run: task frontend:install
       - name: Build frontend (production bundle for vite preview)
         env:
           VITE_BUILD_FOR_PREVIEW: "1"
@@ -60,6 +52,11 @@ jobs:
       - name: Run stubbed E2E tests (${{ matrix.browser }})
         env:
           PLAYWRIGHT_JSON_OUTPUT_FILE: ${{ github.workspace }}/frontend/playwright-report/results.json
+          NPM_CONFIG_PREFER_OFFLINE: "true"
+          NPM_CONFIG_FETCH_RETRIES: "5"
+          NPM_CONFIG_FETCH_RETRY_FACTOR: "2"
+          NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "1000"
+          NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "120000"
         run: task e2e:stubbed-project PROJECT=${{ matrix.project }} -- --workers=3
       - name: Flag flaky tests
         # Runs regardless of the test outcome: a flaky test (passed on retry)


### PR DESCRIPTION
# Description of Changes

- Use the pinned official Playwright `v1.58.2-noble` container image.
- Remove the per-browser `playwright install --with-deps` step from the matrix jobs.
- Keep the browser matrix unchanged for independent Chromium, Firefox, and WebKit reporting.
- Configure Playwright to use the container's root home directory while directing Docker to a separate configuration path.
- Add npm retry and offline-cache settings to reduce transient dependency installation failures.

This prevents three matrix jobs from concurrently downloading Playwright browsers and Linux dependencies, reducing network-related CI failures while preserving separate per-browser test results.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
