### PR TITLE
Send the owner's signature appearance settings when creating a signing session

### DIFF
--- a/frontend/editor/src/core/hooks/signing/signingWorkflowMetadata.test.ts
+++ b/frontend/editor/src/core/hooks/signing/signingWorkflowMetadata.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { buildWorkflowMetadata } from "@app/hooks/signing/useSigningSessionController";
+
+describe("buildWorkflowMetadata", () => {
+  it("carries every appearance setting the owner configured", () => {
+    expect(
+      buildWorkflowMetadata({
+        showSignature: true,
+        pageNumber: 3,
+        reason: "Disposable QA verification",
+        location: "Local test",
+        showLogo: true,
+        includeSummaryPage: false,
+      }),
+    ).toEqual({
+      showSignature: true,
+      pageNumber: 3,
+      reason: "Disposable QA verification",
+      location: "Local test",
+      showLogo: true,
+      includeSummaryPage: false,
+    });
+  });
+
+  it("still carries the summary page flag on its own", () => {
+    expect(buildWorkflowMetadata({ includeSummaryPage: true })).toEqual({
+      includeSummaryPage: true,
+    });
+  });
+
+  it("omits unset keys rather than sending null, which the backend cast would reject", () => {
+    const metadata = buildWorkflowMetadata({ showSignature: true });
+
+    expect(metadata).toEqual({ showSignature: true });
+    expect("pageNumber" in metadata).toBe(false);
+    expect("reason" in metadata).toBe(false);
+    expect("location" in metadata).toBe(false);
+  });
+
+  it("treats blank reason and location as unset", () => {
+    expect(
+      buildWorkflowMetadata({ reason: "   ", location: "", showLogo: false }),
+    ).toEqual({ showLogo: false });
+  });
+
+  it("produces nothing when the owner configured nothing", () => {
+    expect(buildWorkflowMetadata({})).toEqual({});
+  });
+});

--- a/frontend/editor/src/core/hooks/signing/useSigningSessionController.ts
+++ b/frontend/editor/src/core/hooks/signing/useSigningSessionController.ts
@@ -24,6 +24,22 @@ import type { SignatureSettings } from "@app/components/tools/certSign/Signature
 /** Which Shared Signing screen the sidebar tool is currently showing. */
 export type SigningView = "list" | "detail" | "request";
 
+/** The owner's appearance settings as session workflowMetadata; unset keys are omitted, not null. */
+export function buildWorkflowMetadata(
+  settings: SignatureSettings,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries({
+      showSignature: settings.showSignature,
+      pageNumber: settings.pageNumber,
+      reason: settings.reason?.trim() || undefined,
+      location: settings.location?.trim() || undefined,
+      showLogo: settings.showLogo,
+      includeSummaryPage: settings.includeSummaryPage,
+    }).filter(([, value]) => value !== undefined && value !== null),
+  );
+}
+
 /** Data the session-detail sidebar panel needs to render and act. */
 export interface SigningDetailData {
   session: SessionDetail;
@@ -432,11 +448,9 @@ export function useSigningSessionController(enabled: boolean) {
       });
       if (dueDate) formData.append("dueDate", dueDate);
       formData.append("notifyOnCreate", "true");
-      if (signatureSettings.includeSummaryPage) {
-        formData.append(
-          "workflowMetadata",
-          JSON.stringify({ includeSummaryPage: true }),
-        );
+      const workflowMetadata = buildWorkflowMetadata(signatureSettings);
+      if (Object.keys(workflowMetadata).length > 0) {
+        formData.append("workflowMetadata", JSON.stringify(workflowMetadata));
       }
 
       await apiClient.post("/api/v1/security/cert-sign/sessions", formData);


### PR DESCRIPTION
## What

`createSession` serialises the whole `SignatureSettings` object into `workflowMetadata`, not just `includeSummaryPage`.

## Why

The owner picks a visible signature, a reason and a location; none of it reaches the signed PDF. Only one key was sent, so `showSignature`, `pageNumber`, `reason`, `location` and `showLogo` fell back to backend defaults. From a session configured as *Visible / "Disposable QA verification" / "Local test"*:

```json
[{ "rectangle": [0.0, 0.0, 0.0, 0.0], "reason": "Document Signing", "location": "" }]
```

A zero-size rectangle is an invisible signature. Everything downstream already read all five keys; the values never left the browser.

Unset keys are omitted rather than sent as null, because both backend readers use a `containsKey` guard and then cast, so a present null throws.

## Testing

Extracted `buildWorkflowMetadata` so the payload is testable without the six contexts the hook needs. 5 tests. `oxfmt`, `oxlint --max-warnings=0` and `tsc` on both build variants are clean.