### PR TITLE
Resolve Task from PATH in the comment-lint hook windows

### DIFF
--- a/scripts/lint/comment-lint-hook.mjs
+++ b/scripts/lint/comment-lint-hook.mjs
@@ -54,13 +54,15 @@ const result = run();
 if (result.status === 0) process.exit(0);
 
 if (result.status === ENGINE_BROKEN) {
-  process.stderr.write("comment-lint could not run, so comments in this turn were not checked.\n");
+  process.stderr.write(`comment-lint could not run, so comments in this turn were not checked.${reason(result)}\n`);
   process.exit(1);
 }
 
-// Anything else is Task itself failing, which means the check did not happen.
-if (result.status !== FOUND) {
-  process.stderr.write(`comment-lint did not run (task exit ${result.status}), so comments in this turn were not checked.\n`);
+// Anything else is Task itself failing, which means the check did not happen. A
+// findings exit carrying no findings is the same case: Task failed before the
+// linter ran, so blocking on it would name comments nobody can go and read.
+if (result.status !== FOUND || !result.output.trim()) {
+  process.stderr.write(`comment-lint did not run (task exit ${result.status}), so comments in this turn were not checked.${reason(result)}\n`);
   process.exit(1);
 }
 
@@ -68,6 +70,13 @@ if (result.status !== FOUND) {
 // it is passed through rather than rewritten.
 process.stderr.write(`${result.output.trim()}\n\nFix these before finishing.\n`);
 process.exit(2);
+
+// Task's stderr names the real failure, such as an executable missing from PATH,
+// which the captured pipe would otherwise swallow.
+function reason(result) {
+  const message = (result.error ?? "").trim();
+  return message ? `\n${message}` : "";
+}
 
 function readStdin() {
   try {
@@ -92,7 +101,9 @@ function taskCommand() {
   for (const candidate of candidates) {
     if (existsSync(candidate)) return { command: candidate, shell: false };
   }
-  return { command: process.platform === "win32" ? "task.cmd" : "task", shell: process.platform === "win32" };
+  // Bare name on win32 too: the shell resolves it through PATHEXT, so it finds
+  // task.exe, task.cmd or task.bat, whichever the installer shipped.
+  return { command: "task", shell: process.platform === "win32" };
 }
 
 function run() {
@@ -114,6 +125,6 @@ function run() {
     });
     return { status: 0, output };
   } catch (error) {
-    return { status: error.status ?? -1, output: error.stdout ?? "" };
+    return { status: error.status ?? -1, output: error.stdout ?? "", error: error.stderr ?? "" };
   }
 }


### PR DESCRIPTION
What was wrong in scripts/lint/comment-lint-hook.mjs:

The win32 fallback hardcoded task.cmd. Scoop ships only task.exe, so cmd.exe returned exit 1.
The hook maps exit 1 to FOUND, so a missing executable became "findings" with an empty report.
Task's stderr was captured and discarded, so the actual error never surfaced.

The fix (commit b285c0d45b, 17 insertions):

Fall back to bare task on win32 too, still shell: true, so PATHEXT finds task.exe / .cmd / .bat.
FOUND with an empty report is now treated as "did not run", exit 1 (non-blocking) instead of exit 2.
Keep Task's stderr and print it with that message.


## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [ ] I have performed a self-review of my own code
- [ ] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [ ] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
