### PR TITLE
fix(desktop): stop mounting two features whose endpoints the installer does not ship

### DIFF
--- a/frontend/editor/src/cloud/hooks/useFreeCreditsSummary.ts
+++ b/frontend/editor/src/cloud/hooks/useFreeCreditsSummary.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useWallet } from "@app/hooks/useWallet";
+import { useWallet, type UseWalletOptions } from "@app/hooks/useWallet";
 import {
   readCachedCredits,
   writeCachedCredits,
@@ -31,8 +31,11 @@ function toCredits(
  * animates in. The seed is read once, at first render: later reads would fight
  * the live value, and the whole point is that the row stops moving.
  */
-export function useFreeCreditsSummary(): NavFooterCredits | null {
-  const { wallet } = useWallet();
+export function useFreeCreditsSummary(
+  options?: UseWalletOptions,
+): NavFooterCredits | null {
+  const enabled = options?.enabled ?? true;
+  const { wallet } = useWallet({ enabled });
   const [seed] = useState(readCachedCredits);
 
   const live = wallet
@@ -42,9 +45,13 @@ export function useFreeCreditsSummary(): NavFooterCredits | null {
   // useWallet reuses the snapshot reference when nothing changed, so keying on
   // it writes only on a real change, not on every render.
   useEffect(() => {
-    if (live !== undefined) writeCachedCredits(live);
+    if (enabled && live !== undefined) writeCachedCredits(live);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wallet]);
+  }, [enabled, wallet]);
 
+  // Disabled gates the seed as well as the fetch, the way the portal gates both on linkage: the
+  // cache outlives the build that wrote it, so a desktop that once ran against the cloud would
+  // otherwise keep showing that session's figures with nothing left to refresh them.
+  if (!enabled) return null;
   return (live !== undefined ? live : seed) ?? null;
 }

--- a/frontend/editor/src/cloud/hooks/useWallet.ts
+++ b/frontend/editor/src/cloud/hooks/useWallet.ts
@@ -193,7 +193,18 @@ function reuseIfEqual(prev: Wallet | null, next: Wallet): Wallet {
  */
 const WALLET_POLL_MS = 30_000;
 
-export function useWallet(): UseWalletResult {
+export interface UseWalletOptions {
+  /**
+   * False stops this hook reading the wallet at all. For a build wired to a backend that serves
+   * no {@code /api/v1/payg} route — the desktop installer bundles one — asking is a 404 the user
+   * sees, on mount and again on every poll.
+   */
+  enabled?: boolean;
+}
+
+export function useWallet(options?: UseWalletOptions): UseWalletResult {
+  const enabled = options?.enabled ?? true;
+
   // Resolved once: the dev-preview side-channel when rendered outside the real
   // app (saas /dev/payg-preview route), else null (every real build + desktop).
   // The detection + synthesis live behind the @app/hooks/walletDevPreview seam
@@ -228,6 +239,13 @@ export function useWallet(): UseWalletResult {
   const silentRefresh = useRef(false);
 
   useEffect(() => {
+    if (!enabled) {
+      setWallet(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
     const reqId = ++latestReqId.current;
     let cancelled = false;
 
@@ -282,7 +300,7 @@ export function useWallet(): UseWalletResult {
       // still see a definitive "load completed" point. The reqId guard
       // upstream ensures stale results don't commit.
     };
-  }, [devPreview, refetchTick]);
+  }, [devPreview, enabled, refetchTick]);
 
   // The wallet drains as automation, AI and API work runs, so a figure fetched
   // on mount goes stale while the user watches it. Refresh on a timer, and
@@ -290,7 +308,7 @@ export function useWallet(): UseWalletResult {
   // case people actually notice. Hidden tabs don't poll, and the dev-preview
   // wallet is synthesised locally so there is nothing to re-read.
   useEffect(() => {
-    if (devPreview) return;
+    if (!enabled || devPreview) return;
 
     let timer: ReturnType<typeof setInterval> | undefined;
     const refresh = () => {
@@ -322,7 +340,7 @@ export function useWallet(): UseWalletResult {
       stop();
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [devPreview]);
+  }, [devPreview, enabled]);
 
   const refetch = useCallback(async () => {
     setRefetchTick((t) => t + 1);

--- a/frontend/editor/src/desktop/components/notifications/useNotificationsAvailable.test.ts
+++ b/frontend/editor/src/desktop/components/notifications/useNotificationsAvailable.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getCurrentModeMock, subscribeToModeChangesMock } = vi.hoisted(() => ({
+  getCurrentModeMock: vi.fn(),
+  subscribeToModeChangesMock: vi.fn(),
+}));
+
+vi.mock("@app/services/connectionModeService", () => ({
+  connectionModeService: {
+    getCurrentMode: getCurrentModeMock,
+    subscribeToModeChanges: subscribeToModeChangesMock,
+  },
+}));
+
+import { useNotificationsAvailable } from "@app/components/notifications/useNotificationsAvailable";
+
+// Resolved through @app/*, which is how NotificationBell reaches it: desktop must win over the
+// proprietary answer, or this is the proprietary hook and the assertions below pass for nothing.
+describe("useNotificationsAvailable (desktop)", () => {
+  beforeEach(() => {
+    getCurrentModeMock.mockReset();
+    subscribeToModeChangesMock.mockReset();
+    subscribeToModeChangesMock.mockReturnValue(() => {});
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("says no in local mode: the bundled backend serves no notification route", async () => {
+    getCurrentModeMock.mockResolvedValue("local");
+    const { result } = renderHook(() => useNotificationsAvailable());
+    await act(async () => {});
+    expect(result.current).toBe(false);
+  });
+
+  it("says no until the mode is known, so a cold start polls nothing", () => {
+    getCurrentModeMock.mockReturnValue(new Promise<never>(() => {}));
+    const { result } = renderHook(() => useNotificationsAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it.each(["saas", "selfhosted"])(
+    "says yes against a %s server, which does serve them",
+    async (mode) => {
+      getCurrentModeMock.mockResolvedValue(mode);
+      const { result } = renderHook(() => useNotificationsAvailable());
+      await waitFor(() => expect(result.current).toBe(true));
+    },
+  );
+});

--- a/frontend/editor/src/desktop/components/notifications/useNotificationsAvailable.ts
+++ b/frontend/editor/src/desktop/components/notifications/useNotificationsAvailable.ts
@@ -1,0 +1,14 @@
+import { useConfirmedRemoteMode } from "@app/hooks/useConfirmedRemoteMode";
+
+/**
+ * Desktop reads notifications off whichever Stirling server it is connected to, and has none of
+ * its own: the backend in the installer is built without {@code :proprietary}, so
+ * {@code /api/v1/notifications} is not a route it serves.
+ *
+ * Without this seam the desktop build inherits the proprietary answer — an unconditional yes —
+ * because {@code @app/*} resolves desktop → cloud → proprietary → core. The bell then mounts on a
+ * local install and polls a route that 404s, which is what the core stub exists to prevent.
+ */
+export function useNotificationsAvailable(): boolean {
+  return useConfirmedRemoteMode();
+}

--- a/frontend/editor/src/desktop/hooks/useConfirmedRemoteMode.test.ts
+++ b/frontend/editor/src/desktop/hooks/useConfirmedRemoteMode.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getCurrentModeMock, subscribeToModeChangesMock } = vi.hoisted(() => ({
+  getCurrentModeMock: vi.fn(),
+  subscribeToModeChangesMock: vi.fn(),
+}));
+
+vi.mock("@app/services/connectionModeService", () => ({
+  connectionModeService: {
+    getCurrentMode: getCurrentModeMock,
+    subscribeToModeChanges: subscribeToModeChangesMock,
+  },
+}));
+
+import { useConfirmedRemoteMode } from "@app/hooks/useConfirmedRemoteMode";
+
+describe("useConfirmedRemoteMode", () => {
+  beforeEach(() => {
+    getCurrentModeMock.mockReset();
+    subscribeToModeChangesMock.mockReset();
+    subscribeToModeChangesMock.mockReturnValue(() => {});
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("starts false before the mode resolves (pessimistic)", () => {
+    getCurrentModeMock.mockReturnValue(new Promise<never>(() => {}));
+    const { result } = renderHook(() => useConfirmedRemoteMode());
+    expect(result.current).toBe(false);
+  });
+
+  it("stays false in local mode, where the bundled backend answers", async () => {
+    getCurrentModeMock.mockResolvedValue("local");
+    const { result } = renderHook(() => useConfirmedRemoteMode());
+    await act(async () => {});
+    expect(result.current).toBe(false);
+  });
+
+  it.each(["saas", "selfhosted"])(
+    "becomes true once the mode is confirmed %s",
+    async (mode) => {
+      getCurrentModeMock.mockResolvedValue(mode);
+      const { result } = renderHook(() => useConfirmedRemoteMode());
+      await waitFor(() => expect(result.current).toBe(true));
+    },
+  );
+
+  it("reacts to a later mode change", async () => {
+    getCurrentModeMock.mockResolvedValue("local");
+    let notify: ((cfg: { mode: string }) => void) | undefined;
+    subscribeToModeChangesMock.mockImplementation(
+      (cb: (cfg: { mode: string }) => void) => {
+        notify = cb;
+        return () => {};
+      },
+    );
+
+    const { result } = renderHook(() => useConfirmedRemoteMode());
+    await act(async () => {});
+    expect(result.current).toBe(false);
+
+    await act(async () => notify?.({ mode: "selfhosted" }));
+    expect(result.current).toBe(true);
+
+    await act(async () => notify?.({ mode: "local" }));
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/editor/src/desktop/hooks/useConfirmedRemoteMode.ts
+++ b/frontend/editor/src/desktop/hooks/useConfirmedRemoteMode.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { connectionModeService } from "@app/services/connectionModeService";
+
+/**
+ * Whether this desktop is confirmed to be talking to a Stirling server — SaaS or self-hosted —
+ * rather than to the backend it ships with.
+ *
+ * The bundled backend is built by {@code .taskfiles/desktop.yml} with
+ * {@code DISABLE_ADDITIONAL_FEATURES: "true"}, which leaves {@code :proprietary} out of the jar. A
+ * server has it. So a surface that reads a proprietary endpoint may mount here only once the mode
+ * is known to be remote.
+ *
+ * Starts pessimistically FALSE for the same reason as {@link useConfirmedSaaSMode}: an optimistic
+ * start mounts the gated surface on cold start and fires its mount fetch at the local backend
+ * before the real mode arrives, which is the request the gate exists to prevent.
+ */
+export function useConfirmedRemoteMode(): boolean {
+  const [isRemote, setIsRemote] = useState(false);
+
+  useEffect(() => {
+    void connectionModeService
+      .getCurrentMode()
+      .then((mode) => setIsRemote(mode === "saas" || mode === "selfhosted"));
+    return connectionModeService.subscribeToModeChanges((cfg) =>
+      setIsRemote(cfg.mode === "saas" || cfg.mode === "selfhosted"),
+    );
+  }, []);
+
+  return isRemote;
+}

--- a/frontend/editor/src/desktop/hooks/useFreeCreditsSummary.test.tsx
+++ b/frontend/editor/src/desktop/hooks/useFreeCreditsSummary.test.tsx
@@ -1,0 +1,72 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getCurrentModeMock, subscribeToModeChangesMock, apiGetMock } =
+  vi.hoisted(() => ({
+    getCurrentModeMock: vi.fn(),
+    subscribeToModeChangesMock: vi.fn(),
+    apiGetMock: vi.fn(),
+  }));
+
+vi.mock("@app/services/connectionModeService", () => ({
+  connectionModeService: {
+    getCurrentMode: getCurrentModeMock,
+    subscribeToModeChanges: subscribeToModeChangesMock,
+  },
+}));
+
+vi.mock("@app/services/apiClient", () => ({
+  default: { get: apiGetMock },
+}));
+
+// useWallet imports the Stripe portal seam, which on desktop builds a Supabase client at module
+// load and throws without its env vars. The footer meter never mints a portal session.
+vi.mock("@app/services/billing", () => ({
+  createPortalSession: vi.fn(),
+}));
+
+import { useFreeCreditsSummary } from "@app/hooks/useFreeCreditsSummary";
+
+const WALLET = {
+  status: "free",
+  freeRemaining: 120,
+  freeAllowance: 500,
+};
+
+describe("useFreeCreditsSummary (desktop)", () => {
+  beforeEach(() => {
+    getCurrentModeMock.mockReset();
+    subscribeToModeChangesMock.mockReset();
+    subscribeToModeChangesMock.mockReturnValue(() => {});
+    apiGetMock.mockReset();
+    apiGetMock.mockResolvedValue({ data: WALLET });
+    window.localStorage.clear();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it.each(["local", "selfhosted"])(
+    "reads no wallet in %s mode, where nothing serves one",
+    async (mode) => {
+      getCurrentModeMock.mockResolvedValue(mode);
+      const { result } = renderHook(() => useFreeCreditsSummary());
+      await act(async () => {});
+      expect(apiGetMock).not.toHaveBeenCalled();
+      expect(result.current).toBeNull();
+    },
+  );
+
+  it("asks for nothing before the mode resolves", () => {
+    getCurrentModeMock.mockReturnValue(new Promise<never>(() => {}));
+    renderHook(() => useFreeCreditsSummary());
+    expect(apiGetMock).not.toHaveBeenCalled();
+  });
+
+  it("reads the wallet once signed in to the cloud", async () => {
+    getCurrentModeMock.mockResolvedValue("saas");
+    const { result } = renderHook(() => useFreeCreditsSummary());
+    await waitFor(() =>
+      expect(result.current).toEqual({ remaining: 120, total: 500 }),
+    );
+    expect(apiGetMock).toHaveBeenCalledWith("/api/v1/payg/wallet");
+  });
+});

--- a/frontend/editor/src/desktop/hooks/useFreeCreditsSummary.ts
+++ b/frontend/editor/src/desktop/hooks/useFreeCreditsSummary.ts
@@ -1,0 +1,18 @@
+import { useFreeCreditsSummary as useCloudFreeCreditsSummary } from "@cloud/hooks/useFreeCreditsSummary";
+import { useConfirmedSaaSMode } from "@app/hooks/useConfirmedSaaSMode";
+import { type NavFooterCredits } from "@app/components/shared/navFooter/NavFooterCreditsRow";
+
+/**
+ * Free credits for the sidebar footer meter, read only when this desktop is signed in to Stirling
+ * Cloud. The wallet lives in the cloud even when the instance does not, so neither a local install
+ * nor a self-hosted server can answer for it — and the installer's own backend serves no
+ * {@code /api/v1/payg} route at all.
+ *
+ * Desktop needs its own seam because {@code @app/*} resolves desktop → cloud → proprietary → core:
+ * without one, every desktop build inherits the cloud reader and a local install asks the bundled
+ * backend for a wallet on mount and again every poll.
+ */
+export function useFreeCreditsSummary(): NavFooterCredits | null {
+  const isSaaSMode = useConfirmedSaaSMode();
+  return useCloudFreeCreditsSummary({ enabled: isSaaSMode });
+}


### PR DESCRIPTION
# Description of Changes

A freshly installed desktop build shows two error toasts on every start, and keeps polling behind them. Both are the desktop frontend calling routes the bundled backend does not serve.

Closes #7755

**What was wrong.** `tsconfig.desktop.vite.json` resolves `@app/*` as **desktop → cloud → proprietary → core**. Two features have a core stub saying "not available here" and a middle-layer implementation assuming it is, and neither had a `desktop/` seam — so the middle layer won:

| Call | `core` | Wins in desktop | In the installer's jar? |
| --- | --- | --- | --- |
| `/api/v1/notifications` | `useNotificationsAvailable() → false` | `proprietary/.../useNotificationsAvailable.ts → true` | no — `.taskfiles/desktop.yml` builds it with `DISABLE_ADDITIONAL_FEATURES=true`, which drops `:proprietary` |
| `/api/v1/payg/wallet` | `useFreeCreditsSummary() → null` | `cloud/hooks/useFreeCreditsSummary.ts` | no — `:saas` is never included |

`fetchNotifications` already catches its own failure, but `desktop/services/apiClient.ts` runs `handleHttpError` in the response interceptor first, so the toast is up before that catch runs.

**What changed**, using the seam mechanism this repo already defines rather than adding a new one:

- **`useConfirmedRemoteMode`**, a sibling of `useConfirmedSaaSMode`, answering "SaaS *or* self-hosted". Starts `false` for the reason its sibling documents: an optimistic start leaks exactly the mount fetch the gate exists to prevent.
- **A desktop seam for the bell**, gated on that hook. Not switched off — a desktop pointed at a real server reaches a backend that does serve notifications, and that bell works.
- **An optional `enabled` on `cloud/hooks/useWallet.ts`**, defaulting to `true`, so no current caller changes. Disabled means no mount fetch, no poll, **and no cached seed** — the seed matters as much as the fetch, since the cache outlives the build that wrote it and a client that once ran against the cloud would otherwise keep rendering that session's figures. That is the rule `portal/hooks/useFreeCreditsSummary.ts` already applies to linkage.
- **A desktop seam for the footer meter**, gated on `useConfirmedSaaSMode` — SaaS only, not "remote": the wallet is in the cloud even when the instance is not, which is why the portal reads it through `apiClient.saas`.

The portal needed its own seam for this same class of problem, and its comment reasons about self-hosted resolving `@app/*` as proprietary → core. Desktop is the case that reasoning skips, because there `cloud` **is** in the cascade.

**Tests.** `vitest.config.ts` already has a `desktop` project bound to `tsconfig.desktop.vite.json`, so the new tests resolve the real cascade and assert against `@app/*` — the path the components themselves import — rather than against the seam file directly. Both were run against the tree without the seams and fail there, which is the point: `useNotificationsAvailable` returned `true` in local mode (`expected true to be false`), and the footer issued its wallet request before the mode had resolved (`expected "spy" to not be called at all, but actually been called 1 times`).

No new user-facing strings, so no translation files are touched.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

<sub>The two UI checkboxes are unticked because the change removes two surfaces that had nothing to show on a local install: after it, the bell and the credits row are simply absent there, as they already are in a `core` build.</sub>
