### PR TITLE
Warn about small context windows on self-hosted AI providers

### DIFF
--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -818,6 +818,7 @@ openai = "OpenAI API key"
 setPlaceholder = "Saved - leave blank to keep the current key"
 
 [admin.settings.ai.models.baseUrl]
+contextWindow = "Check the model's context window. The engine sends prompts of several thousand tokens and a window below 16,384 will silently truncate them - the oldest part of the prompt is dropped, so the model answers without having seen the request. Ollama defaults to 4,096 and divides that between parallel requests; raise it with OLLAMA_CONTEXT_LENGTH on the server."
 description = "Base URL of the OpenAI-compatible / Ollama endpoint, e.g. http://ollama:11434/v1."
 label = "Provider base URL"
 warning = "The base URL must point at a trusted internal endpoint. The engine will make server-side requests to it, so an untrusted value is SSRF-sensitive."

--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -818,7 +818,7 @@ openai = "OpenAI API key"
 setPlaceholder = "Saved - leave blank to keep the current key"
 
 [admin.settings.ai.models.baseUrl]
-contextWindow = "Check the model's context window. The engine sends prompts of several thousand tokens and a window below 16,384 will silently truncate them - the oldest part of the prompt is dropped, so the model answers without having seen the request. Ollama defaults to 4,096 and divides that between parallel requests; raise it with OLLAMA_CONTEXT_LENGTH on the server."
+contextWindow = "Use a context window of at least 16,384 tokens. Smaller windows silently drop part of the prompt. Ollama defaults to 4,096 - raise OLLAMA_CONTEXT_LENGTH."
 description = "Base URL of the OpenAI-compatible / Ollama endpoint, e.g. http://ollama:11434/v1."
 label = "Provider base URL"
 warning = "The base URL must point at a trusted internal endpoint. The engine will make server-side requests to it, so an untrusted value is SSRF-sensitive."

--- a/frontend/editor/public/locales/en-GB/translation.toml
+++ b/frontend/editor/public/locales/en-GB/translation.toml
@@ -818,7 +818,6 @@ openai = "OpenAI API key"
 setPlaceholder = "Saved - leave blank to keep the current key"
 
 [admin.settings.ai.models.baseUrl]
-contextWindow = "Use a context window of at least 16,384 tokens. Smaller windows silently drop part of the prompt. Ollama defaults to 4,096 - raise OLLAMA_CONTEXT_LENGTH."
 description = "Base URL of the OpenAI-compatible / Ollama endpoint, e.g. http://ollama:11434/v1."
 label = "Provider base URL"
 warning = "The base URL must point at a trusted internal endpoint. The engine will make server-side requests to it, so an untrusted value is SSRF-sensitive."

--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -818,6 +818,7 @@ openai = "OpenAI API key"
 setPlaceholder = "Saved - leave blank to keep the current key"
 
 [admin.settings.ai.models.baseUrl]
+contextWindow = "Check the model's context window. The engine sends prompts of several thousand tokens and a window below 16,384 will silently truncate them - the oldest part of the prompt is dropped, so the model answers without having seen the request. Ollama defaults to 4,096 and divides that between parallel requests; raise it with OLLAMA_CONTEXT_LENGTH on the server."
 description = "Base URL of the OpenAI-compatible / Ollama endpoint, e.g. http://ollama:11434/v1."
 label = "Provider base URL"
 warning = "The base URL must point at a trusted internal endpoint. The engine will make server-side requests to it, so an untrusted value is SSRF-sensitive."

--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -818,7 +818,7 @@ openai = "OpenAI API key"
 setPlaceholder = "Saved - leave blank to keep the current key"
 
 [admin.settings.ai.models.baseUrl]
-contextWindow = "Check the model's context window. The engine sends prompts of several thousand tokens and a window below 16,384 will silently truncate them - the oldest part of the prompt is dropped, so the model answers without having seen the request. Ollama defaults to 4,096 and divides that between parallel requests; raise it with OLLAMA_CONTEXT_LENGTH on the server."
+contextWindow = "Use a context window of at least 16,384 tokens. Smaller windows silently drop part of the prompt. Ollama defaults to 4,096 - raise OLLAMA_CONTEXT_LENGTH."
 description = "Base URL of the OpenAI-compatible / Ollama endpoint, e.g. http://ollama:11434/v1."
 label = "Provider base URL"
 warning = "The base URL must point at a trusted internal endpoint. The engine will make server-side requests to it, so an untrusted value is SSRF-sensitive."

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminAiModelsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminAiModelsSection.tsx
@@ -382,7 +382,7 @@ export default function AdminAiModelsSection() {
                 <Text size="xs">
                   {t(
                     "admin.settings.ai.models.baseUrl.contextWindow",
-                    "Check the model's context window. The engine sends prompts of several thousand tokens and a window below 16,384 will silently truncate them - the oldest part of the prompt is dropped, so the model answers without having seen the request. Ollama defaults to 4,096 and divides that between parallel requests; raise it with OLLAMA_CONTEXT_LENGTH on the server.",
+                    "Use a context window of at least 16,384 tokens. Smaller windows silently drop part of the prompt. Ollama defaults to 4,096 - raise OLLAMA_CONTEXT_LENGTH.",
                   )}
                 </Text>
               </Alert>

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminAiModelsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminAiModelsSection.tsx
@@ -370,6 +370,23 @@ export default function AdminAiModelsSection() {
                 </Text>
               </Alert>
             )}
+
+            {showBaseUrl && (
+              <Alert
+                variant="light"
+                color="blue"
+                icon={
+                  <LocalIcon icon="info-rounded" width="1rem" height="1rem" />
+                }
+              >
+                <Text size="xs">
+                  {t(
+                    "admin.settings.ai.models.baseUrl.contextWindow",
+                    "Check the model's context window. The engine sends prompts of several thousand tokens and a window below 16,384 will silently truncate them - the oldest part of the prompt is dropped, so the model answers without having seen the request. Ollama defaults to 4,096 and divides that between parallel requests; raise it with OLLAMA_CONTEXT_LENGTH on the server.",
+                  )}
+                </Text>
+              </Alert>
+            )}
           </Stack>
         </Paper>
       </Stack>


### PR DESCRIPTION
Replaces #7770, which put this in `engine/.env` where an admin configuring AI through the settings UI would never see it.

Shown only when the provider is Ollama or Custom (OpenAI-compatible), directly under the existing SSRF warning on the base URL field - the point where someone is actually pointing the engine at their own endpoint.

Ollama defaults `OLLAMA_CONTEXT_LENGTH` to 4096 and divides it further between parallel request slots, leaving roughly 2,000 tokens of usable prompt. Measured against a local qwen3:8b: prompts up to ~2,685 tokens arrive intact, anything larger is clipped to exactly 2,050, and the overflow is discarded from the **start** of the prompt - which is where the planner puts the user's request. The model then selects tools without having seen what was asked. Nothing errors and nothing logs.

The engine cannot set this itself: it is an Ollama server option with no equivalent on the OpenAI-compatible endpoint the engine speaks. So the useful thing it can do is tell the person configuring it, at the moment they configure it.

String added to en-GB and en-US only; other locales pick it up through the usual translation flow and fall back to English until then.