### PR TITLE
Find Task on PATH, and stop reporting a failed launch as findings

### DIFF
--- a/scripts/lint/comment-lint-hook.mjs
+++ b/scripts/lint/comment-lint-hook.mjs
@@ -23,7 +23,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -64,6 +64,15 @@ if (result.status !== FOUND) {
   process.exit(1);
 }
 
+// The linter names every finding before it exits 1, so an empty report means
+// Task never launched - reporting it as findings sends Claude after nothing.
+if (!result.output.trim()) {
+  process.stderr.write(
+    "comment-lint could not run (Task produced no output), so comments in this turn were not checked.\n",
+  );
+  process.exit(1);
+}
+
 // The linter's own report already names the file, line, rule and the standard, so
 // it is passed through rather than rewritten.
 process.stderr.write(`${result.output.trim()}\n\nFix these before finishing.\n`);
@@ -89,10 +98,19 @@ function taskCommand() {
     resolve(nodeDir, "../lib/node_modules/@go-task/cli/bin", exe),
     resolve(REPO, "node_modules/@go-task/cli/bin", exe),
   ];
-  for (const candidate of candidates) {
+  for (const candidate of [...candidates, ...onPath(exe)]) {
     if (existsSync(candidate)) return { command: candidate, shell: false };
   }
   return { command: process.platform === "win32" ? "task.cmd" : "task", shell: process.platform === "win32" };
+}
+
+// Scoop installs task.exe with no task.cmd beside it, so the Windows fallback
+// resolves to nothing; find the binary on PATH before settling for that.
+function onPath(exe) {
+  return (process.env.PATH ?? "")
+    .split(delimiter)
+    .filter(Boolean)
+    .map((dir) => join(dir.replace(/^"|"$/g, ""), exe));
 }
 
 function run() {


### PR DESCRIPTION
# Description of Changes

The Stop hook could not launch Task on a Scoop install, and reported that failure as comment findings — so it blocked every turn with an empty report and the line `Fix these before finishing.`, naming nothing to fix. It did that six times in one session before I traced it.

Two causes, both fixed here:

**1. The Windows fallback resolves to nothing.** `taskCommand()` probes three `node_modules` layouts and then falls back to `task.cmd`. Scoop installs `task.exe` plus a `.shim` and never creates a `.cmd`, so the fallback misses and `cmd` exits 1 with empty stdout:

```
status=1  stdout=""  stderr="'task.cmd' is not recognized as an internal or external command"
```

Now it looks for the binary on `PATH` before settling for the shell fallback. That also skips the `cmd` wrapper on machines where it would have worked.

**2. Exit 1 was read as "found something".** The linter's exit codes are 1 = found, 2 = engine broken, and Task's own launch failure is indistinguishable from a finding by status alone. The linter always names its findings before exiting 1, so an empty report now means the launch failed, and says so instead of sending Claude after nothing.

## Verified on the machine that reproduced it

| case | before | after |
| --- | --- | --- |
| real finding present | never reached | exit 2, finding named with file/line/rule |
| nothing to report | `Fix these before finishing.` (empty) | exit 0, silent |
| Task genuinely missing | `Fix these before finishing.` (empty) | exit 1, `comment-lint could not run (Task produced no output)` |

The blocking path was checked end to end by planting a `CMT001 restates-code` violation in a real `.ts` file and confirming the hook exits 2 with the report; the launch-failure path by running with `task` absent from `PATH`.

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Testing

- [x] I have tested my changes locally. All three hook paths verified above.