### PR TITLE
Teach the router with one example per capability

### DIFF
--- a/engine/.env
+++ b/engine/.env
@@ -12,7 +12,7 @@ STIRLING_FAST_MODEL=anthropic:claude-haiku-4-5
 
 # Default output token limits applied by the engine for each model tier.
 STIRLING_SMART_MODEL_MAX_TOKENS=8192
-STIRLING_FAST_MODEL_MAX_TOKENS=2048
+STIRLING_FAST_MODEL_MAX_TOKENS=4096
 
 # Process-wide cap on concurrent model API calls, shared by both model tiers.
 # Per-request fan-outs (chunked reasoner workers, contradiction detection) are

--- a/engine/.env
+++ b/engine/.env
@@ -12,7 +12,7 @@ STIRLING_FAST_MODEL=anthropic:claude-haiku-4-5
 
 # Default output token limits applied by the engine for each model tier.
 STIRLING_SMART_MODEL_MAX_TOKENS=8192
-STIRLING_FAST_MODEL_MAX_TOKENS=4096
+STIRLING_FAST_MODEL_MAX_TOKENS=2048
 
 # Process-wide cap on concurrent model API calls, shared by both model tiers.
 # Per-request fan-outs (chunked reasoner workers, contradiction detection) are

--- a/engine/src/stirling/agents/orchestrator.py
+++ b/engine/src/stirling/agents/orchestrator.py
@@ -7,6 +7,7 @@ from typing import Literal, assert_never
 from pydantic import ConfigDict, Field
 from pydantic_ai import Agent
 from pydantic_ai.output import NativeOutput, ToolOutput
+from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext
 
 from stirling.agents.output_mode import output_retries, uses_tool_output
@@ -65,8 +66,32 @@ _ROUTER_SYSTEM_PROMPT = (
     "- pdf_create: generate a NEW document from scratch (invoice, report, letter) - no input file.\n"
     "- unsupported: none of the above fit, or the user asks about the assistant itself; put a "
     "helpful message in 'message'.\n"
-    "Respond with the capability and (only for unsupported) a message."
+    "Respond with the capability and (only for unsupported) a message.\n"
+    "\n"
+    "Decide by what the user wants BACK, not by which PDF words appear in the message. "
+    "Wanting an answer, or information read out of the document, is pdf_question. Wanting a "
+    "changed file handed back is pdf_edit. A document being mentioned is not a request to act "
+    "on it.\n"
+    "\n"
+    "Examples:\n"
+    '  "How long is the notice period?" -> pdf_question\n'
+    '  "Shorten the notice period to 30 days" -> pdf_edit\n'
+    '  "Is there a table of contents?" -> pdf_question\n'
+    '  "Add a table of contents" -> pdf_edit\n'
+    '  "Does it say anything about encryption?" -> pdf_question\n'
+    '  "Encrypt this file" -> pdf_edit\n'
+    '  "What sections cover the merger?" -> pdf_question\n'
+    '  "Combine these into one file" -> pdf_edit\n'
+    '  "Tell me if the numbers add up" -> pdf_question\n'
+    '  "Put a note on every paragraph that needs work" -> pdf_review\n'
+    '  "Build me a purchase order from scratch" -> pdf_create\n'
+    '  "Make a rule that stamps every upload" -> user_spec\n'
+    '  "Which version of the app is this?" -> unsupported'
 )
+
+
+def _router_model_settings(runtime: AppRuntime) -> ModelSettings:
+    return {**runtime.fast_model_settings, "temperature": 0.0}
 
 
 class OrchestratorAgent:
@@ -146,7 +171,7 @@ class OrchestratorAgent:
                 output_type=NativeOutput([_RouteDecision]),
                 retries=output_retries(runtime.settings.chat_provider),
                 system_prompt=_ROUTER_SYSTEM_PROMPT,
-                model_settings=runtime.fast_model_settings,
+                model_settings=_router_model_settings(runtime),
             )
             if self._route_via_enum
             else None

--- a/engine/src/stirling/agents/orchestrator.py
+++ b/engine/src/stirling/agents/orchestrator.py
@@ -68,21 +68,10 @@ _ROUTER_SYSTEM_PROMPT = (
     "helpful message in 'message'.\n"
     "Respond with the capability and (only for unsupported) a message.\n"
     "\n"
-    "Decide by what the user wants BACK, not by which PDF words appear in the message. "
-    "Wanting an answer, or information read out of the document, is pdf_question. Wanting a "
-    "changed file handed back is pdf_edit. A document being mentioned is not a request to act "
-    "on it.\n"
-    "\n"
-    "Examples:\n"
-    '  "How long is the notice period?" -> pdf_question\n'
-    '  "Shorten the notice period to 30 days" -> pdf_edit\n'
+    "Decide by what the user wants BACK. Information read out of the document is pdf_question; "
+    "a changed file handed back is pdf_edit. Mentioning a document is not asking to change it.\n"
     '  "Is there a table of contents?" -> pdf_question\n'
     '  "Add a table of contents" -> pdf_edit\n'
-    '  "Does it say anything about encryption?" -> pdf_question\n'
-    '  "Encrypt this file" -> pdf_edit\n'
-    '  "What sections cover the merger?" -> pdf_question\n'
-    '  "Combine these into one file" -> pdf_edit\n'
-    '  "Tell me if the numbers add up" -> pdf_question\n'
     '  "Put a note on every paragraph that needs work" -> pdf_review\n'
     '  "Build me a purchase order from scratch" -> pdf_create\n'
     '  "Make a rule that stamps every upload" -> user_spec\n'


### PR DESCRIPTION
The top-level router picks one of six capabilities. On qwen3:8b it was getting that wrong roughly a quarter of the time.

Two changes: six worked examples appended to the router prompt, and `temperature: 0` pinned on the router call. `build_model_settings` only ever set `max_tokens`, so the router ran at qwen3's own defaults (temperature 0.6, top_p 0.95) and the same question could route differently on repeat. The pin is on the router only, so generation elsewhere is unchanged.

## What the numbers say

An ablation isolates each factor. 82 labelled turns against a live Ollama, two independent runs each:

| variant | mean accuracy |
|---|---|
| ships today | 76.2% |
| + temperature 0 | 80.5% |
| + `max_tokens` 4096 | 81.7% |
| + examples | **89.6%** |

The prompt does the work. `max_tokens` was worth about 1.2 points - one case at this sample size - so **it is no longer part of this PR**. Its real justification was avoiding empty responses when thinking exhausts the budget, and no run recorded a single hard failure, so it was not earning its place. Raising it remains reasonable as a separate safety change.

## Why six examples and not more

The first version of this PR carried thirteen, mostly contrasting pairs on the question-versus-edit boundary. Measured against a set with **one example per capability**:

| prompt | mean accuracy | prompt tokens |
|---|---|---|
| 13 examples, boundary-heavy | 87.8% | 648 |
| 4 examples, boundary only | 78.0% | 458 |
| **6 examples, one per capability** | **89.6%** | **517** |

Six is both better and smaller. Cutting to four - still boundary-only - threw the entire gain away, which is the tell: the router's dominant failure was never question-versus-edit, it was bailing to `unsupported` (15 of 19 errors in the original run). A block with no `unsupported`, `pdf_review`, `pdf_create` or `user_spec` example cannot fix the errors that actually dominate. Coverage matters more than volume.

## Also worth knowing

Thinking stays on. With the same prompt, thinking on scored 91.5% against 89.0% off in the original run, and took destructive misroutes - read-only turns sent to a file-mutating capability - from three to zero.

Reproduce with the harness in #7778: `uv run --group engine python evals/routing/runner.py`