### PR TITLE
fix(invites): consume a single-use invite token atomically with account creation

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/InviteLinkController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/InviteLinkController.java
@@ -22,7 +22,7 @@ import stirling.software.proprietary.security.model.InviteToken;
 import stirling.software.proprietary.security.repository.InviteTokenRepository;
 import stirling.software.proprietary.security.repository.TeamRepository;
 import stirling.software.proprietary.security.service.EmailService;
-import stirling.software.proprietary.security.service.SaveUserRequest;
+import stirling.software.proprietary.security.service.InviteRedemptionService;
 import stirling.software.proprietary.security.service.TeamService;
 import stirling.software.proprietary.security.service.UserService;
 import stirling.software.proprietary.service.UserLicenseSettingsService;
@@ -38,6 +38,7 @@ public class InviteLinkController {
     private final ApplicationProperties applicationProperties;
     private final Optional<EmailService> emailService;
     private final UserLicenseSettingsService userLicenseSettingsService;
+    private final InviteRedemptionService inviteRedemptionService;
 
     /**
      * Generate a new invite link (admin only)
@@ -469,19 +470,11 @@ public class InviteLinkController {
                                                 + " then use this link again."));
             }
 
-            // Create the user account
-            SaveUserRequest.Builder builder =
-                    SaveUserRequest.builder()
-                            .username(effectiveEmail)
-                            .password(password)
-                            .teamId(invite.getTeamId())
-                            .role(invite.getRole());
-            userService.saveUserCore(builder.build());
-
-            // Mark invite as used
-            invite.setUsed(true);
-            invite.setUsedAt(LocalDateTime.now());
-            inviteTokenRepository.save(invite);
+            // Consume the token and create the account together, so two redemptions racing on
+            // one single-use link cannot both produce an account.
+            if (!inviteRedemptionService.redeem(invite, effectiveEmail, password)) {
+                return invalidInviteResponse();
+            }
 
             log.info(
                     "User account created via invite link: {} with role: {}",

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/repository/InviteTokenRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/repository/InviteTokenRepository.java
@@ -29,4 +29,18 @@ public interface InviteTokenRepository extends JpaRepository<InviteToken, Long> 
 
     @Query("SELECT COUNT(it) FROM InviteToken it WHERE it.used = false AND it.expiresAt > :now")
     long countActiveInvites(@Param("now") LocalDateTime now);
+
+    /**
+     * Consumes an unused token. The {@code used = false} predicate is re-evaluated under the row
+     * lock the update takes, so of any number of concurrent redemptions of one token exactly one
+     * call sees a row to update. Must be called inside the transaction that creates the account, so
+     * a failed creation releases the token.
+     *
+     * @return 1 when this caller consumed the token, 0 when it was already consumed
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "UPDATE InviteToken it SET it.used = true, it.usedAt = :now WHERE it.id = :id AND"
+                    + " it.used = false")
+    int consumeIfUnused(@Param("id") Long id, @Param("now") LocalDateTime now);
 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/service/InviteRedemptionService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/service/InviteRedemptionService.java
@@ -1,0 +1,53 @@
+package stirling.software.proprietary.security.service;
+
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import stirling.software.common.model.exception.UnsupportedProviderException;
+import stirling.software.proprietary.security.model.InviteToken;
+import stirling.software.proprietary.security.repository.InviteTokenRepository;
+
+/**
+ * Redeems invite tokens. Exists so token consumption and account creation share one transaction: a
+ * controller cannot do that itself, because a self-invoked {@code @Transactional} method never goes
+ * through the proxy.
+ */
+@Service
+@RequiredArgsConstructor
+public class InviteRedemptionService {
+
+    private final InviteTokenRepository inviteTokenRepository;
+    private final UserService userService;
+
+    /**
+     * Consumes {@code invite} and creates its account as one unit. Consumption comes first and
+     * holds the token's row for the rest of the transaction, so concurrent redemptions of a
+     * single-use token serialize and only the first creates an account. Any failure creating the
+     * account propagates and rolls the consumption back, leaving the link usable.
+     *
+     * @param username the account to create, already resolved against the invite's bound email
+     * @return false when another request consumed the token first; no account was created
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public boolean redeem(InviteToken invite, String username, String password)
+            throws SQLException, UnsupportedProviderException {
+        Long teamId = invite.getTeamId();
+        String role = invite.getRole();
+        if (inviteTokenRepository.consumeIfUnused(invite.getId(), LocalDateTime.now()) == 0) {
+            return false;
+        }
+        userService.saveUserCore(
+                SaveUserRequest.builder()
+                        .username(username)
+                        .password(password)
+                        .teamId(teamId)
+                        .role(role)
+                        .build());
+        return true;
+    }
+}

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerMoreTest.java
@@ -32,6 +32,7 @@ import stirling.software.proprietary.security.model.InviteToken;
 import stirling.software.proprietary.security.repository.InviteTokenRepository;
 import stirling.software.proprietary.security.repository.TeamRepository;
 import stirling.software.proprietary.security.service.EmailService;
+import stirling.software.proprietary.security.service.InviteRedemptionService;
 import stirling.software.proprietary.security.service.UserService;
 import stirling.software.proprietary.service.UserLicenseSettingsService;
 
@@ -44,6 +45,7 @@ class InviteLinkControllerMoreTest {
     @Mock private UserService userService;
     @Mock private EmailService emailService;
     @Mock private UserLicenseSettingsService userLicenseSettingsService;
+    @Mock private InviteRedemptionService inviteRedemptionService;
 
     private ApplicationProperties applicationProperties;
     private MockMvc mockMvc;
@@ -65,7 +67,8 @@ class InviteLinkControllerMoreTest {
                         userService,
                         applicationProperties,
                         Optional.of(emailService),
-                        userLicenseSettingsService);
+                        userLicenseSettingsService,
+                        inviteRedemptionService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -296,13 +299,32 @@ class InviteLinkControllerMoreTest {
             invite.setTeamId(3L);
             when(inviteTokenRepository.findByToken("preset")).thenReturn(Optional.of(invite));
             when(userService.usernameExistsIgnoreCase("preset@ex.com")).thenReturn(false);
+            when(inviteRedemptionService.redeem(invite, "preset@ex.com", "secret123"))
+                    .thenReturn(true);
 
             mockMvc.perform(post("/api/v1/invite/accept/preset").param("password", "secret123"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.username").value("preset@ex.com"));
 
-            verify(userService).saveUserCore(any());
-            verify(inviteTokenRepository).save(invite);
+            verify(inviteRedemptionService).redeem(invite, "preset@ex.com", "secret123");
+        }
+
+        @Test
+        @DisplayName("returns 404 when a concurrent redemption consumed the token first")
+        void losesTheRaceForTheToken() throws Exception {
+            InviteToken invite = validInvite("general");
+            invite.setEmail(null);
+            when(inviteTokenRepository.findByToken("general")).thenReturn(Optional.of(invite));
+            when(userService.usernameExistsIgnoreCase("second@ex.com")).thenReturn(false);
+            when(inviteRedemptionService.redeem(invite, "second@ex.com", "secret123"))
+                    .thenReturn(false);
+
+            mockMvc.perform(
+                            post("/api/v1/invite/accept/general")
+                                    .param("email", "second@ex.com")
+                                    .param("password", "secret123"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error").value("Invalid invite link"));
         }
 
         @Test
@@ -320,8 +342,7 @@ class InviteLinkControllerMoreTest {
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.error").value(containsString("limit of 100 users")));
 
-            verify(userService, never()).saveUserCore(any());
-            verify(inviteTokenRepository, never()).save(invite);
+            verify(inviteRedemptionService, never()).redeem(any(), any(), any());
         }
     }
 }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerTest.java
@@ -29,6 +29,7 @@ import stirling.software.proprietary.security.model.InviteToken;
 import stirling.software.proprietary.security.repository.InviteTokenRepository;
 import stirling.software.proprietary.security.repository.TeamRepository;
 import stirling.software.proprietary.security.service.EmailService;
+import stirling.software.proprietary.security.service.InviteRedemptionService;
 import stirling.software.proprietary.security.service.TeamService;
 import stirling.software.proprietary.security.service.UserService;
 import stirling.software.proprietary.service.UserLicenseSettingsService;
@@ -41,6 +42,7 @@ class InviteLinkControllerTest {
     @Mock private UserService userService;
     @Mock private EmailService emailService;
     @Mock private UserLicenseSettingsService userLicenseSettingsService;
+    @Mock private InviteRedemptionService inviteRedemptionService;
 
     private ApplicationProperties applicationProperties;
     private MockMvc mockMvc;
@@ -62,7 +64,8 @@ class InviteLinkControllerTest {
                         userService,
                         applicationProperties,
                         Optional.of(emailService),
-                        userLicenseSettingsService);
+                        userLicenseSettingsService,
+                        inviteRedemptionService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -173,6 +176,8 @@ class InviteLinkControllerTest {
         invite.setEmail(null); // email required from request
         when(inviteTokenRepository.findByToken("abc")).thenReturn(Optional.of(invite));
         when(userService.usernameExistsIgnoreCase("new@example.com")).thenReturn(false);
+        when(inviteRedemptionService.redeem(invite, "new@example.com", "password123"))
+                .thenReturn(true);
 
         mockMvc.perform(
                         post("/api/v1/invite/accept/abc")
@@ -182,7 +187,6 @@ class InviteLinkControllerTest {
                 .andExpect(jsonPath("$.message").value("Account created successfully"))
                 .andExpect(jsonPath("$.username").value("new@example.com"));
 
-        verify(userService).saveUserCore(any());
-        verify(inviteTokenRepository).save(invite);
+        verify(inviteRedemptionService).redeem(invite, "new@example.com", "password123");
     }
 }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/repository/InviteTokenRepositoryDbTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/repository/InviteTokenRepositoryDbTest.java
@@ -1,0 +1,73 @@
+package stirling.software.proprietary.security.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import stirling.software.proprietary.security.model.InviteToken;
+
+/**
+ * Exercises the conditional consume against a real (H2) database, so the {@code used = false}
+ * predicate that makes a single-use link single-use is actually run rather than mocked.
+ */
+@DataJpaTest
+class InviteTokenRepositoryDbTest {
+
+    @Autowired private InviteTokenRepository repository;
+
+    private InviteToken storedInvite() {
+        InviteToken invite = new InviteToken();
+        invite.setToken("tok");
+        invite.setEmail("invitee@example.com");
+        invite.setRole("ROLE_USER");
+        invite.setExpiresAt(LocalDateTime.now().plusHours(24));
+        invite.setCreatedBy("admin");
+        return repository.saveAndFlush(invite);
+    }
+
+    @Test
+    void consumeIfUnusedSucceedsOnceAndThenReportsNothingToConsume() {
+        InviteToken invite = storedInvite();
+        LocalDateTime now = LocalDateTime.now();
+
+        assertEquals(1, repository.consumeIfUnused(invite.getId(), now));
+        assertEquals(0, repository.consumeIfUnused(invite.getId(), now));
+    }
+
+    @Test
+    void consumeIfUnusedMarksTheTokenUsed() {
+        InviteToken invite = storedInvite();
+        // Truncated: H2 stores fewer sub-second digits than LocalDateTime.now() carries.
+        LocalDateTime consumedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+
+        repository.consumeIfUnused(invite.getId(), consumedAt);
+
+        InviteToken reloaded = repository.findByToken("tok").orElseThrow();
+        assertTrue(reloaded.isUsed());
+        assertEquals(consumedAt, reloaded.getUsedAt());
+    }
+
+    @Test
+    void consumeIfUnusedReportsNothingForAnUnknownToken() {
+        assertEquals(0, repository.consumeIfUnused(999_999L, LocalDateTime.now()));
+    }
+
+    @SpringBootConfiguration
+    @EntityScan(
+            basePackages = {
+                "stirling.software.proprietary.security.model",
+                "stirling.software.proprietary.model",
+                "stirling.software.proprietary.access.model"
+            })
+    @EnableJpaRepositories(basePackageClasses = InviteTokenRepository.class)
+    static class TestApp {}
+}

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/service/InviteRedemptionServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/service/InviteRedemptionServiceTest.java
@@ -1,0 +1,82 @@
+package stirling.software.proprietary.security.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import stirling.software.proprietary.security.model.InviteToken;
+import stirling.software.proprietary.security.repository.InviteTokenRepository;
+
+@ExtendWith(MockitoExtension.class)
+class InviteRedemptionServiceTest {
+
+    @Mock private InviteTokenRepository inviteTokenRepository;
+    @Mock private UserService userService;
+
+    private InviteRedemptionService service;
+    private InviteToken invite;
+
+    @BeforeEach
+    void setUp() {
+        service = new InviteRedemptionService(inviteTokenRepository, userService);
+        invite = new InviteToken();
+        invite.setId(7L);
+        invite.setToken("tok");
+        invite.setRole("ROLE_USER");
+        invite.setTeamId(3L);
+        invite.setExpiresAt(LocalDateTime.now().plusHours(1));
+    }
+
+    @Test
+    void consumesTheTokenBeforeCreatingTheAccount() throws Exception {
+        when(inviteTokenRepository.consumeIfUnused(anyLong(), any(LocalDateTime.class)))
+                .thenReturn(1);
+
+        assertTrue(service.redeem(invite, "invitee@example.com", "correct horse"));
+
+        InOrder order = Mockito.inOrder(inviteTokenRepository, userService);
+        order.verify(inviteTokenRepository).consumeIfUnused(anyLong(), any(LocalDateTime.class));
+        order.verify(userService).saveUserCore(any());
+
+        ArgumentCaptor<SaveUserRequest> saved = ArgumentCaptor.forClass(SaveUserRequest.class);
+        verify(userService).saveUserCore(saved.capture());
+        assertTrue("invitee@example.com".equals(saved.getValue().getUsername()));
+        assertTrue(Long.valueOf(3L).equals(saved.getValue().getTeamId()));
+    }
+
+    @Test
+    void createsNoAccountWhenAnotherRedemptionConsumedTheToken() throws Exception {
+        when(inviteTokenRepository.consumeIfUnused(anyLong(), any(LocalDateTime.class)))
+                .thenReturn(0);
+
+        assertFalse(service.redeem(invite, "invitee@example.com", "correct horse"));
+
+        verify(userService, never()).saveUserCore(any());
+    }
+
+    @Test
+    void propagatesACreationFailureSoTheConsumptionRollsBack() throws Exception {
+        when(inviteTokenRepository.consumeIfUnused(anyLong(), any(LocalDateTime.class)))
+                .thenReturn(1);
+        when(userService.saveUserCore(any())).thenThrow(new SQLException("boom"));
+
+        assertThrows(SQLException.class, () -> service.redeem(invite, "invitee@example.com", "pw"));
+    }
+}


### PR DESCRIPTION
# Description of Changes

Fixes **F2** from the invite-flow audit: a single-use invite link could create two accounts.

- `acceptInvite` checked `used`, created the account, then marked the token used. Two requests racing on one token both passed the check, so both created an account (audit reproduced this with two emails on one general link).
- New `InviteRedemptionService.redeem` consumes the token and creates the account in one transaction; a controller cannot do this itself, because a self-invoked `@Transactional` method never goes through the proxy.
- New `InviteTokenRepository.consumeIfUnused` is a conditional `UPDATE ... WHERE used = false`. The predicate is re-evaluated under the row lock, so of any number of concurrent redemptions exactly one updates a row; the loser gets the same 404 a reused link already returned.
- Consumption comes first and holds the row for the rest of the transaction. A failure creating the account propagates and rolls the consumption back, so a 500 does not burn the link.

**Verified against a live instance:** two threads behind a barrier redeeming one general link with different emails returned `[200, 404]`, and exactly one account existed afterwards. On `main` both returned 200.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] `InviteRedemptionTransactionDbTest` invokes the Spring-proxied service without an ambient transaction: checked and unchecked account-creation failures roll back consumption, and a retry can consume the token exactly once
- [x] All 34 invite tests pass locally

- [x] `InviteTokenRepositoryDbTest` (`@DataJpaTest`, H2) proves `consumeIfUnused` returns 1 then 0 for the same token
- [x] `InviteRedemptionServiceTest` pins the consume-before-create order and that a creation failure propagates
- [x] `InviteLinkControllerMoreTest` covers the losing redemption returning 404
- [x] `./gradlew :proprietary:test --tests "*Invite*"` passes
- [x] Live two-thread race against a running backend, as above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invite links are now redeemed atomically, preventing duplicate account creation during concurrent attempts.
  * Invalid or already-used invite links now return an invalid-invite response.
  * If account creation fails, the invite remains available for a later retry.
  * Failed redemptions no longer leave invite links marked as used.

* **Tests**
  * Added coverage for concurrent redemption attempts, token reuse, unknown tokens, successful retries, and account-creation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
