### PR TITLE
Document the Ollama context length requirement

### DIFF
--- a/engine/.env
+++ b/engine/.env
@@ -14,6 +14,18 @@ STIRLING_FAST_MODEL=anthropic:claude-haiku-4-5
 STIRLING_SMART_MODEL_MAX_TOKENS=8192
 STIRLING_FAST_MODEL_MAX_TOKENS=2048
 
+# Ollama users: set OLLAMA_CONTEXT_LENGTH=16384 (or higher) on the Ollama server itself.
+#
+# It defaults to 4096 and is further divided between parallel request slots, which leaves
+# roughly 2,000 tokens of usable prompt. The tool-planning prompt is several times that, and
+# Ollama silently discards the overflow from the START of the prompt - including the user's
+# request - rather than returning an error. The model then selects tools without having seen
+# what was asked, and answers confidently from whatever survived.
+#
+# The engine cannot set this: it is an Ollama server option with no equivalent on the
+# OpenAI-compatible endpoint the engine speaks. Verify with `ollama show <model>` or by
+# comparing `usage.prompt_tokens` in a response against the size of the prompt sent.
+
 # Process-wide cap on concurrent model API calls, shared by both model tiers.
 # Per-request fan-outs (chunked reasoner workers, contradiction detection) are
 # bounded per request; this bounds their product across concurrent requests.


### PR DESCRIPTION
Ollama defaults `OLLAMA_CONTEXT_LENGTH` to 4096 and divides it further between parallel request slots, leaving roughly 2,000 tokens of usable prompt.

Measured against a local qwen3:8b: prompts up to ~2,685 tokens arrive intact, and anything larger is clipped to exactly 2,050. Ollama discards the overflow from the **start** of the prompt, which is where the planner puts the user's request. The model then selects tools without having seen what was asked and answers confidently from whatever survived. Nothing errors and nothing logs.

The engine cannot set this itself - it is an Ollama server option with no equivalent on the OpenAI-compatible endpoint the engine speaks - so this documents it next to the model settings it interacts with.

Verify with `ollama show <model>`, or by comparing `usage.prompt_tokens` in a response against the size of the prompt sent.