### PR TITLE
fix(testing): make the PAYG compose harness bootstrap a clean Postgres

### DIFF
--- a/testing/compose/docker-compose-saas.yml
+++ b/testing/compose/docker-compose-saas.yml
@@ -1,7 +1,8 @@
 services:
   # ---------------------------------------------------------------------
   # Postgres holding the stirling_pdf schema, built by Hibernate
-  # ddl-auto=create-drop when the backend starts (see below). Exposed on
+  # ddl-auto=update when the backend starts (see below). No volume, so
+  # `docker compose down` gives the next run a clean database. Exposed on
   # host port 5433 so the cucumber harness can connect via psycopg from
   # features/steps/payg_*.
   # ---------------------------------------------------------------------
@@ -14,8 +15,9 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      # Bootstrap stirling_pdf schema + seed test team / api key.
-      # Runs once when the container is first created.
+      # Creates the schemas Hibernate's entities live in. Runs once when
+      # the container is first created; the seed rows come later from the
+      # seed-saas service, once the backend has built the tables.
       - ./payg/saas-init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
@@ -64,25 +66,32 @@ services:
       ENABLE_SAAS: "true"
       DISABLE_ADDITIONAL_FEATURES: "false"
 
-      # Datasource — point Flyway + JPA at the test postgres.
+      # Datasource: the throwaway postgres above.
       SAAS_DB_URL: "jdbc:postgresql://postgres-saas:5432/postgres"
       SAAS_DB_USERNAME: "postgres"
       SAAS_DB_PASSWORD: "postgres"
       SAAS_DB_PROJECT_REF: "disabled"
 
-      # On a clean test postgres the Supabase-provisioned `users`/`teams`
-      # tables don't exist, so we let Hibernate's `ddl-auto=create-drop`
-      # build the full schema from the entity graph. The default-pricing-
-      # policy row (seeded in production by the Supabase migrations) is
-      # re-seeded here by testing/compose/payg/saas-seed.sql.
-      SPRING_JPA_HIBERNATE_DDL_AUTO: "create-drop"
+      # The saas profile hides the Supabase-owned tables (users, teams,
+      # payg_*, wallet_*, ...) from Hibernate via MigrationOwnedSchemaFilter,
+      # because in a real SaaS database the Supabase migrations create them.
+      # This throwaway postgres has no Supabase migrations, so Hibernate must
+      # own everything: the default provider below shows it every table
+      # again. `update` rather than `create-drop`: create-drop wipes the
+      # schema on shutdown, leaving nothing to inspect after a failed run,
+      # and a fresh database is one `docker compose down` away anyway. The
+      # default pricing policy row the migrations would seed comes from
+      # testing/compose/payg/saas-seed.sql instead.
+      SPRING_JPA_HIBERNATE_DDL_AUTO: "update"
+      SPRING_JPA_PROPERTIES_HIBERNATE_HBM2DDL_SCHEMA_FILTER_PROVIDER: "org.hibernate.tool.schema.internal.DefaultSchemaFilterProvider"
 
       # Disable Supabase JWT enforcement for the test profile. The
       # PaygChargeInterceptor resolves via ApiKey-token authority — that
       # path is what we cover here.
       SPRING_AUTOCONFIGURE_EXCLUDE: "org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration"
 
-      # Test API key matching the user seeded by saas-init.sql.
+      # Test API key. The backend creates CUSTOM_API_USER for it at boot;
+      # saas-seed.sql then moves that user into the cucumber team.
       SECURITY_CUSTOMGLOBALAPIKEY: "payg-cucumber-key"
       SECURITY_ENABLELOGIN: "false"
 
@@ -94,6 +103,34 @@ services:
 
       SYSTEM_DEFAULTLOCALE: "en-US"
       SYSTEM_MAXFILESIZE: "100"
+    networks:
+      - payg-cucumber-network
+
+  # ---------------------------------------------------------------------
+  # One-shot seed, run once the backend reports healthy. These rows can't
+  # go in /docker-entrypoint-initdb.d: the tables they target don't exist
+  # until Hibernate builds them, which happens when the backend boots, long
+  # after postgres has finished initialising. Exits 0 and stays exited; a
+  # re-run is safe because every statement in the file is idempotent.
+  # ---------------------------------------------------------------------
+  seed-saas:
+    image: postgres:17-alpine
+    container_name: payg-cucumber-seed
+    depends_on:
+      stirling-pdf-saas:
+        condition: service_healthy
+    restart: "no"
+    environment:
+      PGPASSWORD: postgres
+    volumes:
+      - ./payg/saas-seed.sql:/seed.sql:ro
+    command:
+      - psql
+      - --host=postgres-saas
+      - --username=postgres
+      - --dbname=postgres
+      - --set=ON_ERROR_STOP=1
+      - --file=/seed.sql
     networks:
       - payg-cucumber-network
 

--- a/testing/compose/payg/saas-init.sql
+++ b/testing/compose/payg/saas-init.sql
@@ -1,25 +1,14 @@
--- Bootstrap minimal stirling_pdf state for PAYG cucumber tests.
+-- Container-init bootstrap for the PAYG cucumber postgres.
 --
 -- Runs once when the postgres-saas container is first created (loaded via
--- /docker-entrypoint-initdb.d on the official postgres image). Flyway then
--- migrates V1-V13 on backend startup, which fills in the schema; this file
--- only seeds the data rows the cucumber scenarios reference by name.
+-- /docker-entrypoint-initdb.d on the official postgres image), before the
+-- backend has connected. Only the schemas are created here: the tables come
+-- from Hibernate ddl-auto on backend startup, and the seed rows from
+-- saas-seed.sql once those tables exist (see docker-compose-saas.yml).
 --
--- Idempotent — if the container is re-created, this whole file runs again
--- but every INSERT is guarded against duplicates.
+-- Hibernate creates the `stirling_pdf` namespace itself, but SupabaseUser maps
+-- `auth.users` and the `auth` schema is provisioned by Supabase in a real
+-- database, so it has to be created here for the entity table to land.
 
 CREATE SCHEMA IF NOT EXISTS stirling_pdf;
-
--- Note: the actual seed of teams / users / payg_team_extensions / wallet_policy
--- happens AFTER Flyway migrations have applied. We can't insert here because
--- the tables don't exist yet at container-init time. Instead we register a
--- helper function the backend invokes once at startup (or the cucumber
--- harness invokes via psql before running scenarios).
---
--- For "make a start", the simplest approach is to keep this file as the
--- schema bootstrap, and put the seed inserts in a separate sidecar SQL that
--- the cucumber test.sh harness pipes through psql AFTER waiting for backend
--- health. See testing/compose/payg/saas-seed.sql below.
-
--- Reserved for future container-init-time schema bootstrap if we ever need it.
-SELECT 1;
+CREATE SCHEMA IF NOT EXISTS auth;

--- a/testing/compose/payg/saas-seed.sql
+++ b/testing/compose/payg/saas-seed.sql
@@ -1,25 +1,28 @@
 -- Seed test team / payg policy / wallet_policy in PAYG_SHADOW mode for the
--- cucumber harness. Piped through psql AFTER Hibernate has built the schema
--- on backend startup (compose disables Flyway — see docker-compose-saas.yml
--- for the rationale: saas Flyway migrations assume `users` + `teams` exist
--- because Supabase normally provisions them).
+-- cucumber harness. Applied by the `seed-saas` service in
+-- docker-compose-saas.yml once the backend is healthy, which is the earliest
+-- point at which Hibernate has built the tables these rows target. To re-run
+-- it by hand against a live stack:
+--
+--   psql -h localhost -p 5433 -U postgres -d postgres \
+--        -f testing/compose/payg/saas-seed.sql
+--
+-- In a real SaaS database these tables and their seed rows come from the
+-- Supabase migrations; the harness postgres has none, so Hibernate builds
+-- the tables from the entities (see docker-compose-saas.yml) and this file
+-- supplies the rows. Hibernate's DDL carries no SQL DEFAULTs, so every NOT
+-- NULL column is set explicitly below, including the timestamps that
+-- @CreationTimestamp would normally fill in application-side.
 --
 -- Idempotent — guarded against duplicate keys so re-running on the same
 -- container is safe between scenarios.
 
 -- ---------------------------------------------------------------------------
--- 0. Default pricing policy + per-source step limits (V12 in production).
+-- 0. Default pricing policy + per-source step limits.
 --    Required because PricingPolicyService.getEffectivePolicy() throws if
---    no row has is_default = TRUE. Explicit timestamps because Hibernate's
---    @CreationTimestamp is application-side; direct INSERTs bypass it.
+--    no row has is_default = TRUE. free_tier_units 500 matches the launch
+--    free tier, granted per billing period.
 -- ---------------------------------------------------------------------------
--- NOTE: free_tier_units is supplied explicitly because the cucumber harness
--- disables Flyway (see docker-compose-saas.yml). Hibernate's DDL emits NOT
--- NULL without a SQL DEFAULT (the JPA field default `= 0L` is JVM-side only),
--- so the column would otherwise reject this INSERT. 500 matches the launch
--- free tier, now granted per billing period rather than once per team.
--- (Named free_tier_units_per_cycle here until the rename in V19; the harness
--- builds its schema from Hibernate, so the old name made the INSERT fail.)
 INSERT INTO stirling_pdf.pricing_policy (
     version, effective_from, doc_pages_per_unit, doc_bytes_per_unit,
     min_charge_units, file_unit_cap, free_tier_units, is_default,
@@ -62,12 +65,21 @@ WHERE NOT EXISTS (
 );
 
 -- ---------------------------------------------------------------------------
--- 2. payg_team_extensions sidecar — uses the default pricing policy.
+-- 2. payg_team_extensions sidecar, pinned to the default pricing policy with
+--    a full free-tier grant for the current calendar month. Without this row
+--    the team has no grant and every tool call is refused with
+--    402 PAYG_LIMIT_REACHED.
 -- ---------------------------------------------------------------------------
-INSERT INTO stirling_pdf.payg_team_extensions (team_id, pricing_policy_id, stripe_customer_id)
-SELECT t.team_id, NULL, NULL
+INSERT INTO stirling_pdf.payg_team_extensions (
+    team_id, pricing_policy_id, free_units_remaining, free_units_period_start,
+    created_at, updated_at, version
+)
+SELECT t.team_id, p.policy_id, p.free_tier_units, date_trunc('month', CURRENT_TIMESTAMP),
+       CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0
 FROM stirling_pdf.teams t
+CROSS JOIN stirling_pdf.pricing_policy p
 WHERE t.name = 'payg-cucumber-team'
+  AND p.is_default = TRUE
   AND NOT EXISTS (
       SELECT 1 FROM stirling_pdf.payg_team_extensions ext WHERE ext.team_id = t.team_id
   );
@@ -85,8 +97,6 @@ WHERE u.username = 'CUSTOM_API_USER';
 
 -- ---------------------------------------------------------------------------
 -- 4. Team membership row so /teams/* admin paths recognise the user.
---    All timestamp columns set explicitly because Hibernate-generated DDL
---    doesn't carry the Flyway-migration DEFAULT CURRENT_TIMESTAMP.
 -- ---------------------------------------------------------------------------
 INSERT INTO stirling_pdf.team_memberships (
     team_id, user_id, role, invited_at, created_at, updated_at
@@ -102,10 +112,9 @@ WHERE t.name = 'payg-cucumber-team'
   );
 
 -- ---------------------------------------------------------------------------
--- 5. wallet_policy in PAYG_SHADOW mode.
---    auto_group_strategy is the dead column tracked for drop in PR-R11
---    (PAYG_DESIGN.md §7.7) — until that ships, the NOT NULL constraint
---    means we have to populate it. 'AUTO' is the prod default.
+-- 5. wallet_policy in PAYG_SHADOW mode. auto_group_strategy is NOT NULL
+--    with no SQL default, so it has to carry a value; 'AUTO' matches the
+--    entity's field default.
 -- ---------------------------------------------------------------------------
 INSERT INTO stirling_pdf.wallet_policy (
     team_id, engine, cap_period, warn_at_pct, degrade_at_pct,


### PR DESCRIPTION
# Description of Changes

The PAYG cucumber harness could not start on a clean database.

`docker-compose-saas.yml` told Hibernate to build the whole schema with `ddl-auto=create-drop`, but the saas profile wires `MigrationOwnedSchemaFilter`, which hides the ~30 Supabase-owned tables (`users`, `teams`, `payg_*`, `wallet_*`, `pricing_policy`, `processing_job`, ...) from schema management. That filter was added after the harness was written, so the comment describing `create-drop` had quietly become false. On a fresh Postgres, Hibernate created only the inherited tables and the backend died in `InitialSecuritySetup` with `relation "stirling_pdf.users" does not exist`.

**What changed**

- **`docker-compose-saas.yml`** points the throwaway database at Hibernate's `DefaultSchemaFilterProvider`, so Hibernate owns every table there. The comment explains why: this database has no Supabase migrations, unlike a real SaaS one. Also switches to `ddl-auto=update`, because `create-drop` wiped the schema on shutdown and left nothing to inspect after a failed run.
- **`payg/saas-init.sql`** creates the `auth` schema. `SupabaseUser` maps `auth.users`, and Supabase provides that schema in a real database.
- **`payg/saas-seed.sql`** supplies the NOT NULL columns on the `payg_team_extensions` insert. It previously failed, leaving the team with no free-tier grant, so every call was refused with `402 PAYG_LIMIT_REACHED`. The grant now derives from the default policy's `free_tier_units` rather than a second hardcoded copy of it.
- **New `seed-saas` service** applies the seed once the backend reports healthy, so the stack bootstraps from a single `up`. These rows cannot go in `docker-entrypoint-initdb.d` because the tables they target do not exist until Hibernate builds them at backend boot.
- Stale comments referencing Flyway (removed in #7100), migration version numbers, and a `PAYG_DESIGN.md` that is not in this repo are gone.

**Verification**

From a full `down -v`, one `docker compose -f testing/compose/docker-compose-saas.yml up --wait` brings the stack up and seeds it with no manual step. Then:

```bash
curl -X POST http://localhost:8080/api/v1/general/rotate-pdf -H "X-API-KEY: payg-cucumber-key" -F "fileInput=@testing/crop_test.pdf" -F "angle=90"
```

| Check | Result |
|---|---|
| Tables in `stirling_pdf` | 64, including all 9 that were missing |
| Rotate request | HTTP 200, valid PDF |
| `payg_shadow_charge` | 1 row, status `CHARGED`, 1 unit |
| `free_units_remaining` | 500 to 499 |
| Seed re-run | exit 0, all inserts no-op, no duplicates |

`task comment-lint` is clean.

Two things left alone as out of scope. The `features/steps/payg_*` cucumber steps referenced in the compose comments do not exist yet, so the seed has no test suite consuming it. And the backend still maps host port 8080, which collides if you already run Stirling locally.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)