### PR TITLE
Fix the Default Locale field rendering blank for hyphenated language tags

### DIFF
--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminGeneralSection.test.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminGeneralSection.test.tsx
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+
+const h = vi.hoisted(() => ({
+  settings: {} as Record<string, unknown>,
+}));
+
+vi.mock("@app/services/apiClient", () => ({
+  default: { get: vi.fn().mockResolvedValue({ data: {} }), post: vi.fn() },
+}));
+vi.mock("@app/hooks/useAdminSettings", () => ({
+  useAdminSettings: () => ({
+    settings: h.settings,
+    rawSettings: {},
+    loading: false,
+    saving: false,
+    setSettings: vi.fn(),
+    fetchSettings: vi.fn(),
+    saveSettings: vi.fn(),
+    isFieldPending: () => false,
+    hasPendingChanges: () => false,
+  }),
+}));
+vi.mock("@app/components/shared/config/useRestartServer", () => ({
+  useRestartServer: () => ({
+    restartModalOpened: false,
+    showRestartModal: vi.fn(),
+    closeRestartModal: vi.fn(),
+    restartServer: vi.fn(),
+  }),
+}));
+vi.mock("@app/hooks/useSettingsDirty", () => ({
+  useSettingsDirty: () => ({
+    isDirty: false,
+    resetToSnapshot: vi.fn(),
+    markSaved: vi.fn(),
+  }),
+}));
+vi.mock("@app/contexts/PreferencesContext", () => ({
+  usePreferences: () => ({ preferences: {}, updatePreference: vi.fn() }),
+}));
+vi.mock("@app/contexts/UnsavedChangesContext", () => ({
+  useUnsavedChanges: () => ({ markClean: vi.fn() }),
+}));
+vi.mock("@app/hooks/useLoginRequired", () => ({
+  useLoginRequired: () => ({
+    loginEnabled: true,
+    validateLoginEnabled: () => true,
+  }),
+}));
+// Partial mocks: @app/i18n initialises i18next at import time and needs the
+// real initReactI18next, and the component only touches two router hooks.
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}));
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useLocation: () => ({ hash: "", pathname: "/settings/adminGeneral" }),
+  useNavigate: () => vi.fn(),
+}));
+
+import AdminGeneralSection from "@app/components/shared/config/configSections/AdminGeneralSection";
+
+function renderWithLocale(defaultLocale: string) {
+  h.settings = { ui: {}, system: { defaultLocale } };
+  render(
+    <MantineProvider>
+      <AdminGeneralSection />
+    </MantineProvider>,
+  );
+  return screen.getByPlaceholderText("en_US") as HTMLInputElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AdminGeneralSection default locale", () => {
+  // The Select's options are keyed on the underscore form, but
+  // SYSTEM_DEFAULTLOCALE accepts a hyphenated tag too, and the backend stores
+  // whichever form was configured.
+  it("shows the configured language for the underscore form", () => {
+    expect(renderWithLocale("en_GB").value).toBe("English (UK) (en-GB)");
+  });
+
+  it("shows the configured language for the hyphenated form", () => {
+    expect(renderWithLocale("en-GB").value).toBe("English (UK) (en-GB)");
+  });
+
+  it("matches a lowercased region tag", () => {
+    expect(renderWithLocale("en-gb").value).toBe("English (UK) (en-GB)");
+  });
+
+  it("leaves the field empty when no locale is configured", () => {
+    expect(renderWithLocale("").value).toBe("");
+  });
+});

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminGeneralSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminGeneralSection.tsx
@@ -28,6 +28,7 @@ import LoginRequiredBanner from "@app/components/shared/config/LoginRequiredBann
 import { usePreferences } from "@app/contexts/PreferencesContext";
 import { useUnsavedChanges } from "@app/contexts/UnsavedChangesContext";
 import {
+  normalizeLanguageCode,
   supportedLanguages,
   toUnderscoreFormat,
   toUnderscoreLanguages,
@@ -253,6 +254,17 @@ export default function AdminGeneralSection() {
   const selectedLanguages = useMemo(
     () => toUnderscoreLanguages(settings.ui?.languages || []),
     [settings.ui?.languages],
+  );
+  // SYSTEM_DEFAULTLOCALE accepts en-GB as well as en_GB, but every option below
+  // is keyed on the underscore form, so match the stored value to it before
+  // handing it to the Select. Normalising only what is displayed keeps the
+  // configured value untouched when the field is left alone.
+  const defaultLocaleValue = useMemo(
+    () =>
+      toUnderscoreFormat(
+        normalizeLanguageCode(settings.system?.defaultLocale || ""),
+      ),
+    [settings.system?.defaultLocale],
   );
   const watchedFoldersInput = useMemo(
     () => (settings.customPaths?.pipeline?.watchedFoldersDirs || []).join("\n"),
@@ -618,7 +630,7 @@ export default function AdminGeneralSection() {
                   "admin.settings.general.defaultLocale.description",
                   "The default language for new users (e.g., en_US, es_ES)",
                 )}
-                value={settings.system?.defaultLocale || ""}
+                value={defaultLocaleValue}
                 onChange={(value) =>
                   setSettings({
                     ...settings,


### PR DESCRIPTION
# Description of Changes

The Default Locale dropdown builds its option values with `toUnderscoreFormat`, so they all look like `en_GB`. The Select was handed the raw setting, so `SYSTEM_DEFAULTLOCALE=en-GB` matched no option and the field rendered blank — `en_GB` matched and worked. The backend accepts either form, and `updateSupportedLanguages` normalises before applying the language, so the hyphenated tag is valid config everywhere except this one field.

Normalised the value for display only. The saved setting is untouched, so leaving the field alone won't rewrite `en-GB` to `en_GB` on the next save. `selectedLanguages` just above already does the same thing for the languages list.

Added a test for the section covering both forms plus a lowercased region tag. The hyphenated cases fail on main with `expected '' to be 'English (UK) (en-GB)'`.

Closes #7225

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

Notes on the two I left unticked: no screenshot because the change is only visible with a server configured to a hyphenated locale, and the new test asserts the rendered field value instead. I ran the frontend half of the gate rather than the whole of `task check` — `oxlint --max-warnings=0`, `oxfmt --check`, `tsc --noEmit` on the proprietary project, and `vitest --project proprietary` (465 tests, 43 files, all passing). Nothing outside the frontend is touched.
