### PR TITLE
Load the session graph for participant-facing signing endpoints

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/workflow/controller/WorkflowParticipantController.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/workflow/controller/WorkflowParticipantController.java
@@ -82,7 +82,7 @@ public class WorkflowParticipantController {
 
         WorkflowParticipant participant =
                 participantRepository
-                        .findByShareToken(token)
+                        .findByShareTokenWithSession(token)
                         .orElseThrow(
                                 () ->
                                         new ResponseStatusException(
@@ -148,7 +148,7 @@ public class WorkflowParticipantController {
 
         WorkflowParticipant participant =
                 participantRepository
-                        .findByShareToken(request.getParticipantToken())
+                        .findByShareTokenWithSession(request.getParticipantToken())
                         .orElseThrow(
                                 () ->
                                         new ResponseStatusException(
@@ -165,7 +165,9 @@ public class WorkflowParticipantController {
                     HttpStatus.BAD_REQUEST, "Participant has already completed their action");
         }
 
-        if (!participant.getWorkflowSession().isActive()) {
+        // Held across the save below: save() returns a fresh instance whose session is detached.
+        WorkflowSession session = participant.getWorkflowSession();
+        if (!session.isActive()) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST, "Workflow session is no longer active");
         }
@@ -182,7 +184,7 @@ public class WorkflowParticipantController {
             log.info(
                     "Participant {} submitted signature for session {}",
                     participant.getEmail(),
-                    participant.getWorkflowSession().getSessionId());
+                    session.getSessionId());
 
             return ResponseEntity.ok(WorkflowMapper.toParticipantResponse(participant, false));
 
@@ -207,7 +209,7 @@ public class WorkflowParticipantController {
 
         WorkflowParticipant participant =
                 participantRepository
-                        .findByShareToken(token)
+                        .findByShareTokenWithSession(token)
                         .orElseThrow(
                                 () ->
                                         new ResponseStatusException(
@@ -218,6 +220,9 @@ public class WorkflowParticipantController {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST, "Participant has already completed their action");
         }
+
+        // Held across the save below: save() returns a fresh instance whose session is detached.
+        WorkflowSession session = participant.getWorkflowSession();
 
         // Update status to DECLINED
         participant.setStatus(ParticipantStatus.DECLINED);
@@ -236,7 +241,7 @@ public class WorkflowParticipantController {
         log.info(
                 "Participant {} declined workflow session {}",
                 participant.getEmail(),
-                participant.getWorkflowSession().getSessionId());
+                session.getSessionId());
 
         return ResponseEntity.ok(WorkflowMapper.toParticipantResponse(participant, false));
     }
@@ -251,7 +256,7 @@ public class WorkflowParticipantController {
 
         WorkflowParticipant participant =
                 participantRepository
-                        .findByShareToken(token)
+                        .findByShareTokenWithSession(token)
                         .orElseThrow(
                                 () ->
                                         new ResponseStatusException(

--- a/app/proprietary/src/main/java/stirling/software/proprietary/workflow/repository/WorkflowParticipantRepository.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/workflow/repository/WorkflowParticipantRepository.java
@@ -21,6 +21,17 @@ public interface WorkflowParticipantRepository extends JpaRepository<WorkflowPar
     /** Find participant by share token */
     Optional<WorkflowParticipant> findByShareToken(String shareToken);
 
+    /**
+     * Find participant by share token with its session, the session owner and the peer participants
+     * eagerly loaded. Participant endpoints read all three after the loading transaction has ended.
+     */
+    @Query(
+            "SELECT p FROM WorkflowParticipant p LEFT JOIN FETCH p.workflowSession ws LEFT JOIN"
+                    + " FETCH ws.owner LEFT JOIN FETCH ws.participants WHERE p.shareToken ="
+                    + " :shareToken")
+    Optional<WorkflowParticipant> findByShareTokenWithSession(
+            @Param("shareToken") String shareToken);
+
     /** Find all participants in a workflow session */
     List<WorkflowParticipant> findByWorkflowSession(WorkflowSession session);
 

--- a/app/proprietary/src/test/java/stirling/software/proprietary/workflow/controller/WorkflowParticipantControllerMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/workflow/controller/WorkflowParticipantControllerMoreTest.java
@@ -93,7 +93,8 @@ class WorkflowParticipantControllerMoreTest {
 
         @Test
         void invalidToken_throwsForbidden() {
-            when(participantRepository.findByShareToken("bad")).thenReturn(Optional.empty());
+            when(participantRepository.findByShareTokenWithSession("bad"))
+                    .thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> controller.getSessionByToken("bad"))
                     .isInstanceOf(ResponseStatusException.class)
@@ -104,7 +105,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void pendingParticipant_marksViewedAndReturnsSession() {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
 
             ResponseEntity<WorkflowSessionResponse> response = controller.getSessionByToken(TOKEN);
 
@@ -116,7 +118,8 @@ class WorkflowParticipantControllerMoreTest {
         void expiredParticipant_throwsForbidden() {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
             p.setExpiresAt(java.time.LocalDateTime.now().minusDays(1));
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
 
             assertThatThrownBy(() -> controller.getSessionByToken(TOKEN))
                     .isInstanceOf(ResponseStatusException.class)
@@ -127,7 +130,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void signedParticipant_doesNotUpdateStatus() {
             WorkflowParticipant p = participant(ParticipantStatus.SIGNED);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
 
             controller.getSessionByToken(TOKEN);
 
@@ -193,7 +197,8 @@ class WorkflowParticipantControllerMoreTest {
 
         @Test
         void invalidToken_throwsForbidden() {
-            when(participantRepository.findByShareToken("bad")).thenReturn(Optional.empty());
+            when(participantRepository.findByShareTokenWithSession("bad"))
+                    .thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> controller.submitSignature(request("bad")))
                     .isInstanceOf(ResponseStatusException.class)
@@ -204,7 +209,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void alreadyCompleted_throwsBadRequest() {
             WorkflowParticipant p = participant(ParticipantStatus.SIGNED);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
 
             assertThatThrownBy(() -> controller.submitSignature(request(TOKEN)))
                     .isInstanceOf(ResponseStatusException.class)
@@ -216,7 +222,8 @@ class WorkflowParticipantControllerMoreTest {
         void inactiveSession_throwsBadRequest() {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
             p.getWorkflowSession().setFinalized(true); // isActive() false
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
 
             assertThatThrownBy(() -> controller.submitSignature(request(TOKEN)))
                     .isInstanceOf(ResponseStatusException.class)
@@ -227,7 +234,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void serverCert_savesParticipantSigned() {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
             when(metadataEncryptionService.encrypt(org.mockito.ArgumentMatchers.any()))
                     .thenReturn("enc");
             when(participantRepository.save(org.mockito.ArgumentMatchers.any()))
@@ -251,7 +259,8 @@ class WorkflowParticipantControllerMoreTest {
 
         @Test
         void invalidToken_throwsForbidden() {
-            when(participantRepository.findByShareToken("bad")).thenReturn(Optional.empty());
+            when(participantRepository.findByShareTokenWithSession("bad"))
+                    .thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> controller.declineParticipation("bad", null))
                     .isInstanceOf(ResponseStatusException.class)
@@ -262,7 +271,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void alreadyCompleted_throwsBadRequest() {
             WorkflowParticipant p = participant(ParticipantStatus.DECLINED);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
 
             assertThatThrownBy(() -> controller.declineParticipation(TOKEN, null))
                     .isInstanceOf(ResponseStatusException.class)
@@ -273,7 +283,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void withReason_setsDeclinedAndNotifies() {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
             when(participantRepository.save(org.mockito.ArgumentMatchers.any()))
                     .thenAnswer(i -> i.getArgument(0));
 
@@ -288,7 +299,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void withoutReason_usesDefaultNotification() {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
             when(participantRepository.save(org.mockito.ArgumentMatchers.any()))
                     .thenAnswer(i -> i.getArgument(0));
 
@@ -308,7 +320,8 @@ class WorkflowParticipantControllerMoreTest {
 
         @Test
         void invalidToken_throwsForbidden() {
-            when(participantRepository.findByShareToken("bad")).thenReturn(Optional.empty());
+            when(participantRepository.findByShareTokenWithSession("bad"))
+                    .thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> controller.getDocument("bad"))
                     .isInstanceOf(ResponseStatusException.class)
@@ -320,7 +333,8 @@ class WorkflowParticipantControllerMoreTest {
         void expiredParticipant_throwsForbidden() {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
             p.setExpiresAt(java.time.LocalDateTime.now().minusDays(1));
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
 
             assertThatThrownBy(() -> controller.getDocument(TOKEN))
                     .isInstanceOf(ResponseStatusException.class)
@@ -331,7 +345,8 @@ class WorkflowParticipantControllerMoreTest {
         @Test
         void validParticipant_returnsPdf() throws Exception {
             WorkflowParticipant p = participant(ParticipantStatus.PENDING);
-            when(participantRepository.findByShareToken(TOKEN)).thenReturn(Optional.of(p));
+            when(participantRepository.findByShareTokenWithSession(TOKEN))
+                    .thenReturn(Optional.of(p));
             when(workflowSessionService.getOriginalFile("s1")).thenReturn(new byte[] {1, 2, 3});
 
             ResponseEntity<byte[]> response = controller.getDocument(TOKEN);

--- a/app/proprietary/src/test/java/stirling/software/proprietary/workflow/repository/WorkflowParticipantLazySessionDbTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/workflow/repository/WorkflowParticipantLazySessionDbTest.java
@@ -1,0 +1,126 @@
+package stirling.software.proprietary.workflow.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+
+import org.hibernate.LazyInitializationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import stirling.software.proprietary.security.database.repository.UserRepository;
+import stirling.software.proprietary.security.model.User;
+import stirling.software.proprietary.storage.model.ShareAccessRole;
+import stirling.software.proprietary.storage.model.StoredFile;
+import stirling.software.proprietary.storage.repository.StoredFileRepository;
+import stirling.software.proprietary.workflow.dto.WorkflowSessionResponse;
+import stirling.software.proprietary.workflow.model.WorkflowParticipant;
+import stirling.software.proprietary.workflow.model.WorkflowSession;
+import stirling.software.proprietary.workflow.model.WorkflowType;
+import stirling.software.proprietary.workflow.util.WorkflowMapper;
+
+/**
+ * Participant endpoints map the session after the loader's transaction has ended, so the finder has
+ * to bring the session graph back with it.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// H2 has no jsonb type; the domain lets the workflow entities build their schema here.
+@TestPropertySource(
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:workflowlazy;DB_CLOSE_DELAY=-1;INIT=CREATE DOMAIN IF"
+                    + " NOT EXISTS JSONB AS JSON",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password="
+        })
+class WorkflowParticipantLazySessionDbTest {
+
+    @Autowired private WorkflowParticipantRepository participantRepository;
+    @Autowired private WorkflowSessionRepository sessionRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private StoredFileRepository storedFileRepository;
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void plainFinderLeavesTheSessionUnreachable() {
+        String token = seedSession();
+
+        WorkflowParticipant participant =
+                participantRepository.findByShareToken(token).orElseThrow();
+
+        assertThrows(
+                LazyInitializationException.class,
+                () -> participant.getWorkflowSession().isActive());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void fetchJoinedFinderMapsTheSessionOutsideATransaction() {
+        String token = seedSession();
+
+        WorkflowParticipant participant =
+                participantRepository.findByShareTokenWithSession(token).orElseThrow();
+        WorkflowSessionResponse response =
+                WorkflowMapper.toResponse(participant.getWorkflowSession(), null, false);
+
+        assertEquals("owner-" + token, response.getOwnerUsername());
+        assertEquals(1, response.getParticipantCount());
+    }
+
+    /** Persists an owner, a stored file, a session and one participant. Returns the share token. */
+    private String seedSession() {
+        String token = UUID.randomUUID().toString();
+
+        User owner = new User();
+        owner.setUsername("owner-" + token);
+        owner.setPassword("x");
+        owner = userRepository.save(owner);
+
+        StoredFile file = new StoredFile();
+        file.setOwner(owner);
+        file.setOriginalFilename("doc.pdf");
+        file.setStorageKey("key-" + token);
+        file = storedFileRepository.save(file);
+
+        WorkflowSession session = new WorkflowSession();
+        session.setOwner(owner);
+        session.setWorkflowType(WorkflowType.SIGNING);
+        session.setDocumentName("doc.pdf");
+        session.setOriginalFile(file);
+
+        WorkflowParticipant participant = new WorkflowParticipant();
+        participant.setEmail("participant@example.com");
+        participant.setShareToken(token);
+        participant.setAccessRole(ShareAccessRole.EDITOR);
+        session.addParticipant(participant);
+
+        sessionRepository.save(session);
+        return token;
+    }
+
+    @SpringBootConfiguration
+    @EntityScan(
+            basePackages = {
+                "stirling.software.proprietary.workflow.model",
+                "stirling.software.proprietary.storage.model",
+                "stirling.software.proprietary.security.model",
+                "stirling.software.proprietary.model"
+            })
+    @EnableJpaRepositories(
+            basePackages = {
+                "stirling.software.proprietary.workflow.repository",
+                "stirling.software.proprietary.storage.repository",
+                "stirling.software.proprietary.security.database.repository"
+            })
+    static class TestApp {}
+}


### PR DESCRIPTION
## What

Loads the workflow session, its owner and its participants alongside the participant when a share token is resolved, and holds that session across `save()` in the two endpoints that write.

## Why

Every participant-facing endpoint reads session state after the loading transaction has closed. `WorkflowParticipant.workflowSession` is `LAZY`, `open-in-view` is off and `WorkflowParticipantController` is not transactional anywhere, so the entity is detached by then:

- `/participant/session` maps the session, `owner.getUsername()` and the participants collection
- `/participant/submit-signature` checks `getWorkflowSession().isActive()` before writing
- `/participant/decline` and `/participant/document` read the session id and document name

All four throw `LazyInitializationException`. Same root cause as #7846, and the same reason it went unnoticed: before #6433 (Aug 13) `User` used Lombok's non-final `equals`, which a Hibernate proxy overrides, so any `equals` call on a lazy association quietly initialised it. The hand-written replacement is `final`, so ByteBuddy cannot intercept it, the `getId()` inside is served from the identifier without a load, and nothing warms these proxies any more.

`submit-signature` and `decline` need the extra care because `participantRepository.save()` returns a fresh merged instance whose session is detached again, so the session is captured before the write.

`/participant/details` and `/participant/validate-certificate` only read the participant's own columns and keep the plain finder.

## Testing

`task backend:check` passes.

New `WorkflowParticipantLazySessionDbTest` runs the real entities against H2 with no ambient transaction, which is what the controller does. It asserts the plain finder leaves the session unreachable (`LazyInitializationException`) and that the fetch-joined finder maps the full response outside a transaction. The workflow entities use `jsonb`, which H2 does not know, so the test declares it as a domain in the JDBC `INIT` clause.

Mocked controller tests never caught this: they stub the repository, so no proxy is ever created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for workflow participants retrieving sessions, submitting signatures, declining participation, and downloading documents.
  - Prevented session-related errors that could affect participant actions after a request is processed.
  - Ensured participant responses consistently include the relevant workflow session details, owner information, and participant data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->