### PR TITLE
Generate the OpenAPI spec on a free port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -452,8 +452,13 @@ subprojects {
     if (name == 'stirling-pdf') {
         apply plugin: 'org.springdoc.openapi-gradle-plugin'
 
+        // Port 8080 is the app's own port, so a Stirling instance already running there answers
+        // this URL before the forked one does and the spec is generated from THAT build's code.
+        def openApiPort = (rootProject.findProperty('openApiPort') ?: '8390').toString()
+
         openApi {
-            apiDocsUrl = "http://localhost:8080/v1/api-docs"
+            apiDocsUrl = "http://localhost:${openApiPort}/v1/api-docs"
+            customBootRun { args = ["--server.port=${openApiPort}"] }
             outputDir = file("$projectDir")
             outputFileName = "SwaggerDoc.json"
             waitTimeInSeconds = 60 // Increase the wait time to 60 seconds

--- a/build.gradle
+++ b/build.gradle
@@ -452,9 +452,8 @@ subprojects {
     if (name == 'stirling-pdf') {
         apply plugin: 'org.springdoc.openapi-gradle-plugin'
 
-        // Port 8080 is the app's own port, so a Stirling instance already running there answers
-        // this URL before the forked one does and the spec is generated from THAT build's code.
-        def openApiPort = (rootProject.findProperty('openApiPort') ?: '8390').toString()
+        def openApiPort = rootProject.findProperty('openApiPort')?.toString()
+            ?: new ServerSocket(0).withCloseable { it.localPort }.toString()
 
         openApi {
             apiDocsUrl = "http://localhost:${openApiPort}/v1/api-docs"


### PR DESCRIPTION
`generateOpenApiDocs` forks a Spring Boot instance to harvest the spec, but the scrape URL was hardcoded to `http://localhost:8080` - the app's own port. If any Stirling instance is already listening there (a dev server, a container, a WSL relay) the plugin reads **that** build instead of the fork, and `task tool-models` then generates the Python and TypeScript models from whatever happens to be running.

It fails silently and looks like success. I hit it while regenerating models after editing Java annotations: the build passed, the compiled class contained the new text, and the spec contained none of it. Fetching the URL by hand settled it:

```
paths live8080: 276   ours: 276
identical parsed content: True
```

The generated `SwaggerDoc.json` was the running instance's document, not the working tree's.

Now on a random free port, passed to both the fork and the scrape URL so they cannot disagree. Override with `-PopenApiPort=NNNN` to use a specific port.