### PR TITLE
Enforce the admin lock when deleting an integration config

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/integration/service/IntegrationConfigService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/integration/service/IntegrationConfigService.java
@@ -167,6 +167,9 @@ public class IntegrationConfigService {
         if (!ownership.canManage(TYPE, cfg, currentUser)) {
             throw forbidden("You cannot manage this integration");
         }
+        if (cfg.isLocked() && !ownership.isAdmin(currentUser)) {
+            throw forbidden("This integration is locked by an administrator");
+        }
         // Refuse to pull a connection out from under whatever still references it.
         List<String> usages =
                 usageChecks.stream()

--- a/app/proprietary/src/test/java/stirling/software/proprietary/integration/service/IntegrationConfigServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/integration/service/IntegrationConfigServiceTest.java
@@ -196,6 +196,37 @@ class IntegrationConfigServiceTest {
     }
 
     @Test
+    void deleteRefusedOnLockedConfigForNonAdmin() {
+        IntegrationConfig cfg = config(9L);
+        cfg.setLocked(true);
+        when(repository.findById(9L)).thenReturn(Optional.of(cfg));
+        when(ownership.canManage(any(), eq(cfg), any())).thenReturn(true);
+        when(ownership.isAdmin(any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.delete(9L, user(7)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((ResponseStatusException) e).getStatusCode())
+                                        .isEqualTo(HttpStatus.FORBIDDEN));
+        verify(repository, org.mockito.Mockito.never()).delete(any(IntegrationConfig.class));
+    }
+
+    @Test
+    void deleteAllowedOnLockedConfigForAdmin() {
+        IntegrationConfig cfg = config(9L);
+        cfg.setLocked(true);
+        when(repository.findById(9L)).thenReturn(Optional.of(cfg));
+        when(ownership.canManage(any(), eq(cfg), any())).thenReturn(true);
+        when(ownership.isAdmin(any())).thenReturn(true);
+        when(usageCheck.usagesOf(9L)).thenReturn(List.of());
+
+        service.delete(9L, user(7));
+
+        verify(repository).delete(cfg);
+    }
+
+    @Test
     void createDelegatesOwnershipAndSanitizesConfig() {
         when(secretMasker.sanitize(any())).thenReturn(Map.of("bucket", "b"));
         when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));


### PR DESCRIPTION
# Description of Changes

`IntegrationConfigService.update()` refuses a mutation when the config is locked and the caller is not an admin. `delete()` never checked the lock, so a non-admin holding a MANAGE grant on a locked integration was correctly refused an edit and then allowed to delete the same record outright, dropping its resource grants with it.

This adds the same guard to `delete()`, so the lock means the same thing for every mutation.

**Before:** `PUT` on a locked integration returns 403; `DELETE` on the same integration returns 200 and the record is gone.

**After:** both return 403 for a non-admin. An admin can still delete a locked integration.

Covered by two new cases in `IntegrationConfigServiceTest`: refused for a non-admin with MANAGE, allowed for an admin.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] `./gradlew :proprietary:test --tests "*IntegrationConfigServiceTest*"` passes: 20 tests, 0 failures
- [x] `./gradlew spotlessCheck` passes
