### PR TITLE
fix: sanitize flat-ODF uploads so LibreOffice cannot fetch xlink:href

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/OfficeDocumentSanitizer.java
+++ b/app/common/src/main/java/stirling/software/common/util/OfficeDocumentSanitizer.java
@@ -52,6 +52,9 @@ public class OfficeDocumentSanitizer {
                     "odt", "ott", "ods", "ots", "odp", "otp", "odg", "otg", "odf", "odc", "odi",
                     "odm");
 
+    // Single-file (non-zip) ODF XML: LibreOffice fetches xlink:href during import.
+    private static final Set<String> FLAT_ODF_EXTENSIONS = Set.of("fodt", "fods", "fodp", "fodg");
+
     private static final Set<String> ODF_XML_PARTS =
             Set.of("content.xml", "styles.xml", "meta.xml", "settings.xml");
 
@@ -70,7 +73,9 @@ public class OfficeDocumentSanitizer {
             return false;
         }
         String lower = extension.toLowerCase(Locale.ROOT);
-        return OOXML_EXTENSIONS.contains(lower) || ODF_EXTENSIONS.contains(lower);
+        return OOXML_EXTENSIONS.contains(lower)
+                || ODF_EXTENSIONS.contains(lower)
+                || FLAT_ODF_EXTENSIONS.contains(lower);
     }
 
     public byte[] sanitize(byte[] documentBytes, String extension) throws IOException {
@@ -83,6 +88,11 @@ public class OfficeDocumentSanitizer {
         }
         if (!isSanitizableExtension(extension)) {
             return documentBytes;
+        }
+
+        String lower = extension.toLowerCase(Locale.ROOT);
+        if (FLAT_ODF_EXTENSIONS.contains(lower)) {
+            return sanitizeFlatOdf(documentBytes);
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream(documentBytes.length);
@@ -182,6 +192,16 @@ public class OfficeDocumentSanitizer {
         return serializeDocument(doc);
     }
 
+    private byte[] sanitizeFlatOdf(byte[] xmlBytes) throws IOException {
+        try {
+            return sanitizeOdfXml(xmlBytes);
+        } catch (ParserConfigurationException | SAXException | TransformerException e) {
+            log.warn(
+                    "Failed to parse flat ODF for sanitization, leaving as-is: {}", e.getMessage());
+            return xmlBytes;
+        }
+    }
+
     private byte[] sanitizeOdfXml(byte[] xmlBytes)
             throws IOException, ParserConfigurationException, SAXException, TransformerException {
         Document doc = parseSecurely(xmlBytes);
@@ -256,7 +276,16 @@ public class OfficeDocumentSanitizer {
                 || trimmed.startsWith("file:")
                 || trimmed.startsWith("smb:")
                 || trimmed.startsWith("\\\\")
-                || trimmed.startsWith("//");
+                || trimmed.startsWith("//")
+                || trimmed.startsWith("/")
+                || isWindowsAbsolutePath(trimmed);
+    }
+
+    private static boolean isWindowsAbsolutePath(String trimmed) {
+        return trimmed.length() >= 3
+                && Character.isLetter(trimmed.charAt(0))
+                && trimmed.charAt(1) == ':'
+                && (trimmed.charAt(2) == '\\' || trimmed.charAt(2) == '/');
     }
 
     // Preserved only with an explicit allowedDomains entry; MEDIUM default would admit public URLs.

--- a/app/common/src/test/java/stirling/software/common/util/OfficeDocumentSanitizerTest.java
+++ b/app/common/src/test/java/stirling/software/common/util/OfficeDocumentSanitizerTest.java
@@ -343,6 +343,58 @@ class OfficeDocumentSanitizerTest {
         assertTrue(out.contains("#anchor"));
     }
 
+    @Test
+    void isSanitizableExtension_recognizesFlatOdf() {
+        assertTrue(sanitizer.isSanitizableExtension("fodt"));
+        assertTrue(sanitizer.isSanitizableExtension("FODT"));
+        assertTrue(sanitizer.isSanitizableExtension("fods"));
+        assertTrue(sanitizer.isSanitizableExtension("fodp"));
+        assertTrue(sanitizer.isSanitizableExtension("fodg"));
+    }
+
+    @Test
+    void sanitize_flatOdfStripsHttpAndFilePathXlinkHref() throws IOException {
+        String httpRef = "http://127.0.0.1:9/office-ssrf";
+        String unixPathRef = "/tmp/office-local-file.png";
+        String windowsPathRef = "C:\\Windows\\Temp\\office-local-file.png";
+        byte[] original =
+                flatOdfWithHrefs(httpRef, unixPathRef, windowsPathRef, "Pictures/image1.png")
+                        .getBytes(StandardCharsets.UTF_8);
+
+        for (String ext : new String[] {"fodt", "fods", "fodp", "fodg"}) {
+            byte[] cleaned = sanitizer.sanitize(original, ext);
+            String out = new String(cleaned, StandardCharsets.UTF_8);
+            assertFalse(out.contains(httpRef), "HTTP xlink:href should be stripped from ." + ext);
+            assertFalse(
+                    out.contains(unixPathRef),
+                    "Unix file-path xlink:href should be stripped from ." + ext);
+            assertFalse(
+                    out.contains(windowsPathRef),
+                    "Windows file-path xlink:href should be stripped from ." + ext);
+            assertTrue(
+                    out.contains("Pictures/image1.png"),
+                    "Internal href should be preserved in ." + ext);
+        }
+    }
+
+    private static String flatOdfWithHrefs(String... hrefs) {
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.append(
+                "<office:document xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\"");
+        xml.append(" xmlns:draw=\"urn:oasis:names:tc:opendocument:xmlns:drawing:1.0\"");
+        xml.append(" xmlns:xlink=\"http://www.w3.org/1999/xlink\"");
+        xml.append(" office:mimetype=\"application/vnd.oasis.opendocument.text\">");
+        xml.append("<office:body><office:text>");
+        for (String href : hrefs) {
+            xml.append("<draw:frame><draw:image xlink:href=\"")
+                    .append(href)
+                    .append("\" xlink:type=\"simple\"/></draw:frame>");
+        }
+        xml.append("</office:text></office:body></office:document>");
+        return xml.toString();
+    }
+
     private static byte[] zip(Map<String, byte[]> entries) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(baos)) {


### PR DESCRIPTION
## Description of Changes

Office-to-PDF sanitization only covered zip OOXML/ODF. Flat-ODF uploads (`.fodt`, `.fods`, `.fodp`, `.fodg`) skipped that path and were copied raw, so `xlink:href` HTTP and local-path image refs survived into LibreOffice conversion.

This treats those four extensions as sanitizable, runs the existing ODF XML `xlink:href` stripper on the single-file XML, and treats Unix/Windows filesystem paths as external the same way `file:` already was. `ConvertOfficeController` already routes sanitizable extensions through the sanitizer.

Closes #7628

## Checklist

### General

- [x] I have read the Contribution Guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the Testing Guide for more details.

`./gradlew :common:test --tests stirling.software.common.util.OfficeDocumentSanitizerTest`