### PR TITLE
Show real file sizes in the signing steps instead of rounding to megabytes

### DIFF
--- a/frontend/editor/src/core/components/shared/signing/steps/ReviewSessionStep.tsx
+++ b/frontend/editor/src/core/components/shared/signing/steps/ReviewSessionStep.tsx
@@ -9,6 +9,7 @@ import SendIcon from "@mui/icons-material/Send";
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import type { SignatureSettings } from "@app/components/tools/certSign/SignatureSettingsInput";
 import type { FileState } from "@app/types/file";
+import { formatFileSize } from "@app/utils/fileUtils";
 
 interface ReviewSessionStepProps {
   selectedFile: FileState;
@@ -62,7 +63,7 @@ export const ReviewSessionStep: React.FC<ReviewSessionStepProps> = ({
           </Text>
           {selectedFile.size && (
             <Text size="xs" c="dimmed">
-              {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+              {formatFileSize(selectedFile.size)}
             </Text>
           )}
         </div>

--- a/frontend/editor/src/core/components/shared/signing/steps/SelectDocumentStep.tsx
+++ b/frontend/editor/src/core/components/shared/signing/steps/SelectDocumentStep.tsx
@@ -3,6 +3,7 @@ import { Button } from "@app/ui/Button";
 import { useTranslation } from "react-i18next";
 import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
 import type { FileState } from "@app/types/file";
+import { formatFileSize } from "@app/utils/fileUtils";
 
 interface SelectDocumentStepProps {
   selectedFiles: FileState[];
@@ -56,7 +57,7 @@ export const SelectDocumentStep: React.FC<SelectDocumentStepProps> = ({
                 </Text>
                 {selectedFile?.size && (
                   <Text size="xs" c="dimmed">
-                    {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+                    {formatFileSize(selectedFile.size)}
                   </Text>
                 )}
               </div>


### PR DESCRIPTION
## What

The two signing steps call the existing `formatFileSize` helper instead of hardcoding a megabyte conversion.

## Why

Both divided by a megabyte and rounded to two places, so every document under about 5 KB read **0.00 MB** — most of what people send for signature. A 3 KB and a 24 KB PDF looked identical at the moment you confirm what you are sending.

`formatFileSize` already picks the right unit and is used in 53 other places, so this is a swap, not a new implementation. `FileSelectorPicker.formatBytes` is left alone: it already handles B/KB/MB correctly.

## Testing

No new test. `formatFileSize` is covered by `fileUtils.test.ts` (18 tests, passing) and this only routes two call sites to it. `oxfmt`, `oxlint --max-warnings=0` and `tsc` on both build variants are clean.