### PR TITLE
Show teams with no members yet in the user directory

### DIFF
--- a/frontend/editor/src/portal/components/users/UsersDirectory.test.tsx
+++ b/frontend/editor/src/portal/components/users/UsersDirectory.test.tsx
@@ -93,6 +93,16 @@ describe("UsersDirectory — remove action gating", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Rename team")).not.toBeInTheDocument();
   });
+
+  it("lists a team with no members yet, so its first member can be added", () => {
+    renderDirectory(selfHostedCaps, [
+      ...TEAMS,
+      { id: 2, name: "Brand new", userCount: 0, owners: [] },
+    ]);
+
+    expect(screen.getByText("Brand new team")).toBeInTheDocument();
+    expect(screen.getAllByText("Add to team")).toHaveLength(2);
+  });
 });
 
 describe("flavor capabilities — invitations + remove scope", () => {

--- a/frontend/editor/src/portal/components/users/directory.test.ts
+++ b/frontend/editor/src/portal/components/users/directory.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildDirectory } from "@portal/components/users/directory";
+import type { Member } from "@portal/api/users";
+import type { Team } from "@portal/api/teams";
+
+const member = (overrides: Partial<Member> = {}): Member => ({
+  id: "2",
+  name: "Priya",
+  email: "priya@acme.com",
+  username: "priya@acme.com",
+  role: "member",
+  status: "active",
+  lastActive: "-",
+  teamId: 1,
+  teamName: "Acme",
+  ...overrides,
+});
+
+const team = (id: number, name: string): Team => ({
+  id,
+  name,
+  userCount: 0,
+  owners: [],
+});
+
+describe("buildDirectory", () => {
+  it("keeps a team that has no members yet", () => {
+    const dir = buildDirectory(
+      [member()],
+      [team(1, "Acme"), team(2, "Brand new")],
+    );
+
+    expect(dir.teams.map((t) => t.name)).toEqual(["Acme", "Brand new"]);
+    expect(dir.teams[1].members).toEqual([]);
+  });
+
+  it("sorts teams by name regardless of how many members they have", () => {
+    const dir = buildDirectory(
+      [member()],
+      [team(3, "Zephyr"), team(1, "Acme"), team(2, "Meridian")],
+    );
+
+    expect(dir.teams.map((t) => t.name)).toEqual([
+      "Acme",
+      "Meridian",
+      "Zephyr",
+    ]);
+  });
+
+  it("still keeps admins and guests out of their team's section", () => {
+    const dir = buildDirectory(
+      [
+        member({ id: "1", username: "root", role: "admin" }),
+        member({ id: "3", username: "vendor", role: "guest" }),
+        member(),
+      ],
+      [team(1, "Acme")],
+    );
+
+    expect(dir.organization).toHaveLength(1);
+    expect(dir.guests).toHaveLength(1);
+    expect(dir.teams[0].members.map((m) => m.username)).toEqual([
+      "priya@acme.com",
+    ]);
+  });
+});

--- a/frontend/editor/src/portal/components/users/directory.ts
+++ b/frontend/editor/src/portal/components/users/directory.ts
@@ -22,8 +22,8 @@ export interface Directory {
 /**
  * Group the flat roster into the directory shape the Users page renders:
  * admins are the Organization owners, web-only users are Guests, and everyone
- * else sits under their team. Empty teams are omitted from the roster (they're
- * still creatable / visible via team management).
+ * else sits under their team. A team with no members still gets a section, so
+ * a newly created one can be found and given its first member.
  */
 export function buildDirectory(members: Member[], teams: Team[]): Directory {
   const organization = members.filter((m) => m.role === "admin");
@@ -46,7 +46,6 @@ export function buildDirectory(members: Member[], teams: Team[]): Directory {
       members: byTeam.get(t.id) ?? [],
       isPersonal: t.isPersonal,
     }))
-    .filter((g) => g.members.length > 0)
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return { organization, teams: teamGroups, guests };


### PR DESCRIPTION
# Description of Changes

`buildDirectory` dropped any team whose member list was empty, so creating a team with the optional owner field blank looked like it had failed: the form succeeded, the roster was unchanged, and there was no row to add the first member from. The team was only reachable through the legacy Teams settings screen and the team-selection dropdowns, which is not where anyone goes looking for a team they just made.

Removing the filter is enough. `DataTable` already renders a group header for an empty group, and "Add to team" is the first team action, so a new team appears as a section with 0 people and an immediate way to fill it. The internal system team is already excluded server-side by the teams endpoint, so nothing unwanted surfaces.

**Before:** create a team with no owner → nothing appears in Users.

**After:** the team appears with 0 people and an Add to team action.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] New `directory.test.ts` covers the empty team, sort order, and that admins/guests still stay out of team sections
- [x] New `UsersDirectory.test.tsx` case asserts the empty team renders with its Add to team action
- [x] All three fail on `main` and pass here
- [x] `npx vitest run src/portal` passes: 91 files, 584 tests
- [x] `tsc --noEmit` (proprietary variant), `oxlint --max-warnings=0` and `oxfmt` all clean
