### PR TITLE
Fix flaky FolderContext test (stale probe closure); guard against a slow cache read blanking pulled folders

### DIFF
--- a/frontend/editor/src/core/contexts/FolderContext.test.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.test.tsx
@@ -333,10 +333,13 @@ describe("FolderContext stale-folder 404 cleanup", () => {
         </FolderProvider>
       </MemoryRouter>,
     );
+    // Wait on the probe's captured api, not the DOM. The DOM commits before the
+    // passive effect that rebinds `apiRef`, so a DOM-only wait can hand back an
+    // api from the previous render whose folder map is still empty - `rename`
+    // then throws "Unknown folder". Only bites when the runner is slow enough
+    // for React to yield between the commit and its passive effects.
     await waitFor(() =>
-      expect(screen.getByTestId("count").textContent).toBe(
-        String(initial.length),
-      ),
+      expect(apiRef.current?.folderCount).toBe(initial.length),
     );
     if (!apiRef.current) throw new Error("ApiProbe never reported ready");
     return apiRef as { current: ProbeApi };

--- a/frontend/editor/src/core/contexts/FolderContext.test.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.test.tsx
@@ -67,11 +67,20 @@ vi.mock("@app/auth/UseSession", () => ({
 // Stateful IDB mock - the revision-driven refresh re-reads getAllFolders
 // after every state change, so a stateless [] mock would clobber pull results.
 const { mockIdb } = vi.hoisted(() => ({
-  mockIdb: { folders: [] as { id: string }[] },
+  mockIdb: { folders: [] as { id: string }[], slowNextRead: false },
 }));
 vi.mock("@app/services/folderStorage", () => ({
   folderStorage: {
-    getAllFolders: vi.fn(() => Promise.resolve([...mockIdb.folders])),
+    getAllFolders: vi.fn(() => {
+      const snapshot = [...mockIdb.folders];
+      if (mockIdb.slowNextRead) {
+        mockIdb.slowNextRead = false;
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(snapshot), 50),
+        );
+      }
+      return Promise.resolve(snapshot);
+    }),
     replaceAll: vi.fn((next: { id: string }[]) => {
       mockIdb.folders = [...next];
       return Promise.resolve();
@@ -264,6 +273,7 @@ describe("FolderContext stale-folder 404 cleanup", () => {
     mockDelete.mockReset();
     // Reset the stateful IDB mock so each test starts with an empty cache.
     mockIdb.folders = [];
+    mockIdb.slowNextRead = false;
     // Signed-in, non-anonymous user so pullFromServer runs.
     mockAuth.user = { id: "test-user", is_anonymous: false };
     mockAuth.isAnonymous = false;
@@ -418,5 +428,27 @@ describe("FolderContext stale-folder 404 cleanup", () => {
     expect(threw).toBe(true);
     expect(screen.getByTestId("count").textContent).toBe("1");
     expect(screen.getByTestId("error").textContent).not.toBe("<null>");
+  });
+
+  test("a slow cache read cannot blank folders the server pull already applied", async () => {
+    // Mount runs two writers of `folders`: the cache read and the server pull. The cache is
+    // empty until the pull fills it, so a read that resolves last would apply that empty
+    // snapshot over the freshly pulled rows and strand every id in the tree.
+    const parent = makeFolder("parent");
+    const child = makeFolder("child", parent.id);
+    mockIdb.slowNextRead = true;
+
+    const api = await setupWithFolders([parent, child]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    });
+
+    expect(screen.getByTestId("count").textContent).toBe("2");
+    // Still addressable: a mutation here used to throw "Unknown folder".
+    mockUpdate.mockResolvedValueOnce({ ...parent, name: "renamed" });
+    await act(async () => {
+      await api.current.rename(parent.id, "renamed");
+    });
+    expect(screen.getByTestId("error").textContent).toBe("<null>");
   });
 });

--- a/frontend/editor/src/core/contexts/FolderContext.tsx
+++ b/frontend/editor/src/core/contexts/FolderContext.tsx
@@ -315,6 +315,13 @@ export function FolderProvider({ children }: FolderProviderProps) {
     setFolderRevision((r) => r + 1);
   }, []);
 
+  /**
+   * Orders the two writers of `folders`: the cache read in {@link refresh} and the server pull.
+   * Each claims a token before writing, and a read whose token is stale is dropped rather than
+   * applied - otherwise a slow cache read lands after the pull and blanks the rows it just set.
+   */
+  const folderWrite = useRef(0);
+
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -324,6 +331,7 @@ export function FolderProvider({ children }: FolderProviderProps) {
   }, []);
 
   const refresh = useCallback(async () => {
+    const token = ++folderWrite.current;
     setLoading(true);
     try {
       // Three systems of record behind one list; kind says which rules a row follows.
@@ -333,6 +341,8 @@ export function FolderProvider({ children }: FolderProviderProps) {
         localFolderStorage.getAllFolders(),
       ]);
       if (!mountedRef.current) return;
+      // A pull landed while this read was out, so its rows are the newer truth.
+      if (token !== folderWrite.current) return;
       setFolders([...server, ...virtual, ...local]);
     } catch (err) {
       console.error("[FolderContext] cache read failed", err);
@@ -404,6 +414,7 @@ export function FolderProvider({ children }: FolderProviderProps) {
         console.warn("[FolderContext] cache replace failed", cacheErr);
       }
       if (mountedRef.current) {
+        folderWrite.current += 1;
         // Server-wins is for server rows: the other kinds have no server copy.
         setFolders((prev) => [
           ...remote,


### PR DESCRIPTION
Fixes a flaky test: `FolderContext.test.tsx > renameFolder 404 silently drops folder + descendants` fails occasionally under load. The test came in with #6551 and has been green there and on `main` since; the window it depends on is narrow enough that it needed a slow runner to show up at all.

### Root cause (test-side)

`ApiProbe` hands the folder API to the test from inside a `useEffect`, and `setupWithFolders` waited only on the DOM count. React commits the DOM before it runs passive effects, and for a default-lane update those effects run in a separate scheduler task. On a fast machine both happen inside the same 5ms slice, before testing-library's post-`waitFor` drain timer fires. On a loaded runner the render overruns the slice, the drain timer wins, and the test resumes holding the api from the *previous* render, whose `foldersById` is still empty. `rename` then throws `Unknown folder`.

Instrumenting a failing run confirms it: the probe's captured `folderCount` was `0` while the DOM already showed `3`.

**Fix:** `setupWithFolders` now waits on the probe's own `folderCount`, not the DOM. That guarantees the passive effect has rebound the api before any mutation runs. Under 8 busy-loop cores this went from ~1 failure in 25-40 runs to 0 in 40 whole-file runs.

### Also included: token guard in `FolderProvider` (hardening, not the flake fix)

`refresh()` and `pullFromServer()` both write `folders`. In a real browser an IndexedDB read can occasionally resolve after the network pull and overwrite fresh server rows with a stale snapshot until the next revision-driven read restores them. Each writer now claims a token before writing, and a read whose token is stale is dropped. `pullInFlight` already covered pull-vs-pull; this is the other half.

To be clear about what this does and does not do: in the test environment all storage mocks resolve in microtasks and the cache read deterministically lands *before* the pull, so this guard cannot be what fixes the flaky test. It is kept as a small, independently useful hardening with its own regression test (which delays the first cache read so the pull lands first; fails without the guard, passes with it).

### Why now

I couldn't find a CI record of this test failing in the last three weeks of failed `Build and Test` runs, so it has genuinely been rare. #7502 (merged 2026-09-02) grew `FolderProvider` by ~320 lines and added a derived `folders` memo on the same render path, which plausibly widened the window, but I could not confirm that by sampling: 80 interleaved runs each on `main` and on the commit before #7502 produced no failures. Treat the trigger as unknown; the mechanism above is what's established.

`task frontend:check:all` green locally: 344 files, all passing.
