### PR TITLE
Cap auto-split QR detection retry at 300 DPI

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfController.java
@@ -67,6 +67,10 @@ public class AutoSplitPdfController {
     // 150 DPI is sufficient for QR code detection — higher wastes memory and CPU
     private static final int QR_DETECTION_DPI = 150;
 
+    // Ceiling for the retry pass. 300 DPI decodes every divider size 500 does, including a 10mm
+    // code under blur, noise and skew, at a quarter of the pixels.
+    private static final int QR_RETRY_DPI = 300;
+
     // Max total pixels before we downscale to avoid OOM on getRGB() allocation
     private static final long MAX_IMAGE_PIXELS = 100_000_000L; // ~10000x10000
 
@@ -233,8 +237,8 @@ public class AutoSplitPdfController {
 
     /**
      * Render the full page to an image and scan it for a QR code. Tries a low DPI first (fast, low
-     * memory) and only retries at the system's maxDPI if detection fails. The first rendered image
-     * is released before the retry to allow GC to reclaim it.
+     * memory) and only retries at {@link #QR_RETRY_DPI} if detection fails. The first rendered
+     * image is released before the retry to allow GC to reclaim it.
      */
     private String checkPageByRendering(PDFRenderer pdfRenderer, int pageNum) throws IOException {
         log.debug("Rendering page {} at {} DPI for QR detection", pageNum + 1, QR_DETECTION_DPI);
@@ -248,17 +252,17 @@ public class AutoSplitPdfController {
         bim = null; // allow GC before potential high-DPI retry
 
         if (result == null) {
-            int maxDpi = getSystemMaxDpi();
-            if (maxDpi > QR_DETECTION_DPI) {
+            int retryDpi = Math.min(getSystemMaxDpi(), QR_RETRY_DPI);
+            if (retryDpi > QR_DETECTION_DPI) {
                 log.debug(
                         "Retrying page {} at {} DPI (low-DPI detection failed)",
                         pageNum + 1,
-                        maxDpi);
+                        retryDpi);
                 BufferedImage highRes =
                         ExceptionUtils.handleOomRendering(
                                 pageNum + 1,
-                                maxDpi,
-                                () -> pdfRenderer.renderImageWithDPI(pageNum, maxDpi));
+                                retryDpi,
+                                () -> pdfRenderer.renderImageWithDPI(pageNum, retryDpi));
                 result = decodeQRCode(highRes);
             }
         }

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/misc/AutoSplitPdfControllerTest.java
@@ -28,6 +28,7 @@ import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.rendering.PDFRenderer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -484,6 +485,49 @@ class AutoSplitPdfControllerTest {
             m.setAccessible(true);
             Object result = m.invoke(noProps);
             assertEquals(150, result); // QR_DETECTION_DPI
+        }
+    }
+
+    @Nested
+    @DisplayName("checkPageByRendering retry DPI")
+    class RetryDpi {
+
+        /** DPIs the renderer is asked for when no QR decodes, for a given configured maxDPI. */
+        private List<Float> renderedDpis(int configuredMaxDpi) throws Exception {
+            applicationProperties.getSystem().setMaxDPI(configuredMaxDpi);
+            List<Float> dpis = new ArrayList<>();
+            PDFRenderer renderer = mock(PDFRenderer.class);
+            when(renderer.renderImageWithDPI(anyInt(), anyFloat()))
+                    .thenAnswer(
+                            inv -> {
+                                dpis.add(inv.getArgument(1));
+                                return new BufferedImage(40, 40, BufferedImage.TYPE_INT_RGB);
+                            });
+
+            invokeInstance(
+                    "checkPageByRendering",
+                    new Class<?>[] {PDFRenderer.class, int.class},
+                    renderer,
+                    0);
+            return dpis;
+        }
+
+        @Test
+        @DisplayName("retry is capped at 300 even when maxDPI is 500")
+        void capsRetryAt300() throws Exception {
+            assertEquals(List.of(150f, 300f), renderedDpis(500));
+        }
+
+        @Test
+        @DisplayName("a maxDPI below the cap still limits the retry")
+        void respectsLowerConfiguredMax() throws Exception {
+            assertEquals(List.of(150f, 200f), renderedDpis(200));
+        }
+
+        @Test
+        @DisplayName("no retry when maxDPI is already the detection DPI")
+        void skipsRetryAtDetectionDpi() throws Exception {
+            assertEquals(List.of(150f), renderedDpis(150));
         }
     }
 


### PR DESCRIPTION
## Description of Changes

`checkPageByRendering` renders a page at `QR_DETECTION_DPI` (150) to look for a split divider, and if nothing decodes it re-renders **the same page at the system's `maxDPI`** — which defaults to 500.

A decode returns nothing on every page that has no QR divider, which is nearly every page of any real document. So the escalation path built as a rare fallback is actually the default path, and every ordinary page is rendered twice, the second time at 500 DPI.

`maxDPI` is a safety cap on *user-supplied* DPI for the image converters. Borrowing it as a detection resolution silently couples QR scanning to an unrelated setting, and 500 is far past the point where it buys any detection.

### What changed

- New `QR_RETRY_DPI = 300` ceiling for the retry pass.
- The retry uses `Math.min(getSystemMaxDpi(), QR_RETRY_DPI)`, so a deployment that configures a *lower* `maxDPI` still caps the retry there, and the retry is skipped entirely when `maxDPI` is already 150.

## Why 300

Measured, rather than guessed. I rendered a real `https://stirlingpdf.com` divider on A4 at realistic printed sizes and decoded with this controller's exact ZXing settings (`TRY_HARDER` + `ALSO_INVERTED`), including scan degradations:

```
QR size     72dpi  100dpi  120dpi  150dpi  200dpi  250dpi  300dpi  400dpi  500dpi
10mm         xxxx    xxxx    xxxx    xxxx    .xNx    .BNR    .BNR    .BNR    .BNR
15mm         xxxx    .xxx    xxxx    .BNR    .BNR    .BNR    .BNR    .BNR    .BNR
20mm         .xxx    .xxR    .xNR    .BNR    .BNR    .BNR    .BNR    .BNR    .BNR
30mm         .xNR    .BNR    .BNR    .BNR    .BNR    .BNR    .BNR    .BxR    .BxR
50mm         .BNR    .BNR    .BNR    .BNR    .BNR    .BxR    .BxR    .BxR    .BxR
```
`.` clean · `B` 3x3 blur · `N` ±40 noise · `R` 1.5° rotation · `x` failed to decode

**Nothing decodes at 400 or 500 that does not also decode at 300.** For 30mm and 50mm codes 300 is strictly better, because higher DPI raises per-pixel noise energy relative to module size. The predictor is pixels per QR module: ≥3 decodes reliably, <2 fails.

The retry is kept rather than removed because it genuinely earns its place: a 10mm divider fails completely at 150 DPI and needs 250–300.

Cost per A4 page, measured on the same document:

| DPI | megapixels | bitmap | ms/page |
|-----|-----------|--------|---------|
| 150 | 2.2 | 8.3 MB | 34 |
| 300 | 8.7 | 33.2 MB | 114 |
| 500 | 24.2 | 92.2 MB | 255 |

So a page with no divider goes from 289 ms to 148 ms (**~49% faster**), and peak bitmap per page from 92 MB to 33 MB (**~64% less**) — with no loss of detection at any size tested. `decodeQRCode` copies the rendered image into an `int[]` before handing it to ZXing, so the memory saving applies twice.

## Verification

Three tests in `AutoSplitPdfControllerTest.RetryDpi` capture the DPIs the renderer is actually asked for:

- `capsRetryAt300` — **confirmed it catches the regression**; with the cap removed it fails `expected: <[150.0, 300.0]> but was: <[150.0, 500.0]>`
- `respectsLowerConfiguredMax` — `maxDPI` of 200 still caps the retry at 200
- `skipsRetryAtDetectionDpi` — no retry at all when `maxDPI` is 150

All existing auto-split tests pass unchanged.

## Follow-up

The retry still fires on every divider-free page. Skipping it when the 150 DPI pass finds no finder-pattern candidates would cut the cost to ~34 ms/page, but that is a behavioural change to detection and belongs in its own PR.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
