### PR TITLE
Let a linked self-hosted instance read its own SaaS data

### DIFF
--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
@@ -297,18 +297,12 @@ public class SupabaseSecurityConfig {
      * the customer deployed on, so these cannot be served by an allow-list. See {@link
      * #linkedInstanceCors()}.
      *
-     * <p>The first three prefixes host portal endpoints only. {@code ui-data} does not, so those
-     * are listed one by one: the same prefix also serves admin-settings, database, teams, account
-     * and login, none of which the portal reads cross-origin.
+     * <p>All three host cloud-only endpoints, which is what makes a prefix safe here: billing,
+     * procurement and legal documents have no self-hosted equivalent. Anything the instance also
+     * serves itself belongs on {@code apiClient.local} instead of here.
      */
     private static final List<String> LINKED_INSTANCE_PATHS =
-            List.of(
-                    "/api/v1/payg/**",
-                    "/api/v1/procurement/**",
-                    "/api/v1/legal/**",
-                    "/api/v1/proprietary/ui-data/documents",
-                    "/api/v1/proprietary/ui-data/audit-export",
-                    "/api/v1/proprietary/ui-data/infrastructure/audit-log");
+            List.of("/api/v1/payg/**", "/api/v1/procurement/**", "/api/v1/legal/**");
 
     /**
      * Profiles that mean "a developer's machine or a preview environment", never the production

--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
@@ -85,6 +85,9 @@ public class SupabaseSecurityConfig {
     @Value("${app.supabase.clock-skew-seconds:120}")
     private long clockSkewSeconds;
 
+    @Value("${stirling.billing.account-link.enabled:false}")
+    private boolean accountLinkEnabled;
+
     @Bean
     SecurityFilterChain saasSecurityFilterChain(
             HttpSecurity http,
@@ -289,6 +292,25 @@ public class SupabaseSecurityConfig {
             List.of("http://localhost:[*]", "http://127.0.0.1:[*]");
 
     /**
+     * The surface a linked self-hosted instance calls from its own browser with the signed-in
+     * admin's Supabase JWT, mirroring the frontend's {@code apiClient.saas}. Its origin is whatever
+     * the customer deployed on, so these cannot be served by an allow-list. See {@link
+     * #linkedInstanceCors()}.
+     *
+     * <p>The first three prefixes host portal endpoints only. {@code ui-data} does not, so those
+     * are listed one by one: the same prefix also serves admin-settings, database, teams, account
+     * and login, none of which the portal reads cross-origin.
+     */
+    private static final List<String> LINKED_INSTANCE_PATHS =
+            List.of(
+                    "/api/v1/payg/**",
+                    "/api/v1/procurement/**",
+                    "/api/v1/legal/**",
+                    "/api/v1/proprietary/ui-data/documents",
+                    "/api/v1/proprietary/ui-data/audit-export",
+                    "/api/v1/proprietary/ui-data/infrastructure/audit-log");
+
+    /**
      * Profiles that mean "a developer's machine or a preview environment", never the production
      * deployment. Production runs the bare {@code saas} profile.
      */
@@ -375,8 +397,35 @@ public class SupabaseSecurityConfig {
         cfg.setAllowCredentials(true);
         cfg.setMaxAge(3600L);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        // Registered ahead of "/**": the source returns the first pattern that matches, not the
+        // most specific one.
+        if (accountLinkEnabled) {
+            CorsConfiguration linked = linkedInstanceCors();
+            for (String path : LINKED_INSTANCE_PATHS) {
+                source.registerCorsConfiguration(path, linked);
+            }
+        }
         source.registerCorsConfiguration("/**", cfg);
         return source;
+    }
+
+    /**
+     * Any-origin CORS for the reads a linked self-hosted instance makes from its own browser, whose
+     * origin cannot be known in advance.
+     *
+     * <p>Safe only because it carries no credentials: this chain is bearer-token only and nothing
+     * in the SaaS module reads a cookie, so the browser attaches no ambient authority and a hostile
+     * page has nothing to ride on. The same reasoning already justifies disabling CSRF here.
+     * Authorisation is unchanged; this decides only who may read the response.
+     */
+    private static CorsConfiguration linkedInstanceCors() {
+        CorsConfiguration cfg = new CorsConfiguration();
+        cfg.setAllowedOrigins(List.of(CorsConfiguration.ALL));
+        cfg.setAllowedMethods(List.of("GET", "POST", "PATCH", "OPTIONS"));
+        cfg.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+        cfg.setAllowCredentials(false);
+        cfg.setMaxAge(3600L);
+        return cfg;
     }
 
     /**

--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
@@ -297,12 +297,21 @@ public class SupabaseSecurityConfig {
      * the customer deployed on, so these cannot be served by an allow-list. See {@link
      * #linkedInstanceCors()}.
      *
-     * <p>All three host cloud-only endpoints, which is what makes a prefix safe here: billing,
-     * procurement and legal documents have no self-hosted equivalent. Anything the instance also
-     * serves itself belongs on {@code apiClient.local} instead of here.
+     * <p>Each hosts cloud-only endpoints, which is what makes a prefix safe here: billing,
+     * procurement, legal documents and the team's roster of linked instances have no self-hosted
+     * equivalent. Anything the instance also serves itself belongs on {@code apiClient.local}
+     * instead of here.
+     *
+     * <p>Only the {@code instances} half of account-link is listed. The {@code connect/*} handshake
+     * never reaches a browser on the customer's origin: the instance backend calls {@code request}
+     * and {@code claim} server-side, and the approval page is served by us.
      */
     private static final List<String> LINKED_INSTANCE_PATHS =
-            List.of("/api/v1/payg/**", "/api/v1/procurement/**", "/api/v1/legal/**");
+            List.of(
+                    "/api/v1/payg/**",
+                    "/api/v1/procurement/**",
+                    "/api/v1/legal/**",
+                    "/api/v1/account-link/instances/**");
 
     /**
      * Profiles that mean "a developer's machine or a preview environment", never the production

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -12,10 +12,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -350,6 +354,82 @@ class SupabaseSecurityConfigMoreTest {
 
             assertThat(auth.getAuthorities().stream().map(a -> a.getAuthority()).toList())
                     .contains("ROLE_LIMITED_API_USER");
+        }
+    }
+
+    @Nested
+    @DisplayName("linked-instance CORS")
+    class LinkedInstanceCors {
+
+        /** An origin no allow-list could ever contain: a customer's own deployment. */
+        private static final String SELF_HOSTED = "http://54.175.155.236:7779";
+
+        private CorsConfigurationSource source(boolean accountLinkEnabled) {
+            SupabaseSecurityConfig cfg = config(new ApplicationProperties());
+            ReflectionTestUtils.setField(cfg, "accountLinkEnabled", accountLinkEnabled);
+            return cfg.corsConfigurationSource();
+        }
+
+        private CorsConfiguration resolve(CorsConfigurationSource source, String path) {
+            return source.getCorsConfiguration(new MockHttpServletRequest("GET", path));
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "/api/v1/payg/wallet",
+                    "/api/v1/payg/wallet/refresh",
+                    "/api/v1/payg/invoices",
+                    "/api/v1/payg/cap",
+                    "/api/v1/procurement/quote",
+                    "/api/v1/legal/consent",
+                    "/api/v1/proprietary/ui-data/documents",
+                    "/api/v1/proprietary/ui-data/audit-export",
+                    "/api/v1/proprietary/ui-data/infrastructure/audit-log"
+                })
+        @DisplayName("every apiClient.saas path is readable from any origin")
+        void portalReadsAllowAnyOrigin(String path) {
+            CorsConfiguration cfg = resolve(source(true), path);
+
+            assertThat(cfg.checkOrigin(SELF_HOSTED)).isEqualTo("*");
+            // The wildcard is only defensible without credentials. These must never both be set:
+            // the browser rejects the pair outright, and it would be an open credentialed API.
+            assertThat(cfg.getAllowCredentials()).isNotEqualTo(Boolean.TRUE);
+        }
+
+        @Test
+        @DisplayName("PATCH is allowed; the cap endpoint needs it")
+        void patchAllowed() {
+            CorsConfiguration cfg = resolve(source(true), "/api/v1/payg/cap");
+
+            assertThat(cfg.checkHttpMethod(HttpMethod.PATCH)).isNotNull();
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "/api/v1/instance/sync",
+                    // Same prefix as the portal reads above, but not portal surface. Widening
+                    // ui-data to "/**" would hand these to any origin too.
+                    "/api/v1/proprietary/ui-data/admin-settings",
+                    "/api/v1/proprietary/ui-data/database",
+                    "/api/v1/proprietary/ui-data/teams"
+                })
+        @DisplayName("every other path keeps the credentialed allow-list")
+        void otherPathsUnchanged(String path) {
+            CorsConfiguration cfg = resolve(source(true), path);
+
+            assertThat(cfg.getAllowCredentials()).isTrue();
+            assertThat(cfg.checkOrigin(SELF_HOSTED)).isNull();
+        }
+
+        @Test
+        @DisplayName("no wildcard at all when account linking is off")
+        void flagOffKeepsAllowList() {
+            CorsConfiguration cfg = resolve(source(false), "/api/v1/payg/wallet");
+
+            assertThat(cfg.getAllowCredentials()).isTrue();
+            assertThat(cfg.checkOrigin(SELF_HOSTED)).isNull();
         }
     }
 }

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -382,10 +382,7 @@ class SupabaseSecurityConfigMoreTest {
                     "/api/v1/payg/invoices",
                     "/api/v1/payg/cap",
                     "/api/v1/procurement/quote",
-                    "/api/v1/legal/consent",
-                    "/api/v1/proprietary/ui-data/documents",
-                    "/api/v1/proprietary/ui-data/audit-export",
-                    "/api/v1/proprietary/ui-data/infrastructure/audit-log"
+                    "/api/v1/legal/consent"
                 })
         @DisplayName("every apiClient.saas path is readable from any origin")
         void portalReadsAllowAnyOrigin(String path) {
@@ -409,11 +406,13 @@ class SupabaseSecurityConfigMoreTest {
         @ValueSource(
                 strings = {
                     "/api/v1/instance/sync",
-                    // Same prefix as the portal reads above, but not portal surface. Widening
-                    // ui-data to "/**" would hand these to any origin too.
+                    // The instance serves its own audit trail and Documents feed, so the portal
+                    // reads these from apiClient.local. They must never need cross-origin access.
+                    "/api/v1/proprietary/ui-data/documents",
+                    "/api/v1/proprietary/ui-data/audit-export",
+                    "/api/v1/proprietary/ui-data/infrastructure/audit-log",
                     "/api/v1/proprietary/ui-data/admin-settings",
-                    "/api/v1/proprietary/ui-data/database",
-                    "/api/v1/proprietary/ui-data/teams"
+                    "/api/v1/proprietary/ui-data/database"
                 })
         @DisplayName("every other path keeps the credentialed allow-list")
         void otherPathsUnchanged(String path) {

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -382,7 +382,10 @@ class SupabaseSecurityConfigMoreTest {
                     "/api/v1/payg/invoices",
                     "/api/v1/payg/cap",
                     "/api/v1/procurement/quote",
-                    "/api/v1/legal/consent"
+                    "/api/v1/legal/consent",
+                    // The Settings page's "who is linked" table, and its revoke button.
+                    "/api/v1/account-link/instances",
+                    "/api/v1/account-link/instances/42/revoke"
                 })
         @DisplayName("every apiClient.saas path is readable from any origin")
         void portalReadsAllowAnyOrigin(String path) {
@@ -412,7 +415,11 @@ class SupabaseSecurityConfigMoreTest {
                     "/api/v1/proprietary/ui-data/audit-export",
                     "/api/v1/proprietary/ui-data/infrastructure/audit-log",
                     "/api/v1/proprietary/ui-data/admin-settings",
-                    "/api/v1/proprietary/ui-data/database"
+                    "/api/v1/proprietary/ui-data/database",
+                    // The handshake is server-side plus our own approval page, never the
+                    // customer's origin.
+                    "/api/v1/account-link/connect/request",
+                    "/api/v1/account-link/connect/claim"
                 })
         @DisplayName("every other path keeps the credentialed allow-list")
         void otherPathsUnchanged(String path) {

--- a/frontend/editor/src/portal/api/documents.ts
+++ b/frontend/editor/src/portal/api/documents.ts
@@ -123,10 +123,8 @@ export const DOC_AUDIT_TONE: Record<DocAuditKind, StatusTone> = {
   elevation: "purple",
 };
 
-/** GET the audit-derived Documents feed; SaaS or local, scoped server-side. `tier` ignored. */
+/** GET the audit-derived Documents feed, scoped server-side. `tier` ignored. */
 export async function fetchDocuments(tier: Tier): Promise<DocumentsResponse> {
   const path = `/api/v1/proprietary/ui-data/documents?tier=${encodeURIComponent(tier)}`;
-  return apiClient.saas.isConfigured()
-    ? apiClient.saas.json<DocumentsResponse>(path)
-    : apiClient.local.json<DocumentsResponse>(path);
+  return apiClient.local.json<DocumentsResponse>(path);
 }

--- a/frontend/editor/src/portal/api/http.ts
+++ b/frontend/editor/src/portal/api/http.ts
@@ -21,13 +21,6 @@
  *                             state rather than silently routing to the wrong
  *                             domain.
  *
- * Pick the domain from what the endpoint IS, never from whether SaaS happens to
- * be configured. "A SaaS URL is set" is not "I am the SaaS build": a linked
- * self-hosted instance is both configured and still the owner of its own data,
- * and routing on that read sent its audit trail and Documents feed to the cloud.
- * If an endpoint exists in both flavors it belongs on `.local`, which already
- * resolves per flavor via the localBackend seam.
- *
  * Endpoints that don't have a real backend yet still target their eventual
  * domain (almost always `.local`): with Mocks=on the MSW handlers intercept;
  * with Mocks=off they hit the real backend and 404 until the route ships, then

--- a/frontend/editor/src/portal/api/http.ts
+++ b/frontend/editor/src/portal/api/http.ts
@@ -21,6 +21,13 @@
  *                             state rather than silently routing to the wrong
  *                             domain.
  *
+ * Pick the domain from what the endpoint IS, never from whether SaaS happens to
+ * be configured. "A SaaS URL is set" is not "I am the SaaS build": a linked
+ * self-hosted instance is both configured and still the owner of its own data,
+ * and routing on that read sent its audit trail and Documents feed to the cloud.
+ * If an endpoint exists in both flavors it belongs on `.local`, which already
+ * resolves per flavor via the localBackend seam.
+ *
  * Endpoints that don't have a real backend yet still target their eventual
  * domain (almost always `.local`): with Mocks=on the MSW handlers intercept;
  * with Mocks=off they hit the real backend and 404 until the route ships, then
@@ -324,7 +331,5 @@ export const apiClient = {
     json: saasJson,
     text: saasText,
     blob: saasBlob,
-    /** True when a SaaS base URL is resolvable. Doesn't check session liveness. */
-    isConfigured: (): boolean => saasBaseUrl() !== null,
   },
 } as const;

--- a/frontend/editor/src/portal/api/infrastructure.ts
+++ b/frontend/editor/src/portal/api/infrastructure.ts
@@ -106,15 +106,13 @@ export async function revokeApiKey(id: string): Promise<void> {
   await apiClient.local.json<void>(path, { method: "DELETE" });
 }
 
-/** GET the audit log; SaaS or local, backend-scoped (admin → server, SaaS lead → team). */
+/** GET the audit log, backend-scoped (admin → server, SaaS lead → team). */
 export async function fetchAuditLog(tier: Tier): Promise<AuditLogResponse> {
   const path = `/api/v1/proprietary/ui-data/infrastructure/audit-log${q(tier)}`;
-  return apiClient.saas.isConfigured()
-    ? apiClient.saas.json<AuditLogResponse>(path)
-    : apiClient.local.json<AuditLogResponse>(path);
+  return apiClient.local.json<AuditLogResponse>(path);
 }
 
-/** Download the audit log as a CSV/JSON blob (admin-only, whole-server); SaaS or local. */
+/** Download the audit log as a CSV/JSON blob (admin-only, whole-server). */
 export async function exportAuditLog(
   format: "csv" | "json",
   fields: string,
@@ -122,7 +120,5 @@ export async function exportAuditLog(
   const path = `/api/v1/proprietary/ui-data/audit-export?format=${format}&fields=${encodeURIComponent(
     fields,
   )}`;
-  return apiClient.saas.isConfigured()
-    ? apiClient.saas.blob(path)
-    : apiClient.local.blob(path);
+  return apiClient.local.blob(path);
 }


### PR DESCRIPTION
## Current state

A self-hosted instance that has linked its SaaS account talks to SaaS over two channels:

1. **Server to server.** `AccountLinkClient` uses `java.net.http.HttpClient` with the device credential against `/api/v1/instance/*`. No browser, so CORS never applies. This works today.
2. **Browser to SaaS.** The portal's `apiClient.saas` fetches SaaS directly from the instance's own page, carrying the signed-in admin's Supabase JWT.

Channel 2 is blocked. `corsConfigurationSource()` allows a fixed origin list (`localhost:3000/5173/8080`, `stirling.com`, `app.stirling.com`, `api.stirling.com`, the Tauri origins, plus loopback-any-port outside production). A customer's instance is on none of them.

## Problem

**Self-hosted origins cannot be allow-listed.** Every deployment has a different scheme, host and port, they are not known ahead of time, and each entry would be a standing grant to return credentialed responses to that origin. `setAllowCredentials(true)` also rules out `*`, since browsers reject that pair.

**Three endpoints were pointed at the wrong backend.** `fetchDocuments`, `fetchAuditLog` and `exportAuditLog` chose their backend with `apiClient.saas.isConfigured()`, which answers "is a SaaS URL set", not "am I the SaaS build". Those coincide only while self-hosted never sets `VITE_SAAS_API_URL` — which linking now requires.

## Solution

### 1. Send the instance's own data to the instance

Documents and the audit trail are local to a self-hosted deployment. SaaS holds no audit rows for a linked instance: the daily sync carries three counters (`api`, `ai`, `automation`) and nothing else. So a linked instance was silently showing the admin's **cloud team** data in place of the server's, with no error.

`apiClient.local` already resolves per flavor via the `localBackend` seam (self-hosted → local Spring bearer, SaaS → SaaS backend + Supabase JWT), so these three just use it. No-op on the SaaS build, correct on self-hosted.

### 2. Remove the affordance that caused it

`apiClient.saas.isConfigured()` is deleted. With those three call sites fixed it was dead code, and it contradicted the contract the same file documents a few lines above: calls throw `SaasUnconfiguredError` so callers can surface a "configure" state "rather than silently routing to the wrong domain". Removing it makes a relapse a **compile error** rather than a silent wrong-backend read, which is stronger than a lint rule. The module header now states the rule directly.

Nothing replaces it: the correct pattern is already in use in `Usage.tsx`, which catches `SaasUnconfiguredError`, and `http.test.ts` already pins that behaviour.

### 3. Any-origin CORS for the cloud-only surface

What remains genuinely cross-origin is what has no self-hosted equivalent: billing, procurement, and legal documents. Register a second CORS config for those, with `allowedOrigins("*")` and `allowCredentials(false)`, ahead of the existing `/**` entry. `UrlBasedCorsConfigurationSource` returns the first matching pattern rather than the most specific, so order matters; the tests pin the behaviour either way.

| Pattern | Contents |
| --- | --- |
| `/api/v1/payg/**` | wallet, wallet/refresh, invoices, payment-method, cap |
| `/api/v1/procurement/**` | one controller |
| `/api/v1/legal/**` | one controller |
| `/api/v1/account-link/instances/**` | the Settings page's "who is linked" table, and revoke |

All are cloud-only, which is what makes a prefix safe: a team's roster of linked instances spans instances, and an instance knows only itself. Only the `instances` half of account-link is opened; the `connect/*` handshake never reaches a browser on the customer's origin, since the instance backend calls `request` and `claim` server-side and we serve the approval page. Methods are limited to GET, POST, PATCH and OPTIONS; headers to `Authorization`, `Content-Type` and `Accept`. `/api/v1/instance/**` is deliberately excluded: server to server, should never see a browser origin. The block sits behind the existing `stirling.billing.account-link.enabled` flag, so a deployment not running account linking gets no wildcard at all.

## Why the wildcard is safe here

**Only because it carries no credentials**, which holds on this chain:

- bearer-token only: `STATELESS`, no form login, no HTTP basic
- nothing in `app/saas` reads a cookie (no `@CookieValue`, no `getCookies()`)
- the cookie/session chain, `SecurityConfiguration`, is `@Profile("!saas")` and does not run here
- `apiClient.saas` never sets `credentials` on `fetch`, so it defaults to `same-origin` and sends no cookies cross-origin
- the JWT is in localStorage and attached explicitly, so a hostile page has nothing to ride on: it cannot read another origin's storage

That is the same reasoning the file already uses to justify disabling CSRF on this chain.

**Authorisation is unchanged.** Callers still present a JWT and are still resolved to a team by the existing gates; this decides only which origins may read a response. In particular it does **not** let the instance act as a user — the device credential gains no new reach, which a backend proxy would have given it.

**First-party is unaffected.** On the SaaS build `saasApiBase()` returns `""` (`VITE_API_BASE_URL=/`), so `app.stirling.com` calls these paths same-origin and is exempt from CORS entirely. `allowCredentials(false)` cannot reach it.

## How to test

```bash
ENABLE_SAAS=true ./gradlew :saas:test --tests "*SupabaseSecurityConfigMoreTest*"
```

18 cases in the new `LinkedInstanceCors` class: every remaining `apiClient.saas` path resolves to the wildcard config and never has `allowCredentials=true`; PATCH is permitted for the cap endpoint; `/api/v1/instance/sync`, the three now-local ui-data paths, and `admin-settings` / `database` all keep the credentialed allow-list; the `connect/*` endpoints keep it too; and with the flag off there is no wildcard anywhere.

Frontend:

```bash
cd frontend && npx vitest run --root editor src/portal
```

Verified locally: saas 1307 tests / 0 failures, portal 90 files / 578 tests / 0 failures, typecheck clean on the portal, proprietary, saas and cloud cascades.

End to end, against a preview with account linking on: link an instance, open Plan and Usage and confirm the wallet loads with no CORS error; then open Documents and the audit log and confirm they show the instance's own activity.


