### PR TITLE
fix(billing): resolve a user's team from users.team_id, not their oldest membership

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/repository/TeamMembershipRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/repository/TeamMembershipRepository.java
@@ -45,24 +45,6 @@ public interface TeamMembershipRepository extends JpaRepository<TeamMembership, 
     List<TeamMembership> findByUserId(@Param("userId") Long userId);
 
     /**
-     * Resolve the single membership a user belongs to. In the PAYG design every user is owned by
-     * exactly one team — personal-team-for-new-signups, then optionally migrated when they accept
-     * an invite (the old personal team is deleted on accept). For diagnostic safety this picks the
-     * earliest-created row if multiple exist, but in steady state there is exactly one.
-     *
-     * <p>Returns both the team and its role so the PAYG wallet endpoint can answer "what does this
-     * user see?" in a single query rather than a list-then-filter dance.
-     *
-     * @param userId the user ID
-     * @return the user's primary membership, if any
-     */
-    @Query(
-            "SELECT tm FROM TeamMembership tm JOIN FETCH tm.team"
-                    + " WHERE tm.user.id = :userId"
-                    + " ORDER BY tm.createdAt ASC")
-    List<TeamMembership> findPrimaryMembership(@Param("userId") Long userId);
-
-    /**
      * Find all members with a specific role in a team
      *
      * @param teamId the team ID

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/repository/BillingTeamResolutionDbTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/repository/BillingTeamResolutionDbTest.java
@@ -1,0 +1,119 @@
+package stirling.software.proprietary.security.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import stirling.software.common.model.enumeration.TeamRole;
+import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.model.TeamMembership;
+import stirling.software.proprietary.security.database.repository.UserRepository;
+import stirling.software.proprietary.security.model.User;
+
+/**
+ * Pins the resolution rule the billing/read endpoints depend on, against a real (H2) database
+ * rather than a mocked repository.
+ *
+ * <p>The scenario is a genuine joined member: a durable home team the user leads, plus a team they
+ * later joined as a member, with {@code users.team_id} repointed to the joined team (exactly what
+ * {@code SaasTeamService.acceptInvitation} leaves behind — the home membership is kept). The two
+ * memberships are what a mocked unit test cannot produce, and they are why the endpoints must read
+ * {@code users.team_id}: the oldest membership is permanently the home team.
+ */
+@DataJpaTest
+class BillingTeamResolutionDbTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private TeamRepository teamRepository;
+    @Autowired private TeamMembershipRepository membershipRepository;
+
+    @PersistenceContext private EntityManager em;
+
+    @Test
+    void usersTeamIdIsTheJoinedTeamWhileTheOldestMembershipIsTheHomeTeam() {
+        Team home = teamRepository.save(named("home"));
+        Team joined = teamRepository.save(named("joined"));
+
+        User user = new User();
+        user.setUsername("joined-member@acme.test");
+        user.setTeam(joined); // acceptInvitation repoints the FK to the joined team
+        user = userRepository.save(user);
+
+        // Home membership created first (the user leads their personal team), joined membership
+        // later (they accepted an invite). createdAt is stamped explicitly so "oldest" is
+        // deterministic rather than dependent on H2 insert timing.
+        persistMembership(user, home, TeamRole.LEADER, LocalDateTime.of(2026, 1, 1, 0, 0));
+        persistMembership(user, joined, TeamRole.MEMBER, LocalDateTime.of(2026, 6, 1, 0, 0));
+        em.flush();
+        em.clear();
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+
+        // What the endpoints used to do: pick the oldest membership. It is the home team.
+        TeamMembership oldest =
+                membershipRepository.findByUserId(reloaded.getId()).stream()
+                        .min(Comparator.comparing(TeamMembership::getCreatedAt))
+                        .orElseThrow();
+        assertThat(oldest.getTeam().getId()).isEqualTo(home.getId());
+        assertThat(oldest.getRole()).isEqualTo(TeamRole.LEADER);
+
+        // What the endpoints do now: read users.team_id, with the role from that team's row.
+        Long billingTeamId = reloaded.getTeam().getId();
+        TeamMembership billingRow =
+                membershipRepository
+                        .findByTeamIdAndUserId(billingTeamId, reloaded.getId())
+                        .orElseThrow();
+        assertThat(billingTeamId).isEqualTo(joined.getId());
+        assertThat(billingRow.getRole()).isEqualTo(TeamRole.MEMBER);
+
+        // The whole bug in one line: the two strategies resolve to different teams. Reading the
+        // oldest membership shows the home team's wallet/cap and grants the home team's LEADER
+        // role;
+        // reading users.team_id shows the team the user is actually billed against.
+        assertThat(oldest.getTeam().getId()).isNotEqualTo(billingTeamId);
+    }
+
+    private Team named(String name) {
+        Team t = new Team();
+        t.setName(name);
+        return t;
+    }
+
+    private void persistMembership(User user, Team team, TeamRole role, LocalDateTime createdAt) {
+        TeamMembership m = new TeamMembership();
+        m.setUser(user);
+        m.setTeam(team);
+        m.setRole(role);
+        m.setInvitedAt(createdAt);
+        m = membershipRepository.save(m);
+        // @CreationTimestamp stamps createdAt on insert; overwrite it so ordering is deterministic.
+        em.createQuery("update TeamMembership tm set tm.createdAt = :ts where tm.id = :id")
+                .setParameter("ts", createdAt)
+                .setParameter("id", m.getMembershipId())
+                .executeUpdate();
+    }
+
+    @SpringBootConfiguration
+    @EntityScan(
+            basePackages = {
+                "stirling.software.proprietary.security.model",
+                "stirling.software.proprietary.model"
+            })
+    @EnableJpaRepositories(
+            basePackages = {
+                "stirling.software.proprietary.security.database.repository",
+                "stirling.software.proprietary.security.repository"
+            })
+    static class TestApp {}
+}

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/LeaderTeamResolver.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/LeaderTeamResolver.java
@@ -1,6 +1,6 @@
 package stirling.software.saas.accountlink;
 
-import java.util.List;
+import java.util.Optional;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
@@ -8,11 +8,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
-import stirling.software.common.model.enumeration.TeamRole;
-import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
-import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /** Who is allowed to bind a self-hosted instance to a team. */
@@ -21,11 +19,11 @@ import stirling.software.saas.util.AuthenticationUtils;
 @ConditionalOnProperty(name = "stirling.billing.account-link.enabled", havingValue = "true")
 public class LeaderTeamResolver {
 
-    private final TeamMembershipRepository memberRepo;
+    private final UserTeamResolver userTeamResolver;
     private final UserRepository userRepository;
 
-    public LeaderTeamResolver(TeamMembershipRepository memberRepo, UserRepository userRepository) {
-        this.memberRepo = memberRepo;
+    public LeaderTeamResolver(UserTeamResolver userTeamResolver, UserRepository userRepository) {
+        this.userTeamResolver = userTeamResolver;
         this.userRepository = userRepository;
     }
 
@@ -55,14 +53,13 @@ public class LeaderTeamResolver {
         } catch (SecurityException e) {
             return new LeaderTeam(null, null, HttpStatus.UNAUTHORIZED);
         }
-        List<TeamMembership> rows = memberRepo.findPrimaryMembership(user.getId());
-        if (rows.isEmpty()) {
+        Optional<Long> teamId = userTeamResolver.teamId(user);
+        if (teamId.isEmpty()) {
             return new LeaderTeam(null, null, HttpStatus.FORBIDDEN);
         }
-        TeamMembership membership = rows.getFirst();
-        if (requireLeader && membership.getRole() != TeamRole.LEADER) {
+        if (requireLeader && !userTeamResolver.isLeader(user)) {
             return new LeaderTeam(null, null, HttpStatus.FORBIDDEN);
         }
-        return new LeaderTeam(membership.getTeam().getId(), user.getId(), null);
+        return new LeaderTeam(teamId.get(), user.getId(), null);
     }
 }

--- a/app/saas/src/main/java/stirling/software/saas/legal/LegalController.java
+++ b/app/saas/src/main/java/stirling/software/saas/legal/LegalController.java
@@ -20,10 +20,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
-import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /**
@@ -41,7 +40,7 @@ public class LegalController {
 
     private final LegalDocumentRegistry registry;
     private final LegalConsentService consents;
-    private final TeamMembershipRepository memberRepo;
+    private final UserTeamResolver userTeamResolver;
     private final UserRepository userRepository;
 
     /** A legal document rendered for viewing: registry metadata + the static markdown body. */
@@ -86,9 +85,9 @@ public class LegalController {
         if (request == null || request.documentId() == null || request.context() == null) {
             return ResponseEntity.badRequest().build();
         }
-        Optional<TeamMembership> membership = primaryMembership(auth);
-        Long teamId = membership.map(m -> m.getTeam().getId()).orElse(null);
-        Long userId = membership.map(m -> m.getUser().getId()).orElse(null);
+        Optional<User> caller = currentUser(auth);
+        Long teamId = caller.flatMap(userTeamResolver::teamId).orElse(null);
+        Long userId = caller.map(User::getId).orElse(null);
         // Best-effort for real: consent is audit metadata, not an authorisation gate, so a failed
         // write must not fail the trial start or quote generation this call accompanies. Previously
         // that only held because the caller happened to swallow the 500.
@@ -105,14 +104,12 @@ public class LegalController {
         return ResponseEntity.ok().build();
     }
 
-    private Optional<TeamMembership> primaryMembership(Authentication auth) {
-        User user;
+    private Optional<User> currentUser(Authentication auth) {
         try {
-            user = AuthenticationUtils.getCurrentUser(auth, userRepository);
+            return Optional.of(AuthenticationUtils.getCurrentUser(auth, userRepository));
         } catch (SecurityException e) {
             return Optional.empty();
         }
-        return memberRepo.findPrimaryMembership(user.getId()).stream().findFirst();
     }
 
     /**

--- a/app/saas/src/main/java/stirling/software/saas/payg/api/PaygInvoicesController.java
+++ b/app/saas/src/main/java/stirling/software/saas/payg/api/PaygInvoicesController.java
@@ -20,13 +20,12 @@ import io.swagger.v3.oas.annotations.Hidden;
 
 import lombok.extern.slf4j.Slf4j;
 
-import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
-import stirling.software.proprietary.security.repository.TeamMembershipRepository;
 import stirling.software.saas.payg.policy.PaygTeamExtensions;
 import stirling.software.saas.payg.repository.PaygTeamExtensionsRepository;
 import stirling.software.saas.payg.stripe.StripeInvoiceDao;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /**
@@ -57,17 +56,17 @@ public class PaygInvoicesController {
 
     private final StripeInvoiceDao invoiceDao;
     private final PaygTeamExtensionsRepository extRepo;
-    private final TeamMembershipRepository memberRepo;
+    private final UserTeamResolver userTeamResolver;
     private final UserRepository userRepository;
 
     public PaygInvoicesController(
             StripeInvoiceDao invoiceDao,
             PaygTeamExtensionsRepository extRepo,
-            TeamMembershipRepository memberRepo,
+            UserTeamResolver userTeamResolver,
             UserRepository userRepository) {
         this.invoiceDao = Objects.requireNonNull(invoiceDao, "invoiceDao");
         this.extRepo = Objects.requireNonNull(extRepo, "extRepo");
-        this.memberRepo = Objects.requireNonNull(memberRepo, "memberRepo");
+        this.userTeamResolver = Objects.requireNonNull(userTeamResolver, "userTeamResolver");
         this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
     }
 
@@ -99,13 +98,12 @@ public class PaygInvoicesController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        // Resolve the caller's team from their primary membership — same pattern as
-        // PaygWalletController. The team id NEVER comes from the request.
-        List<TeamMembership> rows = memberRepo.findPrimaryMembership(user.getId());
-        if (rows.isEmpty()) {
+        // The team id NEVER comes from the request.
+        Optional<Long> resolvedTeam = userTeamResolver.teamId(user);
+        if (resolvedTeam.isEmpty()) {
             return ResponseEntity.ok(List.of());
         }
-        Long teamId = rows.getFirst().getTeam().getId();
+        Long teamId = resolvedTeam.get();
 
         // No PAYG extension row OR no Stripe customer id → team has never subscribed → no
         // invoices. Empty list, not 404 — the UI distinguishes "no invoices yet" from a

--- a/app/saas/src/main/java/stirling/software/saas/payg/api/PaygPaymentMethodController.java
+++ b/app/saas/src/main/java/stirling/software/saas/payg/api/PaygPaymentMethodController.java
@@ -1,6 +1,5 @@
 package stirling.software.saas.payg.api;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -18,13 +17,12 @@ import io.swagger.v3.oas.annotations.Hidden;
 
 import lombok.extern.slf4j.Slf4j;
 
-import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
-import stirling.software.proprietary.security.repository.TeamMembershipRepository;
 import stirling.software.saas.payg.policy.PaygTeamExtensions;
 import stirling.software.saas.payg.repository.PaygTeamExtensionsRepository;
 import stirling.software.saas.payg.stripe.StripePaymentMethodDao;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /**
@@ -56,17 +54,17 @@ public class PaygPaymentMethodController {
 
     private final StripePaymentMethodDao paymentMethodDao;
     private final PaygTeamExtensionsRepository extRepo;
-    private final TeamMembershipRepository memberRepo;
+    private final UserTeamResolver userTeamResolver;
     private final UserRepository userRepository;
 
     public PaygPaymentMethodController(
             StripePaymentMethodDao paymentMethodDao,
             PaygTeamExtensionsRepository extRepo,
-            TeamMembershipRepository memberRepo,
+            UserTeamResolver userTeamResolver,
             UserRepository userRepository) {
         this.paymentMethodDao = Objects.requireNonNull(paymentMethodDao, "paymentMethodDao");
         this.extRepo = Objects.requireNonNull(extRepo, "extRepo");
-        this.memberRepo = Objects.requireNonNull(memberRepo, "memberRepo");
+        this.userTeamResolver = Objects.requireNonNull(userTeamResolver, "userTeamResolver");
         this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
     }
 
@@ -81,11 +79,11 @@ public class PaygPaymentMethodController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        List<TeamMembership> rows = memberRepo.findPrimaryMembership(user.getId());
-        if (rows.isEmpty()) {
+        Optional<Long> resolvedTeam = userTeamResolver.teamId(user);
+        if (resolvedTeam.isEmpty()) {
             return ResponseEntity.ok(PaymentMethodResponse.absent());
         }
-        Long teamId = rows.getFirst().getTeam().getId();
+        Long teamId = resolvedTeam.get();
 
         Optional<PaygTeamExtensions> ext = extRepo.findById(teamId);
         if (ext.isEmpty() || ext.get().getStripeCustomerId() == null) {

--- a/app/saas/src/main/java/stirling/software/saas/payg/api/PaygWalletController.java
+++ b/app/saas/src/main/java/stirling/software/saas/payg/api/PaygWalletController.java
@@ -32,7 +32,6 @@ import jakarta.validation.constraints.Min;
 
 import lombok.extern.slf4j.Slf4j;
 
-import stirling.software.common.model.enumeration.TeamRole;
 import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
@@ -54,6 +53,7 @@ import stirling.software.saas.payg.repository.WalletLedgerRepository;
 import stirling.software.saas.payg.repository.WalletPolicyRepository;
 import stirling.software.saas.payg.wallet.WalletLedgerEntry;
 import stirling.software.saas.payg.wallet.WalletPolicy;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /**
@@ -109,6 +109,7 @@ public class PaygWalletController {
     private final PaygShadowChargeRepository shadowRepo;
     private final UserRepository userRepository;
     private final PrepaidBundleService prepaidBundleService;
+    private final UserTeamResolver userTeamResolver;
 
     public PaygWalletController(
             EntitlementService entitlementService,
@@ -119,7 +120,8 @@ public class PaygWalletController {
             WalletLedgerRepository ledgerRepo,
             PaygShadowChargeRepository shadowRepo,
             UserRepository userRepository,
-            PrepaidBundleService prepaidBundleService) {
+            PrepaidBundleService prepaidBundleService,
+            UserTeamResolver userTeamResolver) {
         this.entitlementService = Objects.requireNonNull(entitlementService, "entitlementService");
         this.billingService = Objects.requireNonNull(billingService, "billingService");
         this.memberRepo = Objects.requireNonNull(memberRepo, "memberRepo");
@@ -130,6 +132,7 @@ public class PaygWalletController {
         this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
         this.prepaidBundleService =
                 Objects.requireNonNull(prepaidBundleService, "prepaidBundleService");
+        this.userTeamResolver = Objects.requireNonNull(userTeamResolver, "userTeamResolver");
     }
 
     /** The single wallet fetch the frontend makes; every figure on the Plan page comes from it. */
@@ -145,17 +148,15 @@ public class PaygWalletController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        Optional<TeamMembership> primary = primaryMembership(user.getId());
-        if (primary.isEmpty()) {
+        Optional<Long> resolvedTeam = userTeamResolver.teamId(user);
+        if (resolvedTeam.isEmpty()) {
             // Authenticated user without a team — shouldn't happen post-migration, but we don't
             // want to 500. Return a free-tier-shaped empty snapshot so the FE renders the gated UI
             // rather than blowing up on a null body.
             return ResponseEntity.ok(emptySnapshot());
         }
-
-        TeamMembership membership = primary.get();
-        Long teamId = membership.getTeam().getId();
-        boolean isLeader = membership.getRole() == TeamRole.LEADER;
+        Long teamId = resolvedTeam.get();
+        boolean isLeader = userTeamResolver.isLeader(user);
 
         // Billing facts (window, free allowance, per-doc rate, doc cap) and the entitlement
         // snapshot (period spend over that window) share the same composition service, so what
@@ -336,16 +337,15 @@ public class PaygWalletController {
         } catch (SecurityException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        Optional<TeamMembership> primary = primaryMembership(user.getId());
-        if (primary.isEmpty()) {
-            // No team → can't have a wallet to cap.
+        Optional<Long> resolvedTeam = userTeamResolver.teamId(user);
+        if (resolvedTeam.isEmpty()) {
+            // No team, so no wallet to cap.
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
-        TeamMembership membership = primary.get();
-        if (membership.getRole() != TeamRole.LEADER) {
+        if (!userTeamResolver.isLeader(user)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
-        Long teamId = membership.getTeam().getId();
+        Long teamId = resolvedTeam.get();
 
         WalletPolicy policy =
                 policyRepo
@@ -405,14 +405,8 @@ public class PaygWalletController {
         } catch (SecurityException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        primaryMembership(user.getId())
-                .ifPresent(m -> entitlementService.invalidate(m.getTeam().getId()));
+        userTeamResolver.teamId(user).ifPresent(entitlementService::invalidate);
         return ResponseEntity.noContent().build();
-    }
-
-    private Optional<TeamMembership> primaryMembership(Long userId) {
-        List<TeamMembership> rows = memberRepo.findPrimaryMembership(userId);
-        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.getFirst());
     }
 
     private List<MemberRow> buildMemberRows(

--- a/app/saas/src/main/java/stirling/software/saas/procurement/api/ProcurementController.java
+++ b/app/saas/src/main/java/stirling/software/saas/procurement/api/ProcurementController.java
@@ -18,19 +18,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import tools.jackson.databind.ObjectMapper;
-
 import io.swagger.v3.oas.annotations.Hidden;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 import lombok.extern.slf4j.Slf4j;
 
-import stirling.software.common.model.enumeration.TeamRole;
-import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
-import stirling.software.proprietary.security.repository.TeamMembershipRepository;
 import stirling.software.saas.procurement.config.ProcurementConfigurationProperties;
 import stirling.software.saas.procurement.legal.AgreementSigning;
 import stirling.software.saas.procurement.model.ProcurementAgreementSignature;
@@ -41,7 +36,10 @@ import stirling.software.saas.procurement.pricing.ProcurementPricingService;
 import stirling.software.saas.procurement.pricing.QuoteConfig;
 import stirling.software.saas.procurement.pricing.QuoteLineItem;
 import stirling.software.saas.procurement.service.ProcurementService;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
+
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * The enterprise procurement journey for a linked team: read the deal snapshot, start/extend a
@@ -63,19 +61,19 @@ public class ProcurementController {
 
     private final ProcurementService procurement;
     private final ProcurementPricingService pricing;
-    private final TeamMembershipRepository memberRepo;
+    private final UserTeamResolver userTeamResolver;
     private final UserRepository userRepository;
     private final ProcurementConfigurationProperties config;
 
     public ProcurementController(
             ProcurementService procurement,
             ProcurementPricingService pricing,
-            TeamMembershipRepository memberRepo,
+            UserTeamResolver userTeamResolver,
             UserRepository userRepository,
             ProcurementConfigurationProperties config) {
         this.procurement = Objects.requireNonNull(procurement);
         this.pricing = Objects.requireNonNull(pricing);
-        this.memberRepo = Objects.requireNonNull(memberRepo);
+        this.userTeamResolver = Objects.requireNonNull(userTeamResolver);
         this.userRepository = Objects.requireNonNull(userRepository);
         this.config = Objects.requireNonNull(config);
     }
@@ -241,12 +239,13 @@ public class ProcurementController {
     @GetMapping
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<SnapshotResponse> snapshot(Authentication auth) {
-        Optional<TeamMembership> membership = primaryMembership(auth);
-        if (membership.isEmpty()) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        Long teamId = membership.get().getTeam().getId();
+        Optional<User> caller = currentUser(auth);
+        Optional<Long> callerTeam = caller.flatMap(userTeamResolver::teamId);
+        if (callerTeam.isEmpty()) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        Long teamId = callerTeam.get();
         // The licence key is the team's secret entitlement — leader-only. Members still see the
         // journey (stage, trial, quote) but the key is withheld; the .lic file is likewise gated.
-        boolean leader = membership.get().getRole() == TeamRole.LEADER;
+        boolean leader = userTeamResolver.isLeader(caller.get());
         return ResponseEntity.ok(
                 procurement.getDeal(teamId).map(d -> toSnapshot(d, leader)).orElse(EMPTY_SNAPSHOT));
     }
@@ -316,9 +315,7 @@ public class ProcurementController {
         // After the trial exists, so a rejected invite can never stop it starting.
         if (request != null) {
             procurement.sendTrialInvites(
-                    teamId,
-                    primaryMembership(auth).map(TeamMembership::getUser).orElse(null),
-                    request.inviteEmails());
+                    teamId, currentUser(auth).orElse(null), request.inviteEmails());
         }
         return ResponseEntity.ok(toSnapshot(deal, true));
     }
@@ -555,22 +552,20 @@ public class ProcurementController {
 
     // ---- helpers ------------------------------------------------------------
 
-    /** The caller's primary team membership; empty when unauthenticated/teamless. */
-    private Optional<TeamMembership> primaryMembership(Authentication auth) {
-        User user;
+    /** The authenticated caller; empty when unauthenticated. */
+    private Optional<User> currentUser(Authentication auth) {
         try {
-            user = AuthenticationUtils.getCurrentUser(auth, userRepository);
+            return Optional.of(AuthenticationUtils.getCurrentUser(auth, userRepository));
         } catch (SecurityException e) {
             return Optional.empty();
         }
-        return memberRepo.findPrimaryMembership(user.getId()).stream().findFirst();
     }
 
     /** Team id only when the caller is the team leader; null otherwise (commercial actions). */
     private Long requireLeader(Authentication auth) {
-        return primaryMembership(auth)
-                .filter(m -> m.getRole() == TeamRole.LEADER)
-                .map(m -> m.getTeam().getId())
+        return currentUser(auth)
+                .filter(userTeamResolver::isLeader)
+                .flatMap(userTeamResolver::teamId)
                 .orElse(null);
     }
 

--- a/app/saas/src/main/java/stirling/software/saas/security/TeamSecurityExpressions.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/TeamSecurityExpressions.java
@@ -31,6 +31,7 @@ public class TeamSecurityExpressions {
 
     private final TeamMembershipRepository membershipRepository;
     private final UserService userService;
+    private final UserTeamResolver userTeamResolver;
 
     /** Whether the current authenticated user is a {@code LEADER} of the given team. */
     public boolean isTeamLeader(Long teamId) {
@@ -46,23 +47,12 @@ public class TeamSecurityExpressions {
 
     /** Whether the current authenticated user is a {@code LEADER} of their own team. */
     public boolean isCurrentUserTeamLeader() {
-        User currentUser = getCurrentUser();
-        if (currentUser == null || currentUser.getTeam() == null) {
-            return false;
-        }
-        return membershipRepository
-                .findByTeamIdAndUserId(currentUser.getTeam().getId(), currentUser.getId())
-                .map(membership -> membership.getRole() == TeamRole.LEADER)
-                .orElse(false);
+        return userTeamResolver.isLeader(getCurrentUser());
     }
 
     /** The current authenticated user's team id, or {@code null} if unauthenticated / teamless. */
     public Long currentUserTeamId() {
-        User currentUser = getCurrentUser();
-        if (currentUser == null || currentUser.getTeam() == null) {
-            return null;
-        }
-        return currentUser.getTeam().getId();
+        return userTeamResolver.teamId(getCurrentUser()).orElse(null);
     }
 
     /** The current authenticated user's id, or {@code null} if unauthenticated. */

--- a/app/saas/src/main/java/stirling/software/saas/security/UserTeamResolver.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/UserTeamResolver.java
@@ -1,0 +1,76 @@
+package stirling.software.saas.security;
+
+import java.util.Optional;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import stirling.software.common.model.enumeration.TeamRole;
+import stirling.software.proprietary.security.model.User;
+import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+
+/**
+ * The team a user belongs to for team-scoped reads and billing.
+ *
+ * <p>{@code users.team_id} is the answer. It is the personal (home) team at signup and is repointed
+ * to a joined team only when an invitation is <b>accepted</b> ({@code
+ * SaasTeamService.acceptInvitation}); sending an invitation sets {@code invitation.team} and
+ * touches neither {@code users.team_id} nor the membership set. So the FK means exactly "home by
+ * default, the joined team once you have actually joined" — and it is what enforcement ({@code
+ * EntitlementGuard}, {@code PaygChargeInterceptor}) already reads.
+ *
+ * <p>Team-scoped read endpoints previously resolved the caller from their <b>oldest</b> membership
+ * instead. A join keeps the home membership, so the oldest row is permanently the home team: a
+ * joined member was shown, and their leader could edit, the home team's wallet and spend cap while
+ * being billed against the joined one.
+ */
+@Component
+@Profile("saas")
+@RequiredArgsConstructor
+@Slf4j
+public class UserTeamResolver {
+
+    private final TeamMembershipRepository membershipRepository;
+
+    /**
+     * The team to read and bill against, or empty when the user has none. Costs no query: {@code
+     * User.team} is an eager association, so it is already loaded with the user.
+     */
+    public Optional<Long> teamId(User user) {
+        if (user == null || user.getTeam() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(user.getTeam().getId());
+    }
+
+    /**
+     * The user's role in that team. Empty when they have no team or — a data fault, since the FK
+     * and the membership row are written together — no membership row for it, in which case they
+     * get no leader powers.
+     */
+    private Optional<TeamRole> role(User user) {
+        Optional<Long> teamId = teamId(user);
+        if (teamId.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<TeamRole> role =
+                membershipRepository
+                        .findByTeamIdAndUserId(teamId.get(), user.getId())
+                        .map(m -> m.getRole());
+        if (role.isEmpty()) {
+            log.warn(
+                    "users.team_id={} has no membership row for user {}",
+                    teamId.get(),
+                    user.getId());
+        }
+        return role;
+    }
+
+    /** Whether the user leads the team they read and bill against. */
+    public boolean isLeader(User user) {
+        return role(user).filter(r -> r == TeamRole.LEADER).isPresent();
+    }
+}

--- a/app/saas/src/main/java/stirling/software/saas/usage/SaasFleetUsageController.java
+++ b/app/saas/src/main/java/stirling/software/saas/usage/SaasFleetUsageController.java
@@ -3,6 +3,7 @@ package stirling.software.saas.usage;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
@@ -19,12 +20,12 @@ import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.proprietary.audit.AuditLevel;
 import stirling.software.proprietary.config.AuditConfigurationProperties;
-import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.model.api.usage.FleetUsageStats;
 import stirling.software.proprietary.repository.PersistentAuditEventRepository;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /**
@@ -53,6 +54,7 @@ public class SaasFleetUsageController {
 
     private final UserRepository userRepository;
     private final TeamMembershipRepository memberRepo;
+    private final UserTeamResolver userTeamResolver;
     private final PersistentAuditEventRepository auditRepository;
     private final AuditConfigurationProperties auditConfig;
 
@@ -67,13 +69,13 @@ public class SaasFleetUsageController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        List<TeamMembership> primary = memberRepo.findPrimaryMembership(user.getId());
-        if (primary.isEmpty()) {
+        Optional<Long> resolvedTeam = userTeamResolver.teamId(user);
+        if (resolvedTeam.isEmpty()) {
             // Authenticated caller without a team — shouldn't happen post-migration; report an
             // empty fleet rather than 500.
             return ResponseEntity.ok(new FleetUsageStats(0L, null, null));
         }
-        Long teamId = primary.get(0).getTeam().getId();
+        Long teamId = resolvedTeam.get();
 
         List<String> members =
                 memberRepo.findByTeamId(teamId).stream()

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/AccountLinkControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/AccountLinkControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import stirling.software.proprietary.security.database.repository.UserRepository
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.repository.TeamMembershipRepository;
 import stirling.software.saas.accountlink.AccountLinkController.InstanceRow;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /**
@@ -49,7 +51,8 @@ class AccountLinkControllerTest {
         // through the controller.
         controller =
                 new AccountLinkController(
-                        service, new LeaderTeamResolver(memberRepo, userRepository));
+                        service,
+                        new LeaderTeamResolver(new UserTeamResolver(memberRepo), userRepository));
         auth =
                 new AnonymousAuthenticationToken(
                         "k", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_USER")));
@@ -77,8 +80,6 @@ class AccountLinkControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of());
-
             ResponseEntity<List<InstanceRow>> resp = controller.list(auth);
 
             assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
@@ -93,7 +94,8 @@ class AccountLinkControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of(member));
+            user.setTeam(member.getTeam());
+            when(memberRepo.findByTeamIdAndUserId(7L, 42L)).thenReturn(Optional.of(member));
 
             ResponseEntity<List<InstanceRow>> resp = controller.list(auth);
 
@@ -110,7 +112,8 @@ class AccountLinkControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of(leader));
+            user.setTeam(leader.getTeam());
+            when(memberRepo.findByTeamIdAndUserId(7L, 42L)).thenReturn(Optional.of(leader));
 
             ResponseEntity<List<InstanceRow>> resp = controller.list(auth);
 
@@ -128,7 +131,8 @@ class AccountLinkControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of(leader));
+            user.setTeam(leader.getTeam());
+            when(memberRepo.findByTeamIdAndUserId(7L, 42L)).thenReturn(Optional.of(leader));
 
             ResponseEntity<Void> resp = controller.revoke(11L, auth);
 
@@ -144,7 +148,8 @@ class AccountLinkControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of(leader));
+            user.setTeam(leader.getTeam());
+            when(memberRepo.findByTeamIdAndUserId(7L, 42L)).thenReturn(Optional.of(leader));
 
             ResponseEntity<Void> resp = controller.revoke(11L, auth);
 

--- a/app/saas/src/test/java/stirling/software/saas/payg/api/PaygInvoicesControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/payg/api/PaygInvoicesControllerTest.java
@@ -31,6 +31,7 @@ import stirling.software.saas.payg.api.PaygInvoicesController.InvoiceResponse;
 import stirling.software.saas.payg.policy.PaygTeamExtensions;
 import stirling.software.saas.payg.repository.PaygTeamExtensionsRepository;
 import stirling.software.saas.payg.stripe.StripeInvoiceDao;
+import stirling.software.saas.security.UserTeamResolver;
 import stirling.software.saas.util.AuthenticationUtils;
 
 /**
@@ -51,7 +52,9 @@ class PaygInvoicesControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new PaygInvoicesController(invoiceDao, extRepo, memberRepo, userRepository);
+        controller =
+                new PaygInvoicesController(
+                        invoiceDao, extRepo, new UserTeamResolver(memberRepo), userRepository);
         auth =
                 new AnonymousAuthenticationToken(
                         "k", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_USER")));
@@ -76,7 +79,6 @@ class PaygInvoicesControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of());
 
             ResponseEntity<List<InvoiceResponse>> resp = controller.list(null, auth);
 
@@ -93,7 +95,7 @@ class PaygInvoicesControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of(tm));
+            user.setTeam(tm.getTeam());
             when(extRepo.findById(7L)).thenReturn(Optional.empty());
 
             ResponseEntity<List<InvoiceResponse>> resp = controller.list(null, auth);
@@ -130,7 +132,7 @@ class PaygInvoicesControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of(tm));
+            user.setTeam(tm.getTeam());
             when(extRepo.findById(7L)).thenReturn(Optional.of(ext));
             // 1000 should clamp to MAX_LIMIT (100) inside the controller.
             when(invoiceDao.findRecentByCustomer(eq("cus_abc"), eq(100))).thenReturn(List.of(row));
@@ -162,7 +164,7 @@ class PaygInvoicesControllerTest {
         try (var mocked = org.mockito.Mockito.mockStatic(AuthenticationUtils.class)) {
             mocked.when(() -> AuthenticationUtils.getCurrentUser(auth, userRepository))
                     .thenReturn(user);
-            when(memberRepo.findPrimaryMembership(42L)).thenReturn(List.of(tm));
+            user.setTeam(tm.getTeam());
             when(extRepo.findById(7L)).thenReturn(Optional.of(ext));
             when(invoiceDao.findRecentByCustomer(anyString(), anyInt())).thenReturn(List.of());
 

--- a/app/saas/src/test/java/stirling/software/saas/payg/api/PaygPaymentMethodControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/payg/api/PaygPaymentMethodControllerTest.java
@@ -34,6 +34,7 @@ import stirling.software.saas.payg.repository.PaygTeamExtensionsRepository;
 import stirling.software.saas.payg.stripe.StripePaymentMethodDao;
 import stirling.software.saas.payg.stripe.StripePaymentMethodDao.CardSummary;
 import stirling.software.saas.security.EnhancedJwtAuthenticationToken;
+import stirling.software.saas.security.UserTeamResolver;
 
 /**
  * Pure-Mockito unit tests for {@link PaygPaymentMethodController}: the auth/team-resolution and
@@ -54,7 +55,10 @@ class PaygPaymentMethodControllerTest {
     void setUp() {
         controller =
                 new PaygPaymentMethodController(
-                        paymentMethodDao, extRepo, memberRepo, userRepository);
+                        paymentMethodDao,
+                        extRepo,
+                        new UserTeamResolver(memberRepo),
+                        userRepository);
     }
 
     @Test
@@ -75,7 +79,6 @@ class PaygPaymentMethodControllerTest {
     void noTeam_returnsAbsent() {
         User user = userWithId(5L, UUID.randomUUID());
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(5L)).thenReturn(List.of());
 
         ResponseEntity<PaymentMethodResponse> resp = controller.get(jwtAuth(user.getSupabaseId()));
 
@@ -90,8 +93,7 @@ class PaygPaymentMethodControllerTest {
         User user = userWithId(6L, UUID.randomUUID());
         Team team = teamWithId(60L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(6L))
-                .thenReturn(List.of(membership(team, user, TeamRole.LEADER)));
+        user.setTeam(team);
         PaygTeamExtensions ext = mock(PaygTeamExtensions.class);
         when(ext.getStripeCustomerId()).thenReturn(null);
         when(extRepo.findById(60L)).thenReturn(Optional.of(ext));
@@ -108,8 +110,7 @@ class PaygPaymentMethodControllerTest {
         User user = userWithId(7L, UUID.randomUUID());
         Team team = teamWithId(70L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(7L))
-                .thenReturn(List.of(membership(team, user, TeamRole.LEADER)));
+        user.setTeam(team);
         PaygTeamExtensions ext = mock(PaygTeamExtensions.class);
         when(ext.getStripeCustomerId()).thenReturn("cus_123");
         when(extRepo.findById(70L)).thenReturn(Optional.of(ext));
@@ -132,8 +133,7 @@ class PaygPaymentMethodControllerTest {
         User user = userWithId(8L, UUID.randomUUID());
         Team team = teamWithId(80L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(8L))
-                .thenReturn(List.of(membership(team, user, TeamRole.LEADER)));
+        user.setTeam(team);
         PaygTeamExtensions ext = mock(PaygTeamExtensions.class);
         when(ext.getStripeCustomerId()).thenReturn("cus_456");
         when(extRepo.findById(80L)).thenReturn(Optional.of(ext));

--- a/app/saas/src/test/java/stirling/software/saas/payg/api/PaygWalletControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/payg/api/PaygWalletControllerTest.java
@@ -53,6 +53,7 @@ import stirling.software.saas.payg.repository.WalletLedgerRepository;
 import stirling.software.saas.payg.repository.WalletPolicyRepository;
 import stirling.software.saas.payg.wallet.WalletPolicy;
 import stirling.software.saas.security.EnhancedJwtAuthenticationToken;
+import stirling.software.saas.security.UserTeamResolver;
 
 /**
  * Pure-Mockito unit tests for {@link PaygWalletController}. Covers the documented role / state
@@ -86,7 +87,8 @@ class PaygWalletControllerTest {
                         ledgerRepo,
                         shadowRepo,
                         userRepository,
-                        prepaidBundleService);
+                        prepaidBundleService,
+                        new UserTeamResolver(memberRepo));
     }
 
     /**
@@ -147,8 +149,9 @@ class PaygWalletControllerTest {
         User user = userWithId(7L, UUID.randomUUID());
         Team team = teamWithId(42L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(7L))
-                .thenReturn(List.of(membership(team, user, TeamRole.MEMBER)));
+        user.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 7L))
+                .thenReturn(Optional.of(membership(team, user, TeamRole.MEMBER)));
         when(billingService.forTeam(42L)).thenReturn(freeBilling(500L));
         when(entitlementService.getSnapshot(42L)).thenReturn(snapshot(0L, 500L));
         stubEmptyLedgerReads(42L);
@@ -182,8 +185,9 @@ class PaygWalletControllerTest {
         User user = userWithId(8L, UUID.randomUUID());
         Team team = teamWithId(99L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(8L))
-                .thenReturn(List.of(membership(team, user, TeamRole.MEMBER)));
+        user.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 8L))
+                .thenReturn(Optional.of(membership(team, user, TeamRole.MEMBER)));
         // $25 cap (2500 minor) at $0.02/doc → 1250 paid docs/month (the one-time grant is a
         // separate pool, not added to the cap).
         when(billingService.forTeam(99L))
@@ -241,8 +245,9 @@ class PaygWalletControllerTest {
         User user = userWithId(9L, UUID.randomUUID());
         Team team = teamWithId(11L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(9L))
-                .thenReturn(List.of(membership(team, user, TeamRole.LEADER)));
+        user.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 9L))
+                .thenReturn(Optional.of(membership(team, user, TeamRole.LEADER)));
         when(billingService.forTeam(11L)).thenReturn(subscribedBilling("sub_nocap", null, null));
         when(entitlementService.getSnapshot(11L)).thenReturn(snapshot(50L, null));
         stubEmptyLedgerReads(11L);
@@ -271,7 +276,9 @@ class PaygWalletControllerTest {
         TeamMembership memberRow = membership(team, member, TeamRole.MEMBER);
 
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(leader));
-        when(memberRepo.findPrimaryMembership(10L)).thenReturn(List.of(leaderRow));
+        leader.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 10L))
+                .thenReturn(Optional.of(leaderRow));
         when(billingService.forTeam(77L)).thenReturn(freeBilling(500L));
         when(entitlementService.getSnapshot(77L)).thenReturn(snapshot(0L, 500L));
         stubEmptyLedgerReads(77L);
@@ -315,7 +322,6 @@ class PaygWalletControllerTest {
     void getWallet_authenticatedNoTeam_returnsEmptyFreeShape() {
         User user = userWithId(12L, UUID.randomUUID());
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(12L)).thenReturn(List.of());
 
         ResponseEntity<WalletSnapshotResponse> resp =
                 controller.getWallet(jwtAuth(user.getSupabaseId()));
@@ -336,8 +342,9 @@ class PaygWalletControllerTest {
         User leader = userWithId(20L, UUID.randomUUID());
         Team team = teamWithId(33L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(leader));
-        when(memberRepo.findPrimaryMembership(20L))
-                .thenReturn(List.of(membership(team, leader, TeamRole.LEADER)));
+        leader.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 20L))
+                .thenReturn(Optional.of(membership(team, leader, TeamRole.LEADER)));
         when(policyRepo.findByTeamId(33L)).thenReturn(Optional.empty());
 
         ResponseEntity<Void> resp =
@@ -359,8 +366,9 @@ class PaygWalletControllerTest {
         User leader = userWithId(24L, UUID.randomUUID());
         Team team = teamWithId(36L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(leader));
-        when(memberRepo.findPrimaryMembership(24L))
-                .thenReturn(List.of(membership(team, leader, TeamRole.LEADER)));
+        leader.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 24L))
+                .thenReturn(Optional.of(membership(team, leader, TeamRole.LEADER)));
         when(policyRepo.findByTeamId(36L)).thenReturn(Optional.empty());
         TeamBillingContext billing = subscribedBilling("sub_36", null, null);
         when(billingService.forTeam(36L)).thenReturn(billing);
@@ -384,8 +392,9 @@ class PaygWalletControllerTest {
         User leader = userWithId(21L, UUID.randomUUID());
         Team team = teamWithId(34L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(leader));
-        when(memberRepo.findPrimaryMembership(21L))
-                .thenReturn(List.of(membership(team, leader, TeamRole.LEADER)));
+        leader.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 21L))
+                .thenReturn(Optional.of(membership(team, leader, TeamRole.LEADER)));
         WalletPolicy existing = new WalletPolicy();
         existing.setTeamId(34L);
         existing.setCapUnits(1000L);
@@ -409,8 +418,9 @@ class PaygWalletControllerTest {
         User member = userWithId(22L, UUID.randomUUID());
         Team team = teamWithId(35L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(member));
-        when(memberRepo.findPrimaryMembership(22L))
-                .thenReturn(List.of(membership(team, member, TeamRole.MEMBER)));
+        member.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 22L))
+                .thenReturn(Optional.of(membership(team, member, TeamRole.MEMBER)));
 
         ResponseEntity<Void> resp =
                 controller.updateCap(
@@ -425,7 +435,6 @@ class PaygWalletControllerTest {
     void updateCap_noTeam_isForbidden() {
         User user = userWithId(23L, UUID.randomUUID());
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(23L)).thenReturn(List.of());
 
         ResponseEntity<Void> resp =
                 controller.updateCap(
@@ -458,8 +467,7 @@ class PaygWalletControllerTest {
         User user = userWithId(30L, UUID.randomUUID());
         Team team = teamWithId(70L);
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(30L))
-                .thenReturn(List.of(membership(team, user, TeamRole.MEMBER)));
+        user.setTeam(team);
 
         ResponseEntity<Void> resp = controller.refreshWallet(jwtAuth(user.getSupabaseId()));
 
@@ -473,7 +481,6 @@ class PaygWalletControllerTest {
     void refreshWallet_noTeam_isNoOpButOk() {
         User user = userWithId(31L, UUID.randomUUID());
         when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
-        when(memberRepo.findPrimaryMembership(31L)).thenReturn(List.of());
 
         ResponseEntity<Void> resp = controller.refreshWallet(jwtAuth(user.getSupabaseId()));
 

--- a/app/saas/src/test/java/stirling/software/saas/security/TeamSecurityExpressionsMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/TeamSecurityExpressionsMoreTest.java
@@ -44,7 +44,8 @@ class TeamSecurityExpressionsMoreTest {
     private static final long USER_ID = 7L;
 
     private TeamSecurityExpressions expressions() {
-        return new TeamSecurityExpressions(membershipRepository, userService);
+        return new TeamSecurityExpressions(
+                membershipRepository, userService, new UserTeamResolver(membershipRepository));
     }
 
     @AfterEach

--- a/app/saas/src/test/java/stirling/software/saas/security/TeamSecurityExpressionsTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/TeamSecurityExpressionsTest.java
@@ -39,7 +39,8 @@ class TeamSecurityExpressionsTest {
     private static final long USER_ID = 1L;
 
     private TeamSecurityExpressions expressions() {
-        return new TeamSecurityExpressions(membershipRepository, userService);
+        return new TeamSecurityExpressions(
+                membershipRepository, userService, new UserTeamResolver(membershipRepository));
     }
 
     @AfterEach

--- a/app/saas/src/test/java/stirling/software/saas/security/UserTeamResolverTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/UserTeamResolverTest.java
@@ -1,0 +1,106 @@
+package stirling.software.saas.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import stirling.software.common.model.enumeration.TeamRole;
+import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.model.TeamMembership;
+import stirling.software.proprietary.security.model.User;
+import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserTeamResolverTest {
+
+    @Mock private TeamMembershipRepository membershipRepository;
+
+    private UserTeamResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new UserTeamResolver(membershipRepository);
+    }
+
+    /** The id comes straight off the eager association, so it must cost no query. */
+    @Test
+    void teamIdReadsTheForeignKeyWithoutQuerying() {
+        assertThat(resolver.teamId(user(1L, 100L))).contains(100L);
+        verifyNoInteractions(membershipRepository);
+    }
+
+    @Test
+    void teamIdIsEmptyWithoutATeamOrAUser() {
+        assertThat(resolver.teamId(user(2L, null))).isEmpty();
+        assertThat(resolver.teamId(null)).isEmpty();
+        verifyNoInteractions(membershipRepository);
+    }
+
+    /**
+     * The behaviour the fix exists for: a joined member. users.team_id is the joined team, and the
+     * role is read from the joined team's row — not from the older home-team membership a join
+     * leaves in place.
+     */
+    @Test
+    void resolvesTheJoinedTeamAndItsRole() {
+        User joined = user(3L, 200L);
+        when(membershipRepository.findByTeamIdAndUserId(200L, 3L))
+                .thenReturn(Optional.of(membership(TeamRole.MEMBER)));
+
+        assertThat(resolver.teamId(joined)).contains(200L);
+        // MEMBER of the joined team, not LEADER of the home team a join leaves behind.
+        assertThat(resolver.isLeader(joined)).isFalse();
+    }
+
+    @Test
+    void isLeaderWhenTheBillingTeamsRowSaysSo() {
+        User leader = user(4L, 400L);
+        when(membershipRepository.findByTeamIdAndUserId(400L, 4L))
+                .thenReturn(Optional.of(membership(TeamRole.LEADER)));
+
+        assertThat(resolver.isLeader(leader)).isTrue();
+    }
+
+    /** A dangling users.team_id: no role, so no leader powers. */
+    @Test
+    void noRoleWhenTheTeamHasNoMembershipRow() {
+        User dangling = user(5L, 500L);
+        when(membershipRepository.findByTeamIdAndUserId(500L, 5L)).thenReturn(Optional.empty());
+
+        assertThat(resolver.isLeader(dangling)).isFalse();
+        // The team is still reported, so reads stay in step with the enforcement layer.
+        assertThat(resolver.teamId(dangling)).contains(500L);
+    }
+
+    @Test
+    void neverALeaderWithoutATeam() {
+        assertThat(resolver.isLeader(user(6L, null))).isFalse();
+        assertThat(resolver.isLeader(null)).isFalse();
+        verifyNoInteractions(membershipRepository);
+    }
+
+    private static User user(long id, Long teamId) {
+        User u = new User();
+        u.setId(id);
+        if (teamId != null) {
+            Team t = new Team();
+            t.setId(teamId);
+            u.setTeam(t);
+        }
+        return u;
+    }
+
+    private static TeamMembership membership(TeamRole role) {
+        TeamMembership m = new TeamMembership();
+        m.setRole(role);
+        return m;
+    }
+}

--- a/app/saas/src/test/java/stirling/software/saas/usage/SaasFleetUsageControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/usage/SaasFleetUsageControllerTest.java
@@ -32,6 +32,7 @@ import stirling.software.proprietary.repository.PersistentAuditEventRepository;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+import stirling.software.saas.security.UserTeamResolver;
 
 @ExtendWith(MockitoExtension.class)
 class SaasFleetUsageControllerTest {
@@ -47,13 +48,26 @@ class SaasFleetUsageControllerTest {
     void setUp() {
         controller =
                 new SaasFleetUsageController(
-                        userRepository, memberRepo, auditRepository, auditConfig);
+                        userRepository,
+                        memberRepo,
+                        new UserTeamResolver(memberRepo),
+                        auditRepository,
+                        auditConfig);
     }
 
     /** An Authentication whose principal is a User (AuthenticationUtils returns it directly). */
     private Authentication authFor(long userId) {
+        return authFor(userId, null);
+    }
+
+    private Authentication authFor(long userId, Long teamId) {
         User user = mock(User.class);
-        when(user.getId()).thenReturn(userId);
+        lenient().when(user.getId()).thenReturn(userId);
+        if (teamId != null) {
+            Team team = mock(Team.class);
+            lenient().when(team.getId()).thenReturn(teamId);
+            lenient().when(user.getTeam()).thenReturn(team);
+        }
         Authentication auth = mock(Authentication.class);
         when(auth.getPrincipal()).thenReturn(user);
         return auth;
@@ -75,10 +89,9 @@ class SaasFleetUsageControllerTest {
     @Test
     @DisplayName("figures are scoped to the caller's team members")
     void teamScopedFigures() {
-        Authentication auth = authFor(1L);
+        Authentication auth = authFor(1L, 42L);
         TeamMembership leader = memberOf(42L, "leader@acme.test");
         TeamMembership bob = memberOf(42L, "bob@acme.test");
-        when(memberRepo.findPrimaryMembership(1L)).thenReturn(List.of(leader));
         when(memberRepo.findByTeamId(42L)).thenReturn(List.of(leader, bob));
         when(auditConfig.isLevelEnabled(AuditLevel.STANDARD)).thenReturn(true);
         when(auditRepository.countDistinctPrincipalsBySourceExcludingTypeAndPrincipalInAfter(
@@ -106,9 +119,8 @@ class SaasFleetUsageControllerTest {
     @Test
     @DisplayName("audit-derived figures are null when auditing is below STANDARD")
     void auditOffYieldsNulls() {
-        Authentication auth = authFor(1L);
+        Authentication auth = authFor(1L, 42L);
         TeamMembership leader = memberOf(42L, "leader@acme.test");
-        when(memberRepo.findPrimaryMembership(1L)).thenReturn(List.of(leader));
         when(memberRepo.findByTeamId(42L)).thenReturn(List.of(leader));
         when(auditConfig.isLevelEnabled(AuditLevel.STANDARD)).thenReturn(false);
 
@@ -126,9 +138,8 @@ class SaasFleetUsageControllerTest {
     @Test
     @DisplayName("active is clamped to deployed (a subset)")
     void activeClampedToDeployed() {
-        Authentication auth = authFor(1L);
+        Authentication auth = authFor(1L, 42L);
         TeamMembership leader = memberOf(42L, "leader@acme.test");
-        when(memberRepo.findPrimaryMembership(1L)).thenReturn(List.of(leader));
         when(memberRepo.findByTeamId(42L)).thenReturn(List.of(leader));
         when(auditConfig.isLevelEnabled(AuditLevel.STANDARD)).thenReturn(true);
         when(auditRepository.countDistinctPrincipalsBySourceExcludingTypeAndPrincipalInAfter(
@@ -148,7 +159,6 @@ class SaasFleetUsageControllerTest {
     @DisplayName("a caller with no team gets an empty fleet, not a 500")
     void noTeamReturnsEmpty() {
         Authentication auth = authFor(1L);
-        when(memberRepo.findPrimaryMembership(1L)).thenReturn(List.of());
 
         FleetUsageStats stats = controller.fleetStats(auth).getBody();
 


### PR DESCRIPTION
## The bug

Team-scoped read endpoints resolved the caller's team from their **oldest membership** (`findPrimaryMembership().getFirst()`), while enforcement (`EntitlementGuard`, `PaygChargeInterceptor`) reads `users.team_id`. A join *keeps* the home membership, so the oldest row is permanently the home team: a joined member was shown, and their leader could edit, the **home** team's wallet and cap while being billed and blocked against the **joined** team. That mismatch is the "free-limit modal fires at a full allowance" bug.

## Why `users.team_id` is the correct answer

It is the home team at signup, and `SaasTeamService.acceptInvitation` repoints it to a joined team **only on accept** (guarded on `status == PENDING`). Sending an invitation sets `invitation.team` and touches neither the FK nor the membership set. So it already means "home by default, the joined team once you have actually joined" — and it is what enforcement already reads. Display was simply reading something else.

`findPrimaryMembership`'s javadoc claimed "the old personal team is deleted on accept" — untrue since the durable-home model, and how the oldest row came to be mistaken for home.

## What the fix actually is

Seven call sites stop reading the oldest membership and read the FK instead, and **`findPrimaryMembership` is deleted** so the wrong answer is no longer reachable: `PaygWalletController` (wallet + cap + refresh), `PaygInvoicesController`, `PaygPaymentMethodController`, `LegalController`, `ProcurementController`, `SaasFleetUsageController`, `LeaderTeamResolver`.

`UserTeamResolver` is **not** the fix — it is where those sites now point. `teamId()` is an extraction of the one-liner enforcement already used inline; the class earns its place by deduping the `isLeader` chain (6 sites, previously duplicated twice inside `TeamSecurityExpressions`) and giving the rule one documented home. `TeamSecurityExpressions` now delegates rather than keeping a second copy. Five classes no longer need `TeamMembershipRepository` at all.

## Effects

- Wallet and usage figures describe the team you are actually billed against.
- **`PATCH /wallet/cap` now works** — it previously wrote the home team's policy, which enforcement never reads, so caps were silently ineffective.
- `isLeader` is the role in the billing team. Leader-only surfaces were being granted on the home-team role, where a joined member is usually LEADER of their own personal team. The team id was also the home team, so this stayed scoped to the user's own team — wrong gating, no cross-tenant exposure.
- The five id-only endpoints drop from one membership query to zero (`User.team` is `@ManyToOne(fetch = EAGER)`).

## Evidence

- **`BillingTeamResolutionDbTest` (new, real H2)** persists the scenario a mock cannot — a durable home team the user leads plus a later-joined team, `users.team_id` on the joined team — and asserts the oldest membership and `users.team_id` resolve to *different* teams, with the FK path returning the joined one. Verified against `origin/main` by running main's actual resolution (`findPrimaryMembership().getFirst()`) on the same rows: it returns the home team (`expected: 2L but was: 1L`) — **red on main, green here.**
- The 22 `TeamSecurityExpressions` tests pass with **only the constructor wiring line changed** — no case, stub or assertion touched — proving the extraction half changes no behaviour. Plus 6 resolver unit tests, one asserting `teamId()` does no repository query.
- 1295 saas + full proprietary suites green (one unrelated symlink test fails on this machine for lack of the OS privilege, on any branch).

**Still not observed end-to-end:** the persistence test exercises the resolution rule directly, not an HTTP round-trip through each controller (this module has no `@SpringBootTest`). Enforcement is untouched, so display and enforcement agree by value rather than shared code.

No schema change. SaaS only.
