### PR TITLE
Convert image inputs to PDF before JPDFium merge

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/MergeController.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
@@ -47,6 +48,7 @@ import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.ExceptionUtils;
 import stirling.software.common.util.GeneralUtils;
 import stirling.software.common.util.PdfErrorUtils;
+import stirling.software.common.util.PdfUtils;
 import stirling.software.common.util.TempFile;
 import stirling.software.common.util.TempFileManager;
 import stirling.software.common.util.WebResponseUtils;
@@ -277,7 +279,19 @@ public class MergeController {
             List<Integer> invalidIndexes = new ArrayList<>();
             for (int index = 0; index < files.length; index++) {
                 MultipartFile multipartFile = files[index];
-                File tempFile = tempFileManager.convertMultipartFileToFile(multipartFile);
+                File tempFile;
+                if (isImageFile(multipartFile)) {
+                    // Convert images to a single-page PDF so JPDFium can merge them; fall back to
+                    // the raw upload if conversion fails so pre-validate can flag it.
+                    try {
+                        tempFile = convertImageToPdf(multipartFile);
+                    } catch (Exception e) {
+                        ExceptionUtils.logException("image to PDF conversion for merge", e);
+                        tempFile = tempFileManager.convertMultipartFileToFile(multipartFile);
+                    }
+                } else {
+                    tempFile = tempFileManager.convertMultipartFileToFile(multipartFile);
+                }
                 filesToDelete.add(tempFile);
                 inputPaths.add(tempFile.toPath());
 
@@ -374,6 +388,37 @@ public class MergeController {
                 GeneralUtils.generateFilename(firstFilename, "_merged_unsigned.pdf");
 
         return WebResponseUtils.pdfFileToWebResponse(outputTempFile, mergedFileName);
+    }
+
+    private boolean isImageFile(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType != null && contentType.toLowerCase(Locale.ROOT).startsWith("image/")) {
+            return true;
+        }
+        String filename = file.getOriginalFilename();
+        if (filename == null) {
+            return false;
+        }
+        int dot = filename.lastIndexOf('.');
+        if (dot < 0 || dot == filename.length() - 1) {
+            return false;
+        }
+        return ToolFormat.IMAGE
+                .getExtensions()
+                .contains(filename.substring(dot + 1).toLowerCase(Locale.ROOT));
+    }
+
+    private File convertImageToPdf(MultipartFile image) throws IOException {
+        byte[] pdfBytes =
+                PdfUtils.imageToPdf(
+                        new MultipartFile[] {image},
+                        "maintainAspectRatio",
+                        false,
+                        "color",
+                        pdfDocumentFactory);
+        File pdfFile = tempFileManager.createTempFile(".pdf");
+        Files.write(pdfFile.toPath(), pdfBytes);
+        return pdfFile;
     }
 
     private int[] mergeWithJpdfium(

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/MergeControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/MergeControllerTest.java
@@ -305,4 +305,43 @@ class MergeControllerTest {
         assertEquals(mockMergedDocument, result);
         verify(mockMergedDocument, never()).addPage(any(PDPage.class));
     }
+
+    @Test
+    void isImageFile_detectsByContentType() throws Exception {
+        MockMultipartFile jpg =
+                new MockMultipartFile(
+                        "file", "scan", MediaType.IMAGE_JPEG_VALUE, new byte[] {1, 2, 3});
+        assertTrue(invokeIsImageFile(jpg));
+    }
+
+    @Test
+    void isImageFile_detectsByExtension_whenContentTypeMissing() throws Exception {
+        // Uppercase extension and no content type: extension check must still match.
+        MockMultipartFile png = new MockMultipartFile("file", "photo.PNG", null, new byte[] {1});
+        assertTrue(invokeIsImageFile(png));
+    }
+
+    @Test
+    void isImageFile_returnsFalseForPdf() throws Exception {
+        // mockFile1 is document1.pdf with application/pdf content type.
+        assertFalse(invokeIsImageFile(mockFile1));
+    }
+
+    @Test
+    void isImageFile_returnsFalseWhenNoExtensionAndNotImageContentType() throws Exception {
+        MockMultipartFile noExt =
+                new MockMultipartFile(
+                        "file",
+                        "document_no_ext",
+                        MediaType.APPLICATION_PDF_VALUE,
+                        new byte[] {1});
+        assertFalse(invokeIsImageFile(noExt));
+    }
+
+    private boolean invokeIsImageFile(MultipartFile file) throws Exception {
+        Method isImageFileMethod =
+                MergeController.class.getDeclaredMethod("isImageFile", MultipartFile.class);
+        isImageFileMethod.setAccessible(true);
+        return (boolean) isImageFileMethod.invoke(mergeController, file);
+    }
 }


### PR DESCRIPTION
# Description of Changes

**What was changed:** `MergeController` now converts image inputs to a single-page PDF (via the existing `PdfUtils.imageToPdf`) before handing them to the JPDFium merge. Image detection reuses `ToolFormat.IMAGE` extensions plus the `image/*` content type. If conversion fails (e.g. an unsupported vector format), the controller falls back to the raw upload so the existing pre-validate path flags it exactly as before. Added unit tests for the detection logic in `MergeControllerTest`.

**Why:** `/api/v1/general/merge-pdfs` wrote each uploaded file to a temp file as-is and called `PdfDocument.open()` on it. JPDFium can only open PDFs, so any merge that included an image failed with HTTP 500:

```
stirling.software.jpdfium.exception.PdfCorruptException: Invalid/corrupt PDF - docOpen: /tmp/stirling-pdf/stirling-pdf-XXXX.tmp
java.io.IOException: JPDFium merge failed
```

Capturing the temp file JPDFium tries to open confirms it contains the raw JPEG/PNG bytes (header `JFIF`/`PNG`), not a PDF. Reproducible on a clean 2.14.2/2.14.3 container with `DOCKER_ENABLE_SECURITY=false`:

```
curl -F "fileInput=@photo.jpg;type=image/jpeg" -F "fileInput=@alpha.png;type=image/png" \
  http://localhost:8080/api/v1/general/merge-pdfs
# {"error":"Job failed: java.io.IOException: JPDFium merge failed"}
```

**Verified:** with this patch built into the boot JAR and the same request repeated:

- merge of jpg + png → 200, valid 2-page PDF
- merge of image + PDF → 200
- merge of two PDFs (regression control) → 200

Closes #6593

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

Note on testing: ran `:stirling-pdf:spotlessCheck` and `MergeControllerTest` (12/12 green) against `main`, plus the end-to-end merge verification above against a boot JAR built from this branch (`-PbuildWithFrontend=false`, linux-x64).
