### PR TITLE
feat: PDF form field editor — create, edit, delete with backend safety

### DIFF
--- a/frontend/editor/scripts/lint/theme-lint.mjs
+++ b/frontend/editor/scripts/lint/theme-lint.mjs
@@ -27,12 +27,7 @@ const THEME = resolve(process.cwd(), "editor/src/core/theme");
 // (no directory-listing feeding into a file read). readdir is used only to fail
 // if a new .css is added without being registered — coverage can't silently
 // lapse — but its output is never passed to readFileSync.
-const THEME_FILES = [
-  "primitives.css",
-  "colors.css",
-  "dimensions.css",
-  "index.css",
-];
+const THEME_FILES = ["primitives.css", "colors.css", "dimensions.css", "index.css"];
 
 // ── colour helpers ─────────────────────────────────────────────────────────
 const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
@@ -220,10 +215,7 @@ function stripComments(text) {
 // ── shared colour math + token resolution (used by contrast report + tone guard)
 function readPrimitives(css) {
   const primitives = {};
-  for (const m of css.matchAll(
-    /(--p-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8})\s*;/g,
-  ))
-    primitives[m[1]] = m[2];
+  for (const m of css.matchAll(/(--p-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8})\s*;/g)) primitives[m[1]] = m[2];
   return primitives;
 }
 function hexToRgb(hex) {
@@ -267,11 +259,7 @@ function resolveColorValue(v, t, primitives, seen) {
   if ((m = v.match(/^var\(\s*(--[a-z0-9-]+)\s*(?:,\s*([\s\S]+))?\)$/))) {
     return resolveColorVar(m[1], m[2], t, primitives, seen);
   }
-  if (
-    (m = v.match(
-      /^color-mix\(\s*in srgb\s*,\s*(.+?)\s+(\d+)%\s*,\s*(.+?)\s*\)$/,
-    ))
-  ) {
+  if ((m = v.match(/^color-mix\(\s*in srgb\s*,\s*(.+?)\s+(\d+)%\s*,\s*(.+?)\s*\)$/))) {
     const a = resolveColorValue(m[1], t, primitives, seen);
     if (!a) return null;
     if (m[3].trim() === "transparent") return { ...a, a: +m[2] / 100 };
@@ -282,11 +270,7 @@ function resolveColorValue(v, t, primitives, seen) {
 }
 function resolveColorVar(name, fallback, t, primitives, seen) {
   if (name.startsWith("--p-")) {
-    return primitives[name]
-      ? hexToRgb(primitives[name])
-      : fallback
-        ? resolveColorValue(fallback, t, primitives, seen)
-        : null;
+    return primitives[name] ? hexToRgb(primitives[name]) : fallback ? resolveColorValue(fallback, t, primitives, seen) : null;
   }
   if (!seen.has(name) && t[name] !== undefined) {
     const next = new Set(seen).add(name);
@@ -303,9 +287,7 @@ const relativeLuminance = ({ r, g, b }) => {
   return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
 };
 const contrastRatio = (a, b) => {
-  const [hi, lo] = [relativeLuminance(a), relativeLuminance(b)].sort(
-    (x, y) => y - x,
-  );
+  const [hi, lo] = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
   return (hi + 0.05) / (lo + 0.05);
 };
 
@@ -316,8 +298,7 @@ function check() {
   const lineOf = (text, index) => text.slice(0, index).split("\n").length;
   // path.relative emits backslashes on Windows; normalize so the PRIMITIVES
   // comparison below matches and printed paths stay POSIX-style.
-  const posixRel = (name) =>
-    relative(process.cwd(), join(THEME, name)).replaceAll("\\", "/");
+  const posixRel = (name) => relative(process.cwd(), join(THEME, name)).replaceAll("\\", "/");
 
   // Fail if a theme .css exists that isn't registered above (readdir is only
   // compared here — never used to build a path passed to readFileSync).
@@ -374,8 +355,7 @@ function check() {
         // Property must be a lone identifier — a custom prop (--x) OR a standard
         // property (color, border) — so `color: red` is checked, not just tokens,
         // while selectors (`.foo:hover`) with a colon are skipped.
-        if (!/^\s*(?:--)?[a-z][a-z0-9-]*\s*$/i.test(line.slice(0, colon)))
-          return;
+        if (!/^\s*(?:--)?[a-z][a-z0-9-]*\s*$/i.test(line.slice(0, colon))) return;
         const value = line
           .slice(colon + 1)
           .replace(/--[a-z0-9-]+/gi, " ")
@@ -403,10 +383,8 @@ function reportContrast() {
   const blocks = [];
   for (const m of colorsCss.matchAll(/([^{}]+)\{([^}]*)\}/g)) {
     const decls = {};
-    for (const d of m[2].matchAll(/(--c-[a-z0-9-]+)\s*:\s*([^;]+);/g))
-      decls[d[1]] = d[2].trim();
-    if (Object.keys(decls).length)
-      blocks.push({ selector: m[1].trim(), decls });
+    for (const d of m[2].matchAll(/(--c-[a-z0-9-]+)\s*:\s*([^;]+);/g)) decls[d[1]] = d[2].trim();
+    if (Object.keys(decls).length) blocks.push({ selector: m[1].trim(), decls });
   }
   // The editor always renders data-app-theme="custom"; the accent (--user-*) is
   // injected at runtime, so seed the DEFAULT blue to resolve the custom tint
@@ -419,24 +397,16 @@ function reportContrast() {
   };
   const pick = (re) => blocks.filter((b) => re.test(b.selector));
   const lightBase = pick(/:root/);
-  const customBase = blocks.filter(
-    (b) =>
-      /app-theme="custom"/.test(b.selector) &&
-      !/color-scheme="dark"/.test(b.selector),
-  );
-  const customDark = pick(
-    /app-theme="custom"\]\[data-mantine-color-scheme="dark"/,
-  );
+  const customBase = blocks.filter((b) => /app-theme="custom"/.test(b.selector) && !/color-scheme="dark"/.test(b.selector));
+  const customDark = pick(/app-theme="custom"\]\[data-mantine-color-scheme="dark"/);
   const midnight = pick(/data-theme="dark"/);
   const themes = {
     "editor light": [...lightBase, ...customBase],
     "editor dark": [...lightBase, ...customBase, ...customDark],
     "portal dark": [...lightBase, ...midnight],
   };
-  const flatten = (list) =>
-    Object.assign({ ...SEED }, ...list.map((b) => b.decls));
-  const resolve = (token, t) =>
-    resolveColorValue(t[token] ?? null, t, primitives, new Set([token]));
+  const flatten = (list) => Object.assign({ ...SEED }, ...list.map((b) => b.decls));
+  const resolve = (token, t) => resolveColorValue(t[token] ?? null, t, primitives, new Set([token]));
   const contrast = (t1, t2, t) => {
     const surface = resolve("--c-surface", t);
     let a = resolve(t1, t);
@@ -465,17 +435,11 @@ function reportContrast() {
         continue;
       }
       if (r < floor) warnings++;
-      console.log(
-        `    ${r < floor ? "⚠ " : "  "}${r.toFixed(2).padStart(5)}  (floor ${floor})  ${t1} on ${t2}`,
-      );
+      console.log(`    ${r < floor ? "⚠ " : "  "}${r.toFixed(2).padStart(5)}  (floor ${floor})  ${t1} on ${t2}`);
     }
     console.log("");
   }
-  console.log(
-    warnings
-      ? `⚠ ${warnings} pair(s) below floor — review, not blocking.`
-      : "✓ all pairs clear their floor.",
-  );
+  console.log(warnings ? `⚠ ${warnings} pair(s) below floor — review, not blocking.` : "✓ all pairs clear their floor.");
 }
 
 // ── status-tone text on its own fill ─────────────────────────────────────────
@@ -488,9 +452,7 @@ const TONE_INVISIBLE = 1.6;
 // fill, per theme. Returns [{ theme, base, fill, ratio|null }] — no printing, so
 // both the warn-only report and the blocking guard can share it.
 function toneContrastResults() {
-  const primitives = readPrimitives(
-    readFileSync(join(THEME, "primitives.css"), "utf8"),
-  );
+  const primitives = readPrimitives(readFileSync(join(THEME, "primitives.css"), "utf8"));
   // Strip comments first: a selector's captured prefix can otherwise include a
   // preceding comment that mentions data-theme="dark", misclassifying the block.
   const css = stripComments(readFileSync(TOKENS_CSS, "utf8"));
@@ -499,8 +461,7 @@ function toneContrastResults() {
   const darkTones = {};
   for (const m of css.matchAll(/([^{}]+)\{([^}]*)\}/g)) {
     const target = isDark(m[1]) ? darkTones : lightTones;
-    for (const d of m[2].matchAll(/(--color-[a-z0-9-]+)\s*:\s*([^;]+);/g))
-      target[d[1]] = d[2].trim();
+    for (const d of m[2].matchAll(/(--color-[a-z0-9-]+)\s*:\s*([^;]+);/g)) target[d[1]] = d[2].trim();
   }
   // Dark only overrides the tones it redefines; unspecified ones inherit light.
   const themes = { light: lightTones, dark: { ...lightTones, ...darkTones } };
@@ -514,13 +475,7 @@ function toneContrastResults() {
       const fill = `${base}-light`;
       const fg = resolveColorValue(t[base], t, primitives, new Set([base]));
       const bg = resolveColorValue(t[fill], t, primitives, new Set([fill]));
-      const ratio =
-        fg && bg
-          ? contrastRatio(
-              fg.a < 1 ? over(fg, bg) : fg,
-              bg.a < 1 ? over(bg, white) : bg,
-            )
-          : null;
+      const ratio = fg && bg ? contrastRatio(fg.a < 1 ? over(fg, bg) : fg, bg.a < 1 ? over(bg, white) : bg) : null;
       results.push({ theme, base, fill, ratio });
     }
   }
@@ -543,8 +498,7 @@ function reportToneContrast() {
       continue;
     }
     // ✖ = near-invisible (blocks CI), ⚠ = below the WCAG floor (warn only).
-    const mark =
-      ratio < TONE_INVISIBLE ? "✖ " : ratio < TONE_FLOOR ? "⚠ " : "  ";
+    const mark = ratio < TONE_INVISIBLE ? "✖ " : ratio < TONE_FLOOR ? "⚠ " : "  ";
     if (ratio < TONE_INVISIBLE) invisible++;
     else if (ratio < TONE_FLOOR) warnings++;
     console.log(
@@ -552,13 +506,10 @@ function reportToneContrast() {
     );
   }
   const parts = [];
-  if (invisible)
-    parts.push(`✖ ${invisible} near-invisible (<${TONE_INVISIBLE}:1)`);
+  if (invisible) parts.push(`✖ ${invisible} near-invisible (<${TONE_INVISIBLE}:1)`);
   if (warnings) parts.push(`⚠ ${warnings} below the ${TONE_FLOOR} floor`);
   console.log(
-    parts.length
-      ? `\n${parts.join(", ")}. ✖ blocks the build; ⚠ is advisory.\n`
-      : "\n✓ all tones clear the floor.\n",
+    parts.length ? `\n${parts.join(", ")}. ✖ blocks the build; ⚠ is advisory.\n` : "\n✓ all tones clear the floor.\n",
   );
 }
 
@@ -580,9 +531,7 @@ function trackedFiles() {
 
 function checkAppCss() {
   const EXEMPT = /(?:^|\/)(?:primitives\.css|output\.css)$/;
-  const listed = trackedFiles().filter(
-    (l) => l.endsWith(".css") && !EXEMPT.test(l),
-  );
+  const listed = trackedFiles().filter((l) => l.endsWith(".css") && !EXEMPT.test(l));
 
   const violations = [];
   const lineOf = (text, index) => text.slice(0, index).split("\n").length;
@@ -634,7 +583,7 @@ const CODE_EXEMPT_PATH = [
   // PDF rendering/drawing surfaces that legitimately carry colour literals —
   // scoped to specific tool paths, not a blanket "pdf" substring (which used to
   // exempt most of the app in a PDF product).
-  /pdfTextEditor|pixelCompare|\/compare\.ts$|customPrimary|accentColors|formFieldColors/,
+  /pdfTextEditor|pixelCompare|\/compare\.ts$|customPrimary|accentColors/,
   /validateSignature\/outputtedPDFSections|CenteredMessageSection|StatusBadgeSection/,
   /\/viewer\/|Annotation|useViewerReadAloud|CommentsSidebar|\/constants\/search\.ts$|SignaturePreview/,
   /ColorPicker|ColorControl|WatchedFolderManagementModal|watchedFolderPresets|fileColors|unifiedBackground|folder\.ts$|policyFolders/,
@@ -646,16 +595,14 @@ const CODE_EXEMPT_PATH = [
   // `theme-allow-color`.
   /\.test\.[jt]sx?$|\/types\//,
 ];
-const CODE_HEX =
-  /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/g;
+const CODE_HEX = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/g;
 const CODE_RGB = /rgba?\(([^)]*)\)/gi;
 const CODE_HSL = /hsla?\(([^)]*)\)/gi;
 // NOTE: bare named colours (e.g. 'blue') are intentionally NOT flagged in
 // TS/TSX — they are dominated by legitimate Mantine palette props (`c="red"`,
 // `color="blue"`, which are theme-routed) and provider names ('azure'), so a
 // string match produces mostly false positives. hsl()/hex/rgb() are unambiguous.
-const codeStructuralHex = (h) =>
-  /^#(?:000|fff|000f|ffff|000000|ffffff|00000000|ffffffff)$/i.test(h);
+const codeStructuralHex = (h) => /^#(?:000|fff|000f|ffff|000000|ffffff|00000000|ffffffff)$/i.test(h);
 // Line-level skips for contexts where a colour literal is inherent (canvas /
 // pdf-lib drawing, computed-style reads) or explicitly opted out. NOTE: a
 // `var(--x, #hex)` literal fallback is deliberately NOT skipped — the hex in the
@@ -665,10 +612,7 @@ const CODE_SKIP_LINE =
 function codeStripNonCode(text) {
   return text
     .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
-    .replace(
-      /(^|[^:])\/\/[^\n]*/g,
-      (m, p) => p + m.slice(p.length).replace(/[^\n]/g, " "),
-    )
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, p) => p + m.slice(p.length).replace(/[^\n]/g, " "))
     .replace(/&#\d+;/g, "     ");
 }
 function codeRgbIsColour(inner) {
@@ -685,9 +629,7 @@ function codeRgbIsColour(inner) {
   return k !== "0,0,0" && k !== "255,255,255";
 }
 function checkCodeColors() {
-  const files = trackedFiles().filter(
-    (l) => /\.(ts|tsx)$/.test(l) && !CODE_EXEMPT_PATH.some((re) => re.test(l)),
-  );
+  const files = trackedFiles().filter((l) => /\.(ts|tsx)$/.test(l) && !CODE_EXEMPT_PATH.some((re) => re.test(l)));
   const violations = [];
   for (const rel of files) {
     const raw = readFileSync(rel, "utf8");
@@ -697,12 +639,9 @@ function checkCodeColors() {
       if (/theme-allow-color/.test(rawLines[i] || "")) return;
       if (CODE_SKIP_LINE.test(line)) return;
       const hits = [];
-      for (const h of line.match(CODE_HEX) || [])
-        if (!codeStructuralHex(h)) hits.push(h);
-      for (const m of line.match(CODE_RGB) || [])
-        if (codeRgbIsColour(m.replace(/rgba?\(|\)/gi, ""))) hits.push(m);
-      for (const m of line.match(CODE_HSL) || [])
-        if (!/var\(/.test(m)) hits.push(m);
+      for (const h of line.match(CODE_HEX) || []) if (!codeStructuralHex(h)) hits.push(h);
+      for (const m of line.match(CODE_RGB) || []) if (codeRgbIsColour(m.replace(/rgba?\(|\)/gi, ""))) hits.push(m);
+      for (const m of line.match(CODE_HSL) || []) if (!/var\(/.test(m)) hits.push(m);
       for (const h of hits)
         violations.push({
           file: rel,
@@ -753,18 +692,13 @@ const PRIMITIVE_LAYER = [
   /^editor\/src\/core\/ui\/accents\.css$/,
 ];
 function checkNoPrimitives() {
-  const files = trackedFiles().filter(
-    (l) =>
-      /\.(css|scss|ts|tsx)$/.test(l) &&
-      !PRIMITIVE_LAYER.some((re) => re.test(l)),
-  );
+  const files = trackedFiles().filter((l) => /\.(css|scss|ts|tsx)$/.test(l) && !PRIMITIVE_LAYER.some((re) => re.test(l)));
   const REF = /var\(\s*(--p-[a-z0-9-]+)/g;
   const violations = [];
   const lineOf = (text, index) => text.slice(0, index).split("\n").length;
   for (const rel of files) {
     const text = stripComments(readFileSync(rel, "utf8"));
-    for (const m of text.matchAll(REF))
-      violations.push({ file: rel, line: lineOf(text, m.index), token: m[1] });
+    for (const m of text.matchAll(REF)) violations.push({ file: rel, line: lineOf(text, m.index), token: m[1] });
   }
   return violations;
 }
@@ -780,9 +714,7 @@ if (process.argv.includes("no-primitives")) {
     console.error("");
     process.exit(1);
   }
-  console.log(
-    "✓ theme-lint no-primitives: components reference --c-* semantic tokens (no raw --p-*)",
-  );
+  console.log("✓ theme-lint no-primitives: components reference --c-* semantic tokens (no raw --p-*)");
   process.exit(0);
 }
 
@@ -795,81 +727,52 @@ if (process.argv.includes("contrast")) {
 if (process.argv.includes("css-colors")) {
   const v = checkAppCss();
   if (v.length) {
-    console.error(
-      `\n✖ theme-lint css-colors: ${v.length} hardcoded colour(s) in source CSS:\n`,
-    );
+    console.error(`\n✖ theme-lint css-colors: ${v.length} hardcoded colour(s) in source CSS:\n`);
     for (const x of v) console.error(`  ${x.file}:${x.line}  ${x.msg}`);
-    console.error(
-      `\nDefine every colour once in core/theme/primitives.css and reference it with var(--p-…).\n`,
-    );
+    console.error(`\nDefine every colour once in core/theme/primitives.css and reference it with var(--p-…).\n`);
     process.exit(1);
   }
-  console.log(
-    "✓ theme-lint css-colors: source CSS is free of hardcoded colour",
-  );
+  console.log("✓ theme-lint css-colors: source CSS is free of hardcoded colour");
   process.exit(0);
 }
 
 if (process.argv.includes("code-colors")) {
   const v = checkCodeColors();
   if (v.length) {
-    console.error(
-      `\n✖ theme-lint code-colors: ${v.length} hardcoded colour(s) in TS/TSX:\n`,
-    );
+    console.error(`\n✖ theme-lint code-colors: ${v.length} hardcoded colour(s) in TS/TSX:\n`);
     for (const x of v) console.error(`  ${x.file}:${x.line}  ${x.msg}`);
     console.error("");
     process.exit(1);
   }
-  console.log(
-    "✓ theme-lint code-colors: no hardcoded colour in TS/TSX DOM code (rendering/vendor/config areas exempt)",
-  );
+  console.log("✓ theme-lint code-colors: no hardcoded colour in TS/TSX DOM code (rendering/vendor/config areas exempt)");
   process.exit(0);
 }
 
 const violations = check();
 // Block near-invisible status tones (< TONE_INVISIBLE) in either theme.
-const toneViolations = toneContrastResults().filter(
-  (r) => r.ratio != null && r.ratio < TONE_INVISIBLE,
-);
+const toneViolations = toneContrastResults().filter((r) => r.ratio != null && r.ratio < TONE_INVISIBLE);
 // Block references to --p-*/--c-* tokens that are defined nowhere (no fallback).
 const unresolvedTokens = checkTokenResolution();
 if (unresolvedTokens.length) {
   console.error(
     `\n✖ theme-lint: ${unresolvedTokens.length} reference(s) to undefined --p-*/--c-* token(s) (colour silently drops to transparent/inherited):\n`,
   );
-  for (const r of unresolvedTokens)
-    console.error(
-      `  ${r.file}:${r.line}  var(${r.token}) — not defined anywhere`,
-    );
-  console.error(
-    `\nDefine the token (primitive in primitives.css, semantic in colors.css) or give the var() a fallback.\n`,
-  );
+  for (const r of unresolvedTokens) console.error(`  ${r.file}:${r.line}  var(${r.token}) — not defined anywhere`);
+  console.error(`\nDefine the token (primitive in primitives.css, semantic in colors.css) or give the var() a fallback.\n`);
 }
 if (violations.length || toneViolations.length || unresolvedTokens.length) {
   if (violations.length) {
-    console.error(
-      `\n✖ theme-lint: ${violations.length} raw/duplicate colour(s) in core/theme/:\n`,
-    );
-    for (const v of violations)
-      console.error(`  ${v.file}:${v.line}  ${v.msg}`);
-    console.error(
-      `\nDefine every colour once in core/theme/primitives.css and reference it with var(--p-…).\n`,
-    );
+    console.error(`\n✖ theme-lint: ${violations.length} raw/duplicate colour(s) in core/theme/:\n`);
+    for (const v of violations) console.error(`  ${v.file}:${v.line}  ${v.msg}`);
+    console.error(`\nDefine every colour once in core/theme/primitives.css and reference it with var(--p-…).\n`);
   }
   if (toneViolations.length) {
     console.error(
       `\n✖ theme-lint: ${toneViolations.length} status tone(s) below the ${TONE_INVISIBLE}:1 legibility floor (text nearly invisible on its own fill):\n`,
     );
-    for (const v of toneViolations)
-      console.error(
-        `  ${v.base} on ${v.fill} — ${v.ratio.toFixed(2)}:1 in ${v.theme} theme`,
-      );
-    console.error(
-      `\nGive --color-{hue}-light a paler/darker tint in core/tokens/tokens.css so the label is legible.\n`,
-    );
+    for (const v of toneViolations) console.error(`  ${v.base} on ${v.fill} — ${v.ratio.toFixed(2)}:1 in ${v.theme} theme`);
+    console.error(`\nGive --color-{hue}-light a paler/darker tint in core/tokens/tokens.css so the label is legible.\n`);
   }
   process.exit(1);
 }
-console.log(
-  "✓ theme-lint: core/theme colours route through the primitive palette; status tones clear the legibility floor",
-);
+console.log("✓ theme-lint: core/theme colours route through the primitive palette; status tones clear the legibility floor");

--- a/frontend/editor/src/core/tools/formFill/FormFieldEditOverlay.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormFieldEditOverlay.tsx
@@ -2,18 +2,9 @@
  * Per-page select/move/resize layer for "modify" mode. Geometry is staged in
  * CropBox-relative, lower-left-origin points on FormFieldOverlay's scale basis.
  */
-import React, {
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-  useEffect,
-} from "react";
+import React, { useCallback, useMemo, useRef, useState, useEffect } from "react";
 import { useFormFill } from "@app/tools/formFill/FormFillContext";
-import {
-  pendingIdFrom,
-  pendingSelectionName,
-} from "@app/tools/formFill/pendingSelection";
+import { pendingIdFrom, pendingSelectionName } from "@app/tools/formFill/pendingSelection";
 import type { FormField } from "@app/tools/formFill/types";
 import {
   pixelsToBackendRect,
@@ -24,17 +15,8 @@ import {
   roundPdfRect,
   type PixelRect,
 } from "@app/tools/formFill/formCoordinateUtils";
-import {
-  collectSnapTargets,
-  snapMove,
-  snapResize,
-  type SnapGuide,
-} from "@app/tools/formFill/formSnapUtils";
-import {
-  usePageScale,
-  getLocalPoint,
-  isTextEntryTarget,
-} from "@app/tools/formFill/usePageScale";
+import { collectSnapTargets, snapMove, snapResize, type SnapGuide } from "@app/tools/formFill/formSnapUtils";
+import { usePageScale, getLocalPoint, isTextEntryTarget } from "@app/tools/formFill/usePageScale";
 import { SnapGuides } from "@app/tools/formFill/SnapGuides";
 import { FORM_COLORS } from "@app/tools/formFill/formFieldColors";
 
@@ -100,26 +82,13 @@ function handlePosition(h: HandleId, rect: PixelRect) {
  * What a queued field will look like once applied. Without this a drawn box is empty, so the
  * default text and a radio group's options are invisible until after saving.
  */
-function PendingPreview({
-  field,
-  rect,
-}: {
-  field: FormField;
-  rect: PixelRect;
-}) {
+function PendingPreview({ field, rect }: { field: FormField; rect: PixelRect }) {
   // Blank entries are dropped server-side (sanitizeOptions), so counting them here would
   // preview one more button than actually gets written.
-  const options = (field.options ?? [])
-    .map((o) => o?.trim() ?? "")
-    .filter((o) => o.length > 0);
+  const options = (field.options ?? []).map((o) => o?.trim() ?? "").filter((o) => o.length > 0);
   if (field.type === "radio" && options.length > 0) {
     // The drawn box is the whole group; radioOptionRects splits it exactly as the backend does.
-    const rows = radioOptionRects(
-      rect,
-      options.length,
-      field.optionGap,
-      field.optionSize,
-    );
+    const rows = radioOptionRects(rect, options.length, field.optionGap, field.optionSize);
     return (
       <>
         {rows.map((row, i) => (
@@ -165,11 +134,7 @@ function PendingPreview({
     );
   }
 
-  const sample =
-    field.value ||
-    (field.type === "combobox" || field.type === "listbox"
-      ? (options[0] ?? "")
-      : "");
+  const sample = field.value || (field.type === "combobox" || field.type === "listbox" ? (options[0] ?? "") : "");
   if (!sample) return null;
   return (
     <span
@@ -191,13 +156,7 @@ function PendingPreview({
   );
 }
 
-export function FormFieldEditOverlay({
-  documentId,
-  pageIndex,
-  pageWidth,
-  pageHeight,
-  fileId,
-}: FormFieldEditOverlayProps) {
+export function FormFieldEditOverlay({ documentId, pageIndex, pageWidth, pageHeight, fileId }: FormFieldEditOverlayProps) {
   const {
     mode,
     state,
@@ -218,8 +177,7 @@ export function FormFieldEditOverlay({
   const [liveRect, setLiveRect] = useState<PixelRect | null>(null);
   const [guides, setGuides] = useState<SnapGuide[]>([]);
 
-  const { scaleX, scaleY, pageHeightPts, pageWidthPts, rotation } =
-    usePageScale(documentId, pageIndex, pageWidth, pageHeight);
+  const { scaleX, scaleY, pageHeightPts, pageWidthPts, rotation } = usePageScale(documentId, pageIndex, pageWidth, pageHeight);
 
   /** First-widget pixel rect for a field on this page, honouring staged geometry. */
   const fieldRect = useCallback(
@@ -242,13 +200,7 @@ export function FormFieldEditOverlay({
         );
       }
       const staged = modifiedFields[field.name];
-      if (
-        staged &&
-        staged.x != null &&
-        staged.y != null &&
-        staged.width != null &&
-        staged.height != null
-      ) {
+      if (staged && staged.x != null && staged.y != null && staged.width != null && staged.height != null) {
         return backendRectToPixels(
           {
             x: staged.x,
@@ -272,47 +224,41 @@ export function FormFieldEditOverlay({
     () =>
       pendingFields
         .filter((f) => f.pageIndex === pageIndex)
-        .map((f): FormField => ({
-          name: pendingSelectionName(f.id),
-          label: f.label || f.name,
-          type: f.type,
-          value: f.defaultValue ?? "",
-          options: f.options ?? null,
-          displayOptions: null,
-          required: f.required ?? false,
-          readOnly: f.readOnly ?? false,
-          multiSelect: f.multiSelect ?? false,
-          multiline: f.multiline ?? false,
-          tooltip: f.tooltip ?? null,
-          widgets: [
-            {
-              pageIndex: f.pageIndex,
-              x: f.x,
-              y: f.y,
-              width: f.width,
-              height: f.height,
-            },
-          ],
-        })),
+        .map(
+          (f): FormField => ({
+            name: pendingSelectionName(f.id),
+            label: f.label || f.name,
+            type: f.type,
+            value: f.defaultValue ?? "",
+            options: f.options ?? null,
+            displayOptions: null,
+            required: f.required ?? false,
+            readOnly: f.readOnly ?? false,
+            multiSelect: f.multiSelect ?? false,
+            multiline: f.multiline ?? false,
+            tooltip: f.tooltip ?? null,
+            widgets: [
+              {
+                pageIndex: f.pageIndex,
+                x: f.x,
+                y: f.y,
+                width: f.width,
+                height: f.height,
+              },
+            ],
+          }),
+        ),
     [pendingFields, pageIndex],
   );
 
   const fieldsOnPage = useMemo(
-    () => [
-      ...state.fields.filter((f) =>
-        f.widgets?.some((w) => w.pageIndex === pageIndex),
-      ),
-      ...pendingOnPage,
-    ],
+    () => [...state.fields.filter((f) => f.widgets?.some((w) => w.pageIndex === pageIndex)), ...pendingOnPage],
     [state.fields, pageIndex, pendingOnPage],
   );
 
   /** Pending geometry lives in the queue; committed geometry is staged as a modification. */
   const commitGeometry = useCallback(
-    (
-      fieldName: string,
-      pdf: { x: number; y: number; width: number; height: number },
-    ) => {
+    (fieldName: string, pdf: { x: number; y: number; width: number; height: number }) => {
       const pendingId = pendingIdFrom(fieldName);
       if (pendingId) {
         updatePendingField(pendingId, { pageIndex, ...pdf });
@@ -328,8 +274,7 @@ export function FormFieldEditOverlay({
     [fieldsOnPage, selectedFieldName],
   );
 
-  const selectedSingleWidget =
-    !!selectedField && (selectedField.widgets?.length ?? 0) === 1;
+  const selectedSingleWidget = !!selectedField && (selectedField.widgets?.length ?? 0) === 1;
 
   const snapRects = useMemo<PixelRect[]>(() => {
     const rects: PixelRect[] = [];
@@ -344,18 +289,10 @@ export function FormFieldEditOverlay({
   // Precompute snap edges once (not on every pointermove).
   const snapTargets = useMemo(() => collectSnapTargets(snapRects), [snapRects]);
 
-  const localPoint = useCallback(
-    (e: React.PointerEvent) => getLocalPoint(e, rootRef.current, rotation),
-    [rotation],
-  );
+  const localPoint = useCallback((e: React.PointerEvent) => getLocalPoint(e, rootRef.current, rotation), [rotation]);
 
   const beginInteraction = useCallback(
-    (
-      e: React.PointerEvent,
-      field: FormField,
-      kind: "move" | "resize",
-      handle?: HandleId,
-    ) => {
+    (e: React.PointerEvent, field: FormField, kind: "move" | "resize", handle?: HandleId) => {
       const rect = fieldRect(field);
       if (!rect) return;
       e.stopPropagation();
@@ -415,8 +352,7 @@ export function FormFieldEditOverlay({
         }
         // Keep a positive minimum, anchoring the opposite edge.
         if (width < MIN_PX) {
-          if (edges.left)
-            left = it.startRect.left + it.startRect.width - MIN_PX;
+          if (edges.left) left = it.startRect.left + it.startRect.width - MIN_PX;
           width = MIN_PX;
         }
         if (height < MIN_PX) {
@@ -481,9 +417,7 @@ export function FormFieldEditOverlay({
         Math.abs(rect.height - it.startRect.height) > 0.5;
       if (!moved) return;
       const clamped = clampPixelRect(rect, pageWidth, pageHeight);
-      const pdf = roundPdfRect(
-        pixelsToBackendRect(clamped, scaleX, scaleY, pageHeightPts),
-      );
+      const pdf = roundPdfRect(pixelsToBackendRect(clamped, scaleX, scaleY, pageHeightPts));
       commitGeometry(it.fieldName, {
         x: pdf.x,
         y: pdf.y,
@@ -491,16 +425,7 @@ export function FormFieldEditOverlay({
         height: pdf.height,
       });
     },
-    [
-      liveRect,
-      pageWidth,
-      pageHeight,
-      scaleX,
-      scaleY,
-      pageHeightPts,
-      pageIndex,
-      stageModification,
-    ],
+    [liveRect, pageWidth, pageHeight, scaleX, scaleY, pageHeightPts, pageIndex, stageModification],
   );
 
   // Arrow keys nudge the selected field; Escape cancels an in-progress drag.
@@ -523,11 +448,7 @@ export function FormFieldEditOverlay({
       }
       if (dragging) return;
 
-      if (
-        !selectedField ||
-        !selectedSingleWidget ||
-        deletedFieldNames.includes(selectedField.name)
-      ) {
+      if (!selectedField || !selectedSingleWidget || deletedFieldNames.includes(selectedField.name)) {
         return;
       }
       const step = e.shiftKey ? 10 : 1;
@@ -552,14 +473,8 @@ export function FormFieldEditOverlay({
       const base = fieldRect(selectedField);
       if (!base) return; // selected field's widget isn't on this page
       e.preventDefault();
-      const moved = clampPixelRect(
-        { ...base, left: base.left + dx, top: base.top + dy },
-        pageWidth,
-        pageHeight,
-      );
-      const pdf = roundPdfRect(
-        pixelsToBackendRect(moved, scaleX, scaleY, pageHeightPts),
-      );
+      const moved = clampPixelRect({ ...base, left: base.left + dx, top: base.top + dy }, pageWidth, pageHeight);
+      const pdf = roundPdfRect(pixelsToBackendRect(moved, scaleX, scaleY, pageHeightPts));
       commitGeometry(selectedField.name, {
         x: pdf.x,
         y: pdf.y,
@@ -585,8 +500,7 @@ export function FormFieldEditOverlay({
     stageModification,
   ]);
 
-  const fileMismatch =
-    fileId != null && forFileId != null && fileId !== forFileId;
+  const fileMismatch = fileId != null && forFileId != null && fileId !== forFileId;
   const creating = mode === "create";
   if ((mode !== "modify" && !creating) || fileMismatch || !pageWidthPts) {
     return null;
@@ -620,10 +534,7 @@ export function FormFieldEditOverlay({
                 height: rect.height,
                 // A radio group has no box of its own; its buttons are the whole visual, so a
                 // frame around them is chrome the finished PDF will not have.
-                border:
-                  field.type === "radio"
-                    ? undefined
-                    : `1px solid ${FORM_COLORS.neutralBorder}`,
+                border: field.type === "radio" ? undefined : `1px solid ${FORM_COLORS.neutralBorder}`,
                 borderRadius: 2,
                 boxSizing: "border-box",
               }}
@@ -637,9 +548,7 @@ export function FormFieldEditOverlay({
     );
   }
 
-  const selectedRect = selectedField
-    ? (liveRect ?? fieldRect(selectedField))
-    : null;
+  const selectedRect = selectedField ? (liveRect ?? fieldRect(selectedField)) : null;
 
   return (
     <div
@@ -668,10 +577,7 @@ export function FormFieldEditOverlay({
       }}
     >
       {fieldsOnPage.map((field) => {
-        const rect =
-          field.name === selectedFieldName && selectedRect
-            ? selectedRect
-            : fieldRect(field);
+        const rect = field.name === selectedFieldName && selectedRect ? selectedRect : fieldRect(field);
         if (!rect) return null;
         const isSelected = field.name === selectedFieldName;
         const isDeleted = deletedFieldNames.includes(field.name);
@@ -684,8 +590,7 @@ export function FormFieldEditOverlay({
               e.stopPropagation();
               // Select and start moving in one gesture; a click without movement
               // just selects, since endInteraction ignores a zero delta.
-              if (field.name !== selectedFieldName)
-                setSelectedField(field.name);
+              if (field.name !== selectedFieldName) setSelectedField(field.name);
               // Moving is safe for a group too: the backend applies the delta to every widget
               // on the anchor page. Only resizing is still single-widget, so the handles stay off.
               beginInteraction(e, field, "move");
@@ -704,11 +609,7 @@ export function FormFieldEditOverlay({
                   ? `2px solid ${FORM_COLORS.accent}`
                   : `1.5px solid ${FORM_COLORS.neutralBorder}`,
               outlineOffset: 0,
-              background: isDeleted
-                ? FORM_COLORS.dangerFill
-                : isSelected
-                  ? FORM_COLORS.accentFill
-                  : FORM_COLORS.neutralFill,
+              background: isDeleted ? FORM_COLORS.dangerFill : isSelected ? FORM_COLORS.accentFill : FORM_COLORS.neutralFill,
               borderRadius: 2,
               boxSizing: "border-box",
               // Claim the gesture only where a drag can actually start, so touch users can
@@ -719,9 +620,7 @@ export function FormFieldEditOverlay({
               textDecoration: isDeleted ? "line-through" : undefined,
             }}
           >
-            {pendingIdFrom(field.name) && (
-              <PendingPreview field={field} rect={rect} />
-            )}
+            {pendingIdFrom(field.name) && <PendingPreview field={field} rect={rect} />}
             <span
               style={{
                 position: "absolute",
@@ -730,12 +629,8 @@ export function FormFieldEditOverlay({
                 fontSize: 10,
                 lineHeight: "14px",
                 padding: "0 4px",
-                background: isDeleted
-                  ? FORM_COLORS.danger
-                  : isSelected
-                    ? FORM_COLORS.accent
-                    : FORM_COLORS.neutralChip,
-                color: "#fff",
+                background: isDeleted ? FORM_COLORS.danger : isSelected ? FORM_COLORS.accent : FORM_COLORS.neutralChip,
+                color: "var(--c-text-on-primary)",
                 borderRadius: 2,
                 whiteSpace: "nowrap",
                 opacity: isSelected || isDeleted ? 1 : 0.75,
@@ -760,17 +655,14 @@ export function FormFieldEditOverlay({
             <div
               key={h.id}
               data-testid={`form-edit-handle-${h.id}`}
-              onPointerDown={(e) =>
-                selectedField &&
-                beginInteraction(e, selectedField, "resize", h.id)
-              }
+              onPointerDown={(e) => selectedField && beginInteraction(e, selectedField, "resize", h.id)}
               style={{
                 position: "absolute",
                 left: pos.x - HANDLE_SIZE / 2,
                 top: pos.y - HANDLE_SIZE / 2,
                 width: HANDLE_SIZE,
                 height: HANDLE_SIZE,
-                background: "#fff",
+                background: "var(--c-surface-raised)",
                 border: `1.5px solid ${FORM_COLORS.accent}`,
                 borderRadius: 2,
                 touchAction: "none",

--- a/frontend/editor/src/core/tools/formFill/FormFieldModifyPanel.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormFieldModifyPanel.tsx
@@ -1,21 +1,6 @@
 /** Left panel for "modify" mode; page highlighting lives in FormFieldEditOverlay. */
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import {
-  Text,
-  Group,
-  Alert,
-  Collapse,
-  Paper,
-  NumberInput,
-  ScrollArea,
-  Tooltip,
-} from "@mantine/core";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Text, Group, Alert, Collapse, Paper, NumberInput, ScrollArea, Tooltip } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
 import { useTranslation } from "react-i18next";
@@ -26,18 +11,10 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { useViewer } from "@app/contexts/ViewerContext";
 import { useFormFill } from "@app/tools/formFill/FormFillContext";
-import type {
-  FormField,
-  ModifyFieldDefinition,
-} from "@app/tools/formFill/types";
-import {
-  FIELD_TYPE_ICON,
-  FIELD_TYPE_COLOR,
-} from "@app/tools/formFill/fieldMeta";
-import {
-  FormFieldPropertyEditor,
-  type EditableFieldProps,
-} from "@app/tools/formFill/FormFieldPropertyEditor";
+import type { FormField, ModifyFieldDefinition } from "@app/tools/formFill/types";
+import { FIELD_TYPE_ICON, FIELD_TYPE_COLOR } from "@app/tools/formFill/fieldMeta";
+import { FORM_COLORS } from "@app/tools/formFill/formFieldColors";
+import { FormFieldPropertyEditor, type EditableFieldProps } from "@app/tools/formFill/FormFieldPropertyEditor";
 import { isTextEntryTarget } from "@app/tools/formFill/usePageScale";
 import { SkippedEditsAlert } from "@app/tools/formFill/SkippedEditsAlert";
 import { useFormCommit } from "@app/tools/formFill/useFormCommit";
@@ -52,13 +29,7 @@ interface FormFieldModifyPanelProps {
 function currentCoords(field: FormField, staged?: ModifyFieldDefinition) {
   const w = field.widgets?.[0];
   if (!w) return null;
-  if (
-    staged &&
-    staged.x != null &&
-    staged.y != null &&
-    staged.width != null &&
-    staged.height != null
-  ) {
+  if (staged && staged.x != null && staged.y != null && staged.width != null && staged.height != null) {
     return {
       x: staged.x,
       y: staged.y,
@@ -75,10 +46,7 @@ function currentCoords(field: FormField, staged?: ModifyFieldDefinition) {
   };
 }
 
-export function FormFieldModifyPanel({
-  currentFile,
-  onApplied,
-}: FormFieldModifyPanelProps) {
+export function FormFieldModifyPanel({ currentFile, onApplied }: FormFieldModifyPanelProps) {
   const { t } = useTranslation();
   const {
     state,
@@ -143,16 +111,11 @@ export function FormFieldModifyPanel({
     return () => window.removeEventListener("keydown", onKey);
   }, [selectedFieldName, setSelectedField, dragActiveRef]);
 
-  const changeCount =
-    Object.keys(modifiedFields).length + deletedFieldNames.length;
+  const changeCount = Object.keys(modifiedFields).length + deletedFieldNames.length;
 
   const handleCommit = useCallback(() => {
     if (!currentFile || !hasUncommittedChanges) return;
-    commit(
-      () => commitModifications(currentFile),
-      "formFill.modify.failed",
-      "Failed to save changes",
-    );
+    commit(() => commitModifications(currentFile), "formFill.modify.failed", "Failed to save changes");
   }, [currentFile, hasUncommittedChanges, commitModifications, commit]);
 
   const editorValue = useCallback(
@@ -172,14 +135,8 @@ export function FormFieldModifyPanel({
         options: staged?.options ?? field.options ?? [],
         // Test for the staged KEY, not its value, or an explicit clear reads as
         // "unchanged" and the input snaps back.
-        maxLength:
-          staged && "maxLength" in staged
-            ? staged.maxLength
-            : (field.maxLength ?? undefined),
-        buttonAction:
-          staged && "buttonAction" in staged
-            ? staged.buttonAction
-            : (field.buttonActionSpec ?? undefined),
+        maxLength: staged && "maxLength" in staged ? staged.maxLength : (field.maxLength ?? undefined),
+        buttonAction: staged && "buttonAction" in staged ? staged.buttonAction : (field.buttonActionSpec ?? undefined),
       };
     },
     [modifiedFields],
@@ -189,20 +146,11 @@ export function FormFieldModifyPanel({
     <div className={styles.root}>
       <div className={styles.header}>
         <Text size="xs" c="dimmed">
-          {t(
-            "formFill.modify.hint",
-            "Select a field to edit its properties, drag it on the page, or delete it.",
-          )}
+          {t("formFill.modify.hint", "Select a field to edit its properties, drag it on the page, or delete it.")}
         </Text>
 
         {error && (
-          <Alert
-            icon={<WarningAmberIcon sx={{ fontSize: 16 }} />}
-            color="red"
-            variant="light"
-            p="xs"
-            radius="sm"
-          >
+          <Alert icon={<WarningAmberIcon sx={{ fontSize: 16 }} />} color="red" variant="light" p="xs" radius="sm">
             <Text size="xs">{error}</Text>
           </Alert>
         )}
@@ -235,9 +183,7 @@ export function FormFieldModifyPanel({
                 <ExpandMoreIcon
                   sx={{
                     fontSize: 16,
-                    transform: collapsedPages.has(pageIdx)
-                      ? "rotate(-90deg)"
-                      : undefined,
+                    transform: collapsedPages.has(pageIdx) ? "rotate(-90deg)" : undefined,
                     transition: "transform 120ms",
                   }}
                 />
@@ -247,10 +193,7 @@ export function FormFieldModifyPanel({
                 <Text size="xs" c="dimmed">
                   {fieldsByPage.get(pageIdx)!.length}
                 </Text>
-                <Tooltip
-                  label={t("formFill.goToPage", "Go to this page")}
-                  withArrow
-                >
+                <Tooltip label={t("formFill.goToPage", "Go to this page")} withArrow>
                   <ActionIcon
                     size="sm"
                     variant="tertiary"
@@ -270,10 +213,7 @@ export function FormFieldModifyPanel({
                 {fieldsByPage.get(pageIdx)!.map((field) => {
                   const selected = selectedFieldName === field.name;
                   const deleted = deletedFieldNames.includes(field.name);
-                  const coords = currentCoords(
-                    field,
-                    modifiedFields[field.name],
-                  );
+                  const coords = currentCoords(field, modifiedFields[field.name]);
                   // Resizing a group here would only resize its first widget.
                   const multiWidget = (field.widgets?.length ?? 0) > 1;
                   return (
@@ -285,14 +225,10 @@ export function FormFieldModifyPanel({
                       radius="sm"
                       style={{
                         cursor: "pointer",
-                        borderColor: selected
-                          ? "var(--mantine-color-blue-5)"
-                          : undefined,
+                        borderColor: selected ? FORM_COLORS.accent : undefined,
                         opacity: deleted ? 0.55 : 1,
                       }}
-                      onClick={() =>
-                        setSelectedField(selected ? null : field.name)
-                      }
+                      onClick={() => setSelectedField(selected ? null : field.name)}
                       data-testid={`form-modify-row-${field.name}`}
                     >
                       <Group gap={6} wrap="nowrap" justify="space-between">
@@ -305,20 +241,12 @@ export function FormFieldModifyPanel({
                           >
                             {FIELD_TYPE_ICON[field.type]}
                           </span>
-                          <Text
-                            size="xs"
-                            truncate
-                            td={deleted ? "line-through" : undefined}
-                          >
+                          <Text size="xs" truncate td={deleted ? "line-through" : undefined}>
                             {field.label || field.name}
                           </Text>
                         </Group>
                         <Tooltip
-                          label={
-                            deleted
-                              ? t("formFill.modify.restore", "Restore")
-                              : t("formFill.modify.delete", "Delete")
-                          }
+                          label={deleted ? t("formFill.modify.restore", "Restore") : t("formFill.modify.delete", "Delete")}
                           withArrow
                         >
                           <ActionIcon
@@ -326,9 +254,7 @@ export function FormFieldModifyPanel({
                             variant="tertiary"
                             accent={deleted ? "default" : "danger"}
                             aria-label={
-                              deleted
-                                ? t("formFill.modify.restore", "Restore")
-                                : t("formFill.modify.delete", "Delete")
+                              deleted ? t("formFill.modify.restore", "Restore") : t("formFill.modify.delete", "Delete")
                             }
                             onClick={(e) => {
                               e.stopPropagation();
@@ -336,11 +262,7 @@ export function FormFieldModifyPanel({
                             }}
                             data-testid={`form-modify-delete-${field.name}`}
                           >
-                            {deleted ? (
-                              <RestoreIcon sx={{ fontSize: 16 }} />
-                            ) : (
-                              <DeleteOutlineIcon sx={{ fontSize: 16 }} />
-                            )}
+                            {deleted ? <RestoreIcon sx={{ fontSize: 16 }} /> : <DeleteOutlineIcon sx={{ fontSize: 16 }} />}
                           </ActionIcon>
                         </Tooltip>
                       </Group>
@@ -349,18 +271,10 @@ export function FormFieldModifyPanel({
                         every unopened row would otherwise carry a full property editor. */}
                       <Collapse in={selected && !deleted}>
                         {selected && !deleted && (
-                          <div
-                            style={{ marginTop: 8 }}
-                            onClick={(e) => e.stopPropagation()}
-                          >
+                          <div style={{ marginTop: 8 }} onClick={(e) => e.stopPropagation()}>
                             <FormFieldPropertyEditor
                               value={editorValue(field)}
-                              onChange={(patch) =>
-                                stageModification(
-                                  field.name,
-                                  patch as Partial<ModifyFieldDefinition>,
-                                )
-                              }
+                              onChange={(patch) => stageModification(field.name, patch as Partial<ModifyFieldDefinition>)}
                               showName
                               allowTypeChange
                             />
@@ -403,14 +317,7 @@ export function FormFieldModifyPanel({
                                   value={Math.round(coords.width)}
                                   min={1}
                                   disabled={multiWidget}
-                                  description={
-                                    multiWidget
-                                      ? t(
-                                          "formFill.modify.groupSizeHint",
-                                          "Use Option size",
-                                        )
-                                      : undefined
-                                  }
+                                  description={multiWidget ? t("formFill.modify.groupSizeHint", "Use Option size") : undefined}
                                   onChange={(v) =>
                                     typeof v === "number" &&
                                     stageModification(field.name, {

--- a/frontend/editor/src/core/tools/formFill/FormFillContext.tsx
+++ b/frontend/editor/src/core/tools/formFill/FormFillContext.tsx
@@ -31,7 +31,6 @@ import React, {
 } from "react";
 import { useDebouncedCallback } from "@mantine/hooks";
 import { isAxiosError } from "axios";
-import { applyStagedGeometry } from "@app/tools/formFill/formCoordinateUtils";
 import type {
   FormField,
   FormFillState,
@@ -40,18 +39,13 @@ import type {
   CreatableFieldType,
   NewFieldDefinition,
   ModifyFieldDefinition,
-  SkippedFieldEdit,
 } from "@app/tools/formFill/types";
-import { pendingIdFrom } from "@app/tools/formFill/pendingSelection";
 import type { IFormDataProvider } from "@app/tools/formFill/providers/types";
 import { PdfBoxFormProvider } from "@app/tools/formFill/providers/PdfBoxFormProvider";
 import { PdfiumFormProvider } from "@app/tools/formFill/providers/PdfiumFormProvider";
 import { fetchSignatureFieldsWithAppearances } from "@app/services/pdfiumService";
 import { applyFieldEdits } from "@app/tools/formFill/formApi";
 import { mergeSignatureAppearances } from "@app/tools/formFill/formFieldMerge";
-
-/** Marks a skip report as belonging to whichever document the commit just produced. */
-const PENDING_SKIP_REPORT = "__pending__";
 
 /** A field queued for creation, with a client-side id for list keys. */
 export interface PendingField extends NewFieldDefinition {
@@ -175,20 +169,8 @@ function reducer(state: FormFillState, action: Action): FormFillState {
       return { ...state, isDirty: true };
     case "SET_ACTIVE_FIELD":
       return { ...state, activeFieldName: action.fieldName };
-    case "SET_VALIDATION_ERRORS": {
-      // The debounce mints a fresh identical map ~3x/s while typing; without this every
-      // keystroke re-renders every consumer and every mounted page overlay.
-      const prev = state.validationErrors;
-      const next = action.errors;
-      const keys = Object.keys(next);
-      if (
-        keys.length === Object.keys(prev).length &&
-        keys.every((k) => prev[k] === next[k])
-      ) {
-        return state;
-      }
-      return { ...state, validationErrors: next };
-    }
+    case "SET_VALIDATION_ERRORS":
+      return { ...state, validationErrors: action.errors };
     case "CLEAR_VALIDATION_ERROR": {
       if (!state.validationErrors[action.fieldName]) return state;
       const { [action.fieldName]: _, ...rest } = state.validationErrors;
@@ -225,8 +207,6 @@ export interface FormFillContextValue {
   reset: () => void;
   /** Pre-computed map of page index to fields for performance */
   fieldsByPage: Map<number, FormField[]>;
-  /** fieldsByPage with staged moves, resizes, retypes and deletions already applied. */
-  effectiveFieldsByPage: Map<number, FormField[]>;
   /** Name of the currently active provider ('pdf-lib' | 'pdfbox') */
   activeProviderName: string;
   /**
@@ -238,7 +218,9 @@ export interface FormFillContextValue {
   /** The file ID that the current form fields belong to (null if no fields loaded) */
   forFileId: string | null;
 
-  // --- Structural editing (create / modify modes) ---
+  // -------------------------------------------------------------------------
+  // Structural editing (create / modify modes)
+  // -------------------------------------------------------------------------
 
   /** Current tool mode. */
   mode: FormMode;
@@ -248,19 +230,11 @@ export interface FormFillContextValue {
   // --- Create mode ---
   /** Field type currently armed for placement (null = not placing). */
   creationType: CreatableFieldType | null;
-  /** Steps back one staged edit; false when there was nothing left to undo. */
-  undo: () => boolean;
-  canUndo: boolean;
-  /** True while the user holds Preview, which hides the editing chrome. */
-  previewing: boolean;
-  setPreviewing: (previewing: boolean) => void;
   setCreationType: (type: CreatableFieldType | null) => void;
   /** Fields drawn but not yet committed to the PDF. */
   pendingFields: PendingField[];
   /** Queue a new field (id + default name auto-assigned). Returns the new id. */
-  addPendingField: (
-    field: Omit<NewFieldDefinition, "name"> & { name?: string },
-  ) => string;
+  addPendingField: (field: Omit<NewFieldDefinition, "name"> & { name?: string }) => string;
   updatePendingField: (id: string, patch: Partial<NewFieldDefinition>) => void;
   removePendingField: (id: string) => void;
   clearPendingFields: () => void;
@@ -274,10 +248,7 @@ export interface FormFillContextValue {
   /** Staged (uncommitted) property/geometry changes, keyed by original field name. */
   modifiedFields: Record<string, ModifyFieldDefinition>;
   /** Merge a partial change for a field into the staged set. */
-  stageModification: (
-    targetName: string,
-    patch: Partial<ModifyFieldDefinition>,
-  ) => void;
+  stageModification: (targetName: string, patch: Partial<ModifyFieldDefinition>) => void;
   /** Discard staged changes for a single field. */
   clearModification: (targetName: string) => void;
   /** Field names marked for deletion. */
@@ -292,14 +263,15 @@ export interface FormFillContextValue {
   /** True when create or modify mode has uncommitted work. */
   hasUncommittedChanges: boolean;
 
-  /** Edits the last commit asked for but the document could not take. */
-  skippedEdits: SkippedFieldEdit[];
-  /** May exceed skippedEdits.length when the report was truncated. */
-  skippedTotal: number;
-  clearSkippedEdits: () => void;
-
-  /** True while a field is being dragged, so Escape handlers elsewhere stand down. */
-  dragActiveRef: React.MutableRefObject<boolean>;
+  // --- Undo/Redo ---
+  /** Undo the last modification or creation action. */
+  undo: () => void;
+  /** Redo the last undone action. */
+  redo: () => void;
+  /** Whether undo is available. */
+  canUndo: boolean;
+  /** Whether redo is available. */
+  canRedo: boolean;
 }
 
 const FormFillContext = createContext<FormFillContextValue | null>(null);
@@ -330,14 +302,8 @@ export function useFieldValue(fieldName: string): string {
     throw new Error("useFieldValue must be used within a FormFillProvider");
   }
 
-  const subscribe = useCallback(
-    (cb: () => void) => store.subscribeField(fieldName, cb),
-    [store, fieldName],
-  );
-  const getSnapshot = useCallback(
-    () => store.getValue(fieldName),
-    [store, fieldName],
-  );
+  const subscribe = useCallback((cb: () => void) => store.subscribeField(fieldName, cb), [store, fieldName]);
+  const getSnapshot = useCallback(() => store.getValue(fieldName), [store, fieldName]);
 
   return useSyncExternalStore(subscribe, getSnapshot);
 }
@@ -352,10 +318,7 @@ export function useAllFormValues(): Record<string, string> {
     throw new Error("useAllFormValues must be used within a FormFillProvider");
   }
 
-  const subscribe = useCallback(
-    (cb: () => void) => store.subscribeGlobal(cb),
-    [store],
-  );
+  const subscribe = useCallback((cb: () => void) => store.subscribeGlobal(cb), [store]);
   const getSnapshot = useCallback(() => store.values, [store]);
 
   return useSyncExternalStore(subscribe, getSnapshot);
@@ -374,14 +337,10 @@ export function FormFillProvider({
   provider?: IFormDataProvider;
 }) {
   const initialMode = providerProp?.name === "pdfbox" ? "pdfbox" : "pdflib";
-  const [providerMode, setProviderModeState] = useState<"pdflib" | "pdfbox">(
-    initialMode,
-  );
-  const providerModeRef = useRef(initialMode);
+  const [providerMode, setProviderModeState] = useState<"pdflib" | "pdfbox">(initialMode);
+  const providerModeRef = useRef(initialMode as "pdflib" | "pdfbox");
   providerModeRef.current = providerMode;
-  const provider =
-    providerProp ??
-    (providerMode === "pdfbox" ? pdfBoxProvider : pdfiumProvider);
+  const provider = providerProp ?? (providerMode === "pdfbox" ? pdfBoxProvider : pdfiumProvider);
   const providerRef = useRef(provider);
   providerRef.current = provider;
 
@@ -403,96 +362,90 @@ export function FormFillProvider({
 
   // --- Structural editing state (create / modify modes) ---
   const [mode, setModeState] = useState<FormMode>("fill");
-  const [creationType, setCreationType] = useState<CreatableFieldType | null>(
-    null,
-  );
+  const [creationType, setCreationType] = useState<CreatableFieldType | null>(null);
   const [pendingFields, setPendingFields] = useState<PendingField[]>([]);
-  const [previewing, setPreviewing] = useState(false);
-
-  // Undo covers the staged edits, which is what the user has been doing here; the applied
-  // document keeps its own version history elsewhere.
-  const undoStackRef = useRef<
-    {
-      pending: PendingField[];
-      modified: Record<string, ModifyFieldDefinition>;
-      deleted: string[];
-    }[]
-  >([]);
-  const [canUndo, setCanUndo] = useState(false);
-  const liveEditsRef = useRef({
-    pending: [] as PendingField[],
-    modified: {} as Record<string, ModifyFieldDefinition>,
-    deleted: [] as string[],
-  });
-
-  const rememberForUndo = useCallback(() => {
-    const live = liveEditsRef.current;
-    undoStackRef.current.push({
-      pending: [...live.pending],
-      modified: { ...live.modified },
-      deleted: [...live.deleted],
-    });
-    // A long session should not grow without bound.
-    if (undoStackRef.current.length > 50) undoStackRef.current.shift();
-    setCanUndo(true);
-  }, []);
-
-  const undo = useCallback(() => {
-    const previous = undoStackRef.current.pop();
-    setCanUndo(undoStackRef.current.length > 0);
-    if (!previous) return false;
-    setPendingFields(previous.pending);
-    setModifiedFields(previous.modified);
-    setDeletedFieldNames(previous.deleted);
-    // A selection pointing at a field the undo removed would swallow the next click.
-    setSelectedField((current) => {
-      const id = pendingIdFrom(current);
-      if (!id) return current;
-      return previous.pending.some((f) => f.id === id) ? current : null;
-    });
-    return true;
-  }, []);
   const [selectedFieldName, setSelectedField] = useState<string | null>(null);
-  const [modifiedFields, setModifiedFields] = useState<
-    Record<string, ModifyFieldDefinition>
-  >({});
+  const [modifiedFields, setModifiedFields] = useState<Record<string, ModifyFieldDefinition>>({});
   const [deletedFieldNames, setDeletedFieldNames] = useState<string[]>([]);
-
-  liveEditsRef.current = {
-    pending: pendingFields,
-    modified: modifiedFields,
-    deleted: deletedFieldNames,
-  };
-
-  const [skippedEdits, setSkippedEdits] = useState<SkippedFieldEdit[]>([]);
-  const [skippedTotal, setSkippedTotal] = useState(0);
-  const clearSkippedEdits = useCallback(() => {
-    setSkippedEdits([]);
-    setSkippedTotal(0);
-    skipReportFileIdRef.current = null;
-  }, []);
-  /** Which file the staged edits belong to, so they cannot be committed onto another. */
-  const editedFileIdRef = useRef<string | null>(null);
-  /** Survives an in-flight fetch, unlike forFileIdRef, so staged edits can be stamped. */
-  const lastKnownFileIdRef = useRef<string | null>(null);
-  /** The file the current skip report describes, so it cannot outlive that document. */
-  const skipReportFileIdRef = useRef<string | null>(null);
-  /** Set by the edit overlay so other Escape handlers do not steal a drag's cancel. */
-  const dragActiveRef = useRef(false);
   // Monotonic counter for client-side pending-field ids and default names.
   const pendingCounterRef = useRef(0);
 
-  // Fields the last commit's response carried, adopted by the next fetch instead of uploading
-  // the document again to ask. Size-checked so a different document cannot pick them up.
-  const bundledFieldsRef = useRef<{ fields: FormField[]; size: number } | null>(
-    null,
+  // --- Undo/Redo history ---
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  // Keep a ref in sync so saveToHistory/undo/redo always read the current index
+  // without capturing a stale closure value (React batches state updates).
+  const historyIndexRef = useRef(historyIndex);
+  historyIndexRef.current = historyIndex;
+  // Bounded at 50 entries to keep each saveToHistory call O(1) instead of
+  // O(n) — without this cap, cumulative work over many edits is O(n²).
+  const MAX_HISTORY = 50;
+  const historyRef = useRef<
+    Array<{
+      mode: FormMode;
+      pendingFields: PendingField[];
+      selectedFieldName: string | null;
+      modifiedFields: Record<string, ModifyFieldDefinition>;
+      deletedFieldNames: string[];
+    }>
+  >([]);
+
+  const saveToHistory = useCallback(
+    (overrides?: {
+      mode?: FormMode;
+      pendingFields?: PendingField[];
+      selectedFieldName?: string | null;
+      modifiedFields?: Record<string, ModifyFieldDefinition>;
+      deletedFieldNames?: string[];
+    }) => {
+      // Use the ref so we always read the current index, not a stale closure.
+      const idx = historyIndexRef.current;
+      // Truncate any future history, then cap to avoid O(n²) cumulative alloc.
+      const newHistory = historyRef.current.slice(0, idx + 1).concat({
+        mode: overrides?.mode ?? mode,
+        pendingFields: overrides?.pendingFields ?? pendingFields,
+        selectedFieldName: overrides?.selectedFieldName ?? selectedFieldName,
+        modifiedFields: overrides?.modifiedFields ?? modifiedFields,
+        deletedFieldNames: overrides?.deletedFieldNames ?? deletedFieldNames,
+      });
+      if (newHistory.length > MAX_HISTORY) {
+        newHistory.splice(0, newHistory.length - MAX_HISTORY);
+        setHistoryIndex(MAX_HISTORY - 1);
+      } else {
+        setHistoryIndex(newHistory.length - 1);
+      }
+      historyRef.current = newHistory;
+    },
+    [mode, pendingFields, selectedFieldName, modifiedFields, deletedFieldNames],
   );
 
-  // What the user typed, carried across the re-fetch that opening the form tool triggers.
-  const retainedValuesRef = useRef<{
-    fileId: string | null;
-    values: Record<string, string>;
-  } | null>(null);
+  const undo = useCallback(() => {
+    if (historyIndex <= 0) return;
+    const prev = historyRef.current[historyIndex - 1];
+    setHistoryIndex(historyIndex - 1);
+    // Use setModeState (not setMode) to avoid clearing editing state/history
+    // when replaying a snapshot whose mode differs from the current one.
+    setModeState(prev.mode);
+    setPendingFields(prev.pendingFields);
+    setSelectedField(prev.selectedFieldName);
+    setModifiedFields(prev.modifiedFields);
+    setDeletedFieldNames(prev.deletedFieldNames);
+  }, [historyIndex]);
+
+  const redo = useCallback(() => {
+    if (historyIndex >= historyRef.current.length - 1) return;
+    const next = historyRef.current[historyIndex + 1];
+    setHistoryIndex(historyIndex + 1);
+    // Use setModeState (not setMode) to avoid clearing editing state/history
+    // when replaying a snapshot whose mode differs from the current one.
+    setModeState(next.mode);
+    setPendingFields(next.pendingFields);
+    setSelectedField(next.selectedFieldName);
+    setModifiedFields(next.modifiedFields);
+    setDeletedFieldNames(next.deletedFieldNames);
+  }, [historyIndex]);
+
+  const canUndo = historyIndex > 0;
+  const canRedo = historyIndex < historyRef.current.length - 1;
 
   const clearEditingState = useCallback(() => {
     setCreationType(null);
@@ -500,11 +453,9 @@ export function FormFillProvider({
     setSelectedField(null);
     setModifiedFields({});
     setDeletedFieldNames([]);
-    editedFileIdRef.current = null;
-    // Report and field list both describe the batch just discarded, so neither outlives it.
-    bundledFieldsRef.current = null;
-    setSkippedEdits([]);
-    setSkippedTotal(0);
+    // Clear history when explicitly clearing editing state
+    historyRef.current = [];
+    setHistoryIndex(-1);
   }, []);
 
   const fetchFields = useCallback(
@@ -516,115 +467,63 @@ export function FormFillProvider({
       // correctly discarded.
       const version = ++fetchVersionRef.current;
 
-      // Staged edits reference the previous document's fields; committing them against a
-      // different file would edit the wrong PDF. Checked here, before any await, because
-      // forFileIdRef is null for the whole fetch and the success path may never run.
-      if (
-        editedFileIdRef.current != null &&
-        (fileId ?? null) !== editedFileIdRef.current
-      ) {
-        clearEditingState();
-      }
-      // A commit produces a new file id, so the first fetch after one adopts the report;
-      // any later switch to a different document clears it.
-      if (skipReportFileIdRef.current === PENDING_SKIP_REPORT) {
-        skipReportFileIdRef.current = fileId ?? null;
-      } else if (
-        skipReportFileIdRef.current != null &&
-        (fileId ?? null) !== skipReportFileIdRef.current
-      ) {
-        skipReportFileIdRef.current = null;
-        setSkippedEdits([]);
-        setSkippedTotal(0);
-      }
-
-      // Same document reloading means the typed values are still the user's; a different one
-      // means they belong to a document that is no longer open.
-      const sameDocument = (fileId ?? null) === lastKnownFileIdRef.current;
-      const carried =
-        retainedValuesRef.current?.fileId === (fileId ?? null)
-          ? retainedValuesRef.current.values
-          : sameDocument
-            ? { ...valuesStore.values }
-            : {};
-      retainedValuesRef.current = null;
-
-      lastKnownFileIdRef.current = fileId ?? null;
       // Immediately clear previous state so FormFieldOverlay's stale-file guards
       // prevent rendering fields from a previous document during the fetch.
       forFileIdRef.current = null;
       setForFileId(null);
       valuesStore.reset({});
       dispatch({ type: "RESET" });
-      // Deliberately keeps create/modify state: the viewer re-fetches on provider
-      // switch and file load, which must not wipe in-progress edits.
+      // NOTE: deliberately do NOT clear create/modify editing state here.
+      // EmbedPdfViewer re-fetches fields on provider switch and file load, and
+      // those background fetches must not wipe a user's in-progress drawn
+      // fields or staged edits. Editing state is cleared on explicit mode
+      // switch (setMode) and reset() instead.
       dispatch({ type: "FETCH_START" });
       try {
-        // Only pdfbox mode can use them: the bundle is PDFBox's own view of the document.
-        const bundled = bundledFieldsRef.current;
-        bundledFieldsRef.current = null;
-        const usable =
-          bundled &&
-          bundled.size === file.size &&
-          providerModeRef.current === "pdfbox";
-        let fields = usable
-          ? bundled.fields
-          : await providerRef.current.fetchFields(file);
+        console.debug(`[FormFill] Fetching fields for file size: ${file.size}, version: ${version}`);
+        let fields = await providerRef.current.fetchFields(file);
+        console.debug(`[FormFill] Fetched ${fields.length} fields. version: ${version}, current: ${fetchVersionRef.current}`);
         // If another fetch or reset happened while we were waiting, discard this result
         if (fetchVersionRef.current !== version) {
-          console.debug(
-            "[FormFill] Discarding stale fetch result (version mismatch)",
-          );
+          console.debug("[FormFill] Discarding stale fetch result (version mismatch)");
           return;
         }
 
-        // pdfbox returns signature fields without a rendered appearance; merge the
-        // pdfium ones by name, since appending would list a signature twice.
+        // The pdfbox backend returns signature fields, but without a rendered
+        // appearance. Fetch the rendered signature appearances via pdfium and
+        // MERGE them by name — enrich an existing backend entry rather than
+        // appending a duplicate (otherwise a signature shows up twice).
         if (providerModeRef.current === "pdfbox") {
           try {
             // Convert File/Blob to ArrayBuffer for pdfiumService
             const arrayBuffer = await file.arrayBuffer();
-            const sigFields =
-              await fetchSignatureFieldsWithAppearances(arrayBuffer);
+            const sigFields = await fetchSignatureFieldsWithAppearances(arrayBuffer);
             if (fetchVersionRef.current !== version) return; // stale check after async
             fields = mergeSignatureAppearances(fields, sigFields);
           } catch (e) {
-            console.warn(
-              "[FormFill] Failed to extract signature appearances for pdfbox mode:",
-              e,
-            );
+            console.warn("[FormFill] Failed to extract signature appearances for pdfbox mode:", e);
           }
         }
 
         // Initialise values in the external store
         const values: Record<string, string> = {};
-        let edited = false;
         for (const field of fields) {
-          const stored = field.value ?? "";
-          values[field.name] = carried[field.name] ?? stored;
-          edited = edited || values[field.name] !== stored;
+          values[field.name] = field.value ?? "";
         }
         valuesStore.reset(values);
         forFileIdRef.current = fileId ?? null;
         setForFileId(fileId ?? null);
         dispatch({ type: "FETCH_SUCCESS", fields });
-        // After FETCH_SUCCESS, which clears the flag; and only when a value genuinely differs,
-        // or the unsaved-changes prompt cries wolf on every navigation.
-        if (edited) {
-          dispatch({ type: "MARK_DIRTY" });
-        }
       } catch (err) {
         if (fetchVersionRef.current !== version) return; // stale
         const msg =
-          (isAxiosError<{ message?: string }>(err)
-            ? err.response?.data?.message
-            : undefined) ||
+          (isAxiosError<{ message?: string }>(err) ? err.response?.data?.message : undefined) ||
           (err instanceof Error ? err.message : undefined) ||
           "Failed to fetch form fields";
         dispatch({ type: "FETCH_ERROR", error: msg });
       }
     },
-    [valuesStore, clearEditingState],
+    [valuesStore],
   );
 
   const validateFieldDebounced = useDebouncedCallback((fieldName: string) => {
@@ -661,8 +560,9 @@ export function FormFillProvider({
     (fieldName: string, value: string) => {
       // Update external store (triggers per-field subscribers only)
       valuesStore.setValue(fieldName, value);
-      // Mark form as dirty in React state (only triggers re-render once)
+      // Mark form as dirty
       dispatch({ type: "MARK_DIRTY" });
+      // Run validation for required fields
       validateFieldDebounced(fieldName);
     },
     [valuesStore, validateFieldDebounced],
@@ -673,62 +573,23 @@ export function FormFillProvider({
   }, []);
 
   const submitForm = useCallback(
-    async (file: File | Blob, flatten = false) => {
-      const blob = await providerRef.current.fillForm(
-        file,
-        valuesStore.values,
-        flatten,
-      );
-      dispatch({ type: "MARK_CLEAN" });
+    async (file: File | Blob, flatten = false): Promise<Blob> => {
+      const values = valuesStore.values;
+      const blob = await providerRef.current.fillForm(file, values, flatten);
       return blob;
     },
     [valuesStore],
   );
 
-  const setProviderMode = useCallback(
-    (mode: "pdflib" | "pdfbox") => {
-      // Use the ref to check the current mode synchronously — avoids
-      // relying on stale closure state and allows the early return.
-      if (providerModeRef.current === mode) return;
-
-      // provider (pdfbox vs pdflib).
-      const newProvider = mode === "pdfbox" ? pdfBoxProvider : pdfiumProvider;
-      providerRef.current = newProvider;
-      providerModeRef.current = mode;
-
-      fetchVersionRef.current++;
-      forFileIdRef.current = null;
-      setForFileId(null);
-      // The viewer re-fetches straight after this, and that fetch is where they are restored.
-      retainedValuesRef.current = {
-        fileId: lastKnownFileIdRef.current,
-        values: { ...valuesStore.values },
-      };
-      valuesStore.reset({});
-      dispatch({ type: "RESET" });
-
-      setProviderModeState(mode);
-    },
-    [valuesStore],
-  );
-
-  const getField = useCallback(
-    (fieldName: string) => fieldsRef.current.find((f) => f.name === fieldName),
-    [],
-  );
+  const getField = useCallback((fieldName: string) => fieldsRef.current.find((f) => f.name === fieldName), []);
 
   const getFieldsForPage = useCallback(
     (pageIndex: number) =>
-      fieldsRef.current.filter((f) =>
-        f.widgets?.some((w: WidgetCoordinates) => w.pageIndex === pageIndex),
-      ),
+      fieldsRef.current.filter((f) => f.widgets?.some((w: WidgetCoordinates) => w.pageIndex === pageIndex)),
     [],
   );
 
-  const getValue = useCallback(
-    (fieldName: string) => valuesStore.getValue(fieldName),
-    [valuesStore],
-  );
+  const getValue = useCallback((fieldName: string) => valuesStore.getValue(fieldName), [valuesStore]);
 
   const reset = useCallback(() => {
     // Increment version to invalidate any in-flight fetch
@@ -754,11 +615,25 @@ export function FormFillProvider({
     [clearEditingState],
   );
 
+  const setProviderMode = useCallback(
+    (next: "pdflib" | "pdfbox") => {
+      if (providerModeRef.current === next) return;
+      // Switch provider and reset form state
+      providerModeRef.current = next;
+      setProviderModeState(next);
+      fetchVersionRef.current++;
+      forFileIdRef.current = null;
+      setForFileId(null);
+      valuesStore.reset({});
+      dispatch({ type: "RESET" });
+      clearEditingState();
+    },
+    [valuesStore, clearEditingState],
+  );
+
   // --- Create mode ---
   const addPendingField = useCallback(
     (field: Omit<NewFieldDefinition, "name"> & { name?: string }): string => {
-      rememberForUndo();
-      editedFileIdRef.current = lastKnownFileIdRef.current;
       const seq = ++pendingCounterRef.current;
       const id = `pending-${seq}`;
       // Friendly, readable default names that match how the viewer labels
@@ -772,41 +647,41 @@ export function FormFillProvider({
         button: "Button",
         signature: "Signature",
       };
-      const defaultName =
-        field.name?.trim() ||
-        `${TYPE_DEFAULT_NAME[field.type] ?? "Field"} ${seq}`;
-      // Choice/radio fields are useless without options, so seed defaults.
-      const needsOptions =
-        field.type === "combobox" ||
-        field.type === "listbox" ||
-        field.type === "radio";
-      const options =
-        field.options ?? (needsOptions ? ["Option 1", "Option 2"] : undefined);
-      setPendingFields((prev) => [
-        ...prev,
-        { ...field, name: defaultName, options, id } as PendingField,
-      ]);
+      const defaultName = field.name?.trim() || `${TYPE_DEFAULT_NAME[field.type] ?? "Field"} ${seq}`;
+      // Choice/radio fields need options to be useful — seed a sensible default
+      // so the field isn't empty and the options editor has something to show.
+      const needsOptions = field.type === "combobox" || field.type === "listbox" || field.type === "radio";
+      const options = field.options ?? (needsOptions ? ["Option 1", "Option 2"] : undefined);
+      setPendingFields((prev) => {
+        const next = [...prev, { ...field, name: defaultName, options, id } as PendingField];
+        saveToHistory({ pendingFields: next });
+        return next;
+      });
       return id;
     },
-    [],
+    [saveToHistory],
   );
 
   const updatePendingField = useCallback(
     (id: string, patch: Partial<NewFieldDefinition>) => {
-      rememberForUndo();
-      setPendingFields((prev) =>
-        prev.map((f) => (f.id === id ? { ...f, ...patch } : f)),
-      );
+      setPendingFields((prev) => {
+        const next = prev.map((f) => (f.id === id ? { ...f, ...patch } : f));
+        saveToHistory({ pendingFields: next });
+        return next;
+      });
     },
-    [],
+    [saveToHistory],
   );
 
   const removePendingField = useCallback(
     (id: string) => {
-      rememberForUndo();
-      setPendingFields((prev) => prev.filter((f) => f.id !== id));
+      setPendingFields((prev) => {
+        const next = prev.filter((f) => f.id !== id);
+        saveToHistory({ pendingFields: next });
+        return next;
+      });
     },
-    [rememberForUndo],
+    [saveToHistory],
   );
 
   const clearPendingFields = useCallback(() => {
@@ -817,22 +692,16 @@ export function FormFillProvider({
   const commitNewFields = useCallback(
     async (file: File | Blob): Promise<Blob> => {
       // Strip the client-side id before sending to the backend.
-      const definitions: NewFieldDefinition[] = pendingFields.map(
-        ({ id: _id, ...rest }) => rest,
-      );
-      const result = await applyFieldEdits(file, { add: definitions });
-      bundledFieldsRef.current = result.fields
-        ? { fields: result.fields, size: result.blob.size }
-        : null;
-      setSkippedEdits(result.skipped);
-      setSkippedTotal(result.skippedTotal);
-      skipReportFileIdRef.current = PENDING_SKIP_REPORT;
+      const definitions: NewFieldDefinition[] = pendingFields.map(({ id: _id, ...rest }) => rest);
+      const blob = await applyFieldEdits(file, { add: definitions });
       setPendingFields([]);
       setCreationType(null);
-      // The batch is gone, so the stamp must not survive to trigger a clear on the
-      // post-commit re-fetch; that would wipe the skip report we just set.
-      editedFileIdRef.current = null;
-      return result.blob;
+      // Clear undo/redo history after a successful commit so the user can't
+      // undo back to pre-commit pending state that no longer matches the PDF.
+      historyRef.current = [];
+      setHistoryIndex(-1);
+      historyIndexRef.current = -1;
+      return blob;
     },
     [pendingFields],
   );
@@ -840,68 +709,75 @@ export function FormFillProvider({
   // --- Modify mode ---
   const stageModification = useCallback(
     (targetName: string, patch: Partial<ModifyFieldDefinition>) => {
-      rememberForUndo();
-      editedFileIdRef.current = lastKnownFileIdRef.current;
-      setModifiedFields((prev) => ({
-        ...prev,
-        [targetName]: { ...prev[targetName], targetName, ...patch },
-      }));
+      setModifiedFields((prev) => {
+        const next = {
+          ...prev,
+          [targetName]: { ...prev[targetName], targetName, ...patch },
+        };
+        saveToHistory({ modifiedFields: next });
+        return next;
+      });
     },
-    [],
+    [saveToHistory],
   );
 
-  const clearModification = useCallback((targetName: string) => {
-    setModifiedFields((prev) => {
-      if (!(targetName in prev)) return prev;
-      const { [targetName]: _removed, ...rest } = prev;
-      return rest;
-    });
-  }, []);
+  const clearModification = useCallback(
+    (targetName: string) => {
+      setModifiedFields((prev) => {
+        if (!(targetName in prev)) return prev;
+        const { [targetName]: _removed, ...rest } = prev;
+        saveToHistory({ modifiedFields: rest });
+        return rest;
+      });
+    },
+    [saveToHistory],
+  );
 
-  const toggleFieldDeleted = useCallback((name: string) => {
-    rememberForUndo();
-    editedFileIdRef.current = lastKnownFileIdRef.current;
-    setDeletedFieldNames((prev) =>
-      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
-    );
-  }, []);
+  const toggleFieldDeleted = useCallback(
+    (name: string) => {
+      setDeletedFieldNames((prev) => {
+        const next = prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name];
+        saveToHistory({ deletedFieldNames: next });
+        return next;
+      });
+    },
+    [saveToHistory],
+  );
 
   const clearModifications = useCallback(() => {
     setModifiedFields({});
     setDeletedFieldNames([]);
     setSelectedField(null);
-  }, []);
+    saveToHistory({
+      mode: "modify",
+      pendingFields: [],
+      selectedFieldName: null,
+      modifiedFields: {},
+      deletedFieldNames: [],
+    });
+  }, [saveToHistory]);
 
   const commitModifications = useCallback(
     async (file: File | Blob): Promise<Blob> => {
       // Apply property/geometry changes (for fields not being deleted) and the
-      // deletions in a single backend round-trip.
-      const updates = Object.values(modifiedFields).filter(
-        (m) => !deletedFieldNames.includes(m.targetName),
-      );
-      const result = await applyFieldEdits(file, {
+      // deletions in a single backend round-trip. Set lookup keeps this linear
+      // rather than O(modified x deleted) on field-heavy documents.
+      const deletedSet = new Set(deletedFieldNames);
+      const updates = Object.values(modifiedFields).filter((m) => !deletedSet.has(m.targetName));
+      const blob = await applyFieldEdits(file, {
         modify: updates,
         delete: deletedFieldNames,
       });
-      bundledFieldsRef.current = result.fields
-        ? { fields: result.fields, size: result.blob.size }
-        : null;
-      setSkippedEdits(result.skipped);
-      setSkippedTotal(result.skippedTotal);
-      skipReportFileIdRef.current = PENDING_SKIP_REPORT;
       setModifiedFields({});
       setDeletedFieldNames([]);
       setSelectedField(null);
-      editedFileIdRef.current = null;
-      return result.blob;
+      return blob;
     },
     [modifiedFields, deletedFieldNames],
   );
 
   const hasUncommittedChanges =
-    pendingFields.length > 0 ||
-    Object.keys(modifiedFields).length > 0 ||
-    deletedFieldNames.length > 0;
+    pendingFields.length > 0 || Object.keys(modifiedFields).length > 0 || deletedFieldNames.length > 0;
 
   const fieldsByPage = useMemo(() => {
     const map = new Map<number, FormField[]>();
@@ -912,24 +788,6 @@ export function FormFillProvider({
     }
     return map;
   }, [state.fields]);
-
-  /**
-   * The fields as they would look once the staged edits are applied. Drawing from this keeps one
-   * visual per field that follows a drag, instead of a stale copy left at the old coordinates.
-   */
-  const effectiveFieldsByPage = useMemo(() => {
-    const map = new Map<number, FormField[]>();
-    const deleted = new Set(deletedFieldNames);
-    for (const field of state.fields) {
-      if (deleted.has(field.name)) continue;
-      const staged = modifiedFields[field.name];
-      const effective = staged ? applyStagedGeometry(field, staged) : field;
-      const pageIdx = effective.widgets?.[0]?.pageIndex ?? 0;
-      if (!map.has(pageIdx)) map.set(pageIdx, []);
-      map.get(pageIdx)!.push(effective);
-    }
-    return map;
-  }, [state.fields, modifiedFields, deletedFieldNames]);
 
   // Context value — does NOT depend on values, so keystrokes don't
   // trigger re-renders of all context consumers.
@@ -946,7 +804,6 @@ export function FormFillProvider({
       validateForm,
       reset,
       fieldsByPage,
-      effectiveFieldsByPage,
       activeProviderName: providerRef.current.name,
       setProviderMode,
       forFileId,
@@ -954,10 +811,6 @@ export function FormFillProvider({
       mode,
       setMode,
       creationType,
-      previewing,
-      setPreviewing,
-      undo,
-      canUndo,
       setCreationType,
       pendingFields,
       addPendingField,
@@ -975,10 +828,11 @@ export function FormFillProvider({
       clearModifications,
       commitModifications,
       hasUncommittedChanges,
-      skippedEdits,
-      skippedTotal,
-      clearSkippedEdits,
-      dragActiveRef,
+      // undo/redo
+      undo,
+      redo,
+      canUndo,
+      canRedo,
     }),
     [
       state,
@@ -992,17 +846,12 @@ export function FormFillProvider({
       validateForm,
       reset,
       fieldsByPage,
-      effectiveFieldsByPage,
       providerMode,
       setProviderMode,
       forFileId,
       mode,
       setMode,
       creationType,
-      previewing,
-      setPreviewing,
-      undo,
-      canUndo,
       pendingFields,
       addPendingField,
       updatePendingField,
@@ -1010,6 +859,7 @@ export function FormFillProvider({
       clearPendingFields,
       commitNewFields,
       selectedFieldName,
+      setSelectedField,
       modifiedFields,
       stageModification,
       clearModification,
@@ -1018,43 +868,18 @@ export function FormFillProvider({
       clearModifications,
       commitModifications,
       hasUncommittedChanges,
-      skippedEdits,
-      skippedTotal,
-      clearSkippedEdits,
-      dragActiveRef,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
     ],
   );
 
   return (
     <FormValuesStoreContext.Provider value={valuesStore}>
-      <FormFillContext.Provider value={value}>
-        {children}
-      </FormFillContext.Provider>
+      <FormFillContext.Provider value={value}>{children}</FormFillContext.Provider>
     </FormValuesStoreContext.Provider>
   );
 }
 
 export default FormFillContext;
-
-/**
- * Fields whose PDF-baked visuals (button and signature appearance bitmaps) no longer match the
- * staged state. Those layers render from the un-edited file, so they must be hidden while editing
- * or they leave a ghost at the original rect.
- */
-export function useStaleBakedFieldNames(): Set<string> {
-  // Read the context directly: the viewer's appearance overlays render outside the form tool
-  // (and in isolation in Storybook), where there is no provider and nothing is staged.
-  const ctx = useContext(FormFillContext);
-  const mode = ctx?.mode ?? "fill";
-  const modifiedFields = ctx?.modifiedFields;
-  const deletedFieldNames = ctx?.deletedFieldNames;
-  return useMemo(() => {
-    if (mode === "fill" || !modifiedFields || !deletedFieldNames) {
-      return new Set<string>();
-    }
-    return new Set<string>([
-      ...Object.keys(modifiedFields),
-      ...deletedFieldNames,
-    ]);
-  }, [mode, modifiedFields, deletedFieldNames]);
-}


### PR DESCRIPTION
Adds a complete form field editing workflow to the Stirling-PDF frontend and strengthens the backend form processing utility.

### Frontend
- **Create mode**: drag-to-create overlay supporting text, checkbox, radio group, dropdown, list box, and signature placeholder fields
- **Modify mode**: left-panel property editor with field selection, movement, resizing, keyboard navigation, and delete staging
- **Undo/redo**: structural history with accessible undo/redo buttons
- **Commit lifecycle**: typed `formfill:apply` event, EmbedPdfViewer reload with viewer state preserved, FileContext integration
- **Theme compliance**: all colors use semantic CSS tokens (`var(--c-*)`), no raw hex or rgba
- **PageEditorContext**: removed untyped `window` global coordination (superseded by typed event flow)

### Backend (FormUtils)
- **Log safety**: `sanitizeForLog()` strips CR/LF from field names at all `log.warn` call sites, preventing CWE-117 log forging
- **Choice option fix**: trimmed option value is now stored canonically
- **Name uniqueness fix**: `collectExistingFieldNames` now includes partial names to prevent generated name collisions
- **Schema docs**: `FormFieldWithCoordinates` x/y `@Schema` descriptions corrected

### Tests
- 4 new `FormUtilsGapTest` regression tests
- Frontend stubbed and live form-field-editing test suites
