### PR TITLE
Comment pass over the connect flow

### DIFF
--- a/frontend/editor/src/portal/components/account-link/ConnectGuardedRoute.tsx
+++ b/frontend/editor/src/portal/components/account-link/ConnectGuardedRoute.tsx
@@ -3,7 +3,6 @@ import { Navigate } from "react-router-dom";
 import { useConnectGate } from "@portal/hooks/useConnectGate";
 
 interface Props {
-  /** The gated page. */
   children: ReactNode;
   /** Where to send someone who cannot open it yet, e.g. the list this builder belongs to. */
   fallback: string;

--- a/frontend/editor/src/portal/components/account-link/LinkAccountModal.test.tsx
+++ b/frontend/editor/src/portal/components/account-link/LinkAccountModal.test.tsx
@@ -59,7 +59,6 @@ function renderModal(
   );
 }
 
-/** Clicks a footer button by its label. */
 function click(label: string | RegExp) {
   act(() => screen.getByRole("button", { name: label }).click());
 }
@@ -118,8 +117,8 @@ describe("LinkAccountModal", () => {
     const { container } = renderModal();
     click(CONNECT);
 
-    // The provider buttons this flow used to carry sent the admin to Stirling and
-    // abandoned them there. Nothing should collect credentials on this origin.
+    // Nothing collects credentials on this origin: the admin signs in on Stirling, so a provider
+    // button here would send them there and abandon them.
     expect(container.querySelector("input[type=password]")).toBeNull();
     expect(container.querySelector("input[type=email]")).toBeNull();
   });

--- a/frontend/editor/src/portal/components/account-link/LinkAccountModal.tsx
+++ b/frontend/editor/src/portal/components/account-link/LinkAccountModal.tsx
@@ -169,8 +169,8 @@ export function LinkAccountModal({
       );
     }
 
-    // Step 2. Nothing to confirm and nothing to go back to: the request is out and the browser is
-    // leaving. Close is there so a stalled hand-off is not a dead end.
+    // Nothing to confirm and nothing to go back to: the request is out and the browser is leaving.
+    // Close is there so a stalled hand-off is not a dead end.
     if (step === 2) {
       return (
         <>
@@ -182,8 +182,8 @@ export function LinkAccountModal({
       );
     }
 
-    // Step 3, still finishing: offering a retry over a call that has not answered is how you get
-    // two handshakes.
+    // Still finishing: offering a retry over a call that has not answered is how you get two
+    // handshakes.
     if (outcome?.state === "working") {
       return (
         <>

--- a/frontend/editor/src/portal/components/account-link/connect/ConnectBenefitsSlide.stories.tsx
+++ b/frontend/editor/src/portal/components/account-link/connect/ConnectBenefitsSlide.stories.tsx
@@ -8,5 +8,5 @@ const meta: Meta<typeof ConnectBenefitsSlide> = {
 export default meta;
 type Story = StoryObj<typeof ConnectBenefitsSlide>;
 
-/** Step 1 of the Connect flow: the case for linking, which the old modal never made. */
+/** Step 1 of the Connect flow: the case for linking. */
 export const Default: Story = {};

--- a/frontend/editor/src/portal/components/account-link/connect/ConnectBenefitsSlide.tsx
+++ b/frontend/editor/src/portal/components/account-link/connect/ConnectBenefitsSlide.tsx
@@ -4,9 +4,9 @@ import "@portal/components/account-link/connect/connect.css";
 /**
  * Step 1 of the connect flow: what connecting a Stirling account gets you.
  *
- * <p>The step this flow was missing. Before it, the only thing an admin ever saw was a login form
- * subtitled "the account this server should bill against", which frames connecting as the moment
- * they start paying rather than what they gain.
+ * <p>Leads with what the admin gains. A login form subtitled "the account this server should bill
+ * against" frames connecting as the moment they start paying, which is the opposite of the reason
+ * to do it.
  *
  * <p>Names what you get rather than selling it. The Processor owns pipelines, policies, sources and
  * audit, so it is one row naming its parts rather than four competing ones. Credits come last: put

--- a/frontend/editor/src/portal/components/account-link/connect/ConnectBenefitsSlide.tsx
+++ b/frontend/editor/src/portal/components/account-link/connect/ConnectBenefitsSlide.tsx
@@ -2,24 +2,21 @@ import { useTranslation } from "react-i18next";
 import "@portal/components/account-link/connect/connect.css";
 
 /**
- * Step 1 of the connect flow: what connecting a Stirling account gets you.
+ * Step 1 of the connect flow: the case for linking.
  *
  * <p>Leads with what the admin gains. A login form subtitled "the account this server should bill
  * against" frames connecting as the moment they start paying, which is the opposite of the reason
  * to do it.
  *
- * <p>Names what you get rather than selling it. The Processor owns pipelines, policies, sources and
- * audit, so it is one row naming its parts rather than four competing ones. Credits come last: put
- * them first and the whole screen reads as a price list.
+ * <p>The Processor is one row naming its parts rather than four rows competing with each other, and
+ * credits come last: put them first and the screen reads as a price list.
  *
- * <p>Nothing about the mechanics. What happens next is one click away and the progress bar already
- * says there is more of it, so explaining the redirect here only gave the admin something to read
- * past.
+ * <p>Nothing about the mechanics. The next step is one click away and the progress bar already says
+ * there is more of it.
  *
- * <p>The credits line promises a <b>monthly</b> allowance, which the billing model does not grant
- * yet: {@code freeGrantUnits} is a one-time lifetime pool seeded at team creation. Copy leading
- * implementation is deliberate here, but it is a claim about money, so it needs the recurring grant
- * to land before this ships to customers.
+ * <p>TODO(#7712): the credits row promises a monthly allowance the billing model does not grant.
+ * {@code freeGrantUnits} is a one-time lifetime pool seeded at team creation, so either the grant
+ * becomes recurring or the copy drops "per month" before this reaches customers.
  */
 export function ConnectBenefitsSlide() {
   const { t } = useTranslation();

--- a/frontend/editor/src/portal/components/account-link/connect/ConnectHandoffGhost.tsx
+++ b/frontend/editor/src/portal/components/account-link/connect/ConnectHandoffGhost.tsx
@@ -5,11 +5,11 @@ import "@portal/components/account-link/connect/connect.css";
 /**
  * Step 2 of the connect flow: the moment between asking and arriving.
  *
- * <p>A ghost rather than a screen. This step used to explain the redirect and wait for a second
- * click, which asked the admin to read something they had already decided on and put a page between
- * them and the thing they clicked. The explanation moved to step 1, next to the button that names
- * the destination, and what is left here is the hand-off itself: the browser is on its way out, so
- * the step shows the shape of what is coming rather than pretending to be content.
+ * <p>A ghost rather than a screen. Explaining the redirect here and waiting for a second click
+ * would ask the admin to read something they have already decided on, and put a page between them
+ * and the thing they clicked. The explanation belongs on step 1, next to the button that names the
+ * destination; what is left here is the hand-off itself, so the step shows the shape of what is
+ * coming rather than pretending to be content.
  *
  * <p>Normally on screen for well under a second. It matters when the instance's own backend is slow
  * to open the handshake, which is exactly when a blank dialog would look broken. Carries no error

--- a/frontend/editor/src/portal/components/account-link/connect/ConnectHandoffGhost.tsx
+++ b/frontend/editor/src/portal/components/account-link/connect/ConnectHandoffGhost.tsx
@@ -3,17 +3,13 @@ import { Skeleton } from "@app/ui";
 import "@portal/components/account-link/connect/connect.css";
 
 /**
- * Step 2 of the connect flow: the moment between asking and arriving.
+ * Step 2 of the connect flow: the browser is on its way to Stirling.
  *
- * <p>A ghost rather than a screen. Explaining the redirect here and waiting for a second click
- * would ask the admin to read something they have already decided on, and put a page between them
- * and the thing they clicked. The explanation belongs on step 1, next to the button that names the
- * destination; what is left here is the hand-off itself, so the step shows the shape of what is
- * coming rather than pretending to be content.
+ * <p>A ghost rather than a screen, because the admin has already decided by this point. It earns
+ * its place when the instance's own backend is slow to open the handshake, which is when a blank
+ * dialog would look broken.
  *
- * <p>Normally on screen for well under a second. It matters when the instance's own backend is slow
- * to open the handshake, which is exactly when a blank dialog would look broken. Carries no error
- * state: a failed hand-off drops back to step 1, which is where the reason is shown.
+ * <p>No error state: a failed hand-off drops back to step 1, which is where the reason is shown.
  */
 export function ConnectHandoffGhost() {
   const { t } = useTranslation();

--- a/frontend/editor/src/portal/components/billing/PortalBillingGate.test.tsx
+++ b/frontend/editor/src/portal/components/billing/PortalBillingGate.test.tsx
@@ -4,9 +4,9 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 /**
  * Usage is a page about an account this instance may not have, so it must not render while
- * unconnected. It used to, which was two bugs: dismissing the dialog stranded the admin on a page
+ * unconnected. Two things turn on that: dismissing the dialog must not strand the admin on a page
  * with nothing on it, and the page reports `linked` as a fact from a wallet read, so a browser
- * holding a SaaS session with no link to this server flipped the whole portal to linked.
+ * holding a SaaS session with no link to this server must not flip the whole portal to linked.
  */
 const gate = { gated: false, loading: false, available: true };
 const connect = vi.fn();

--- a/frontend/editor/src/portal/components/billing/PortalBillingGate.tsx
+++ b/frontend/editor/src/portal/components/billing/PortalBillingGate.tsx
@@ -20,9 +20,7 @@ import type { Wallet } from "@portal/api/billing";
  * (the browser can hold a SaaS session with no link between it and this server) would flip the
  * whole portal to linked.
  *
- * <p>It also maps the page's callbacks onto the link dimension: the wallet's subscription status
- * refines the plan badge, and a lapsed SaaS session re-opens the re-auth. That keeps the "link"
- * concept entirely out of the Usage page. The SaaS build shadows this with a passthrough.
+ * <p>Mapping the page's callbacks here is what keeps the "link" concept out of the Usage page.
  */
 export function PortalBillingGate() {
   const applyLinkFacts = useApplyLinkFacts();

--- a/frontend/editor/src/portal/components/billing/PortalBillingGate.tsx
+++ b/frontend/editor/src/portal/components/billing/PortalBillingGate.tsx
@@ -14,11 +14,11 @@ import type { Wallet } from "@portal/api/billing";
  * came from. The nav does not send anyone here in that state (see the sidebar's requiresLink), so
  * this is the backstop for a typed URL or an old bookmark.
  *
- * <p>The Usage page must not render while unconnected, which it used to. Two things went wrong.
- * It is a page about an account this instance does not have, so dismissing the dialog stranded the
- * admin on it; and {@link onWalletLoaded} reports {@code linked} as a fact, so a wallet read that
- * happened to succeed — the browser can hold a SaaS session with no link between it and this
- * server — flipped the whole portal to linked.
+ * <p>The Usage page must not render while unconnected, for two reasons. It is a page about an
+ * account this instance does not have, so dismissing the dialog would strand the admin on it; and
+ * {@link onWalletLoaded} reports {@code linked} as a fact, so a wallet read that happens to succeed
+ * (the browser can hold a SaaS session with no link between it and this server) would flip the
+ * whole portal to linked.
  *
  * <p>It also maps the page's callbacks onto the link dimension: the wallet's subscription status
  * refines the plan badge, and a lapsed SaaS session re-opens the re-auth. That keeps the "link"

--- a/frontend/editor/src/portal/views/Sources.gated.test.tsx
+++ b/frontend/editor/src/portal/views/Sources.gated.test.tsx
@@ -4,11 +4,11 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { PortalViewProviders } from "@portal/test/TestQueryProvider";
 
 /**
- * The deep link into the create flow, which is the hole the first attempt at this left open.
+ * The deep link into the create flow, which the gate has to cover in its own right.
  *
  * `?new=1` opens the modal from an effect rather than through the click handler, so guarding
- * openCreate did nothing for it. Both the Documents review queue and the pipelines empty state
- * arrive here that way, and each was a way past the gate.
+ * openCreate does nothing for it. Both the Documents review queue and the pipelines empty state
+ * arrive here that way, so each is a way past the gate unless the deep link is guarded too.
  */
 const { connect } = vi.hoisted(() => ({ connect: vi.fn() }));
 const gate = { gated: true };


### PR DESCRIPTION
Comment pass over #7415, run with the gate from #7663. Targets that branch, so it can go in before the PR does.

No functional change. Every changed line is a comment, checked mechanically: the diff has zero non-comment lines, and none of the comments touched was a directive (`@ts-expect-error`, `oxlint-disable`, `@vitest-environment` and friends).

Nine files, **+34/-45**, so the comment volume goes down.

## What the gate found

Two findings on 2,490 added lines, both real:

| | |
| --- | --- |
| `LinkAccountModal.tsx:172` | `CMT003` step-narration. `// Step 2.` in front of `if (step === 2)` |
| `PortalBillingGate.tsx:17` | `CMT004` diff-narration. "must not render while unconnected, which it used to" |

Two findings on a 58-file change is a low rate, and the reason is worth saying: the comments on this PR are largely already what the standard asks for. The pass reviewed all 492 added comment lines across 41 files.

## The release blocker, now tracked

`ConnectBenefitsSlide` tells an admin **"Credits: 500 free per month"** at the moment they decide to connect. `freeGrantUnits` is a one-time lifetime pool seeded at team creation, so the account gets 500 once.

The PR already knew this and said so in a doc comment. Prose in a doc block is not a tracking mechanism, so it is now **#7712**, referenced from the source as `TODO(#7712)`. Either the grant becomes recurring or the copy drops "per month"; that is a product call, so the copy is untouched here.

## Comments that say what the code used to do

Nine changes are that class. `CMT004` matched one of them, because its patterns are narrower than the idea:

- `ConnectHandoffGhost.tsx` "This step used to explain the redirect and wait for a second click"
- `ConnectBenefitsSlide.tsx` "The step this flow was missing. Before it, the only thing an admin ever saw was..."
- `ConnectBenefitsSlide.stories.tsx` "the case for linking, which the old modal never made"
- `PortalBillingGate.test.tsx` "It used to, which was two bugs"
- `LinkAccountModal.test.tsx` "The provider buttons this flow used to carry sent the admin to Stirling and abandoned them there"
- `Sources.gated.test.tsx` "which is the hole the first attempt at this left open"

Each carried a real reason, so none was deleted outright. They state the reason in the present instead:

```
- <p>A ghost rather than a screen. This step used to explain the redirect and wait for a second
- click, which asked the admin to read something they had already decided on ...
+ <p>A ghost rather than a screen, because the admin has already decided by this point.
```

A reader who never saw the old version loses nothing.

## Length

Three doc blocks were carrying paragraphs the code already says. Trimmed to the part that is not derivable:

| | |
| --- | --- |
| `ConnectHandoffGhost.tsx` | 13 lines to 9 |
| `PortalBillingGate.tsx` | 18 lines to 16 |
| `ConnectBenefitsSlide.tsx` | 20 lines to 17, and one paragraph is now the tracked TODO |

`ConnectHandoffGhost` is the clearest case: 13 lines of prose over a component that renders a lede and three skeleton bars. What survives is the step placement, the reason it is a placeholder rather than an interstitial (a decision someone could reverse), and the absent error state. What went was the restatement of the skeleton and a point `ConnectBenefitsSlide` already makes from the other side.

`PortalBillingGate` lost the paragraph describing the four lines directly beneath it. What survives is the part a reader cannot get from the code: that this is the seam the SaaS build shadows, and that `onWalletLoaded` reports `linked` as a fact, so a wallet read that happens to succeed would flip the whole portal to linked. That is the comment that stops someone simplifying the gate away.

Two more were pure restatement of the name above them, and are deleted rather than reworded:

- `ConnectGuardedRoute.tsx` `/** The gated page. */` on `children: ReactNode`
- `LinkAccountModal.test.tsx` `/** Clicks a footer button by its label. */` on `click(label)`, which also said "footer" when the helper matches any button

Kept on purpose: comments that reject an *alternative* rather than narrate this code's past. `ConnectDoneSlide` on why the plan card was not reused, `useConnectPrompt` on why the onboarding storage helpers were not, `useDevConnectBypass` on why the bypass is not a setting. Each is a decision a reader could otherwise undo.

Also dropped the two em dashes in `PortalBillingGate.tsx` for parentheses.

## Two gaps this exposed in the gate itself

Both are in #7663, not here:

- `CMT004` matches `this used to` but not `this step used to`, `it used to`, `the old X`, `was missing`, or `the first attempt`. It found one of seven history comments on this PR.
- `CMT007` reads `@param` and `@returns` but not a bare doc comment on a field or property, so `/** The gated page. */` above `children` went unreported.

## How to check

```bash
git diff --stat claude/selfhosted-saas-pairing-modal-1009f6...claude/pairing-modal-comment-pass
```

To confirm nothing but comments changed:

```bash
git diff -U0 claude/selfhosted-saas-pairing-modal-1009f6...HEAD | grep -E "^[+-]" | grep -vE "^(\+\+\+|---)" | grep -vE "^[+-]\s*(//|/\*|\*|\{/\*)|^[+-]\s*$"
```

Empty output. `oxfmt --check` and `oxlint` are clean on all nine, and the gate reports clean on the diff.

Tests: `PortalBillingGate.test.tsx` passes 5/5. `LinkAccountModal.test.tsx` and `Sources.gated.test.tsx` could not load in my worktree because the `node_modules` I borrowed is missing `@tanstack/react-table`, which `package.json` declares on `main` as well, so it is a stale install rather than anything in this change. CI does a clean install and will cover them.
