### PR TITLE
Treat mid-write idle timeout as a client disconnect

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
+++ b/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
@@ -211,7 +211,9 @@ public class GlobalExceptionHandler {
                 String lower = msg.toLowerCase(java.util.Locale.ROOT);
                 if (lower.contains("broken pipe")
                         || lower.contains("connection reset")
-                        || lower.contains("an established connection was aborted")) {
+                        || lower.contains("an established connection was aborted")
+                        || lower.contains("idle timeout expired")
+                        || lower.contains("failed to write")) {
                     return true;
                 }
             }

--- a/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
+++ b/app/core/src/main/java/stirling/software/SPDF/exception/GlobalExceptionHandler.java
@@ -5,9 +5,12 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -196,27 +199,56 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Connector-level signals that the response could not be written because the peer is gone,
+     * matched by simple name so no container has to be on the classpath: {@code AbortedException}
+     * (Reactor Netty), {@code ClientAbortException} (Tomcat), {@code EofException} (Jetty) and
+     * {@code AsyncRequestNotUsableException}, which Spring MVC raises from {@code
+     * StandardServletAsyncWebRequest} when a write on an async response fails - the shape a
+     * mid-write idle timeout arrives in.
+     *
+     * <p>This is {@code DisconnectedClientHelper.EXCEPTION_TYPE_NAMES} minus bare {@code
+     * EOFException}: Spring's set is tuned for log routing, but PDFBox and the JDK's own stream
+     * decoders throw {@code java.io.EOFException} for truncated user input, and treating those as a
+     * disconnect would drop a real server-side failure's body and stack trace. Jetty's {@code
+     * EofException} still matches by its own name even though it extends {@code EOFException}, so
+     * this must stay a name test rather than an {@code instanceof}.
+     */
+    private static final Set<String> CLIENT_DISCONNECT_TYPE_NAMES =
+            Set.of(
+                    "AbortedException",
+                    "ClientAbortException",
+                    "EofException",
+                    "AsyncRequestNotUsableException");
+
+    /**
      * Checks whether the given IOException indicates that the client disconnected before the
-     * response could be written (broken pipe, connection reset, etc.). When this happens there is
-     * no point in serialising a {@link ProblemDetail} body because the socket is already closed -
-     * and attempting to do so may trigger a secondary {@code HttpMessageNotWritableException} if
-     * the response Content-Type was already committed as a non-JSON type (e.g. image/png).
+     * response could be written: a broken pipe, a connection reset, or a mid-write idle timeout.
+     * When this happens there is no point in serialising a {@link ProblemDetail} body because the
+     * socket is already closed - and attempting to do so may trigger a secondary {@code
+     * HttpMessageNotWritableException} if the response Content-Type was already committed as a
+     * non-JSON type (e.g. image/png).
+     *
+     * <p>Everything else, including a read-side idle timeout on a slow upload, keeps its
+     * ProblemDetail body and its stack trace.
      */
     private static boolean isClientDisconnectException(IOException ex) {
         // Walk the causal chain - Jetty/Tomcat may wrap the low-level SocketException
         Throwable current = ex;
-        while (current != null) {
+        Throwable previous = null;
+        while (current != null && current != previous) {
+            if (CLIENT_DISCONNECT_TYPE_NAMES.contains(current.getClass().getSimpleName())) {
+                return true;
+            }
             String msg = current.getMessage();
             if (msg != null) {
-                String lower = msg.toLowerCase(java.util.Locale.ROOT);
+                String lower = msg.toLowerCase(Locale.ROOT);
                 if (lower.contains("broken pipe")
                         || lower.contains("connection reset")
-                        || lower.contains("an established connection was aborted")
-                        || lower.contains("idle timeout expired")
-                        || lower.contains("failed to write")) {
+                        || lower.contains("an established connection was aborted")) {
                     return true;
                 }
             }
+            previous = current;
             current = current.getCause();
         }
         return false;
@@ -1222,12 +1254,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleIOException(
             IOException ex, HttpServletRequest request) {
 
-        // Broken pipe / connection reset means the client disconnected.
-        // Attempting to write a ProblemDetail response will fail because the
-        // response Content-Type may already be committed (e.g. image/png) and
-        // the client is gone anyway. Log at WARN and return an empty body.
+        // Attempting to write a ProblemDetail response to a disconnected client will fail because
+        // the response Content-Type may already be committed (e.g. image/png) and the client is
+        // gone anyway. Log at WARN and return an empty body.
         if (isClientDisconnectException(ex)) {
-            log.warn("Client disconnected at {}: {}", request.getRequestURI(), ex.getMessage());
+            log.warn(
+                    "Client disconnected at {}: {}",
+                    request.getRequestURI(),
+                    NestedExceptionUtils.getMostSpecificCause(ex).getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
 

--- a/app/core/src/main/resources/application.properties
+++ b/app/core/src/main/resources/application.properties
@@ -64,6 +64,7 @@ spring.devtools.livereload.enabled=true
 spring.devtools.restart.exclude=stirling.software.proprietary.security/**
 spring.web.resources.mime-mappings.webmanifest=application/manifest+json
 spring.mvc.async.request-timeout=${SYSTEM_CONNECTIONTIMEOUTMILLISECONDS:1200000}
+server.jetty.connection-idle-timeout=${SYSTEM_IDLETIMEOUTMILLISECONDS:60000}ms
 server.jetty.max-http-request-header-size=32768
 
 spring.datasource.url=jdbc:h2:file:./configs/stirling-pdf-DB-2.3.232;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL

--- a/app/core/src/main/resources/application.properties
+++ b/app/core/src/main/resources/application.properties
@@ -64,7 +64,10 @@ spring.devtools.livereload.enabled=true
 spring.devtools.restart.exclude=stirling.software.proprietary.security/**
 spring.web.resources.mime-mappings.webmanifest=application/manifest+json
 spring.mvc.async.request-timeout=${SYSTEM_CONNECTIONTIMEOUTMILLISECONDS:1200000}
-server.jetty.connection-idle-timeout=${SYSTEM_IDLETIMEOUTMILLISECONDS:60000}ms
+# Jetty connector idle timeout, raised from its 30s default: a slow client draining a large
+# download can stall a single write for longer than that and be cut mid-response.
+# The unit is inside the placeholder so an override may carry its own (e.g. 30s).
+server.jetty.connection-idle-timeout=${SYSTEM_IDLETIMEOUTMILLISECONDS:60000ms}
 server.jetty.max-http-request-header-size=32768
 
 spring.datasource.url=jdbc:h2:file:./configs/stirling-pdf-DB-2.3.232;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL

--- a/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
@@ -258,6 +258,24 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    void handleIOException_idleTimeout_returns_empty_body() {
+        IOException ex =
+                new IOException(
+                        "ServletOutputStream failed to write: java.util.concurrent"
+                                + ".TimeoutException: Idle timeout expired: 30000/30000 ms");
+        ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+        assertNull(resp.getBody());
+    }
+
+    @Test
+    void handleIOException_writeFailureInCause_returns_empty_body() {
+        IOException ex = new IOException("wrapper", new IOException("failed to write"));
+        ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertNull(resp.getBody());
+    }
+
+    @Test
     void handleIOException_noSuchFile_returns_500() {
         NoSuchFileException ex = new NoSuchFileException("/tmp/abc123.pdf");
         ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);

--- a/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/exception/GlobalExceptionHandlerTest.java
@@ -4,13 +4,16 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.NoSuchFileException;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jetty.io.EofException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +28,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -258,11 +262,12 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void handleIOException_idleTimeout_returns_empty_body() {
+    void handleIOException_idleTimeoutMidWrite_returns_empty_body() {
         IOException ex =
-                new IOException(
-                        "ServletOutputStream failed to write: java.util.concurrent"
-                                + ".TimeoutException: Idle timeout expired: 30000/30000 ms");
+                new AsyncRequestNotUsableException(
+                        "ServletOutputStream failed to write: "
+                                + "java.util.concurrent.TimeoutException: Idle timeout expired",
+                        new TimeoutException("Idle timeout expired: 60000/60000 ms"));
         ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
         assertNull(resp.getBody());
@@ -270,8 +275,55 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleIOException_writeFailureInCause_returns_empty_body() {
-        IOException ex = new IOException("wrapper", new IOException("failed to write"));
+        IOException ex =
+                new IOException(
+                        "wrapper",
+                        new AsyncRequestNotUsableException("ServletOutputStream failed to write"));
         ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+        assertNull(resp.getBody());
+    }
+
+    @Test
+    void handleIOException_serverSideWriteFailure_keeps_problem_detail_body() {
+        IOException ex =
+                new IOException("Failed to write temp file /tmp/x.png: No space left on device");
+        ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+        assertNotNull(resp.getBody());
+    }
+
+    @Test
+    void handleIOException_readSideIdleTimeout_keeps_problem_detail_body() {
+        IOException ex = new IOException("Idle timeout expired: 60000/60000 ms");
+        ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+        assertNotNull(resp.getBody());
+    }
+
+    @Test
+    void handleIOException_truncatedUploadEof_keeps_problem_detail_body() {
+        IOException ex = new EOFException("Unexpected end of ZLIB input stream");
+        ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+        assertNotNull(resp.getBody());
+    }
+
+    @Test
+    void handleIOException_eofBuriedInServerFailure_keeps_problem_detail_body() {
+        IOException ex =
+                new IOException(
+                        "Error parsing uploaded PDF", new EOFException("Missing 'endstream'"));
+        ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+        assertNotNull(resp.getBody());
+    }
+
+    @Test
+    void handleIOException_jettyEofException_returns_empty_body() {
+        IOException ex = new EofException("Early EOF");
+        ResponseEntity<ProblemDetail> resp = handler.handleIOException(ex, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
         assertNull(resp.getBody());
     }
 


### PR DESCRIPTION
## Problem

When a large download stalls under load, Jetty's default 30s idle timeout fires **mid-write**. The resulting exception chain is:

```
AsyncRequestNotUsableException: ServletOutputStream failed to write:
    java.util.concurrent.TimeoutException: Idle timeout expired: 30000/30000 ms
```

`GlobalExceptionHandler.isClientDisconnectException` only matched `broken pipe`, `connection reset` and `an established connection was aborted`, so this case fell through to the normal 500 path, which tries to serialise a `ProblemDetail` onto a response whose Content-Type is already committed (e.g. `application/octet-stream`). That throws a **secondary** `HttpMessageNotWritableException`, which buries the real cause in the logs.

Observed directly in container logs while load-testing `/api/v1/convert/pdf/img` at high concurrency - every timed-out download logged the secondary exception instead of the real one.

## Fix

Match client disconnects by connector exception type rather than message text: `AsyncRequestNotUsableException`, the shape a mid-write idle timeout arrives in, plus `AbortedException`, `ClientAbortException` and Jetty's `EofException`. A read-side idle timeout, a truncated upload or a server-side write failure still keeps its ProblemDetail body and stack trace. On a real disconnect the handler already does the right thing: log at WARN and return an empty 500 body rather than attempting to write a response that cannot be written.

It also raises the Jetty connector idle timeout from its 30s default to 60s, overridable with `SYSTEM_IDLETIMEOUTMILLISECONDS`. The rest is the error handling being honest about what happened, so the log shows the real cause and no misleading secondary exception.

## Testing

Added unit tests to `GlobalExceptionHandlerTest`:
- `handleIOException_idleTimeoutMidWrite_returns_empty_body` - the exact Jetty message
- `handleIOException_writeFailureInCause_returns_empty_body` - the failure nested in the cause chain
- `handleIOException_jettyEofException_returns_empty_body` - the connector's own EOF
- three negative cases: a read-side idle timeout, a server-side write failure and a truncated-upload `EOFException` all keep their ProblemDetail body

`task backend:fix`, `task backend:check` and comment-lint all pass.

## Related

The underlying reason those downloads stall - `/pdf/img` building the whole ZIP in a `ByteArrayOutputStream` before sending a byte - is a larger streaming refactor tracked separately. This PR is the small, safe robustness fix for the error path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client disconnects and connection-related errors to prevent unnecessary error responses.
  * Added a configurable 60-second default for idle server connections.
  * Preserved meaningful error details for server-side failures and incomplete uploads while suppressing responses for expected disconnect scenarios.

* **Tests**
  * Expanded coverage for timeouts, wrapped connection failures, client disconnects, and truncated uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->