### PR TITLE
chore: prevent duplicate Dependabot Gradle PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,6 @@ updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directories:
       - "/" # Location of package manifests
-      - "/app/common"
-      - "/app/core"
-      - "/app/proprietary"
-      - "/app/saas"
-      - "/buildSrc"
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
## Description of Changes

- Removed overlapping Gradle subdirectory entries from .github/dependabot.yml.
- Dependabot now monitors the root Gradle project through /.
- Prevents duplicate pull requests for dependencies declared in Gradle subprojects.

Closes: Not applicable

---

## Checklist

### General

- [ ] I have read the Contribution Guidelines
- [ ] I have read the Stirling-PDF Developer Guide (if applicable)
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant documentation (if applicable)
- [ ] I have read the translation tag documentation (for new translation tags only)

### UI Changes (if applicable)

- [ ] Screenshots or videos are attached

### Testing (if applicable)

- [ ] I have tested my changes locally