### PR TITLE
Refuse a policy re-run this browser cannot place, before it bills (Review Flow PR 5c)

### DIFF
--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -5513,6 +5513,7 @@ noDocumentLinked = "This failure is not linked to a specific document, so it can
 notOnThisDevice = "This document is not on this device, so it cannot be opened or retried here."
 occurrences = "{{count}} times"
 open = "Notifications"
+policyNotHere = "This policy is not available in this browser, so it cannot be run again from here."
 rerunRejected = "The policy could not be run again just now. Try again in a moment."
 rerunUndelivered = "The policy re-run started, but its result cannot be delivered here, so this failure stays open."
 retryUnavailable = "This document can no longer be retried from this browser."

--- a/frontend/editor/src/proprietary/components/notifications/notificationActions.test.tsx
+++ b/frontend/editor/src/proprietary/components/notifications/notificationActions.test.tsx
@@ -857,7 +857,7 @@ describe("retrying an attended policy run", () => {
   });
 
   it("says an untracked plain re-run cannot be delivered either", async () => {
-    // Same hole without a password: the cache could not place the policy, so nothing polls the run.
+    // Same hole without a password: the run went, but nothing here can poll or import it.
     rerunPolicy.mockResolvedValue({ ok: true, tracked: false });
 
     expect(await registry().OPEN_IN_TOOL?.run(policyContext())).toEqual({
@@ -865,6 +865,34 @@ describe("retrying an attended policy run", () => {
       message:
         "The policy re-run started, but its result cannot be delivered here, so this failure stays open.",
     });
+    expect(reportNotificationResolved).not.toHaveBeenCalled();
+  });
+
+  it("says a policy this browser cannot place was not run, so nothing was billed for", async () => {
+    // Refused before submission, so a repeat press explains again rather than charging again.
+    rerunPolicy.mockResolvedValue({ ok: false, reason: "unplaceable" });
+
+    expect(await registry().OPEN_IN_TOOL?.run(policyContext())).toEqual({
+      ok: false,
+      message:
+        "This policy is not available in this browser, so it cannot be run again from here.",
+    });
+    expect(reportNotificationResolved).not.toHaveBeenCalled();
+  });
+
+  it("keeps the unlocked document when the policy cannot be placed, and says the policy did not run", async () => {
+    rechainPolicyOnDocument.mockResolvedValue({
+      ok: false,
+      reason: "unplaceable",
+    });
+
+    expect(await registry().DECRYPT?.run(policyContext(), "hunter2")).toEqual({
+      ok: false,
+      message:
+        "The document was unlocked and opened here, but the policy could not be run on it again.",
+    });
+    // The password still bought them the unlocked document; only the re-run was refused.
+    expect(consumeFiles).toHaveBeenCalled();
     expect(reportNotificationResolved).not.toHaveBeenCalled();
   });
 

--- a/frontend/editor/src/proprietary/components/notifications/notificationActions.ts
+++ b/frontend/editor/src/proprietary/components/notifications/notificationActions.ts
@@ -329,6 +329,20 @@ export function useNotificationActions(): ClientActionRegistry {
           ),
         };
       }
+      if (outcome.reason === "unplaceable") {
+        return {
+          ok: false,
+          message: adopted
+            ? t(
+                "notifications.unlockedNotRerun",
+                "The document was unlocked and opened here, but the policy could not be run on it again.",
+              )
+            : t(
+                "notifications.policyNotHere",
+                "This policy is not available in this browser, so it cannot be run again from here.",
+              ),
+        };
+      }
       if (adopted) {
         return {
           ok: false,

--- a/frontend/editor/src/proprietary/hooks/tools/shared/useResolutionContinuation.test.ts
+++ b/frontend/editor/src/proprietary/hooks/tools/shared/useResolutionContinuation.test.ts
@@ -167,6 +167,23 @@ describe("useResolutionContinuation", () => {
     expect(fetchNotifications).not.toHaveBeenCalled();
   });
 
+  it("leaves the row open when the policy cannot be placed here, having submitted nothing", async () => {
+    fetchNotifications.mockResolvedValue({
+      notifications: [policyRow()],
+      viewerReviewsTeam: false,
+    });
+    rechainPolicyOnDocument.mockResolvedValue({
+      ok: false,
+      reason: "unplaceable",
+    });
+
+    continuation()(unlockRun());
+
+    await waitFor(() => expect(rechainPolicyOnDocument).toHaveBeenCalled());
+    expect(reportNotificationResolved).not.toHaveBeenCalled();
+    expect(refreshNotificationsNow).not.toHaveBeenCalled();
+  });
+
   it("leaves the row open when the re-run cannot be delivered", async () => {
     fetchNotifications.mockResolvedValue({
       notifications: [policyRow()],

--- a/frontend/editor/src/proprietary/services/notificationPolicyRetry.test.ts
+++ b/frontend/editor/src/proprietary/services/notificationPolicyRetry.test.ts
@@ -86,16 +86,17 @@ describe("rerunPolicy", () => {
     expect(isDispatched("security", "f-1")).toBe(true);
   });
 
-  it("still runs a policy the local cache cannot place, and says the run is untracked", async () => {
-    // A run with no category cannot be imported or chained, so nothing delivers its output.
+  it("submits nothing for a policy the local cache cannot place", async () => {
+    // A run with no category cannot be imported or chained, so it would bill and deliver nothing,
+    // and the row would keep offering the same click.
     policies.value = {};
     getStirlingFile.mockResolvedValue(new File(["%PDF-1.7"], "invoice.pdf"));
 
     await expect(rerunPolicy(target)).resolves.toEqual({
-      ok: true,
-      tracked: false,
+      ok: false,
+      reason: "unplaceable",
     });
-    expect(runStoredPolicy).toHaveBeenCalled();
+    expect(runStoredPolicy).not.toHaveBeenCalled();
     expect(getRun("run-1")).toBeUndefined();
   });
 
@@ -151,6 +152,16 @@ describe("rechainPolicyOnDocument", () => {
     expect(runStoredPolicy).toHaveBeenCalledWith("pol-1", [unlocked], "f-1");
     expect(getRun("run-1")).toMatchObject({ fileId: "f-unlocked" });
     expect(isDispatched("security", "f-unlocked")).toBe(true);
+  });
+
+  it("submits nothing when the cache cannot place the policy, even with the bytes in hand", async () => {
+    policies.value = {};
+
+    await expect(
+      rechainPolicyOnDocument(target, unlocked, "f-unlocked"),
+    ).resolves.toEqual({ ok: false, reason: "unplaceable" });
+
+    expect(runStoredPolicy).not.toHaveBeenCalled();
   });
 
   it("runs untracked rather than filing the output against the wrong document, and admits it", async () => {

--- a/frontend/editor/src/proprietary/services/notificationPolicyRetry.ts
+++ b/frontend/editor/src/proprietary/services/notificationPolicyRetry.ts
@@ -27,6 +27,8 @@ export type PolicyRerunOutcome =
   /** Running on the server, with nothing here to collect it. See {@link submit}. */
   | { ok: true; tracked: false }
   | { ok: false; reason: "missingFile" }
+  /** The local policy cache cannot place the policy, so nothing was submitted. */
+  | { ok: false; reason: "unplaceable" }
   /** The server refused the run. `message` is its own, or null when it gave nothing usable. */
   | { ok: false; reason: "rejected"; message: string | null };
 
@@ -90,6 +92,9 @@ async function submit(
 ): Promise<PolicyRerunOutcome> {
   // Resolved before the run, so a lookup that throws cannot leave a live run unrecorded.
   const categoryId = resume?.categoryId ?? categoryForPolicy(target.policyId);
+  // Nothing here could poll or import what such a run produced, so it would bill and deliver
+  // nothing, and the row would go on offering the same click. Refused before it costs anything.
+  if (!categoryId) return { ok: false, reason: "unplaceable" };
   // At the resume point where there is one, so the rest of the chain carries on from there.
   const policyId = resume?.policyId ?? target.policyId;
   const runTarget = resolvePolicyRunTarget();
@@ -102,7 +107,7 @@ async function submit(
   }
 
   // The run already went, so it is left to run: refusing now only wastes a second submission.
-  if (!categoryId || !workspaceFileId) return { ok: true, tracked: false };
+  if (!workspaceFileId) return { ok: true, tracked: false };
 
   // Marks (category, file) dispatched as it records: the pair has run once, and this is it again.
   recordRunStart({


### PR DESCRIPTION
Review Flow PR 5c, stacked on #7762. Closes #7787.

## What's changed

A policy re-run that the local cache cannot resolve to a category is now **refused before submission** rather than fired and left untracked. Previously the run went to the server, billed, and delivered nothing here (nothing could poll or import it), while the row stayed open with the same button on it, so every press charged again for the same undelivered result.

`submit` already resolved the category before calling `runStoredPolicy`. The check now sits in front of the call: no category, no run, and a new `{ ok: false, reason: "unplaceable" }` outcome. The row reads:

- **Retry**: "This policy is not available in this browser, so it cannot be run again from here."
- **Decrypt and retry**: the document is still unlocked and adopted, and the row reads "The document was unlocked and opened here, but the policy could not be run on it again."

A repeat press repeats the message at no cost. Nothing is remembered: the offer comes back on its own once the cache can place the policy again (for example after a team switch settles), which is the right behaviour for the states that cause this.

## What still fires untracked

One path remains: a run whose output has **no workspace document to attach to** (adoption returned no id). That run still submits and reports `tracked: false`, because by that point it has already been recorded server-side and refusing would only waste a second submission. That is attribution, not placement, and is unchanged.

## How to test

Needs a proprietary or SaaS build with login and a stored policy that fails on a locked document.

1. Create a policy failure (upload a locked PDF, Skip for now) so the bell shows a row with **Decrypt and retry**.
2. Make the policy unplaceable locally: clear the policy cache in DevTools (`localStorage` policies entry) without reloading, or switch team.
3. Press **Retry** from the row's menu. Expect: the message above, **no** `POST /api/v1/policies/{id}/run` in the Network tab, row stays open.
4. Press again. Expect: same message, still no request.
5. Press **Decrypt and retry** with the right password. Expect: the document unlocks and replaces the original in the workbench, the "could not be run on it again" message, and still no policy run request.
6. Restore the cache (reload). Press **Retry**. Expect: exactly one `POST .../run`, and the row resolves as before.

## Not in this PR

The broader question from #7787 of whether an unplaceable run should ever be submitted for a policy whose `outputMode` delivers elsewhere (folder, S3) is answered here as "no, not from the bell": the bell only offers what it can see through, and the processor remains the route for the rest.
