### PR TITLE
fix: recover from IndexedDB InvalidBlob rejections

### DIFF
--- a/frontend/editor/src/core/services/fileStorage.blobFallback.test.ts
+++ b/frontend/editor/src/core/services/fileStorage.blobFallback.test.ts
@@ -29,14 +29,24 @@ class FailingRequest extends EventTarget {
   onerror: ((event: Event) => void) | null = null;
   onsuccess: ((event: Event) => void) | null = null;
 
-  constructor(readonly error: DOMException) {
+  constructor(
+    readonly error: DOMException,
+    transaction?: IDBTransaction,
+  ) {
     super();
-    queueMicrotask(() => this.onerror?.(new Event("error")));
+    queueMicrotask(() => {
+      const event = new Event("error", { cancelable: true });
+      this.onerror?.(event);
+      if (!event.defaultPrevented) transaction?.abort();
+    });
   }
 }
 
 /** Record every add, optionally failing the blob-valued ones. */
-function instrumentAdd(options: { rejectBlobs: boolean }) {
+function instrumentAdd(options: {
+  rejectBlobs: boolean;
+  error?: DOMException;
+}) {
   IDBObjectStore.prototype.add = function (
     this: IDBObjectStore,
     value: unknown,
@@ -46,10 +56,11 @@ function instrumentAdd(options: { rejectBlobs: boolean }) {
     attempts.push(isBlob ? "blob" : "copy");
     if (isBlob && options.rejectBlobs) {
       return new FailingRequest(
-        new DOMException(
-          "Error preparing Blob/File data to be stored in object store",
-          "UnknownError",
-        ),
+        options.error ??
+          new DOMException(
+            "Error preparing Blob/File data to be stored in object store",
+            "UnknownError",
+          ),
       ) as unknown as IDBRequest<IDBValidKey>;
     }
     return key === undefined
@@ -131,11 +142,12 @@ async function freshFileStorage() {
       import("@app/services/fileStorage"),
       import("@app/types/fileContext"),
     ]);
-  const store = async (name: string) => {
+  const store = async (name: string, thumbnailUrl?: string) => {
     const file = new File(["%PDF-1.7 stirling"], name, {
       type: "application/pdf",
     });
     const stub = createNewStirlingFileStub(file);
+    stub.thumbnailUrl = thumbnailUrl;
     await fileStorage.storeStirlingFile(
       createStirlingFile(file, stub.id),
       stub,
@@ -240,6 +252,60 @@ describe("storeStirlingFile — blob-value fallback", () => {
     expect((await fileStorage.getStirlingFile(id))?.name).toBe("second.pdf");
   });
 
+  test("falls back for Chromium InvalidBlob DataErrors", async () => {
+    expectConsole.warn(/IndexedDB rejected a Blob value/);
+    const { fileStorage, store } = await freshFileStorage();
+    instrumentAdd({
+      rejectBlobs: true,
+      error: new DOMException(
+        "Failed to write blobs (InvalidBlob)",
+        "DataError",
+      ),
+    });
+
+    const first = await store("invalid-blob.pdf");
+    expect(attempts).toEqual(["blob", "copy"]);
+    expect((await fileStorage.getStirlingFile(first))?.name).toBe(
+      "invalid-blob.pdf",
+    );
+
+    attempts = [];
+    const second = await store("after-invalid-blob.pdf");
+    expect(attempts).toEqual(["copy"]);
+    expect((await fileStorage.getStirlingFile(second))?.name).toBe(
+      "after-invalid-blob.pdf",
+    );
+  });
+
+  test("does not misclassify unrelated DataErrors", async () => {
+    const { store } = await freshFileStorage();
+    instrumentAdd({
+      rejectBlobs: true,
+      error: new DOMException("The provided key is invalid", "DataError"),
+    });
+
+    await expect(store("bad-key.pdf")).rejects.toThrow(
+      /provided key is invalid/,
+    );
+    expect(attempts).toEqual(["blob"]);
+  });
+
+  test("preserves the DataCloneError fallback", async () => {
+    expectConsole.warn(/IndexedDB rejected a Blob value/);
+    const { fileStorage, store } = await freshFileStorage();
+    instrumentAdd({
+      rejectBlobs: true,
+      error: new DOMException("Value could not be cloned", "DataCloneError"),
+    });
+
+    const id = await store("clone-error.pdf");
+
+    expect(attempts).toEqual(["blob", "copy"]);
+    expect((await fileStorage.getStirlingFile(id))?.name).toBe(
+      "clone-error.pdf",
+    );
+  });
+
   /** Committing is not evidence the bytes survived, and by the next reload the
    *  source File is gone: without this the upload looks fine and the file is dead. */
   test("repairs a record whose stored blob loses its backing store", async () => {
@@ -269,6 +335,17 @@ describe("storeStirlingFile — blob-value fallback", () => {
     } as typeof IDBObjectStore.prototype.add;
 
     await expect(store("too-big.pdf")).rejects.toThrow(/no space left/);
+    expect(attempts).toEqual(["blob"]);
+  });
+
+  test("does not retry a failure a copy can't fix (duplicate key)", async () => {
+    const { store } = await freshFileStorage();
+    instrumentAdd({
+      rejectBlobs: true,
+      error: new DOMException("Key already exists", "ConstraintError"),
+    });
+
+    await expect(store("duplicate.pdf")).rejects.toThrow(/already exists/);
     expect(attempts).toEqual(["blob"]);
   });
 });
@@ -513,5 +590,72 @@ describe("maintenanceMayRewrite", () => {
     // On engines that genuinely support blobs (Chrome), nothing changes.
     expect(maintenanceMayRewrite(blobRecord, true)).toBe(true);
     expect(maintenanceMayRewrite(copyRecord, true)).toBe(true);
+  });
+
+  test("settles an InvalidBlob TTL rewrite and does not retry it", async () => {
+    expectConsole.warn(/thumbnail TTL bump skipped/);
+    expectConsole.warn(/IndexedDB rejected a Blob value/);
+    const { fileStorage, store } = await freshFileStorage();
+    instrumentAdd({ rejectBlobs: false });
+    const id = await store("thumbnail.pdf", "data:image/png;base64,dGVzdA==");
+
+    let ttlPutAttempts = 0;
+    IDBObjectStore.prototype.put = function (this: IDBObjectStore) {
+      ttlPutAttempts++;
+      return new FailingRequest(
+        new DOMException("Failed to write blobs (InvalidBlob)", "DataError"),
+        this.transaction,
+      ) as unknown as IDBRequest<IDBValidKey>;
+    } as typeof IDBObjectStore.prototype.put;
+
+    await expect(fileStorage.getAllStirlingFileStubs()).resolves.toEqual([
+      expect.objectContaining({ id }),
+    ]);
+    await vi.waitFor(() => expect(ttlPutAttempts).toBe(1));
+
+    attempts = [];
+    await store("after-ttl-failure.pdf");
+    expect(attempts).toEqual(["copy"]);
+
+    await expect(fileStorage.getAllStirlingFileStubs()).resolves.toHaveLength(
+      2,
+    );
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(ttlPutAttempts).toBe(1);
+  });
+
+  test("uses a synchronous InvalidBlob TTL failure as the no-blob verdict", async () => {
+    expectConsole.warn(/thumbnail TTL bump could not be issued/);
+    expectConsole.warn(/IndexedDB rejected a Blob value/);
+    const { fileStorage, store } = await freshFileStorage();
+    instrumentAdd({ rejectBlobs: false });
+    const id = await store(
+      "synchronous-thumbnail.pdf",
+      "data:image/png;base64,dGVzdA==",
+    );
+
+    let ttlPutAttempts = 0;
+    IDBObjectStore.prototype.put = function () {
+      ttlPutAttempts++;
+      throw new DOMException(
+        "Failed to write blobs (InvalidBlob)",
+        "DataError",
+      );
+    } as typeof IDBObjectStore.prototype.put;
+
+    await expect(fileStorage.getAllStirlingFileStubs()).resolves.toEqual([
+      expect.objectContaining({ id }),
+    ]);
+    await vi.waitFor(() => expect(ttlPutAttempts).toBe(1));
+
+    attempts = [];
+    await store("after-synchronous-ttl-failure.pdf");
+    expect(attempts).toEqual(["copy"]);
+
+    await expect(fileStorage.getAllStirlingFileStubs()).resolves.toHaveLength(
+      2,
+    );
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(ttlPutAttempts).toBe(1);
   });
 });

--- a/frontend/editor/src/core/services/fileStorage.ts
+++ b/frontend/editor/src/core/services/fileStorage.ts
@@ -67,13 +67,20 @@ export function legacyDerivedFromTool(
 /**
  * Can't persist a Blob/File value, so a copy would work? WebKit reports
  * `UnknownError` ("Error preparing Blob/File data...") when it can't write the
- * blob's backing file; a refused structured clone is `DataCloneError`.
+ * blob's backing file; a refused structured clone is `DataCloneError`;
+ * Chromium/WebView2 reports `DataError` when an `InvalidBlob` reaches its blob
+ * writer.
  * Narrow on purpose: retrying quota or duplicate-key failures would fail again
  * and hide the real cause.
  */
 function isBlobValueRejection(error: unknown): boolean {
-  const name = (error as DOMException | null)?.name;
-  return name === "UnknownError" || name === "DataCloneError";
+  const exception = error as DOMException | null;
+  return (
+    exception?.name === "UnknownError" ||
+    exception?.name === "DataCloneError" ||
+    (exception?.name === "DataError" &&
+      exception.message.includes("InvalidBlob"))
+  );
 }
 
 /** This engine loses Blob values, remembered per browser: session-scoped, each
@@ -264,6 +271,7 @@ class FileStorageService {
             };
           } catch (error) {
             this.unwritableRecords.add(id);
+            this.noteBlobRefusal(error);
             console.warn(
               `[fileStorage] thumbnail TTL bump could not be issued for ${id}:`,
               error,


### PR DESCRIPTION
# Description of Changes

Extend the existing narrow Blob-rejection classifier in `fileStorage.ts` to accept the Chromium/WebView2 `DataError` only when its message identifies an `InvalidBlob` write failure, while continuing to reject unrelated `DataError` cases. Reuse the current `noteBlobRefusal` and durable no-Blob verdict so initial file persistence retries with an ArrayBuffer and subsequent writes skip the known-bad Blob path. Preserve thumbnail TTL maintenance's best-effort behavior: a rejected metadata rewrite must settle the listing, mark that record unwritable for the session, and feed the same capability verdict instead of repeatedly attempting Blob writes.

On the Windows 11 MSI build, PDF pages can stop rendering while the console reports `ERR_BLOB_OUT_OF_MEMORY`, PDFium error 3, and IndexedDB `DataError: Failed to write blobs (InvalidBlob)` during thumbnail TTL maintenance. The repository already degrades from Blob-backed records to ArrayBuffer copies when IndexedDB reports `UnknownError` or `DataCloneError`, but it does not recognize Chromium/WebView2's `DataError` with the `InvalidBlob` signature. Consequently, the failed maintenance write does not disable Blob persistence, so later records can continue through the same unsupported path and reach consumers as unreadable PDF bytes. The transient desktop backend-startup message is not part of this storage failure and remains out of scope.

Closes #7541

## Checklist

Not applicable to this change.

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)
  Not verified: this needs a person on the named hardware or environment.

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
- Store a PDF when IndexedDB rejects its Blob-valued `add` with `DataError` and an `InvalidBlob` message; verify the service retries with an ArrayBuffer and the stored file remains readable. - After the first `InvalidBlob` rejection, store another PDF and verify it goes directly through the copy path without another Blob attempt. - Return a generic `DataError` without the `InvalidBlob` signature and verify it is propagated rather than misclassified as a recoverable Blob-capability failure.
