### PR TITLE
Fold the About group into one page, and stop wrapping single rows in a group

### DIFF
--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -10538,6 +10538,7 @@ backToSections = "All settings"
 title = "Settings"
 
 [settings.about]
+description = "Tours, legal documents and the licences of everything bundled with this build."
 title = "About"
 
 [settings.ai]

--- a/frontend/editor/public/og-metadata.json
+++ b/frontend/editor/public/og-metadata.json
@@ -530,6 +530,11 @@
       "title": "Frontend Third Party Licenses Settings - Stirling PDF",
       "description": "The Free Adobe Acrobat alternative (10M+ Downloads)"
     },
+    "/settings/about": {
+      "image": "/og_images/home.png",
+      "title": "About Settings - Stirling PDF",
+      "description": "The Free Adobe Acrobat alternative (10M+ Downloads)"
+    },
     "/settings/payg": {
       "image": "/og_images/home.png",
       "title": "Payg Settings - Stirling PDF",
@@ -720,6 +725,7 @@
     "/settings/legal": "/settings/legal",
     "/settings/backendThirdPartyLicenses": "/settings/backendThirdPartyLicenses",
     "/settings/frontendThirdPartyLicenses": "/settings/frontendThirdPartyLicenses",
+    "/settings/about": "/settings/about",
     "/settings/payg": "/settings/payg",
     "/settings/account-link": "/settings/account-link",
     "/settings/users": "/settings/users",

--- a/frontend/editor/public/og-metadata.saas.json
+++ b/frontend/editor/public/og-metadata.saas.json
@@ -532,6 +532,11 @@
       "title": "Frontend Third Party Licenses Settings - Stirling PDF",
       "description": "The Free Adobe Acrobat alternative (10M+ Downloads)"
     },
+    "/settings/about": {
+      "image": "/og_images/home.png",
+      "title": "About Settings - Stirling PDF",
+      "description": "The Free Adobe Acrobat alternative (10M+ Downloads)"
+    },
     "/settings/payg": {
       "image": "/og_images/home.png",
       "title": "Payg Settings - Stirling PDF",
@@ -733,6 +738,7 @@
     "/settings/legal": "/settings/legal",
     "/settings/backendThirdPartyLicenses": "/settings/backendThirdPartyLicenses",
     "/settings/frontendThirdPartyLicenses": "/settings/frontendThirdPartyLicenses",
+    "/settings/about": "/settings/about",
     "/settings/payg": "/settings/payg",
     "/settings/account-link": "/settings/account-link",
     "/settings/users": "/settings/users",

--- a/frontend/editor/src/core/components/onboarding/adminStepsConfig.ts
+++ b/frontend/editor/src/core/components/onboarding/adminStepsConfig.ts
@@ -182,12 +182,12 @@ const ADMIN_STEP_SPECS: AdminStepSpec[] = [
   },
   {
     step: AdminTourStep.WRAP_UP,
-    selector: '[data-tour="admin-help-nav"]',
+    selector: '[data-tour="admin-about-nav"]',
     contentKey: "adminOnboarding.wrapUp",
     contentDefault:
-      "That's the admin tour! You've seen the enterprise features that make Stirling PDF a powerful, customisable solution for organisations. You can replay it anytime — just open <strong>Settings</strong> and find it here in the <strong>Tours</strong> section under Help.",
+      "That's the admin tour! You've seen the enterprise features that make Stirling PDF a powerful, customisable solution for organisations. You can replay it anytime — just open <strong>Settings</strong> and find it here under <strong>About</strong>.",
     position: "right",
-    section: "help",
+    section: "about",
     waitForSelectorOnEnter: true,
   },
 ];

--- a/frontend/editor/src/core/components/settings/useSettingsNav.tsx
+++ b/frontend/editor/src/core/components/settings/useSettingsNav.tsx
@@ -1,6 +1,7 @@
 import { useConfigNavSections } from "@app/components/shared/config/configNavSections";
 import { useAppConfig } from "@app/contexts/AppConfigContext";
 import type { SettingsNav } from "@app/components/settings/settingsNavTypes";
+import { BASE_SECTION_ALIASES } from "@app/data/settingsAliases";
 
 export type { SettingsNav };
 
@@ -21,5 +22,5 @@ export function useSettingsNav(onLeave: () => void): SettingsNav {
     onLeave,
     config?.showSettingsWhenNoLogin ?? true,
   );
-  return { sections };
+  return { sections, aliases: BASE_SECTION_ALIASES };
 }

--- a/frontend/editor/src/core/components/shared/config/configNavSections.tsx
+++ b/frontend/editor/src/core/components/shared/config/configNavSections.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import HotkeysSection from "@app/components/shared/config/configSections/HotkeysSection";
 import GeneralSection from "@app/components/shared/config/configSections/GeneralSection";
-import HelpSection from "@app/components/shared/config/configSections/HelpSection";
-import LegalSection from "@app/components/shared/config/configSections/LegalSection";
-import {
-  BackendThirdPartyLicensesSection,
-  FrontendThirdPartyLicensesSection,
-} from "@app/components/shared/config/configSections/ThirdPartyLicensesSection";
+import AboutSection from "@app/components/shared/config/configSections/AboutSection";
 import type {
   ConfigNavItem,
   ConfigNavSection,
@@ -63,53 +58,23 @@ export const useConfigNavSections = (
         },
       ],
     },
-    // Reference material: read once, rarely revisited, so it starts folded.
+    // Reference material: read once and rarely revisited, so it is one page
+    // rather than four rows you have to open in turn.
     {
       id: "about",
       title: t("settings.about.title", "About"),
-      collapsedByDefault: true,
       items: [
         {
-          key: "help",
-          label: t("settings.help.label", "Tours"),
+          key: "about",
+          label: t("settings.about.title", "About"),
           description: t(
-            "settings.help.description",
-            "Guided walkthroughs of the editor and the admin area.",
+            "settings.about.description",
+            "Tours, legal documents and the licences of everything bundled with this build.",
           ),
           icon: "help-rounded",
           component: (
-            <HelpSection isAdmin={_isAdmin} onRequestClose={onRequestClose} />
+            <AboutSection isAdmin={_isAdmin} onRequestClose={onRequestClose} />
           ),
-        },
-        {
-          key: "legal",
-          label: t("settings.legal.label", "Legal"),
-          description: t(
-            "settings.legal.description",
-            "Terms, privacy policy and your cookie preferences.",
-          ),
-          icon: "gavel-rounded",
-          component: <LegalSection />,
-        },
-        {
-          key: "backendThirdPartyLicenses",
-          label: t("settings.licenses.backendLabel", "Backend Licenses"),
-          description: t(
-            "settings.licenses.backendDescription",
-            "Licenses for backend dependencies bundled with this server.",
-          ),
-          icon: "article-rounded",
-          component: <BackendThirdPartyLicensesSection />,
-        },
-        {
-          key: "frontendThirdPartyLicenses",
-          label: t("settings.licenses.frontendLabel", "Frontend Licenses"),
-          description: t(
-            "settings.licenses.frontendDescription",
-            "Licenses for frontend dependencies bundled into the release build.",
-          ),
-          icon: "code-rounded",
-          component: <FrontendThirdPartyLicensesSection />,
         },
       ],
     },

--- a/frontend/editor/src/core/components/shared/config/configSections/AboutSection.css
+++ b/frontend/editor/src/core/components/shared/config/configSections/AboutSection.css
@@ -1,0 +1,21 @@
+.about-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6, 2rem);
+}
+
+.about-section__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 0.75rem);
+}
+
+/* Permanent, not just while the focus pulse is on: an anchored jump lands the
+   heading under the sticky search bar otherwise. */
+.about-section__heading {
+  margin: 0;
+  scroll-margin-top: 1rem;
+  font-size: 0.9375rem;
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--c-text);
+}

--- a/frontend/editor/src/core/components/shared/config/configSections/AboutSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/AboutSection.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from "react-i18next";
+import HelpSection from "@app/components/shared/config/configSections/HelpSection";
+import LegalSection from "@app/components/shared/config/configSections/LegalSection";
+import {
+  BackendThirdPartyLicensesSection,
+  FrontendThirdPartyLicensesSection,
+} from "@app/components/shared/config/configSections/ThirdPartyLicensesSection";
+import "@app/components/shared/config/configSections/AboutSection.css";
+
+export interface AboutSectionProps {
+  isAdmin: boolean;
+  /** Tours need the settings page out of the way before they can run. */
+  onRequestClose: () => void;
+}
+
+/**
+ * The reference material that used to be four nav rows. Each card keeps the
+ * label its row had and carries that row's id, so `?focus=` deep links and
+ * search results for the retired keys still land on the right card.
+ *
+ * Backend licences come last: it is the only card here that fetches, and the
+ * only one that can render an error in place of its list.
+ */
+export default function AboutSection({
+  isAdmin,
+  onRequestClose,
+}: AboutSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="settings-section-container">
+      <div className="about-section">
+        <section className="about-section__card">
+          <h2 className="about-section__heading" id="help">
+            {t("settings.help.label", "Tours")}
+          </h2>
+          <HelpSection isAdmin={isAdmin} onRequestClose={onRequestClose} />
+        </section>
+
+        <section className="about-section__card">
+          <h2 className="about-section__heading" id="legal">
+            {t("settings.legal.label", "Legal")}
+          </h2>
+          <LegalSection />
+        </section>
+
+        <section className="about-section__card">
+          <h2
+            className="about-section__heading"
+            id="frontendThirdPartyLicenses"
+          >
+            {t("settings.licenses.frontendLabel", "Frontend Licenses")}
+          </h2>
+          <FrontendThirdPartyLicensesSection />
+        </section>
+
+        <section className="about-section__card">
+          <h2 className="about-section__heading" id="backendThirdPartyLicenses">
+            {t("settings.licenses.backendLabel", "Backend Licenses")}
+          </h2>
+          <BackendThirdPartyLicensesSection />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/editor/src/core/components/shared/config/configSections/ThirdPartyLicensesSection.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/ThirdPartyLicensesSection.tsx
@@ -27,19 +27,13 @@ interface LicensesResponse {
 }
 
 interface LicensesSectionBodyProps {
-  title: string;
-  description: string;
   dependencies: Dependency[];
 }
 
 const getModuleUrl = (dependency: Dependency) =>
   dependency.moduleUrl || dependency.moduleLicenseUrl;
 
-function LicensesSectionBody({
-  title,
-  description,
-  dependencies,
-}: LicensesSectionBodyProps) {
+function LicensesSectionBody({ dependencies }: LicensesSectionBodyProps) {
   const { t } = useTranslation();
   const sortedDependencies = useMemo(
     () =>
@@ -60,15 +54,6 @@ function LicensesSectionBody({
     <Stack gap="lg">
       <Paper withBorder p="md" radius="md">
         <Stack gap="md">
-          <div>
-            <Text fw={600} size="sm">
-              {title}
-            </Text>
-            <Text size="xs" c="dimmed" mt={4}>
-              {description}
-            </Text>
-          </div>
-
           <Group justify="space-between" align="center">
             <div>
               <Text fw={600} size="sm">
@@ -201,36 +186,14 @@ export function BackendThirdPartyLicensesSection() {
     );
   }
 
-  return (
-    <LicensesSectionBody
-      title={t("settings.licenses.backendTitle", "Backend 3rd Party Licenses")}
-      description={t(
-        "settings.licenses.backendDescription",
-        "Licenses for backend dependencies bundled with this server.",
-      )}
-      dependencies={dependencies}
-    />
-  );
+  return <LicensesSectionBody dependencies={dependencies} />;
 }
 
 export function FrontendThirdPartyLicensesSection() {
-  const { t } = useTranslation();
   const dependencies =
     (frontendLicenses as LicensesResponse).dependencies ?? [];
 
-  return (
-    <LicensesSectionBody
-      title={t(
-        "settings.licenses.frontendTitle",
-        "Frontend 3rd Party Licenses",
-      )}
-      description={t(
-        "settings.licenses.frontendDescription",
-        "Licenses for frontend dependencies bundled into the release build.",
-      )}
-      dependencies={dependencies}
-    />
-  );
+  return <LicensesSectionBody dependencies={dependencies} />;
 }
 
 export default function ThirdPartyLicensesSection() {

--- a/frontend/editor/src/core/components/shared/config/types.ts
+++ b/frontend/editor/src/core/components/shared/config/types.ts
@@ -41,6 +41,8 @@ export const VALID_NAV_KEYS = [
   "legal",
   "backendThirdPartyLicenses",
   "frontendThirdPartyLicenses",
+  // Holds all four of the rows above; they stay listed so their deep links alias.
+  "about",
   "payg",
   "account-link",
   // Server administration moved off the processor's own nav (see

--- a/frontend/editor/src/core/data/settingsAliases.ts
+++ b/frontend/editor/src/core/data/settingsAliases.ts
@@ -1,0 +1,17 @@
+import type { NavKey } from "@app/components/shared/config/types";
+
+/**
+ * Retired section keys and the section that now holds their content, so a
+ * bookmark or search result for a folded row still lands on the right page
+ * instead of falling through to whichever row happens to be first.
+ *
+ * Core owns this because folds happen in core: the portal's own alias map is
+ * merged over it, never substituted for it, so a build without the processor
+ * still resolves these.
+ */
+export const BASE_SECTION_ALIASES: Partial<Record<string, NavKey>> = {
+  help: "about",
+  legal: "about",
+  backendThirdPartyLicenses: "about",
+  frontendThirdPartyLicenses: "about",
+};

--- a/frontend/editor/src/core/data/settingsSearchIndex.ts
+++ b/frontend/editor/src/core/data/settingsSearchIndex.ts
@@ -102,4 +102,46 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
     labelFallback: "Keyboard Shortcuts",
     keywords: ["hotkey", "shortcut", "keybinding", "keyboard"],
   },
+  // --- About: one row per card the four folded rows became, carrying the
+  // labels and search terms those rows had.
+  {
+    section: "about",
+    anchor: "help",
+    labelKey: "settings.help.label",
+    labelFallback: "Tours",
+    keywords: ["tour", "walkthrough", "guide", "onboarding", "help"],
+  },
+  {
+    section: "about",
+    anchor: "legal",
+    labelKey: "settings.legal.label",
+    labelFallback: "Legal",
+    keywords: ["terms", "privacy", "policy", "cookie", "consent", "gdpr"],
+  },
+  {
+    section: "about",
+    anchor: "frontendThirdPartyLicenses",
+    labelKey: "settings.licenses.frontendLabel",
+    labelFallback: "Frontend Licenses",
+    keywords: [
+      "licence",
+      "license",
+      "attribution",
+      "dependencies",
+      "open source",
+    ],
+  },
+  {
+    section: "about",
+    anchor: "backendThirdPartyLicenses",
+    labelKey: "settings.licenses.backendLabel",
+    labelFallback: "Backend Licenses",
+    keywords: [
+      "licence",
+      "license",
+      "attribution",
+      "dependencies",
+      "open source",
+    ],
+  },
 ];

--- a/frontend/editor/src/core/pages/SettingsPage.tsx
+++ b/frontend/editor/src/core/pages/SettingsPage.tsx
@@ -229,24 +229,29 @@ const SettingsPageInner: React.FC = () => {
             const open =
               holdsActive ||
               !(collapsed[groupId] ?? section.collapsedByDefault ?? false);
+            // A header that toggles a single row costs a line and a click to
+            // show what it already named; the row stands on its own instead.
+            const solo = section.items.length === 1;
             return (
               <div key={groupId} className="modal-nav-section">
-                <button
-                  type="button"
-                  className="settings-page__group"
-                  aria-expanded={open}
-                  aria-controls={`settings-group-${groupId}`}
-                  onClick={() => toggleGroup(groupId, open)}
-                >
-                  <span>{section.title}</span>
-                  <LocalIcon
-                    icon="expand-more-rounded"
-                    width={16}
-                    height={16}
-                    className="settings-page__group-chevron"
-                  />
-                </button>
-                {open && (
+                {!solo && (
+                  <button
+                    type="button"
+                    className="settings-page__group"
+                    aria-expanded={open}
+                    aria-controls={`settings-group-${groupId}`}
+                    onClick={() => toggleGroup(groupId, open)}
+                  >
+                    <span>{section.title}</span>
+                    <LocalIcon
+                      icon="expand-more-rounded"
+                      width={16}
+                      height={16}
+                      className="settings-page__group-chevron"
+                    />
+                  </button>
+                )}
+                {(solo || open) && (
                   <div
                     id={`settings-group-${groupId}`}
                     className="modal-nav-section-items"

--- a/frontend/editor/src/core/tests/stubbed/cookie-preferences.spec.ts
+++ b/frontend/editor/src/core/tests/stubbed/cookie-preferences.spec.ts
@@ -19,7 +19,7 @@ test.describe("18. Cookie Preferences", () => {
       // inside the "About" group the page ships folded.
       await openSettings(page);
       await expandSettingsGroups(page);
-      const legalNav = page.locator('[data-tour="admin-legal-nav"]').first();
+      const legalNav = page.locator('[data-tour="admin-about-nav"]').first();
       await expect(legalNav).toBeVisible({ timeout: 5000 });
       await legalNav.click();
 

--- a/frontend/editor/src/core/tests/stubbed/main-dashboard.spec.ts
+++ b/frontend/editor/src/core/tests/stubbed/main-dashboard.spec.ts
@@ -106,7 +106,7 @@ test.describe("2. Main Dashboard / Home Page", () => {
 
       await openSettings(page);
       await expandSettingsGroups(page);
-      const legalNav = page.locator('[data-tour="admin-legal-nav"]').first();
+      const legalNav = page.locator('[data-tour="admin-about-nav"]').first();
       await expect(legalNav).toBeVisible({ timeout: 10000 });
       await legalNav.click();
 

--- a/frontend/editor/src/core/tests/stubbed/tour-onboarding.spec.ts
+++ b/frontend/editor/src/core/tests/stubbed/tour-onboarding.spec.ts
@@ -213,7 +213,7 @@ test.describe("15.7 Tour selectors - admin modal nav items", () => {
     "adminConnections",
     "adminAudit",
     "adminUsage",
-    "help",
+    "about",
   ] as const;
 
   for (const section of adminNavSections) {

--- a/frontend/editor/src/desktop/components/shared/config/configNavSections.tsx
+++ b/frontend/editor/src/desktop/components/shared/config/configNavSections.tsx
@@ -73,16 +73,16 @@ export const useConfigNavSections = (
     ],
   };
 
-  // In local mode only show Preferences + Connection Mode + Legal — everything
+  // In local mode only show Preferences + Connection Mode + About — everything
   // else requires a server and will 500 or show irrelevant admin UI.
   if (isLocalMode) {
     const result: ConfigNavSection[] = [];
     if (sections.length > 0) result.push(sections[0]);
     result.push(connectionModeSection);
-    const legalSection = sections.find((section) =>
-      section.items.some((item) => item.key === "legal"),
-    );
-    if (legalSection) result.push(legalSection);
+    // Matched on the group id: its items were four rows and are now one, and a
+    // miss here drops the group silently.
+    const aboutSection = sections.find((section) => section.id === "about");
+    if (aboutSection) result.push(aboutSection);
     return result;
   }
 

--- a/frontend/editor/src/proprietary/components/settings/useSettingsNav.tsx
+++ b/frontend/editor/src/proprietary/components/settings/useSettingsNav.tsx
@@ -44,6 +44,9 @@ export function useSettingsNav(onLeave: () => void): SettingsNav {
   return {
     ...base,
     sections,
-    aliases: portalSections.length > 0 ? PORTAL_SECTION_ALIASES : undefined,
+    aliases:
+      portalSections.length > 0
+        ? { ...base.aliases, ...PORTAL_SECTION_ALIASES }
+        : base.aliases,
   };
 }


### PR DESCRIPTION
# Description of Changes

Stacks on #7792. First slice of the settings consolidation: 29 nav rows -> 26, and the pattern the rest of the fold will follow.

## Two changes

**A group holding one row no longer renders a header.** Every group draws a collapse button with a chevron, so a single-row group cost a line and a click to reveal what its header already named. `About` was the worst case — you clicked "About" to open "About". Applies generally, so `Developer > API Keys` loses its header too.

**Tours, Legal, Frontend Licenses and Backend Licenses become one About page.** Each keeps its old label as a card heading carrying that row's id, so nothing becomes harder to find:

- `?focus=` deep links resolve — `/settings/about?focus=backendThirdPartyLicenses` scrolls to the card.
- The four retired keys alias to `about`, so `/settings/legal` lands on the merged page rather than falling through to whichever row is first.
- Four `SETTINGS_SEARCH_INDEX` rows re-home the old labels and add their search terms, so super-search still deep-links each one by name.

Backend licences sit last: it is the only card that fetches, and the only one that can render an error in place of its list.

## Alias plumbing, needed before any fold

`aliases` was populated by no nav builder in the repo — the proprietary hook returned `PORTAL_SECTION_ALIASES` only when portal sections existed, and `undefined` otherwise. So a fold in core would have resolved nowhere for anyone without processor access. Core now owns a base map that is always returned, and the portal map merges over it rather than replacing it.

SaaS is deliberately left alone: it builds its own nav and still ships its own `help` and `legal` rows, so it must not inherit these aliases.

## Two silent breakages this would otherwise have shipped

- **Desktop local mode** picked the About group out by looking for an item keyed `legal`. With the rows folded that find returns `undefined` and the whole group vanishes with no error. Now matched on the group id.
- **The admin tour's final step** waits on `[data-tour="admin-help-nav"]` with `waitForSelectorOnEnter`, so a stale key hangs the tour rather than failing it. Retargeted, along with its copy.

Also fixed in passing: both licence cards rendered their own title and description directly under the page header that already showed the same strings — three stacked headings, two identical. The card now takes its heading from the page.

## Verified

Ran live against the stubbed harness, reading the rendered DOM:

- nav shape: a header is present exactly when a group has more than one row (0 violations across every group)
- all four card anchors resolve with the right labels
- `/settings/legal` lands on About; `?focus=backendThirdPartyLicenses` scrolls to the card
- the two specs that clicked the retired Legal row, plus the tour selector list, updated and passing

`task fix` and `task check` both pass — backend, 342 frontend test files, engine — plus `og:check` after regenerating both manifests for the new key.

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Translations

- [x] One new key, `settings.about.description`, added to en-US.

### UI Changes

- [x] Behaviour verified against the rendered DOM rather than by screenshot alone.

### Testing

- [x] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally.