### PR TITLE
Remove the restart required after licence activation

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/config/EnterpriseEndpointAspect.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/config/EnterpriseEndpointAspect.java
@@ -3,10 +3,13 @@ package stirling.software.proprietary.security.config;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
+
+import stirling.software.common.service.LicenseServiceInterface;
 
 @Aspect
 @Component
@@ -14,17 +17,26 @@ public class EnterpriseEndpointAspect {
 
     private final boolean runningEE;
 
-    public EnterpriseEndpointAspect(@Qualifier("runningEE") boolean runningEE) {
+    private final LicenseServiceInterface licenseService;
+
+    public EnterpriseEndpointAspect(
+            @Qualifier("runningEE") boolean runningEE,
+            @Autowired(required = false) LicenseServiceInterface licenseService) {
         this.runningEE = runningEE;
+        this.licenseService = licenseService;
     }
 
     @Around(
             "@annotation(stirling.software.proprietary.security.config.EnterpriseEndpoint) || @within(stirling.software.proprietary.security.config.EnterpriseEndpoint)")
     public Object checkEnterpriseAccess(ProceedingJoinPoint joinPoint) throws Throwable {
-        if (!runningEE) {
+        if (!isEnterprise()) {
             throw new ResponseStatusException(
                     HttpStatus.FORBIDDEN, "This endpoint requires an Enterprise license");
         }
         return joinPoint.proceed();
+    }
+
+    private boolean isEnterprise() {
+        return runningEE || (licenseService != null && licenseService.isRunningEE());
     }
 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/config/PremiumEndpointAspect.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/config/PremiumEndpointAspect.java
@@ -3,10 +3,13 @@ package stirling.software.proprietary.security.config;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
+
+import stirling.software.common.service.LicenseServiceInterface;
 
 @Aspect
 @Component
@@ -14,17 +17,27 @@ public class PremiumEndpointAspect {
 
     private final boolean runningProOrHigher;
 
-    public PremiumEndpointAspect(@Qualifier("runningProOrHigher") boolean runningProOrHigher) {
+    private final LicenseServiceInterface licenseService;
+
+    public PremiumEndpointAspect(
+            @Qualifier("runningProOrHigher") boolean runningProOrHigher,
+            @Autowired(required = false) LicenseServiceInterface licenseService) {
         this.runningProOrHigher = runningProOrHigher;
+        this.licenseService = licenseService;
     }
 
     @Around(
             "@annotation(stirling.software.proprietary.security.config.PremiumEndpoint) || @within(stirling.software.proprietary.security.config.PremiumEndpoint)")
     public Object checkPremiumAccess(ProceedingJoinPoint joinPoint) throws Throwable {
-        if (!runningProOrHigher) {
+        if (!isProOrHigher()) {
             throw new ResponseStatusException(
                     HttpStatus.FORBIDDEN, "This endpoint requires a Server or Enterprise license");
         }
         return joinPoint.proceed();
+    }
+
+    private boolean isProOrHigher() {
+        return runningProOrHigher
+                || (licenseService != null && licenseService.isRunningProOrHigher());
     }
 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/DynamicLicenseService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/DynamicLicenseService.java
@@ -12,9 +12,21 @@ import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVeri
  * admins update the license key, the changes are immediately reflected in the UI, config endpoints
  * and the premium/enterprise endpoint gates without requiring a restart.
  *
- * <p>Note: components that build boot-time structures from the license (datasource selection in
- * DatabaseConfig, the security filter chain in SecurityConfiguration) still read the cached startup
- * beans, and a license change reaches those only on restart.
+ * <p>Hazard: this is not the only reader of the license. Everything below still resolves it once at
+ * startup from the {@code runningProOrHigher} / {@code runningEE} beans, so a license change
+ * reaches them only on restart.
+ *
+ * <ul>
+ *   <li>Structures built at boot: the datasource selection in DatabaseConfig, the security filter
+ *       chain in SecurityConfiguration, the {@code enterprise} endpoint group EndpointConfiguration
+ *       disables in its constructor, and ClusterLicenseGate.
+ *   <li>Request-time checks against the frozen flag: AuditService (which events it records),
+ *       AuditCleanupService (retention cap), DatabaseNotificationService and PdfMetadataService.
+ * </ul>
+ *
+ * <p>TODO(#7848): AuditService keeps dropping every event outside PDF_PROCESS and FILE_OPERATION
+ * after a post-boot activation, so the audit dashboard the live gate has just unlocked shows a
+ * truncated trail until restart.
  */
 @Service
 @RequiredArgsConstructor

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/DynamicLicenseService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/configuration/ee/DynamicLicenseService.java
@@ -9,14 +9,12 @@ import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVeri
 
 /**
  * Service that provides dynamic license checking instead of cached beans. This ensures that when
- * admins update the license key, the changes are immediately reflected in the UI and config
- * endpoints without requiring a restart.
+ * admins update the license key, the changes are immediately reflected in the UI, config endpoints
+ * and the premium/enterprise endpoint gates without requiring a restart.
  *
- * <p>Note: Some components (EnterpriseEndpointAspect, PremiumEndpointAspect, filters) still inject
- * cached beans at startup for performance. These will require a restart to reflect license changes.
- * This is acceptable because: 1. Most deployments add licenses during initial setup 2. License
- * changes in production typically warrant a restart anyway 3. UI reflects changes immediately
- * (banner disappears, license status updates)
+ * <p>Note: components that build boot-time structures from the license (datasource selection in
+ * DatabaseConfig, the security filter chain in SecurityConfiguration) still read the cached startup
+ * beans, and a license change reaches those only on restart.
  */
 @Service
 @RequiredArgsConstructor

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/filter/EnterpriseEndpointFilter.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/filter/EnterpriseEndpointFilter.java
@@ -2,6 +2,7 @@ package stirling.software.proprietary.security.filter;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -12,12 +13,24 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import stirling.software.common.service.LicenseServiceInterface;
+
 @Component
 public class EnterpriseEndpointFilter extends OncePerRequestFilter {
     private final boolean runningProOrHigher;
 
-    public EnterpriseEndpointFilter(@Qualifier("runningProOrHigher") boolean runningProOrHigher) {
+    private final LicenseServiceInterface licenseService;
+
+    public EnterpriseEndpointFilter(
+            @Qualifier("runningProOrHigher") boolean runningProOrHigher,
+            @Autowired(required = false) LicenseServiceInterface licenseService) {
         this.runningProOrHigher = runningProOrHigher;
+        this.licenseService = licenseService;
+    }
+
+    private boolean isProOrHigher() {
+        return runningProOrHigher
+                || (licenseService != null && licenseService.isRunningProOrHigher());
     }
 
     @Override
@@ -25,7 +38,7 @@ public class EnterpriseEndpointFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        if (!runningProOrHigher && isPrometheusEndpointRequest(request)) {
+        if (!isProOrHigher() && isPrometheusEndpointRequest(request)) {
             // Allow only health checks to pass through for non-pro users
             String uri = request.getRequestURI();
 

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/filter/EnterpriseEndpointFilter.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/filter/EnterpriseEndpointFilter.java
@@ -38,7 +38,7 @@ public class EnterpriseEndpointFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        if (!isProOrHigher() && isPrometheusEndpointRequest(request)) {
+        if (isPrometheusEndpointRequest(request) && !isProOrHigher()) {
             // Allow only health checks to pass through for non-pro users
             String uri = request.getRequestURI();
 

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/config/LicenceEndpointGateTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/config/LicenceEndpointGateTest.java
@@ -1,0 +1,163 @@
+package stirling.software.proprietary.security.config;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.server.ResponseStatusException;
+
+import stirling.software.common.service.LicenseServiceInterface;
+import stirling.software.proprietary.security.filter.EnterpriseEndpointFilter;
+
+/**
+ * The licence gates read the live licence rather than the boolean captured at startup, so
+ * activating a key opens them without a restart. The startup value stays a floor the live check can
+ * only widen, which keeps profiles that grant premium without a key (saas) working.
+ */
+class LicenceEndpointGateTest {
+
+    private static ProceedingJoinPoint proceedingJoinPoint() throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        when(joinPoint.proceed()).thenReturn("proceeded");
+        return joinPoint;
+    }
+
+    private static LicenseServiceInterface licence(boolean proOrHigher, boolean enterprise) {
+        LicenseServiceInterface service = mock(LicenseServiceInterface.class);
+        when(service.isRunningProOrHigher()).thenReturn(proOrHigher);
+        when(service.isRunningEE()).thenReturn(enterprise);
+        return service;
+    }
+
+    @Nested
+    class Premium {
+
+        @Test
+        @DisplayName("a licence activated after startup opens the gate without a restart")
+        void liveLicenceOpensTheGate() throws Throwable {
+            PremiumEndpointAspect aspect = new PremiumEndpointAspect(false, licence(true, false));
+
+            assertEquals("proceeded", aspect.checkPremiumAccess(proceedingJoinPoint()));
+        }
+
+        @Test
+        @DisplayName("no licence at startup and none activated stays forbidden")
+        void unlicensedStaysForbidden() throws Throwable {
+            PremiumEndpointAspect aspect = new PremiumEndpointAspect(false, licence(false, false));
+            ProceedingJoinPoint joinPoint = proceedingJoinPoint();
+
+            ResponseStatusException thrown =
+                    assertThrows(
+                            ResponseStatusException.class,
+                            () -> aspect.checkPremiumAccess(joinPoint));
+            assertEquals(HttpStatus.FORBIDDEN, thrown.getStatusCode());
+        }
+
+        @Test
+        @DisplayName("a profile granting premium without a key keeps access")
+        void startupGrantSurvivesAnUnlicensedLiveCheck() throws Throwable {
+            PremiumEndpointAspect aspect = new PremiumEndpointAspect(true, licence(false, false));
+
+            assertEquals("proceeded", aspect.checkPremiumAccess(proceedingJoinPoint()));
+        }
+
+        @Test
+        @DisplayName("builds with no licence service fall back to the startup value")
+        void noLicenceServiceFallsBackToStartup() throws Throwable {
+            PremiumEndpointAspect granted = new PremiumEndpointAspect(true, null);
+            PremiumEndpointAspect denied = new PremiumEndpointAspect(false, null);
+            ProceedingJoinPoint joinPoint = proceedingJoinPoint();
+
+            assertEquals("proceeded", granted.checkPremiumAccess(proceedingJoinPoint()));
+            assertThrows(ResponseStatusException.class, () -> denied.checkPremiumAccess(joinPoint));
+        }
+    }
+
+    @Nested
+    class Enterprise {
+
+        @Test
+        @DisplayName("a licence activated after startup opens the gate without a restart")
+        void liveLicenceOpensTheGate() throws Throwable {
+            EnterpriseEndpointAspect aspect =
+                    new EnterpriseEndpointAspect(false, licence(true, true));
+
+            assertEquals("proceeded", aspect.checkEnterpriseAccess(proceedingJoinPoint()));
+        }
+
+        @Test
+        @DisplayName("a Server licence does not open an Enterprise-only endpoint")
+        void serverLicenceIsNotEnterprise() throws Throwable {
+            EnterpriseEndpointAspect aspect =
+                    new EnterpriseEndpointAspect(false, licence(true, false));
+            ProceedingJoinPoint joinPoint = proceedingJoinPoint();
+
+            ResponseStatusException thrown =
+                    assertThrows(
+                            ResponseStatusException.class,
+                            () -> aspect.checkEnterpriseAccess(joinPoint));
+            assertEquals(HttpStatus.FORBIDDEN, thrown.getStatusCode());
+        }
+
+        @Test
+        @DisplayName("a profile granting enterprise without a key keeps access")
+        void startupGrantSurvivesAnUnlicensedLiveCheck() throws Throwable {
+            EnterpriseEndpointAspect aspect =
+                    new EnterpriseEndpointAspect(true, licence(false, false));
+
+            assertEquals("proceeded", aspect.checkEnterpriseAccess(proceedingJoinPoint()));
+        }
+    }
+
+    @Nested
+    class ActuatorFilter {
+
+        private static MockHttpServletResponse filter(
+                boolean startupGrant, LicenseServiceInterface service, String uri)
+                throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+            request.setRequestURI(uri);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            new EnterpriseEndpointFilter(startupGrant, service)
+                    .doFilter(request, response, new MockFilterChain());
+            return response;
+        }
+
+        @Test
+        @DisplayName("a licence activated after startup unblocks metrics without a restart")
+        void liveLicenceUnblocksMetrics() throws Exception {
+            assertEquals(
+                    HttpStatus.OK.value(),
+                    filter(false, licence(true, false), "/actuator/prometheus").getStatus());
+        }
+
+        @Test
+        @DisplayName("metrics stay hidden while unlicensed")
+        void unlicensedHidesMetrics() throws Exception {
+            assertEquals(
+                    HttpStatus.NOT_FOUND.value(),
+                    filter(false, licence(false, false), "/actuator/prometheus").getStatus());
+        }
+
+        @Test
+        @DisplayName("health checks stay reachable while unlicensed")
+        void healthChecksAlwaysPass() {
+            assertDoesNotThrow(
+                    () ->
+                            assertEquals(
+                                    HttpStatus.OK.value(),
+                                    filter(false, licence(false, false), "/actuator/health")
+                                            .getStatus()));
+        }
+    }
+}

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/config/LicenceEndpointGateTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/config/LicenceEndpointGateTest.java
@@ -3,7 +3,11 @@ package stirling.software.proprietary.security.config;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -16,8 +20,14 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.server.ResponseStatusException;
 
+import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.service.LicenseServiceInterface;
+import stirling.software.proprietary.security.configuration.ee.DynamicLicenseService;
+import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVerifier;
+import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVerifier.License;
+import stirling.software.proprietary.security.configuration.ee.LicenseKeyChecker;
 import stirling.software.proprietary.security.filter.EnterpriseEndpointFilter;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 
 /**
  * The licence gates read the live licence rather than the boolean captured at startup, so
@@ -150,6 +160,17 @@ class LicenceEndpointGateTest {
         }
 
         @Test
+        @DisplayName("a request outside actuator never reaches the licence service")
+        void nonActuatorRequestsSkipTheLicenceLookup() throws Exception {
+            LicenseServiceInterface service = mock(LicenseServiceInterface.class);
+
+            assertEquals(
+                    HttpStatus.OK.value(),
+                    filter(false, service, "/api/v1/general/merge-pdfs").getStatus());
+            verify(service, never()).isRunningProOrHigher();
+        }
+
+        @Test
         @DisplayName("health checks stay reachable while unlicensed")
         void healthChecksAlwaysPass() {
             assertDoesNotThrow(
@@ -158,6 +179,64 @@ class LicenceEndpointGateTest {
                                     HttpStatus.OK.value(),
                                     filter(false, licence(false, false), "/actuator/health")
                                             .getStatus()));
+        }
+    }
+
+    /**
+     * The live check is a read of the tier {@link LicenseKeyChecker} stored the last time the key
+     * changed. Keygen is contacted on that refresh, never on the request path, so no gate pays for
+     * a verification per request.
+     */
+    @Nested
+    class LiveLookup {
+
+        private static LicenseKeyChecker checkerFor(KeygenLicenseVerifier verifier) {
+            ApplicationProperties properties = new ApplicationProperties();
+            properties.getPremium().setEnabled(true);
+            properties.getPremium().setKey("a-key");
+            LicenseKeyChecker checker =
+                    new LicenseKeyChecker(
+                            verifier, properties, mock(UserLicenseSettingsService.class));
+            checker.init();
+            return checker;
+        }
+
+        @Test
+        @DisplayName("no gate re-verifies the key while serving a request")
+        void gatesReadTheStoredTier() throws Throwable {
+            KeygenLicenseVerifier verifier = mock(KeygenLicenseVerifier.class);
+            when(verifier.verifyLicense(anyString())).thenReturn(License.ENTERPRISE);
+            DynamicLicenseService service = new DynamicLicenseService(checkerFor(verifier));
+            MockHttpServletRequest request =
+                    new MockHttpServletRequest("GET", "/actuator/prometheus");
+            request.setRequestURI("/actuator/prometheus");
+            clearInvocations(verifier);
+
+            new EnterpriseEndpointFilter(false, service)
+                    .doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+            new PremiumEndpointAspect(false, service).checkPremiumAccess(proceedingJoinPoint());
+            new EnterpriseEndpointAspect(false, service)
+                    .checkEnterpriseAccess(proceedingJoinPoint());
+
+            verify(verifier, never()).verifyLicense(anyString());
+        }
+
+        @Test
+        @DisplayName("the stored tier is what a post-startup activation refreshes")
+        void resyncOpensTheGate() throws Throwable {
+            KeygenLicenseVerifier verifier = mock(KeygenLicenseVerifier.class);
+            when(verifier.verifyLicense(anyString())).thenReturn(License.NORMAL);
+            LicenseKeyChecker checker = checkerFor(verifier);
+            PremiumEndpointAspect aspect =
+                    new PremiumEndpointAspect(false, new DynamicLicenseService(checker));
+            ProceedingJoinPoint blocked = proceedingJoinPoint();
+
+            assertThrows(ResponseStatusException.class, () -> aspect.checkPremiumAccess(blocked));
+
+            when(verifier.verifyLicense(anyString())).thenReturn(License.SERVER);
+            checker.resyncLicense();
+
+            assertEquals("proceeded", aspect.checkPremiumAccess(proceedingJoinPoint()));
         }
     }
 }


### PR DESCRIPTION
## What

`EnterpriseEndpointAspect` now asks `LicenseServiceInterface` per request instead of holding the `runningEE` boolean resolved at startup, so activating a licence opens the enterprise gate immediately instead of after a restart.

Main already converted the sibling gates in #7945 (`PremiumEndpointAspect` and `EnterpriseEndpointFilter`), so what remains here is the enterprise aspect plus the coverage and the hazard documentation for the whole set.

## Why

Enter a valid licence key, the Plan UI shows **Enterprise**, then Create Team returns **403** with the dialog left open. Restart the backend and the identical action succeeds.

`runningProOrHigher` and `runningEE` are `@Bean boolean` values resolved once at startup. `LicenseKeyChecker.updateLicenseKey()` re-evaluates its own state, which is why the Plan screen updates, but the gates held frozen copies. `TeamController` is `@PremiumEndpoint`, so it kept rejecting.

`AdminLicenseController:136` already returns `"requiresRestart", false` on activation, so the API and the gates disagreed.

## The gates are a live read, with no startup floor

The gate is the live check alone, not `startup || live`. SaaS stays correct because `SaasLicenseOverride` is a `@Primary LicenseServiceInterface` and outranks `DynamicLicenseService` under the `saas` profile. Nothing previously exercised that resolution, so `SaasLicenseBeanCoverageTest` now pins it.

Because the read is live in both directions, a lapsed or revoked licence, or one that `LicenseKeyChecker`'s 7-day recheck cannot confirm, now closes the gate on the next request rather than at the next restart.

Other readers of the startup beans are unchanged and still need a restart: the security filter chain in `SecurityConfiguration`, `ClusterLicenseGate`, `AuditService`, `AuditCleanupService` and `DatabaseNotificationService`. Those are listed on `DynamicLicenseService`, with a TODO for the audit trail staying truncated after a post-boot activation.

## Testing

`LicenceEndpointGateTest`, 7 tests across `Enterprise`, `ActuatorFilter` and `LiveLookup`: a live licence opening the gate, a Server licence not counting as Enterprise, a lapsed licence closing it, the actuator passthrough, and the fact that no gate re-verifies the key with Keygen on the request path. `SaasLicenseBeanCoverageTest` adds the `@Primary` override check. `:proprietary:spotlessCheck` passes.
