### PR TITLE
Keep a policy's name and icon when saving from the setup wizard

### DIFF
--- a/frontend/editor/src/portal/api/policies.test.ts
+++ b/frontend/editor/src/portal/api/policies.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSimplePolicy } from "@portal/api/policies";
+import { buildWireFromSetup, parseSimplePolicy } from "@portal/api/policies";
 import { policyStep, policyStepToWire } from "@app/policies/operations";
 import type { Policy } from "@portal/api/pipelines";
 
@@ -42,5 +42,81 @@ describe("parseSimplePolicy", () => {
     const entry = parseSimplePolicy(policy);
     expect(entry?.policy?.state.runOn).toBe("export");
     expect(entry?.policy?.state.runsOnEditor).toBe(true);
+  });
+});
+
+describe("buildWireFromSetup", () => {
+  const t = ((key: string) => key) as unknown as Parameters<
+    typeof buildWireFromSetup
+  >[2];
+
+  function customised(): Policy {
+    return {
+      ...classificationPolicy(false),
+      name: "QA Licensed Security Export",
+      icon: "shield",
+    };
+  }
+
+  it("keeps the stored name and icon when the wizard saves an existing policy", () => {
+    const entry = parseSimplePolicy(customised());
+    expect(entry).not.toBeNull();
+
+    const wire = buildWireFromSetup(
+      entry!,
+      {
+        required: entry!.policy!.state.required,
+        extraOptions: entry!.policy!.state.extraOptions,
+        runsOnEditor: true,
+        fieldValues: entry!.policy!.state.fieldValues,
+        sources: entry!.policy!.state.sources,
+        scopeTypes: entry!.policy!.state.scopeTypes,
+        reviewerEmail: entry!.policy!.state.reviewerEmail,
+        outputMode: "new_version",
+        outputName: "",
+        outputNamePosition: "suffix",
+        runOn: "upload",
+        maxRetries: 0,
+        retryDelayMinutes: 0,
+        steps: entry!.policy!.steps,
+      },
+      t,
+    );
+
+    expect(wire.name).toBe("QA Licensed Security Export");
+    expect(wire.icon).toBe("shield");
+  });
+
+  it("falls back to the category name for a policy that has none yet", () => {
+    const entry = parseSimplePolicy(classificationPolicy(false));
+    const blank = {
+      ...entry!,
+      policy: {
+        ...entry!.policy!,
+        state: { ...entry!.policy!.state, name: "" },
+      },
+    };
+
+    const wire = buildWireFromSetup(
+      blank,
+      {
+        required: false,
+        runsOnEditor: true,
+        fieldValues: {},
+        sources: [],
+        scopeTypes: [],
+        reviewerEmail: "",
+        outputMode: "new_version",
+        outputName: "",
+        outputNamePosition: "suffix",
+        runOn: "upload",
+        maxRetries: 0,
+        retryDelayMinutes: 0,
+        steps: [],
+      },
+      t,
+    );
+
+    expect(wire.name).toBe("portal.policies.defaultName");
   });
 });

--- a/frontend/editor/src/portal/api/policies.ts
+++ b/frontend/editor/src/portal/api/policies.ts
@@ -630,7 +630,8 @@ export function buildWireFromSetup(
     categoryId: entry.category.id,
     ...toWirePolicy({
       id: entry.policy?.state.backendId ?? "",
-      name: policyDisplayName(entry, t),
+      name: entry.policy?.state.name?.trim() || policyDisplayName(entry, t),
+      icon: entry.policy?.state.icon ?? "",
       enabled,
       required: result.required,
       extraOptions: result.extraOptions,

--- a/frontend/editor/src/proprietary/policies/codec.test.ts
+++ b/frontend/editor/src/proprietary/policies/codec.test.ts
@@ -5,6 +5,7 @@ import type { PolicyDecodedState } from "@app/policies/types";
 const FULL_STATE: PolicyDecodedState = {
   id: "pol_123",
   name: "Security Policy",
+  icon: "shield",
   enabled: true,
   required: true,
   policyKey: "security",

--- a/frontend/editor/src/proprietary/policies/codec.ts
+++ b/frontend/editor/src/proprietary/policies/codec.ts
@@ -52,6 +52,7 @@ export function toWirePolicy(state: PolicyDecodedState): WirePolicy {
   return {
     id: state.id,
     name: state.name,
+    icon: state.icon,
     owner: "",
     enabled: state.enabled,
     required: state.required,
@@ -82,6 +83,7 @@ export function fromWirePolicy(policy: WirePolicy): PolicyDecodedState {
   return {
     id: policy.id,
     name: policy.name,
+    icon: policy.icon ?? "",
     enabled: policy.enabled,
     required: policy.required ?? false,
     policyKey,

--- a/frontend/editor/src/proprietary/policies/types.ts
+++ b/frontend/editor/src/proprietary/policies/types.ts
@@ -56,6 +56,8 @@ export interface WirePolicy {
   name: string;
   owner?: string;
   enabled: boolean;
+  /** Row icon key; first-class on the record (see the pipeline `Policy.icon`). */
+  icon?: string;
   /** Org-mandated policy; first-class on the record (see the pipeline `Policy.required`). */
   required?: boolean;
   trigger: null;
@@ -101,6 +103,7 @@ export interface PolicyRunView {
 export interface PolicyDecodedState {
   id: string;
   name: string;
+  icon: string;
   enabled: boolean;
   /** Org-mandated policy; first-class on the record, not part of the options bag. */
   required: boolean;


### PR DESCRIPTION
# Description of Changes

Open a customised policy's detail drawer, click Edit settings, then Save without changing a field. The stored record comes back renamed to the category default and with its icon cleared.

`buildWireFromSetup` rebuilt the record from the category rather than the policy being edited: the name always came from `policyDisplayName`, and the wire codec had no `icon` field at all, so the stored one was dropped on every wizard save. `parseSimplePolicy` already patches both fields back onto the entry specifically so the Customise hand-off preserves them, with a comment saying so - the wizard's save path just never read them.

**Changes**

- `icon` is now modelled on `WirePolicy` / `PolicyDecodedState` and carried through the codec both ways, so it survives a round trip like every other first-class field.
- The wizard save keeps the policy's existing name, falling back to the category default only when there is not one.

**Before:** no-change save on "QA Licensed Security Export" (shield) → stored as "Security Pipeline" with no icon, same policy ID.

**After:** name and icon come back unchanged.

Scope note: this fixes the identity half only. The wizard also forces `convertPDFToImage` on for watermark steps, which is deliberate (a watermark that cannot be stripped) but silently overrides a builder-set `false`; that needs a product decision rather than a fix, so it is left alone here.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] New `buildWireFromSetup` cases in `policies.test.ts`: the stored name and icon survive a wizard save, and a policy with no name still falls back to the category default. The first fails on `main`
- [x] `npx vitest run src/portal src/proprietary/policies` passes: 94 files, 633 tests
- [x] `tsc --noEmit` clean on the proprietary, portal and core variants; `oxlint --max-warnings=0` and `oxfmt` clean
