### PR TITLE
fix: use CPU utilization in ResourceMonitor

### DIFF
--- a/app/common/src/main/java/stirling/software/common/service/ResourceMonitor.java
+++ b/app/common/src/main/java/stirling/software/common/service/ResourceMonitor.java
@@ -28,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ResourceMonitor {
 
+    private static final double DEFAULT_CPU_USAGE = 0.5;
+
     @Value("${stirling.resource.memory.critical-threshold:0.9}")
     private double memoryCriticalThreshold = 0.9; // 90% usage is critical
 
@@ -134,9 +136,7 @@ public class ResourceMonitor {
     /** Updates the resource metrics by sampling current system state. */
     private void updateResourceMetrics() {
         try {
-            // Get CPU usage
-            double cpuUsage = osMXBean.getSystemLoadAverage() / osMXBean.getAvailableProcessors();
-            if (cpuUsage < 0) cpuUsage = getAlternativeCpuLoad(); // Fallback if not available
+            double cpuUsage = getCpuUsage();
 
             // Get memory usage
             long heapUsed = memoryMXBean.getHeapMemoryUsage().getUsed();
@@ -185,38 +185,26 @@ public class ResourceMonitor {
         }
     }
 
-    /**
-     * Alternative method to estimate CPU load if getSystemLoadAverage() is not available. This is a
-     * fallback and less accurate than the official JMX method.
-     *
-     * @return Estimated CPU load as a value between 0.0 and 1.0
-     */
-    private double getAlternativeCpuLoad() {
-        try {
-            // Try to get CPU time if available through reflection
-            // This is a fallback since we can't directly cast to platform-specific classes
-            try {
-                java.lang.reflect.Method m =
-                        osMXBean.getClass().getDeclaredMethod("getProcessCpuLoad");
-                m.setAccessible(true);
-                return (double) m.invoke(osMXBean);
-            } catch (Exception e) {
-                // Try the older method
-                try {
-                    java.lang.reflect.Method m =
-                            osMXBean.getClass().getDeclaredMethod("getSystemCpuLoad");
-                    m.setAccessible(true);
-                    return (double) m.invoke(osMXBean);
-                } catch (Exception e2) {
-                    log.trace(
-                            "Could not get CPU load through reflection, assuming moderate load (0.5)");
-                    return 0.5;
-                }
+    private double getCpuUsage() {
+        if (osMXBean instanceof com.sun.management.OperatingSystemMXBean extendedOsMXBean) {
+            double cpuUsage = extendedOsMXBean.getCpuLoad();
+            if (isAvailableCpuSample(cpuUsage)) {
+                return Math.min(cpuUsage, 1.0);
             }
-        } catch (Exception e) {
-            log.trace("Could not get CPU load, assuming moderate load (0.5)");
-            return 0.5; // Default to moderate load
         }
+
+        double loadAverage = osMXBean.getSystemLoadAverage();
+        int availableProcessors = osMXBean.getAvailableProcessors();
+        if (isAvailableCpuSample(loadAverage) && availableProcessors > 0) {
+            return Math.min(loadAverage / availableProcessors, 1.0);
+        }
+
+        log.trace("Could not get CPU load, assuming moderate load ({})", DEFAULT_CPU_USAGE);
+        return DEFAULT_CPU_USAGE;
+    }
+
+    private static boolean isAvailableCpuSample(double cpuSample) {
+        return Double.isFinite(cpuSample) && cpuSample >= 0;
     }
 
     /**

--- a/app/common/src/test/java/stirling/software/common/service/ResourceMonitorMoreTest.java
+++ b/app/common/src/test/java/stirling/software/common/service/ResourceMonitorMoreTest.java
@@ -1,12 +1,12 @@
 package stirling.software.common.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
-import java.lang.management.OperatingSystemMXBean;
 import java.time.Instant;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -16,9 +16,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sun.management.OperatingSystemMXBean;
 
 import stirling.software.common.service.ResourceMonitor.ResourceMetrics;
 import stirling.software.common.service.ResourceMonitor.ResourceStatus;
@@ -63,103 +67,87 @@ class ResourceMonitorMoreTest {
     @DisplayName("updateResourceMetrics status transitions")
     class UpdateMetrics {
 
-        @Test
-        @DisplayName("high CPU load drives the status to CRITICAL")
-        void criticalOnHighCpu() {
-            // load average / processors = 4 / 2 = 2.0 -> well over critical threshold.
-            when(osMXBean.getSystemLoadAverage()).thenReturn(4.0);
-            when(osMXBean.getAvailableProcessors()).thenReturn(2);
+        @ParameterizedTest
+        @CsvSource({"0.5, OK", "0.8, WARNING", "0.95, CRITICAL"})
+        @DisplayName("CPU utilization drives resource status")
+        void statusFollowsCpuUtilization(double cpuUsage, ResourceStatus expectedStatus) {
+            when(osMXBean.getCpuLoad()).thenReturn(cpuUsage);
             stubMemory(1L, 1L);
 
             ReflectionTestUtils.invokeMethod(resourceMonitor, "updateResourceMetrics");
 
-            assertThat(currentStatus.get()).isEqualTo(ResourceStatus.CRITICAL);
-            assertThat(latestMetrics.get().getCpuUsage()).isEqualTo(2.0);
+            assertThat(currentStatus.get()).isEqualTo(expectedStatus);
+            assertThat(latestMetrics.get().getCpuUsage()).isEqualTo(cpuUsage);
         }
 
         @Test
-        @DisplayName("moderately high CPU load drives the status to WARNING")
-        void warningOnModerateCpu() {
-            // 1.6 / 2 = 0.8 -> above high (0.75) but below critical (0.9).
-            when(osMXBean.getSystemLoadAverage()).thenReturn(1.6);
-            when(osMXBean.getAvailableProcessors()).thenReturn(2);
+        @DisplayName("CPU utilization takes precedence over load average")
+        void utilizationTakesPrecedenceOverLoadAverage() {
+            when(osMXBean.getCpuLoad()).thenReturn(0.2);
+            lenient().when(osMXBean.getSystemLoadAverage()).thenReturn(20.0);
             stubMemory(1L, 1L);
-
-            ReflectionTestUtils.invokeMethod(resourceMonitor, "updateResourceMetrics");
-
-            assertThat(currentStatus.get()).isEqualTo(ResourceStatus.WARNING);
-        }
-
-        @Test
-        @DisplayName("low load keeps the status at OK")
-        void okOnLowLoad() {
-            when(osMXBean.getSystemLoadAverage()).thenReturn(0.2);
-            when(osMXBean.getAvailableProcessors()).thenReturn(4);
-            stubMemory(1L, 1L);
-            currentStatus.set(ResourceStatus.WARNING); // ensure a transition log path is hit
 
             ReflectionTestUtils.invokeMethod(resourceMonitor, "updateResourceMetrics");
 
             assertThat(currentStatus.get()).isEqualTo(ResourceStatus.OK);
+            assertThat(latestMetrics.get().getCpuUsage()).isEqualTo(0.2);
         }
 
         @Test
-        @DisplayName("a negative load average triggers the alternative CPU fallback")
-        void negativeLoadUsesFallback() {
-            // getSystemLoadAverage returns -1 on platforms (e.g. Windows) where it is unsupported.
-            when(osMXBean.getSystemLoadAverage()).thenReturn(-1.0);
+        @DisplayName("unsupported CPU utilization falls back to bounded load average")
+        void unsupportedUtilizationUsesBoundedLoadAverage() {
+            when(osMXBean.getCpuLoad()).thenReturn(-1.0);
+            when(osMXBean.getSystemLoadAverage()).thenReturn(8.0);
+            when(osMXBean.getAvailableProcessors()).thenReturn(2);
+            stubMemory(1L, 1L);
+
+            ReflectionTestUtils.invokeMethod(resourceMonitor, "updateResourceMetrics");
+
+            assertThat(latestMetrics.get().getCpuUsage()).isEqualTo(1.0);
+            assertThat(currentStatus.get()).isEqualTo(ResourceStatus.CRITICAL);
+        }
+
+        @Test
+        @DisplayName("invalid CPU samples use the safe default")
+        void invalidCpuSamplesUseSafeDefault() {
+            when(osMXBean.getCpuLoad()).thenReturn(Double.NaN);
+            when(osMXBean.getSystemLoadAverage()).thenReturn(Double.POSITIVE_INFINITY);
             when(osMXBean.getAvailableProcessors()).thenReturn(4);
             stubMemory(1L, 1L);
 
             ReflectionTestUtils.invokeMethod(resourceMonitor, "updateResourceMetrics");
 
-            // The mock OS bean has no getProcessCpuLoad/getSystemCpuLoad, so fallback yields 0.5.
             assertThat(latestMetrics.get().getCpuUsage()).isEqualTo(0.5);
             assertThat(currentStatus.get()).isEqualTo(ResourceStatus.OK);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"0.8, WARNING", "0.95, CRITICAL"})
+        @DisplayName("memory pressure drives status when CPU utilization is low")
+        void statusFollowsMemoryPressure(double memoryUsage, ResourceStatus expectedStatus) {
+            when(osMXBean.getCpuLoad()).thenReturn(0.1);
+            long maxMemory = Runtime.getRuntime().maxMemory();
+            stubMemory((long) (maxMemory * memoryUsage), 0L);
+
+            ReflectionTestUtils.invokeMethod(resourceMonitor, "updateResourceMetrics");
+
+            assertThat(currentStatus.get()).isEqualTo(expectedStatus);
         }
 
         @Test
         @DisplayName("an exception while sampling is swallowed and status is unchanged")
         void samplingExceptionSwallowed() {
-            when(osMXBean.getSystemLoadAverage()).thenReturn(0.1);
-            when(osMXBean.getAvailableProcessors()).thenReturn(2);
+            when(osMXBean.getCpuLoad()).thenReturn(0.1);
             when(memoryMXBean.getHeapMemoryUsage())
                     .thenThrow(new RuntimeException("jmx unavailable"));
             currentStatus.set(ResourceStatus.OK);
 
-            // Must not propagate; the catch in updateResourceMetrics handles it.
-            ReflectionTestUtils.invokeMethod(resourceMonitor, "updateResourceMetrics");
+            assertDoesNotThrow(
+                    () ->
+                            ReflectionTestUtils.invokeMethod(
+                                    resourceMonitor, "updateResourceMetrics"));
 
             assertThat(currentStatus.get()).isEqualTo(ResourceStatus.OK);
-        }
-    }
-
-    @Nested
-    @DisplayName("getAlternativeCpuLoad")
-    class AlternativeCpuLoad {
-
-        @Test
-        @DisplayName("uses getProcessCpuLoad via reflection when present")
-        void usesProcessCpuLoad() {
-            // A bean exposing getProcessCpuLoad lets the reflective fallback return its value.
-            OperatingSystemMXBean withCpuLoad = new OsBeanWithProcessCpuLoad(0.42);
-            ReflectionTestUtils.setField(resourceMonitor, "osMXBean", withCpuLoad);
-
-            double load =
-                    (double)
-                            ReflectionTestUtils.invokeMethod(
-                                    resourceMonitor, "getAlternativeCpuLoad");
-            assertThat(load).isEqualTo(0.42);
-        }
-
-        @Test
-        @DisplayName("defaults to 0.5 when no CPU-load method is available")
-        void defaultsWhenUnavailable() {
-            double load =
-                    (double)
-                            ReflectionTestUtils.invokeMethod(
-                                    resourceMonitor, "getAlternativeCpuLoad");
-            assertThat(load).isEqualTo(0.5);
         }
     }
 
@@ -210,50 +198,6 @@ class ResourceMonitorMoreTest {
 
             live.shutdown();
             assertThat(scheduler.isShutdown()).isTrue();
-        }
-    }
-
-    /** Minimal OS bean stub exposing getProcessCpuLoad so the reflective fallback can find it. */
-    private static class OsBeanWithProcessCpuLoad implements OperatingSystemMXBean {
-        private final double cpuLoad;
-
-        OsBeanWithProcessCpuLoad(double cpuLoad) {
-            this.cpuLoad = cpuLoad;
-        }
-
-        // Reflectively located by getAlternativeCpuLoad.
-        public double getProcessCpuLoad() {
-            return cpuLoad;
-        }
-
-        @Override
-        public String getName() {
-            return "stub";
-        }
-
-        @Override
-        public String getArch() {
-            return "stub";
-        }
-
-        @Override
-        public String getVersion() {
-            return "stub";
-        }
-
-        @Override
-        public int getAvailableProcessors() {
-            return 1;
-        }
-
-        @Override
-        public double getSystemLoadAverage() {
-            return -1.0;
-        }
-
-        @Override
-        public javax.management.ObjectName getObjectName() {
-            return null;
         }
     }
 }


### PR DESCRIPTION
# Description of Changes

Sample recent system CPU utilization from the JDK's extended operating-system MXBean when the runtime exposes it, because that metric has the 0.0-to-1.0 semantics expected by the configured thresholds and is container-aware on the supported JDK. Keep a portable fallback for runtimes where that utilization metric is unsupported: normalize the available load average, reject unavailable or non-finite samples, and bound any fallback result before publishing metrics or deriving status. Preserve the existing ResourceMetrics and ResourceStatus contracts so downstream queueing continues to consume corrected values without call-site changes.

ResourceMonitor currently divides the operating-system load average by the available processor count and treats the result as CPU utilization. Load average measures runnable or waiting work rather than CPU time and is not bounded by the processor count, so Docker users see impossible readings such as 215.7% or 713.1%. Those values repeatedly push the shared resource status through OK, WARNING, and CRITICAL even when memory is stable and the container is healthy. The incorrect status also affects job-admission decisions, not only the informational log messages.

Closes #5643

## Checklist

Not applicable to this change.

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [ ] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)
  Not verified: this needs a person on the named hardware or environment.

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
- With recent CPU utilization below, between, and above the configured thresholds, publish the same bounded utilization and select OK, WARNING, and CRITICAL respectively. - With a valid low utilization reading and an independently high system load average, use utilization and remain OK instead of reporting CPU above 100%. - When the utilization API returns its unsupported sentinel, fall back to normalized load average; cap an overloaded fallback at 1.0 so metrics and logs never exceed 100%.
