### PR TITLE
fix: validate frontend dependency installation

### DIFF
--- a/.github/labeler-config-srvaroa.yml
+++ b/.github/labeler-config-srvaroa.yml
@@ -67,6 +67,7 @@ labels:
       - 'frontend/**'
       - 'frontend/.*'
       - 'frontend/**/.*'
+      - '.taskfiles/frontend.yml'
 
   - label: 'Tauri'
     files:

--- a/.taskfiles/frontend.yml
+++ b/.taskfiles/frontend.yml
@@ -23,7 +23,7 @@ tasks:
       - package-lock.json
       - package.json
     status:
-      - test -d node_modules
+      - npm ls --depth=0
     env:
       CI: '{{ .CI | default "false" }}'
 


### PR DESCRIPTION
# Description of Changes

The current check only verifies the existence of the `node_modules` directory. After an incomplete or corrupted installation, this can lead to the task being incorrectly marked as complete.

`npm ls --depth=0` instead checks whether the direct frontend dependencies are actually installed and consistent. This reliably detects and automatically repairs corrupted installations.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
