### PR TITLE
Fetch the session owner when loading a signing session for finalisation

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/workflow/repository/WorkflowSessionRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/workflow/repository/WorkflowSessionRepository.java
@@ -19,9 +19,10 @@ public interface WorkflowSessionRepository extends JpaRepository<WorkflowSession
     /** Find workflow session by unique session ID */
     Optional<WorkflowSession> findBySessionId(String sessionId);
 
-    /** Find workflow session by unique session ID with participants eagerly loaded */
+    /** Find workflow session by unique session ID with participants and owner eagerly loaded */
     @Query(
-            "SELECT ws FROM WorkflowSession ws LEFT JOIN FETCH ws.participants WHERE ws.sessionId = :sessionId")
+            "SELECT ws FROM WorkflowSession ws LEFT JOIN FETCH ws.participants LEFT JOIN FETCH"
+                    + " ws.owner WHERE ws.sessionId = :sessionId")
     Optional<WorkflowSession> findBySessionIdWithParticipants(@Param("sessionId") String sessionId);
 
     /** Find all workflow sessions owned by a specific user */


### PR DESCRIPTION
## What

Adds `LEFT JOIN FETCH ws.owner` to `findBySessionIdWithParticipants`.

## Why

Finalising a signing session with **Include Signature Summary Page** enabled always fails with a 500. Everyone signs, the session says *Ready to finalise*, and the owner can never produce the document.

```
org.hibernate.LazyInitializationException: Could not initialize proxy
  [...security.model.User#33] - no session
    at SigningFinalizationService.appendSignatureSummaryPage(:421)
```

Line 421 reads `session.getOwner().getUsername()` for the summary page. `owner` is `LAZY`, the query fetch-joined only `participants`, `open-in-view` is off, and `finalizeSession` is not transactional, so the entity is detached by then. The earlier `getOwner().equals(owner)` check does not initialise it: `User.equals` is deliberately proxy-safe.

Only the summary page reads the owner, which is why other sessions finalise fine.

## Testing

`task backend:check` passes. No unit test: the workflow entities use `jsonb`, so a `@DataJpaTest` needs bespoke H2 scaffolding for a one-line query change.