### PR TITLE
Default dpi to 300 when omitted from convert to image

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
@@ -103,7 +103,12 @@ public class ConvertImgPDFController {
         String imageFormat = request.getImageFormat();
         String singleOrMultiple = request.getSingleOrMultiple();
         String colorType = request.getColorType();
-        int dpi = request.getDpi();
+        // Spring binds an empty dpi form field to null, which the field default cannot cover
+        Integer requestedDpi = request.getDpi();
+        int dpi =
+                (requestedDpi == null || requestedDpi <= 0)
+                        ? ConvertToImageRequest.DEFAULT_DPI
+                        : requestedDpi;
         String pageNumbers = request.getPageNumbers();
         boolean includeAnnotations = Boolean.TRUE.equals(request.getIncludeAnnotations());
         Path tempFile = null;

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequest.java
@@ -11,6 +11,8 @@ import stirling.software.SPDF.model.api.PDFWithPageNums;
 @EqualsAndHashCode(callSuper = true)
 public class ConvertToImageRequest extends PDFWithPageNums {
 
+    public static final int DEFAULT_DPI = 300;
+
     @Schema(
             description = "The output image format",
             defaultValue = "png",
@@ -38,7 +40,7 @@ public class ConvertToImageRequest extends PDFWithPageNums {
             description = "The DPI (dots per inch) for the output image(s)",
             defaultValue = "300",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private Integer dpi;
+    private Integer dpi = DEFAULT_DPI;
 
     @Schema(
             description = "Include annotations such as comments in the output image(s)",

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFControllerGapTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFControllerGapTest.java
@@ -491,6 +491,54 @@ class ConvertImgPDFControllerGapTest {
         }
 
         @Test
+        @DisplayName("omitted dpi falls back to the documented default instead of throwing")
+        void nullDpiUsesDefault() throws Exception {
+            MockMultipartFile file = imagePdf(tinyPdfBytes(1));
+
+            ConvertToImageRequest request = new ConvertToImageRequest();
+            request.setFileInput(file);
+            request.setImageFormat("png");
+            request.setSingleOrMultiple("single");
+            request.setColorType("color");
+            request.setDpi(null);
+            request.setPageNumbers("all");
+            request.setIncludeAnnotations(false);
+
+            Mockito.when(pdfDocumentFactory.load(any(MockMultipartFile.class)))
+                    .thenReturn(tinyDocument(1));
+
+            byte[] imageBytes = "png-image".getBytes();
+            ResponseEntity<byte[]> expected = ResponseEntity.ok(imageBytes);
+
+            try (MockedStatic<PdfUtils> pu = Mockito.mockStatic(PdfUtils.class);
+                    MockedStatic<WebResponseUtils> wr =
+                            Mockito.mockStatic(WebResponseUtils.class)) {
+
+                pu.when(
+                                () ->
+                                        PdfUtils.convertFromPdf(
+                                                eq(pdfDocumentFactory),
+                                                any(byte[].class),
+                                                eq("PNG"),
+                                                eq(ImageType.RGB),
+                                                eq(true),
+                                                eq(ConvertToImageRequest.DEFAULT_DPI),
+                                                any(String.class),
+                                                eq(false)))
+                        .thenReturn(imageBytes);
+                wr.when(
+                                () ->
+                                        WebResponseUtils.bytesToWebResponse(
+                                                eq(imageBytes),
+                                                any(String.class),
+                                                any(MediaType.class)))
+                        .thenReturn(expected);
+
+                assertSame(expected, controller.convertToImage(request));
+            }
+        }
+
+        @Test
         @DisplayName("single-image PNG path returns the rendered bytes")
         void singleImagePng() throws Exception {
             byte[] pdfBytes = tinyPdfBytes(1);

--- a/app/core/src/test/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequestTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/model/api/converters/ConvertToImageRequestTest.java
@@ -17,6 +17,19 @@ class ConvertToImageRequestTest {
     }
 
     @Nested
+    @DisplayName("defaults")
+    class Defaults {
+
+        @Test
+        @DisplayName("dpi defaults to the value the schema documents")
+        void dpiDefaultMatchesSchema() {
+            assertThat(new ConvertToImageRequest().getDpi())
+                    .isEqualTo(ConvertToImageRequest.DEFAULT_DPI)
+                    .isEqualTo(300);
+        }
+    }
+
+    @Nested
     @DisplayName("accessors")
     class Accessors {
 


### PR DESCRIPTION
## Description of Changes

`ConvertToImageRequest` documents a DPI default of 300:

```java
@Schema(description = "...", defaultValue = "300", requiredMode = Schema.RequiredMode.REQUIRED)
private Integer dpi;
```

But `@Schema(defaultValue = ...)` is OpenAPI metadata — it takes no part in Spring's request binding. The field was a bare `Integer` with no initialiser and no `@NotNull`, and the controller reads it as:

```java
int dpi = request.getDpi();
```

So **any API client that omits `dpi` gets a `NullPointerException`** rather than the documented 300:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()"
  because the return value of "ConvertToImageRequest.getDpi()" is null
```

The UI never hits this because the frontend always sends a value. `ConvertPdfToCbzRequest` and `ConvertPdfToCbrRequest` declare `private int dpi = 150` and were never affected.

### What changed

- `dpi` now defaults to `DEFAULT_DPI` (300), so the bound object matches what the schema advertises.
- The controller coerces null or non-positive values to the default, mirroring the guard the CBZ and CBR paths already have. This is needed on top of the field initialiser because Spring binds an *empty* form field to null, which an initialiser alone does not cover.

**This changes only the omitted-parameter case.** An explicit `dpi` behaves exactly as before — no change to the effective default for any existing caller.

## Verification

- `nullDpiUsesDefault` in `ConvertImgPDFControllerGapTest` asserts `convertFromPdf` receives 300 when `dpi` is null. **Confirmed it reproduces the bug** — against the original code it fails with the NPE quoted above.
- `dpiDefaultMatchesSchema` pins the field default to the documented value so the two cannot drift apart again.
- All existing `ConvertImgPDFController` and `ConvertToImageRequest` tests pass unchanged.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
