### PR TITLE
Load watermark font once per document

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/WatermarkController.java
@@ -3,22 +3,16 @@ package stirling.software.SPDF.controller.api.security;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyEditorSupport;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 
 import javax.imageio.ImageIO;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
-import org.apache.pdfbox.pdmodel.font.PDType1Font;
-import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
@@ -113,6 +107,11 @@ public class WatermarkController {
         // Load the input PDF with proper resource management
         try (PDDocument document = pdfDocumentFactory.load(pdfFile)) {
 
+            PDFont font =
+                    "text".equalsIgnoreCase(watermarkType)
+                            ? loadWatermarkFont(document, alphabet)
+                            : null;
+
             // Create a page in the document
             for (PDPage page : document.getPages()) {
                 // Get the page's content stream
@@ -133,13 +132,12 @@ public class WatermarkController {
                         addTextWatermark(
                                 contentStream,
                                 watermarkText,
-                                document,
                                 page,
                                 rotation,
                                 widthSpacer,
                                 heightSpacer,
                                 fontSize,
-                                alphabet,
+                                font,
                                 customColor);
                     } else if ("image".equalsIgnoreCase(watermarkType)) {
                         addImageWatermark(
@@ -175,21 +173,13 @@ public class WatermarkController {
         }
     }
 
-    private void addTextWatermark(
-            PDPageContentStream contentStream,
-            String watermarkText,
-            PDDocument document,
-            PDPage page,
-            float rotation,
-            int widthSpacer,
-            int heightSpacer,
-            float fontSize,
-            String alphabet,
-            String colorString)
-            throws IOException {
-        String resourceDir = "";
-        PDFont font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
-        resourceDir =
+    /**
+     * Load the watermark font once for the whole document. {@link PDType0Font#load} embeds a font
+     * object into {@code document} on every call, so calling this per page holds one full copy of
+     * the TTF per page in memory (10 MB each for the CJK faces).
+     */
+    private PDFont loadWatermarkFont(PDDocument document, String alphabet) throws IOException {
+        String resourceDir =
                 switch (alphabet) {
                     case "arabic" -> "static/fonts/NotoSansArabic-Regular.ttf";
                     case "japanese" -> "static/fonts/NotoSansJP-Regular.ttf";
@@ -199,17 +189,22 @@ public class WatermarkController {
                     default -> "static/fonts/NotoSans-Regular.ttf";
                 };
 
-        ClassPathResource classPathResource = new ClassPathResource(resourceDir);
-        String fileExtension = resourceDir.substring(resourceDir.lastIndexOf('.'));
-        File tempFile = Files.createTempFile("NotoSansFont", fileExtension).toFile();
-        try (InputStream is = classPathResource.getInputStream();
-                FileOutputStream os = new FileOutputStream(tempFile)) {
-            IOUtils.copy(is, os);
-            font = PDType0Font.load(document, tempFile);
-        } finally {
-            Files.deleteIfExists(tempFile.toPath());
+        try (InputStream is = new ClassPathResource(resourceDir).getInputStream()) {
+            return PDType0Font.load(document, is);
         }
+    }
 
+    private void addTextWatermark(
+            PDPageContentStream contentStream,
+            String watermarkText,
+            PDPage page,
+            float rotation,
+            int widthSpacer,
+            int heightSpacer,
+            float fontSize,
+            PDFont font,
+            String colorString)
+            throws IOException {
         contentStream.setFont(font, fontSize);
 
         Color redactColor;

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/security/WatermarkControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/security/WatermarkControllerTest.java
@@ -10,12 +10,19 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.junit.jupiter.api.BeforeEach;
@@ -386,6 +393,67 @@ class WatermarkControllerTest {
             ResponseEntity<Resource> response = watermarkController.addWatermark(request);
             assertNotNull(response.getBody());
             assertTrue(drainBody(response).length > 0);
+        }
+
+        @Test
+        @DisplayName("Should embed the watermark font once, not once per page")
+        void testAddTextWatermark_EmbedsFontOnce() throws Exception {
+            int pageCount = 12;
+            byte[] multiPagePdf;
+            try (PDDocument doc = new PDDocument()) {
+                for (int i = 0; i < pageCount; i++) {
+                    doc.addPage(new PDPage(PDRectangle.A4));
+                }
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                doc.save(baos);
+                multiPagePdf = baos.toByteArray();
+            }
+
+            AddWatermarkRequest request = new AddWatermarkRequest();
+            request.setFileInput(
+                    new MockMultipartFile(
+                            "fileInput",
+                            "multi.pdf",
+                            MediaType.APPLICATION_PDF_VALUE,
+                            multiPagePdf));
+            request.setWatermarkType("text");
+            request.setWatermarkText("WATERMARK");
+            request.setAlphabet("roman");
+            request.setFontSize(30);
+            request.setRotation(45);
+            request.setOpacity(0.5f);
+            request.setWidthSpacer(50);
+            request.setHeightSpacer(50);
+            request.setCustomColor("#d3d3d3");
+            request.setConvertPDFToImage(false);
+
+            when(pdfDocumentFactory.load(any(MultipartFile.class)))
+                    .thenAnswer(inv -> Loader.loadPDF(multiPagePdf));
+
+            byte[] watermarked = drainBody(watermarkController.addWatermark(request));
+
+            Set<COSBase> fontPrograms =
+                    Collections.newSetFromMap(new IdentityHashMap<COSBase, Boolean>());
+            try (PDDocument out = Loader.loadPDF(watermarked)) {
+                assertEquals(pageCount, out.getNumberOfPages());
+                for (PDPage page : out.getPages()) {
+                    PDResources resources = page.getResources();
+                    for (COSName fontName : resources.getFontNames()) {
+                        PDFontDescriptor descriptor =
+                                resources.getFont(fontName).getFontDescriptor();
+                        if (descriptor != null && descriptor.getFontFile2() != null) {
+                            fontPrograms.add(descriptor.getFontFile2().getCOSObject());
+                        }
+                    }
+                }
+            }
+
+            // One embedded font program shared by every page. Loading it inside the page
+            // loop embeds a fresh copy per page, which is what OOMs large documents.
+            assertEquals(
+                    1,
+                    fontPrograms.size(),
+                    "watermark font should be embedded once for the whole document");
         }
     }
 


### PR DESCRIPTION
## Description of Changes

`addTextWatermark` is called once per page, and every call ran `PDType0Font.load(document, tempFile)`. That call embeds a **new font object into the document each time**, so a watermark job held one full copy of the TTF per page for the life of the request.

For a 1000-page document with the default Latin face (`NotoSans-Regular.ttf`, 582 KB) that is ~570 MB of raw font bytes before PDFBox's parsed glyph tables and subsetting structures — which is what pushes a large watermark past the heap and OOM-kills containers under 8 GB. The CJK faces make it much worse: `NotoSansKR-Regular.ttf` is 10.4 MB, so the same document needs an order of magnitude more again.

Each call also wrote the font to a temp file and deleted it, so a 1000-page job did 1000 create/write/delete cycles.

### What changed

- `loadWatermarkFont` extracted, called **once** before the page loop; the loaded `PDFont` is passed into `addTextWatermark`.
- Loads via `PDType0Font.load(PDDocument, InputStream)` straight from the classpath resource, so the temp file is gone entirely.
- `addTextWatermark` takes the `PDFont` instead of the `alphabet` string, and no longer needs the `PDDocument`.
- Dropped the dead `PDType1Font` initialiser that was overwritten before use, plus the imports that went with it.

The page loop itself was already correct — it streams one page at a time. The allocation was purely inside it.

## Verification

Added `testAddTextWatermark_EmbedsFontOnce`, which watermarks a 12-page document and counts the distinct embedded `FontFile2` streams reachable from page resources.

Confirmed it catches the regression — reintroducing the per-page load fails it:

```
expected: <1> but was: <12>
```

All 23 existing watermark tests pass unchanged.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
