### PR TITLE
Keep a new form field's label when no tooltip is supplied

### DIFF
--- a/app/common/src/main/java/stirling/software/common/util/FormUtils.java
+++ b/app/common/src/main/java/stirling/software/common/util/FormUtils.java
@@ -3595,7 +3595,7 @@ public class FormUtils {
 
         if (definition.tooltip() != null && !definition.tooltip().isBlank()) {
             widget.getCOSObject().setString(COSName.TU, definition.tooltip());
-        } else {
+        } else if (!reuseFieldDict) {
             try {
                 widget.getCOSObject().removeItem(COSName.TU);
             } catch (Exception e) {

--- a/app/common/src/test/java/stirling/software/common/util/FormUtilsEditRegressionTest.java
+++ b/app/common/src/test/java/stirling/software/common/util/FormUtilsEditRegressionTest.java
@@ -908,4 +908,53 @@ class FormUtilsEditRegressionTest {
                     1, page, "a retyped field must stay on its own page, not move to the last");
         }
     }
+
+    @Test
+    void creatingAFieldKeepsTheLabelItWasGiven() throws IOException {
+        byte[] saved;
+        try (PDDocument document = new PDDocument()) {
+            setupForm(document);
+            FormUtils.addNewFields(
+                    document, List.of(labelledField("qa_added", "QA additional response", null)));
+            saved = save(document);
+        }
+
+        try (PDDocument reloaded = Loader.loadPDF(saved)) {
+            PDAcroForm acroForm = reloaded.getDocumentCatalog().getAcroForm(null);
+            PDField field = acroForm.getField("qa_added");
+            assertNotNull(field, "'qa_added' should exist");
+            assertEquals(
+                    "QA additional response",
+                    field.getAlternateFieldName(),
+                    "a created field must keep the label it was given");
+        }
+    }
+
+    @Test
+    void creatingAFieldWithATooltipStillStoresTheTooltip() throws IOException {
+        byte[] saved;
+        try (PDDocument document = new PDDocument()) {
+            setupForm(document);
+            FormUtils.addNewFields(
+                    document, List.of(labelledField("qa_added", "Ignored label", "Hover text")));
+            saved = save(document);
+        }
+
+        try (PDDocument reloaded = Loader.loadPDF(saved)) {
+            PDAcroForm acroForm = reloaded.getDocumentCatalog().getAcroForm(null);
+            PDField field = acroForm.getField("qa_added");
+            assertNotNull(field, "'qa_added' should exist");
+            assertEquals(
+                    "Hover text",
+                    field.getWidgets().get(0).getCOSObject().getString(COSName.TU),
+                    "an explicit tooltip must win over the label");
+        }
+    }
+
+    private static FormUtils.NewFormFieldDefinition labelledField(
+            String name, String label, String tooltip) {
+        return new FormUtils.NewFormFieldDefinition(
+                name, label, "text", 0, 50f, 700f, 200f, 20f, null, null, null, null, tooltip, null,
+                null, null, null, null);
+    }
 }


### PR DESCRIPTION
## What

`registerNewField` only clears `/TU` when the widget has its own dictionary, instead of clearing it unconditionally.

## Why

Creating a form field with a label saves the field but drops the label. Editing the same field's label through **Modify** keeps it, which makes the loss look random.

The label is written and then deleted four lines later:

```java
field.setAlternateFieldName(definition.label());   // writes /TU on the field dict
...
} else {
    widget.getCOSObject().removeItem(COSName.TU);  // same dictionary
}
```

On a newly created field PDFBox returns a widget wrapping the field's own dictionary, and `/TU` on a field dictionary *is* the alternate field name. So clearing the empty tooltip deletes the label. `modifyFormFields` is unaffected because it only touches `/TU` when a tooltip is supplied.

An explicit tooltip still wins, since one key cannot hold both.

## Testing

Two tests in `FormUtilsEditRegressionTest`. The label one is verified to fail on main (`26 tests completed, 1 failed`); the other guards against dropping tooltips instead. FormUtils suites and `:common:spotlessCheck` pass.