### PR TITLE
Remove the apiClient.saas.isConfigured footgun

### DIFF
--- a/frontend/editor/src/portal/api/http.ts
+++ b/frontend/editor/src/portal/api/http.ts
@@ -21,6 +21,13 @@
  *                             state rather than silently routing to the wrong
  *                             domain.
  *
+ * Pick the domain from what the endpoint IS, never from whether SaaS happens to
+ * be configured. "A SaaS URL is set" is not "I am the SaaS build": a linked
+ * self-hosted instance is both configured and still the owner of its own data,
+ * and routing on that read sent its audit trail and Documents feed to the cloud.
+ * If an endpoint exists in both flavors it belongs on `.local`, which already
+ * resolves per flavor via the localBackend seam.
+ *
  * Endpoints that don't have a real backend yet still target their eventual
  * domain (almost always `.local`): with Mocks=on the MSW handlers intercept;
  * with Mocks=off they hit the real backend and 404 until the route ships, then
@@ -324,7 +331,5 @@ export const apiClient = {
     json: saasJson,
     text: saasText,
     blob: saasBlob,
-    /** True when a SaaS base URL is resolvable. Doesn't check session liveness. */
-    isConfigured: (): boolean => saasBaseUrl() !== null,
   },
 } as const;


### PR DESCRIPTION
> Stacked on #7798. Review that first; this targets its branch, and the diff shown here is only the extra commit.

## Current state

`apiClient.saas` exposed an `isConfigured()` helper:

```ts
/** True when a SaaS base URL is resolvable. Doesn't check session liveness. */
isConfigured: (): boolean => saasBaseUrl() !== null,
```

## Problem

It answers *"is a SaaS URL set"*. Every caller read it as *"am I the SaaS build"* and used it to choose a backend:

```ts
return apiClient.saas.isConfigured()
  ? apiClient.saas.json<DocumentsResponse>(path)
  : apiClient.local.json<DocumentsResponse>(path);
```

Those two questions give the same answer only while self-hosted never sets `VITE_SAAS_API_URL` — which is exactly the assumption account linking breaks. #7798 covers the damage that did: a linked instance sent its own Documents feed and audit trail to SaaS, which holds no audit rows for it, so the portal silently showed the admin's cloud team data.

The helper also contradicted the contract this file already documents a few lines above it: calls throw `SaasUnconfiguredError` so callers can surface a "configure" state "rather than silently routing to the wrong domain". `isConfigured()` was the affordance that made silently routing to the wrong domain the easy option.

## Solution

Delete it. Its last three callers went away in #7798, so it is dead code, and removing it makes a relapse a **compile error** rather than a silent wrong-backend read — stronger than any lint rule.

Also adds a short note to the module header stating the rule directly: pick the domain from what the endpoint *is*, and if it exists in both flavors it belongs on `.local`, which already resolves per flavor through the `localBackend` seam.

Nothing replaces it. The correct pattern is already in use in `Usage.tsx`, which catches `SaasUnconfiguredError`, and `http.test.ts` already pins that behaviour.

## How to test

```bash
cd frontend && npx vitest run --root editor src/portal
```

Verified locally: 90 files / 578 tests / 0 failures, and typecheck clean on the portal, proprietary, saas and cloud cascades — the deletion has no remaining references anywhere.
