### PR TITLE
fix(invites): reject malformed emails and unknown teams when an invite is created

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/InviteLinkController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/InviteLinkController.java
@@ -25,6 +25,7 @@ import stirling.software.proprietary.security.service.EmailService;
 import stirling.software.proprietary.security.service.SaveUserRequest;
 import stirling.software.proprietary.security.service.TeamService;
 import stirling.software.proprietary.security.service.UserService;
+import stirling.software.proprietary.security.util.EmailAddresses;
 import stirling.software.proprietary.service.UserLicenseSettingsService;
 
 @InviteApi
@@ -72,8 +73,9 @@ public class InviteLinkController {
 
             // If email is provided, validate and check for conflicts
             if (email != null && !email.trim().isEmpty()) {
-                // Validate email format
-                if (!email.contains("@")) {
+                // The address becomes the account's username at redemption, so it has to be
+                // usable now: a link minted for "a@" only fails when someone tries to redeem it.
+                if (!EmailAddresses.isValid(email)) {
                     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                             .body(Map.of("error", "Invalid email address"));
                 }
@@ -150,8 +152,11 @@ public class InviteLinkController {
                 }
             } else {
                 Team selectedTeam = teamRepository.findById(effectiveTeamId).orElse(null);
-                if (selectedTeam != null
-                        && TeamService.INTERNAL_TEAM_NAME.equals(selectedTeam.getName())) {
+                if (selectedTeam == null) {
+                    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                            .body(Map.of("error", "Team not found"));
+                }
+                if (TeamService.INTERNAL_TEAM_NAME.equals(selectedTeam.getName())) {
                     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                             .body(Map.of("error", "Cannot assign users to Internal team"));
                 }
@@ -436,8 +441,7 @@ public class InviteLinkController {
                             .body(Map.of("error", "Email address is required"));
                 }
 
-                // Validate email format
-                if (!email.contains("@")) {
+                if (!EmailAddresses.isValid(email)) {
                     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                             .body(Map.of("error", "Invalid email address"));
                 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/InviteLinkController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/InviteLinkController.java
@@ -75,7 +75,7 @@ public class InviteLinkController {
             if (email != null && !email.trim().isEmpty()) {
                 // The address becomes the account's username at redemption, so it has to be
                 // usable now: a link minted for "a@" only fails when someone tries to redeem it.
-                if (!EmailAddresses.isValid(email)) {
+                if (!EmailAddresses.isValidAccountAddress(email)) {
                     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                             .body(Map.of("error", "Invalid email address"));
                 }
@@ -441,7 +441,7 @@ public class InviteLinkController {
                             .body(Map.of("error", "Email address is required"));
                 }
 
-                if (!EmailAddresses.isValid(email)) {
+                if (!EmailAddresses.isValidAccountAddress(email)) {
                     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                             .body(Map.of("error", "Invalid email address"));
                 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/TeamController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/TeamController.java
@@ -40,6 +40,11 @@ public class TeamController {
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/create")
     public ResponseEntity<?> createTeam(@RequestParam("name") String name) {
+        if (name == null || name.isBlank()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", "Team name is required."));
+        }
+        name = name.trim();
         if (teamRepository.existsByNameIgnoreCase(name)) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(Map.of("error", "Team name already exists."));
@@ -54,6 +59,11 @@ public class TeamController {
     @PostMapping("/rename")
     public ResponseEntity<?> renameTeam(
             @RequestParam("teamId") Long teamId, @RequestParam("newName") String newName) {
+        if (newName == null || newName.isBlank()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", "Team name is required."));
+        }
+        newName = newName.trim();
         Optional<Team> existing = teamRepository.findById(teamId);
         if (existing.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
@@ -53,6 +53,7 @@ import stirling.software.proprietary.security.service.SaveUserRequest;
 import stirling.software.proprietary.security.service.TeamMembershipService;
 import stirling.software.proprietary.security.service.TeamService;
 import stirling.software.proprietary.security.service.UserService;
+import stirling.software.proprietary.security.util.EmailAddresses;
 import stirling.software.proprietary.security.session.SessionPersistentRegistry;
 import stirling.software.proprietary.service.UserLicenseSettingsService;
 
@@ -888,8 +889,7 @@ public class UserController {
     private InviteResult processEmailInvite(
             String email, Long teamId, String role, String loginUrl) {
         try {
-            // Validate email format (basic check)
-            if (!email.contains("@") || !email.contains(".")) {
+            if (!EmailAddresses.isValid(email)) {
                 return InviteResult.failure(email + ": Invalid email format");
             }
 

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
@@ -889,7 +889,7 @@ public class UserController {
     private InviteResult processEmailInvite(
             String email, Long teamId, String role, String loginUrl) {
         try {
-            if (!EmailAddresses.isValid(email)) {
+            if (!EmailAddresses.isValidAccountAddress(email)) {
                 return InviteResult.failure(email + ": Invalid email format");
             }
 

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/controller/api/UserController.java
@@ -53,8 +53,8 @@ import stirling.software.proprietary.security.service.SaveUserRequest;
 import stirling.software.proprietary.security.service.TeamMembershipService;
 import stirling.software.proprietary.security.service.TeamService;
 import stirling.software.proprietary.security.service.UserService;
-import stirling.software.proprietary.security.util.EmailAddresses;
 import stirling.software.proprietary.security.session.SessionPersistentRegistry;
+import stirling.software.proprietary.security.util.EmailAddresses;
 import stirling.software.proprietary.service.UserLicenseSettingsService;
 
 @UserApi

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/service/UserService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/service/UserService.java
@@ -6,7 +6,6 @@ import static stirling.software.proprietary.security.service.MfaService.MFA_REQU
 import static stirling.software.proprietary.security.service.MfaService.MFA_SECRET_KEY;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +38,6 @@ import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.enumeration.Role;
 import stirling.software.common.model.exception.UnsupportedProviderException;
 import stirling.software.common.service.UserServiceInterface;
-import stirling.software.common.util.RegexPatternUtils;
 import stirling.software.proprietary.access.model.PrincipalType;
 import stirling.software.proprietary.access.model.ResourceType;
 import stirling.software.proprietary.access.repository.ResourceGrantRepository;
@@ -56,6 +54,7 @@ import stirling.software.proprietary.security.model.exception.UserLimitExceededE
 import stirling.software.proprietary.security.repository.TeamRepository;
 import stirling.software.proprietary.security.saml2.CustomSaml2AuthenticatedPrincipal;
 import stirling.software.proprietary.security.session.SessionPersistentRegistry;
+import stirling.software.proprietary.security.util.UsernameRules;
 import stirling.software.proprietary.service.UserLicenseSettingsService;
 import stirling.software.proprietary.storage.model.FileShare;
 import stirling.software.proprietary.storage.model.StorageCleanupEntry;
@@ -598,28 +597,7 @@ public class UserService implements UserServiceInterface {
     }
 
     public boolean isUsernameValid(String username) {
-        // Checks whether the simple username is formatted correctly
-        // Regular expression for user name: Min. 3 characters, max. 50 characters
-        boolean isValidSimpleUsername =
-                RegexPatternUtils.getInstance()
-                        .getUsernameValidationPattern()
-                        .matcher(username)
-                        .matches();
-
-        // Checks whether the email address is formatted correctly
-        // Regular expression for email addresses: Max. 320 characters, with RFC-like validation
-        boolean isValidEmail =
-                RegexPatternUtils.getInstance()
-                        .getEmailValidationPattern()
-                        .matcher(username)
-                        .matches();
-
-        List<String> notAllowedUserList = new ArrayList<>();
-        notAllowedUserList.add("ALL_USERS".toLowerCase(Locale.ROOT));
-        notAllowedUserList.add("anonymoususer");
-        String normalizedUsername = username.toLowerCase(Locale.ROOT);
-        boolean notAllowedUser = notAllowedUserList.contains(normalizedUsername);
-        return (isValidSimpleUsername || isValidEmail) && !notAllowedUser;
+        return UsernameRules.isValid(username);
     }
 
     private String getInvalidUsernameMessage() {

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/util/EmailAddresses.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/util/EmailAddresses.java
@@ -3,9 +3,9 @@ package stirling.software.proprietary.security.util;
 import java.util.regex.Pattern;
 
 /**
- * The shape an address must have before it is accepted as a future account's username. Deliberately
- * structural, not deliverable: full RFC 5322 buys nothing here, and only a sent message proves an
- * address exists.
+ * The shape an address must have to be worth mailing, and the stricter shape it must have to also
+ * become an account. Deliberately structural, not deliverable: full RFC 5322 buys nothing here, and
+ * only a sent message proves an address exists.
  */
 public final class EmailAddresses {
 
@@ -14,7 +14,18 @@ public final class EmailAddresses {
 
     private EmailAddresses() {}
 
-    public static boolean isValid(String value) {
+    /** Whether the address is worth handing to a mail server. Says nothing about account rules. */
+    public static boolean hasDeliverableShape(String value) {
         return value != null && PATTERN.matcher(value.trim()).matches();
+    }
+
+    /**
+     * Whether an account may be created for this address. Both halves are load-bearing: the shape
+     * keeps undeliverable invites from being minted, and {@link UsernameRules} is what {@code
+     * saveUserCore} enforces, so accepting an address it rejects turns into a failure at redemption
+     * rather than at the request that offered it.
+     */
+    public static boolean isValidAccountAddress(String value) {
+        return hasDeliverableShape(value) && UsernameRules.isValid(value.trim());
     }
 }

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/util/EmailAddresses.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/util/EmailAddresses.java
@@ -10,8 +10,7 @@ import java.util.regex.Pattern;
 public final class EmailAddresses {
 
     /** Requires a domain with a 2-character-or-longer TLD; rejects "a@" and "a@b". */
-    private static final Pattern PATTERN =
-            Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$");
+    private static final Pattern PATTERN = Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$");
 
     private EmailAddresses() {}
 

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/util/EmailAddresses.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/util/EmailAddresses.java
@@ -1,0 +1,21 @@
+package stirling.software.proprietary.security.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * The shape an address must have before it is accepted as a future account's username. Deliberately
+ * structural, not deliverable: full RFC 5322 buys nothing here, and only a sent message proves an
+ * address exists.
+ */
+public final class EmailAddresses {
+
+    /** Requires a domain with a 2-character-or-longer TLD; rejects "a@" and "a@b". */
+    private static final Pattern PATTERN =
+            Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$");
+
+    private EmailAddresses() {}
+
+    public static boolean isValid(String value) {
+        return value != null && PATTERN.matcher(value.trim()).matches();
+    }
+}

--- a/app/proprietary/src/main/java/stirling/software/proprietary/security/util/UsernameRules.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/security/util/UsernameRules.java
@@ -1,0 +1,30 @@
+package stirling.software.proprietary.security.util;
+
+import java.util.Locale;
+import java.util.Set;
+
+import stirling.software.common.util.RegexPatternUtils;
+
+/**
+ * The names an account may be stored under: a plain username, or an email address. Authority for
+ * {@code UserService.saveUserCore}, which throws when it is not satisfied, so any gate that decides
+ * an account can be created later must agree with this or it promises an account the writer will
+ * refuse.
+ */
+public final class UsernameRules {
+
+    private static final Set<String> RESERVED = Set.of("all_users", "anonymoususer");
+
+    private UsernameRules() {}
+
+    public static boolean isValid(String username) {
+        if (username == null) {
+            return false;
+        }
+        RegexPatternUtils patterns = RegexPatternUtils.getInstance();
+        boolean matchesShape =
+                patterns.getUsernameValidationPattern().matcher(username).matches()
+                        || patterns.getEmailValidationPattern().matcher(username).matches();
+        return matchesShape && !RESERVED.contains(username.toLowerCase(Locale.ROOT));
+    }
+}

--- a/app/proprietary/src/main/java/stirling/software/proprietary/storage/service/FileStorageService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/storage/service/FileStorageService.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
@@ -32,6 +31,7 @@ import stirling.software.common.model.ApplicationProperties;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.service.EmailService;
+import stirling.software.proprietary.security.util.EmailAddresses;
 import stirling.software.proprietary.storage.crypto.StorageEncryptionErrors;
 import stirling.software.proprietary.storage.crypto.StorageKeyRevokedException;
 import stirling.software.proprietary.storage.model.FileShare;
@@ -57,10 +57,6 @@ import stirling.software.proprietary.storage.repository.StoredFileRepository;
 @RequiredArgsConstructor
 @Slf4j
 public class FileStorageService {
-
-    // Requires at least 2-character TLD; rejects obvious non-addresses like a@b.c
-    private static final Pattern EMAIL_PATTERN =
-            Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$");
 
     private final StoredFileRepository storedFileRepository;
     private final FileShareRepository fileShareRepository;
@@ -858,7 +854,7 @@ public class FileStorageService {
     }
 
     private boolean isEmailAddress(String value) {
-        return value != null && EMAIL_PATTERN.matcher(value.trim()).matches();
+        return EmailAddresses.hasDeliverableShape(value);
     }
 
     private boolean isOwner(StoredFile file, User owner) {

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerMoreTest.java
@@ -96,6 +96,37 @@ class InviteLinkControllerMoreTest {
         }
 
         @Test
+        @DisplayName("rejects an address that has no deliverable domain")
+        void rejectsMalformedEmail() throws Exception {
+            mockMvc.perform(
+                            post("/api/v1/invite/generate")
+                                    .principal(adminPrincipal)
+                                    .param("email", "a@"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("Invalid email address"));
+
+            verify(inviteTokenRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rejects a team that does not exist")
+        void rejectsUnknownTeam() throws Exception {
+            when(userService.usernameExistsIgnoreCase("new@ex.com")).thenReturn(false);
+            when(inviteTokenRepository.findByEmail("new@ex.com")).thenReturn(Optional.empty());
+            when(teamRepository.findById(999_999L)).thenReturn(Optional.empty());
+
+            mockMvc.perform(
+                            post("/api/v1/invite/generate")
+                                    .principal(adminPrincipal)
+                                    .param("email", "new@ex.com")
+                                    .param("teamId", "999999"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("Team not found"));
+
+            verify(inviteTokenRepository, never()).save(any());
+        }
+
+        @Test
         @DisplayName("returns conflict when the user already exists")
         void userAlreadyExists() throws Exception {
             when(userService.usernameExistsIgnoreCase("dup@ex.com")).thenReturn(true);
@@ -286,6 +317,23 @@ class InviteLinkControllerMoreTest {
             mockMvc.perform(post("/api/v1/invite/accept/noemail").param("password", "secret123"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.error").value("Email address is required"));
+        }
+
+        @Test
+        @DisplayName("rejects a malformed email on a general link")
+        void rejectsMalformedEmailOnAccept() throws Exception {
+            InviteToken invite = validInvite("general");
+            invite.setEmail(null);
+            when(inviteTokenRepository.findByToken("general")).thenReturn(Optional.of(invite));
+
+            mockMvc.perform(
+                            post("/api/v1/invite/accept/general")
+                                    .param("email", "a@")
+                                    .param("password", "secret123"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("Invalid email address"));
+
+            verify(userService, never()).saveUserCore(any());
         }
 
         @Test

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/InviteLinkControllerMoreTest.java
@@ -109,6 +109,19 @@ class InviteLinkControllerMoreTest {
         }
 
         @Test
+        @DisplayName("rejects an address that could not become an account")
+        void rejectsEmailThatCannotBecomeAUsername() throws Exception {
+            mockMvc.perform(
+                            post("/api/v1/invite/generate")
+                                    .principal(adminPrincipal)
+                                    .param("email", "o'brien@example.com"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("Invalid email address"));
+
+            verify(inviteTokenRepository, never()).save(any());
+        }
+
+        @Test
         @DisplayName("rejects a team that does not exist")
         void rejectsUnknownTeam() throws Exception {
             when(userService.usernameExistsIgnoreCase("new@ex.com")).thenReturn(false);

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/TeamControllerNameTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/TeamControllerNameTest.java
@@ -1,0 +1,104 @@
+package stirling.software.proprietary.security.controller.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import stirling.software.proprietary.access.repository.ResourceGrantRepository;
+import stirling.software.proprietary.integration.repository.IntegrationConfigRepository;
+import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.security.database.repository.UserRepository;
+import stirling.software.proprietary.security.repository.TeamRepository;
+import stirling.software.proprietary.security.service.TeamMembershipService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TeamController - team names")
+class TeamControllerNameTest {
+
+    @Mock private TeamRepository teamRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ResourceGrantRepository resourceGrantRepository;
+    @Mock private IntegrationConfigRepository integrationConfigRepository;
+    @Mock private TeamMembershipService teamMembershipService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        TeamController controller =
+                new TeamController(
+                        teamRepository,
+                        userRepository,
+                        resourceGrantRepository,
+                        integrationConfigRepository,
+                        teamMembershipService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    @DisplayName("refuses to create a team whose name is only whitespace")
+    void createRejectsBlankName() throws Exception {
+        mockMvc.perform(post("/api/v1/team/create").param("name", "   "))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Team name is required."));
+
+        verify(teamRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("stores a created team's name trimmed")
+    void createTrimsName() throws Exception {
+        when(teamRepository.existsByNameIgnoreCase("Finance")).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/team/create").param("name", "  Finance  "))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Team> saved = ArgumentCaptor.forClass(Team.class);
+        verify(teamRepository).save(saved.capture());
+        org.junit.jupiter.api.Assertions.assertEquals("Finance", saved.getValue().getName());
+    }
+
+    @Test
+    @DisplayName("refuses to rename a team to only whitespace")
+    void renameRejectsBlankName() throws Exception {
+        mockMvc.perform(post("/api/v1/team/rename").param("teamId", "1").param("newName", " "))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Team name is required."));
+
+        verify(teamRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("stores a renamed team's name trimmed")
+    void renameTrimsName() throws Exception {
+        Team team = new Team();
+        team.setId(1L);
+        team.setName("Old");
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(team));
+        when(teamRepository.existsByNameIgnoreCase("Finance")).thenReturn(false);
+
+        mockMvc.perform(
+                        post("/api/v1/team/rename")
+                                .param("teamId", "1")
+                                .param("newName", "  Finance  "))
+                .andExpect(status().isOk());
+
+        org.junit.jupiter.api.Assertions.assertEquals("Finance", team.getName());
+    }
+}

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/UserControllerMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/controller/api/UserControllerMoreTest.java
@@ -473,5 +473,24 @@ class UserControllerMoreTest {
 
             verify(userService).saveUserCore(any());
         }
+
+        @Test
+        @DisplayName("refuses an address the account writer would reject")
+        void rejectsAddressThatCannotBecomeAUsername() throws Exception {
+            applicationProperties.getMail().setEnableInvites(true);
+
+            mockMvc.perform(
+                            post("/api/v1/user/admin/inviteUsers")
+                                    .principal(auth("admin"))
+                                    .param("emails", "o'brien@example.com"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.failureCount").value(1))
+                    .andExpect(jsonPath("$.successCount").value(0))
+                    .andExpect(
+                            jsonPath("$.errors")
+                                    .value("o'brien@example.com: Invalid email format; "));
+
+            verify(userService, never()).saveUserCore(any());
+        }
     }
 }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/service/UserServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/service/UserServiceTest.java
@@ -35,6 +35,7 @@ import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.model.exception.UserLimitExceededException;
 import stirling.software.proprietary.security.repository.TeamRepository;
 import stirling.software.proprietary.security.session.SessionPersistentRegistry;
+import stirling.software.proprietary.security.util.EmailAddresses;
 import stirling.software.proprietary.storage.model.FileShare;
 import stirling.software.proprietary.storage.model.StoredFile;
 import stirling.software.proprietary.storage.repository.FileShareAccessRepository;
@@ -289,6 +290,26 @@ class UserServiceTest {
     void isUsernameValidRejectsReservedAndAcceptsEmail() {
         assertFalse(userService.isUsernameValid("ALL_USERS"));
         assertTrue(userService.isUsernameValid("valid@example.com"));
+    }
+
+    @Test
+    void saveUserCoreAcceptsEveryAddressTheInviteGateLetsThrough() {
+        for (String address :
+                List.of(
+                        "a@b.co",
+                        "first.last+tag@sub.example.co.uk",
+                        "o'brien@example.com",
+                        "a!b@ex.com",
+                        "a@ex..com",
+                        "-a@ex.com",
+                        "admin@localhost",
+                        "a@b")) {
+            if (EmailAddresses.isValidAccountAddress(address)) {
+                assertTrue(
+                        userService.isUsernameValid(address.trim()),
+                        address + " passes the invite gate but saveUserCore would reject it");
+            }
+        }
     }
 
     @Test

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/util/EmailAddressesTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/util/EmailAddressesTest.java
@@ -12,17 +12,69 @@ class EmailAddressesTest {
     @ParameterizedTest
     @ValueSource(strings = {"a@", "@example.com", "a@b", "a@b.c", "no-at-sign", "a b@ex.com", ""})
     void rejectsAddressesThatCouldNotBeDelivered(String value) {
-        assertFalse(EmailAddresses.isValid(value));
+        assertFalse(EmailAddresses.isValidAccountAddress(value));
+        assertFalse(EmailAddresses.hasDeliverableShape(value));
     }
 
     @Test
     void rejectsNull() {
-        assertFalse(EmailAddresses.isValid(null));
+        assertFalse(EmailAddresses.isValidAccountAddress(null));
+        assertFalse(EmailAddresses.hasDeliverableShape(null));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"a@b.co", "first.last+tag@sub.example.co.uk", "  a@b.com  "})
     void acceptsAddressesWithARealDomain(String value) {
-        assertTrue(EmailAddresses.isValid(value));
+        assertTrue(EmailAddresses.isValidAccountAddress(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "a!b@ex.com",
+                "o'brien@example.com",
+                "a<b>@ex.com",
+                "a\"b@ex.com",
+                "a@-ex.com",
+                "a@ex..com",
+                "a@ex.com.",
+                "-a@ex.com",
+                "a@[192.168.0.1]",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@ex.com"
+            })
+    void refusesWhatTheAccountWriterWouldRefuse(String value) {
+        assertTrue(EmailAddresses.hasDeliverableShape(value));
+        assertFalse(UsernameRules.isValid(value.trim()));
+        assertFalse(EmailAddresses.isValidAccountAddress(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "a@b.co",
+                "first.last+tag@sub.example.co.uk",
+                "  a@b.com  ",
+                "a!b@ex.com",
+                "o'brien@example.com",
+                "a@ex..com",
+                "-a@ex.com",
+                "admin@localhost",
+                "a@b",
+                "a@"
+            })
+    void everythingAcceptedCanBecomeAnAccount(String value) {
+        if (EmailAddresses.isValidAccountAddress(value)) {
+            assertTrue(UsernameRules.isValid(value.trim()));
+        }
+    }
+
+    @Test
+    void refusesSingleLabelMailDomainsEvenThoughAnAccountCouldHoldThem() {
+        assertTrue(UsernameRules.isValid("admin@localhost"));
+        assertFalse(EmailAddresses.isValidAccountAddress("admin@localhost"));
     }
 }

--- a/app/proprietary/src/test/java/stirling/software/proprietary/security/util/EmailAddressesTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/security/util/EmailAddressesTest.java
@@ -1,0 +1,28 @@
+package stirling.software.proprietary.security.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EmailAddressesTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a@", "@example.com", "a@b", "a@b.c", "no-at-sign", "a b@ex.com", ""})
+    void rejectsAddressesThatCouldNotBeDelivered(String value) {
+        assertFalse(EmailAddresses.isValid(value));
+    }
+
+    @Test
+    void rejectsNull() {
+        assertFalse(EmailAddresses.isValid(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a@b.co", "first.last+tag@sub.example.co.uk", "  a@b.com  "})
+    void acceptsAddressesWithARealDomain(String value) {
+        assertTrue(EmailAddresses.isValid(value));
+    }
+}


### PR DESCRIPTION
# Description of Changes

Fixes **F10** from the invite-flow audit: invalid inputs produced invitations that only failed when someone tried to use them.

- `POST /api/v1/invite/generate` accepted the malformed address `a@` (it only tested for an `@`) and a `teamId` of `999999` (it looked the team up, ignored the miss, and stored the id anyway). Both answered 200. Redeeming either link then answered 500 "Failed to create account", because `saveUserCore` rejects the username or the team at that point. The invitee sees the failure; the administrator never does.
- New `EmailAddresses.isValidAccountAddress` is the one rule: a structural shape requiring a domain with a real TLD, plus the shared `UsernameRules` check `saveUserCore` itself enforces, so a gate cannot promise an account the writer will refuse (`o'brien@example.com` has the shape and is now refused). It replaces the `contains("@")` test on link generation and on the general-link acceptance path, and the `contains("@") && contains(".")` test on the ordinary email invite. `FileStorageService` drops its own copy of the shape check for the shared `hasDeliverableShape`.
- An unknown `teamId` now answers 400 "Team not found" instead of being stored.
- Also from F10's evidence: `POST /api/v1/team/{create,rename}` accepted a whitespace-only name, which the UI already refuses. Both now answer 400 and store the name trimmed.

**Verified against a live instance:** `a@` and `teamId=999999` are both refused with a field-specific 400 and no token is written; a whitespace-only team name is refused.

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Testing (if applicable)

- [x] `EmailAddressesTest` covers the rejected and accepted shapes
- [x] `InviteLinkControllerMoreTest` covers the malformed address and unknown team on generate, and the malformed address on accept
- [x] New `TeamControllerNameTest` covers blank names and trimming on create and rename
- [x] `./gradlew :proprietary:test --tests "*InviteLink*" --tests "*TeamController*" --tests "*EmailAddresses*" --tests "*UserController*"` passes
- [x] Live check against a running backend, as above



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent validation for email addresses and usernames across invitations, accounts, and file storage.
  * Team creation and renaming now trim names and reject blank values.
  * Unknown teams selected for invitations now return a clear error.

* **Bug Fixes**
  * Improved handling of malformed or invalid invitation email addresses.
  * Prevented reserved usernames and invalid account addresses from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->