### PR TITLE
Fix PDF Text Editor mangling characters outside WinAnsiEncoding (ő, ű, ů, ğ …)

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
+++ b/app/core/src/main/java/stirling/software/SPDF/service/PdfJsonConversionService.java
@@ -4192,10 +4192,13 @@ public class PdfJsonConversionService {
             // If standard encoding failed, fall through to Type3 glyph mapping (for subset fonts)
             // or return null to trigger fallback font
         } else if (!isType3Font || fontModel == null) {
-            // For non-Type3 fonts without Type3 metadata, use standard encoding
+            // For non-Type3 fonts without Type3 metadata, use standard encoding.
+            // The result goes out byte for byte: a character code indexes the font's own
+            // encoding and carries no ASCII meaning, so codes below 0x20 are ordinary - subset
+            // fonts hand them out from 0x01 up - and dropping them deletes glyphs. Hungarian
+            // "ő"/"ű" and other characters outside WinAnsiEncoding land there routinely.
             try {
-                byte[] encoded = font.encode(text);
-                return sanitizeEncoded(encoded);
+                return font.encode(text);
             } catch (IllegalArgumentException ex) {
                 log.debug(
                         "[FONT-DEBUG] Font {} cannot encode text '{}': {}",
@@ -4257,7 +4260,7 @@ public class PdfJsonConversionService {
             baos.write(charCode);
         }
         if (mappedAll) {
-            return sanitizeEncoded(baos.toByteArray());
+            return baos.toByteArray();
         }
         // Fallback to rawCharCodes for actual Type3 fonts if mapping failed
         if (rawCharCodes != null && !rawCharCodes.isEmpty()) {
@@ -4289,35 +4292,6 @@ public class PdfJsonConversionService {
             baos.write(code);
         }
         return baos.toByteArray();
-    }
-
-    private byte[] sanitizeEncoded(byte[] encoded) {
-        if (encoded == null || encoded.length == 0) {
-            return new byte[0];
-        }
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(encoded.length);
-        for (byte b : encoded) {
-            if (isStrippedControlByte(b)) {
-                continue;
-            }
-            baos.write(b);
-        }
-        byte[] sanitized = baos.toByteArray();
-        if (sanitized.length == 0) {
-            return sanitized;
-        }
-        return sanitized;
-    }
-
-    private boolean isStrippedControlByte(byte value) {
-        if (value == 0) {
-            return true;
-        }
-        int unsigned = Byte.toUnsignedInt(value);
-        if (unsigned <= 0x1F) {
-            return !(unsigned == 0x09 || unsigned == 0x0A || unsigned == 0x0D);
-        }
-        return false;
     }
 
     private int countGlyphs(COSString value, PDFont font) {

--- a/frontend/editor/src/core/tools/pdfTextEditor/pdfTextEditorUtils.test.ts
+++ b/frontend/editor/src/core/tools/pdfTextEditor/pdfTextEditorUtils.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { groupPageTextElements } from "@app/tools/pdfTextEditor/pdfTextEditorUtils";
+import type {
+  PdfJsonPage,
+  PdfJsonTextElement,
+} from "@app/tools/pdfTextEditor/pdfTextEditorTypes";
+
+const FONT_SIZE = 10;
+const SPACE_WIDTH = 2.78;
+const BASELINE = 700;
+
+/**
+ * Builds a text element the way PdfJsonConversionService emits them: position
+ * carried by the text matrix, width being the summed glyph advances of the run.
+ */
+const textElement = (
+  text: string,
+  x: number,
+  width: number,
+  fontId: string,
+): PdfJsonTextElement => ({
+  text,
+  fontId,
+  fontSize: FONT_SIZE,
+  fontMatrixSize: FONT_SIZE,
+  spaceWidth: SPACE_WIDTH,
+  width,
+  height: FONT_SIZE,
+  textMatrix: [1, 0, 0, 1, x, BASELINE],
+});
+
+const pageOf = (elements: PdfJsonTextElement[]): PdfJsonPage => ({
+  pageNumber: 1,
+  width: 595,
+  height: 842,
+  textElements: elements,
+});
+
+const groupTextOf = (elements: PdfJsonTextElement[]): string =>
+  groupPageTextElements(pageOf(elements), 0, undefined, "singleLine")
+    .map((group) => group.text)
+    .join("");
+
+describe("groupPageTextElements word reconstruction", () => {
+  it("keeps a word intact when a fallback font splits it mid-word", () => {
+    // A run only breaks where the text state changes. "ű" (U+0171) is outside
+    // WinAnsiEncoding, so producers emit it from a fallback font and the run
+    // splits mid-word - with the two halves still flush against each other.
+    const head = textElement("Középfeszültség", 100, 70, "F1");
+    const tail = textElement("ű", 170, 5.56, "F2");
+
+    expect(groupTextOf([head, tail])).toBe("Középfeszültségű");
+  });
+
+  it("keeps the spaces a run already carries", () => {
+    // Runs span whole phrases including their spaces, so nothing needs to be
+    // inserted for the word breaks inside one.
+    const head = textElement("HÁLÓZATON VÉGZEND", 100, 80, "F1");
+    const tail = textElement("Ő", 180, 6.5, "F2");
+
+    expect(groupTextOf([head, tail])).toBe("HÁLÓZATON VÉGZENDŐ");
+  });
+
+  it("inserts a space when the geometry shows a real gap", () => {
+    // Separately positioned runs - table cells, columns - carry no space glyph
+    // between them, so the gap is the only signal that a break belongs there.
+    const first = textElement("Középfeszültség", 100, 70, "F1");
+    const second = textElement("hálózat", 100 + 70 + SPACE_WIDTH, 33, "F1");
+
+    expect(groupTextOf([first, second])).toBe("Középfeszültség hálózat");
+  });
+});

--- a/frontend/editor/src/core/tools/pdfTextEditor/pdfTextEditorUtils.ts
+++ b/frontend/editor/src/core/tools/pdfTextEditor/pdfTextEditorUtils.ts
@@ -12,9 +12,8 @@ import {
 const LINE_TOLERANCE = 2;
 const GAP_FACTOR = 0.6;
 const SPACE_MIN_GAP = 1.5;
-const MIN_CHAR_WIDTH_FACTOR = 0.35;
-const MAX_CHAR_WIDTH_FACTOR = 1.25;
-const EXTRA_GAP_RATIO = 0.8;
+const SPACE_WIDTH_FALLBACK = 0.25;
+const SPACE_GAP_RATIO = 0.5;
 
 type FontMetrics = {
   unitsPerEm: number;
@@ -310,17 +309,6 @@ const getSpacingHint = (element: PdfJsonTextElement): number => {
   return Math.max(characterSpacing, 0);
 };
 
-const estimateCharWidth = (
-  element: PdfJsonTextElement,
-  avgFontSize: number,
-  metrics?: FontMetricsMap,
-): number => {
-  const rawWidth = getWidth(element, metrics);
-  const minWidth = avgFontSize * MIN_CHAR_WIDTH_FACTOR;
-  const maxWidth = avgFontSize * MAX_CHAR_WIDTH_FACTOR;
-  return Math.min(Math.max(rawWidth, minWidth), maxWidth);
-};
-
 const mergeBounds = (bounds: BoundingBox[]): BoundingBox => {
   if (bounds.length === 0) {
     return { left: 0, right: 0, top: 0, bottom: 0 };
@@ -344,21 +332,21 @@ const shouldInsertSpace = (
   const prevRight = getX(prev) + getWidth(prev, metrics);
   const trailingGap = Math.max(0, getX(current) - prevRight);
   const avgFontSize = (getFontSize(prev) + getFontSize(current)) / 2;
-  const baselineAdvance = Math.max(0, getX(current) - getX(prev));
-  const charWidthEstimate = estimateCharWidth(prev, avgFontSize, metrics);
-  const inferredGap = Math.max(0, baselineAdvance - charWidthEstimate);
-  const spacingHint = Math.max(
+
+  // Runs carry their own spaces: the extractor only breaks a run where the text
+  // state changes, which happens mid-word whenever the producer swaps font for
+  // a single glyph (non-WinAnsi characters such as "ő"/"ű" come from a fallback
+  // font). So a boundary is a word break only when the geometry shows one, and
+  // the yardstick is the font's own space: half of it is the usual threshold
+  // for deciding a gap was meant to be read as a space.
+  const spaceWidth = Math.max(
     SPACE_MIN_GAP,
     getSpacingHint(prev),
     getSpacingHint(current),
-    avgFontSize * GAP_FACTOR,
+    avgFontSize * SPACE_WIDTH_FALLBACK,
   );
 
-  if (trailingGap > spacingHint) {
-    return true;
-  }
-
-  if (inferredGap > spacingHint * EXTRA_GAP_RATIO) {
+  if (trailingGap > spaceWidth * SPACE_GAP_RATIO) {
     return true;
   }
 


### PR DESCRIPTION
# Description of Changes

The PDF Text Editor mangles text that uses characters outside `WinAnsiEncoding`. Two independent root causes, one per commit. Hungarian `ő`/`ű` are the clearest case, but the same holds for Czech `ů`, Turkish `ğ`, Polish and others — any character a producer has to address through an embedded subset's own codes.

## 1. Saving drops glyphs whose character code is below 0x20

`sanitizeEncoded` discarded every encoded byte in `0x01`–`0x1F`. A character code indexes the font's own encoding and carries no ASCII meaning — a font may place a glyph at `0x01`, and subset fonts routinely do — so this deleted glyphs from the rebuilt PDF, silently, with nothing logged.

The code already knew this was destructive. From the normalized-Type3 branch:

> `NOTE: Do NOT sanitize encoded bytes for normalized Type3 fonts / Multi-byte encodings (UTF-16BE, CID fonts) have null bytes that are essential / Removing them corrupts the byte boundaries and produces garbled text`

That branch skipped the sanitizer; the single-byte paths kept it, and took the same damage unnoticed.

**Reproduction** — a 41-page Hungarian document, `PDF → JSON → PDF` with no edits at all:

```
ő/ű in the source PDF        2575
ő/ű after round trip, before  2445   (130 lost)
ő/ű after round trip, after   2575   (none lost)
```

The affected page's extracted text is byte-identical to the source after the change, and the rendered page matches the original.

## 2. The editor inserts spaces inside words

Text runs carry their own spaces; the extractor only breaks a run where the text state changes. That happens mid-word whenever the producer swaps font for a single glyph, which is exactly what happens at a non-WinAnsi character.

`shouldInsertSpace` measured the advance from the **start** of the previous run and compared it against a single glyph (`estimateCharWidth`, clamped to `1.25 × fontSize`). For any multi-glyph run that over-reports enormously. Between words the verdict happened to be right, which is why the flaw stayed invisible; at a mid-word split it invented a space **inside** the word — and since `createGroup` seeds `originalText` from the same function, that space was carried into the saved PDF.

Replaced with the geometric test the data actually supports: a boundary is a word break when the gap reaches half the font's own space width.

**Measured against PDFBox's own `PDFTextStripper` output** for the same document (16 005 tokens as ground truth):

| | word splits before ő/ű | token agreement with PDFBox |
|---|---|---|
| before | 989 | 66.47% |
| after | 30 | 72.33% |

The 30 remaining are gaps the source PDF genuinely contains — verified by rendering the original page.

This also lets `estimateCharWidth`, `MIN/MAX_CHAR_WIDTH_FACTOR` and `EXTRA_GAP_RATIO` go.

## Notes on testing

`pdfTextEditorUtils.test.ts` is new and covers the frontend change (the mid-word split, a run's own spaces, and a real gap that must still produce a space).

I did **not** add a unit test for the backend change, deliberately. I tried twice in `PdfJsonConversionServiceRoundTripTest`: with that harness the rebuild emits no text-showing operators at all, so an assertion there passes and fails identically with and without the fix. No existing test in the class asserts on rebuilt text either. A test that cannot distinguish the two states would be worse than none — happy to add one if you can point me at a harness where the rebuild path produces real output.

The round-trip numbers above are reproducible in minutes: run the endpoint against any PDF containing `ő`/`ű` from a subset font, feed the JSON back to `/api/v1/convert/text-editor/pdf`, and count.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
- [x] Backend: `:stirling-pdf:test` — 3613 tests, 0 failures
- [x] Frontend: `vitest run --root editor` — 2420 tests, 1 pre-existing locale-dependent failure in `portal/billing/sharedBillingFormat.test.ts` (asserts the English month name `Jun`; unrelated to this change), plus `oxlint --max-warnings=0` and `oxfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015quyvWXibJeFxyDadqp4aU
