### PR TITLE
Apply documented defaults to AddWatermarkRequest fields

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/AddWatermarkRequest.java
@@ -23,7 +23,7 @@ public class AddWatermarkRequest extends PDFFile {
     private String watermarkType;
 
     @Schema(description = "The watermark text", defaultValue = "Stirling Software")
-    private String watermarkText;
+    private String watermarkText = "Stirling Software";
 
     @Schema(description = "The watermark image")
     private MultipartFile watermarkImage;
@@ -32,32 +32,32 @@ public class AddWatermarkRequest extends PDFFile {
             description = "The selected alphabet",
             allowableValues = {"roman", "arabic", "japanese", "korean", "chinese", "thai"},
             defaultValue = "roman")
-    private String alphabet;
+    private String alphabet = "roman";
 
     @Schema(description = "The font size of the watermark text", defaultValue = "30")
     @DecimalMin(value = "1.0", message = "Font size must be at least 1.0")
-    private float fontSize;
+    private float fontSize = 30;
 
     @Schema(description = "The rotation of the watermark in degrees", defaultValue = "0")
-    private float rotation;
+    private float rotation = 0;
 
     @Schema(description = "The opacity of the watermark (0.0 - 1.0)", defaultValue = "0.5")
-    private float opacity;
+    private float opacity = 0.5f;
 
     @Schema(description = "The width spacer between watermark elements", defaultValue = "50")
     @Min(value = 0, message = "Width spacer must be non-negative")
-    private int widthSpacer;
+    private int widthSpacer = 50;
 
     @Schema(description = "The height spacer between watermark elements", defaultValue = "50")
     @Min(value = 0, message = "Height spacer must be non-negative")
-    private int heightSpacer;
+    private int heightSpacer = 50;
 
     @Schema(description = "The color for watermark", defaultValue = "#d3d3d3")
-    private String customColor;
+    private String customColor = "#d3d3d3";
 
     @Schema(
             description = "Convert the redacted PDF to an image",
             defaultValue = "false",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Boolean convertPDFToImage;
+    private Boolean convertPDFToImage = false;
 }


### PR DESCRIPTION
`/api/v1/security/add-watermark` fails on any request that omits optional fields, in two different ways.

**1. `fontSize` rejects the request.** The field is a primitive `float`, so an absent multipart field binds to `0.0f`, which then fails `@DecimalMin("1.0")`:

```
400  {"errors":["fontSize: Font size must be at least 1.0"]}
```

The `@Schema(defaultValue = "30")` is OpenAPI documentation only - it never participates in binding. Any client generated from the spec hits this immediately.

**2. Supplying `fontSize` then reveals a 500.** `alphabet` has no default, so it arrives null and `switch (alphabet)` in `WatermarkController:193` throws:

```
500  {"error":"Job failed: Cannot invoke \"String.hashCode()\" because \"<local13>\" is null"}
```

(String switch compiles to a `hashCode()` call, hence the message.)

## Fix

Give the fields the defaults their `@Schema` already advertises. This mirrors `AddStampRequest`, which already declares `private String alphabet = "roman";` - the watermark model just never got the same treatment.

## Testing

Built the jar and ran it against real PDFs:

| Request | Before | After |
|---|---|---|
| Minimal (`watermarkType` + text only) | 400 | 200, watermark drawn |
| Every optional field omitted | 400 | 200, "Stirling Software" drawn |
| Explicit overrides (`fontSize=60`, `opacity=0.8`) | 200 | 200, "SECRET" drawn |
| `fontSize=0` | 400 | 400 (validation still enforced) |
| 1000-page document | 400 | 200, 1000 pages, watermark drawn |

Outputs verified with PyMuPDF - valid PDFs, correct page counts, watermark text actually present on page 1, not just a 200 status.

`task backend:fix` and `task backend:check` both pass.

## Note

Watermarking a 1000-page document needs ~2.8 GB of heap. With the default `MaxRAMPercentage=50` that is fine on an 8 GB container, but it OOMs under a 2 GB heap. This change does not cause that - it just lets the request get far enough to reach it, where previously it was rejected at validation.