### PR TITLE
Confirm before deleting a policy from the detail drawer

### DIFF
--- a/frontend/editor/public/locales/en-US/translation.toml
+++ b/frontend/editor/public/locales/en-US/translation.toml
@@ -8953,6 +8953,13 @@ cancel = "Cancel"
 confirm = "Clear history"
 title = "Clear processed history?"
 
+[portal.policies.detail.delete]
+bodyActive = "\"{{name}}\" is active and enforcing on your documents. Deleting it stops that immediately and cannot be undone. Pause it instead if you only want it to stop running."
+bodyPaused = "\"{{name}}\" will be removed for everyone. This cannot be undone."
+cancel = "Cancel"
+confirm = "Delete"
+title = "Delete this pipeline?"
+
 [portal.policies.detail.emptyActivity]
 description = "Documents will appear here once this pipeline runs."
 title = "No activity yet"

--- a/frontend/editor/src/portal/components/policies/PolicyDetailPanel.test.tsx
+++ b/frontend/editor/src/portal/components/policies/PolicyDetailPanel.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fireEvent,
+  render as baseRender,
+  screen,
+} from "@testing-library/react";
+import { PortalTestProviders } from "@portal/test/TestQueryProvider";
+import { decorateForStory } from "@portal/components/policies/storyFixtures";
+import { PolicyDetailPanel } from "@portal/components/policies/PolicyDetailPanel";
+
+const render = (ui: Parameters<typeof baseRender>[0]) =>
+  baseRender(ui, { wrapper: PortalTestProviders });
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+  initReactI18next: { type: "3rdParty", init: vi.fn() },
+}));
+
+function renderPanel() {
+  const base = decorateForStory("security");
+  const onDelete = vi.fn();
+  render(
+    <PolicyDetailPanel
+      policy={{
+        ...base,
+        state: { ...base.state, isDefault: false, name: "QA Security Export" },
+      }}
+      onClose={vi.fn()}
+      onEdit={vi.fn()}
+      onTogglePause={vi.fn()}
+      onDelete={onDelete}
+    />,
+  );
+  return { onDelete };
+}
+
+describe("PolicyDetailPanel", () => {
+  it("asks before deleting an active policy instead of removing it on one click", () => {
+    const { onDelete } = renderPanel();
+
+    fireEvent.click(screen.getByText("portal.policies.detail.actions.delete"));
+
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("portal.policies.detail.delete.title"),
+    ).toBeInTheDocument();
+  });
+
+  it("deletes once the confirmation is accepted", () => {
+    const { onDelete } = renderPanel();
+
+    fireEvent.click(screen.getByText("portal.policies.detail.actions.delete"));
+    fireEvent.click(screen.getByText("portal.policies.detail.delete.confirm"));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the policy alone when the confirmation is dismissed", () => {
+    const { onDelete } = renderPanel();
+
+    fireEvent.click(screen.getByText("portal.policies.detail.actions.delete"));
+    fireEvent.click(screen.getByText("portal.policies.detail.delete.cancel"));
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/editor/src/portal/components/policies/PolicyDetailPanel.tsx
+++ b/frontend/editor/src/portal/components/policies/PolicyDetailPanel.tsx
@@ -104,6 +104,7 @@ export function PolicyDetailPanel({
 }: PolicyDetailPanelProps) {
   const { t } = useTranslation();
   const [confirmingClear, setConfirmingClear] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   if (!policy) return null;
   const { category, config, state, steps, stats, activity } = policy;
   const isPaused = state.status === "paused";
@@ -140,7 +141,7 @@ export function PolicyDetailPanel({
                 variant="tertiary"
                 accent="danger"
                 size="sm"
-                onClick={onDelete}
+                onClick={() => setConfirmingDelete(true)}
                 disabled={busy}
                 style={{ marginRight: "auto" }}
               >
@@ -337,6 +338,43 @@ export function PolicyDetailPanel({
         }
       >
         {t("portal.policies.detail.clearHistory.body")}
+      </Modal>
+      <Modal
+        open={confirmingDelete}
+        onClose={() => setConfirmingDelete(false)}
+        width="sm"
+        title={t("portal.policies.detail.delete.title")}
+        footer={
+          <div className="portal-policies__detail-foot">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setConfirmingDelete(false)}
+              disabled={busy}
+            >
+              {t("portal.policies.detail.delete.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              accent="danger"
+              size="sm"
+              disabled={busy}
+              onClick={() => {
+                setConfirmingDelete(false);
+                onDelete();
+              }}
+            >
+              {t("portal.policies.detail.delete.confirm")}
+            </Button>
+          </div>
+        }
+      >
+        {t(
+          isPaused
+            ? "portal.policies.detail.delete.bodyPaused"
+            : "portal.policies.detail.delete.bodyActive",
+          { name: state.name?.trim() || t(category.label) },
+        )}
       </Modal>
     </>
   );


### PR DESCRIPTION
# Description of Changes
<img width="492" height="697" alt="image" src="https://github.com/user-attachments/assets/f8cfce6c-dfb4-4d35-b8fd-9b8f83890e31" />

Delete in the policy detail drawer was wired straight to its handler, so one click removed an active policy and its stored record with no confirmation and no undo. The Clear processed history button sitting right beside it already confirms, which makes the missing prompt easy to walk into.

This adds a confirmation that names the policy and says what stops. When the policy is still active it also points at Pause as the non-destructive option, since "stop it running" is usually what was actually wanted.

**Before:** click Delete → the policy is gone.

**After:** click Delete → a prompt naming the policy; the delete only runs once it is accepted.

New strings under `portal.policies.detail.delete` in `en-US`.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [x] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Testing (if applicable)

- [x] New `PolicyDetailPanel.test.tsx` covers prompt-on-click, delete-on-accept and no-delete-on-dismiss; all three fail on `main` and pass here
- [x] `npx vitest run src/portal` passes: 91 files, 583 tests
- [x] `tsc --noEmit` (proprietary variant), `oxlint --max-warnings=0` and `oxfmt` all clean; the new TOML section parses and sits in sorted position
