### PR TITLE
feat(licensing): take Team capacity from SaaS, with the licence as fallback

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/AccountLinkClient.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/AccountLinkClient.java
@@ -343,6 +343,8 @@ public class AccountLinkClient {
         Long periodCap =
                 root.hasNonNull("periodCapUnits") ? root.get("periodCapUnits").asLong() : null;
         EntitlementState state = mapState(root.path("state").asText(null));
+        Integer licensedUsers =
+                root.hasNonNull("licensedUsers") ? root.get("licensedUsers").asInt() : null;
         return new InstanceEntitlement(
                 subscribed,
                 freeRemaining,
@@ -351,7 +353,8 @@ public class AccountLinkClient {
                 state,
                 parseUnitCalcPolicy(root),
                 parseDateTime(root, "periodStart"),
-                parseDateTime(root, "periodEnd"));
+                parseDateTime(root, "periodEnd"),
+                licensedUsers);
     }
 
     /** Parses the nested unit-calc policy; null if absent or any knob is invalid (e.g. zero). */

--- a/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/InstanceEntitlement.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/accountlink/InstanceEntitlement.java
@@ -31,7 +31,8 @@ public record InstanceEntitlement(
         EntitlementState state,
         UnitCalcPolicy unitCalcPolicy,
         LocalDateTime periodStart,
-        LocalDateTime periodEnd) {
+        LocalDateTime periodEnd,
+        Integer licensedUsers) {
 
     /** Gate-only view with no metering config — used by the revoked sentinel and gate tests. */
     public InstanceEntitlement(
@@ -46,6 +47,7 @@ public record InstanceEntitlement(
                 periodSpendUnits,
                 periodCapUnits,
                 state,
+                null,
                 null,
                 null,
                 null);

--- a/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.common.model.ApplicationProperties;
+import stirling.software.proprietary.accountlink.EntitlementCache;
+import stirling.software.proprietary.accountlink.InstanceEntitlement;
 import stirling.software.proprietary.model.UserLicenseSettings;
 import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVerifier.License;
 import stirling.software.proprietary.security.configuration.ee.LicenseKeyChecker;
@@ -50,6 +52,9 @@ public class UserLicenseSettingsService {
     private final UserService userService;
     private final ApplicationProperties applicationProperties;
     private final ObjectProvider<LicenseKeyChecker> licenseKeyChecker;
+
+    /** Absent unless this instance is linked to SaaS (account-link disabled by default). */
+    private final ObjectProvider<EntitlementCache> entitlementCache;
 
     /**
      * Gets the current user license settings, creating them if they don't exist.
@@ -309,6 +314,16 @@ public class UserLicenseSettingsService {
         validateSettingsIntegrity();
         UserLicenseSettings settings = getOrCreateSettings();
 
+        // A linked instance takes its capacity from SaaS, because that is where the Team plan is
+        // sold and the subscription is the authority. The licence below is the fallback, and it
+        // drains: it only still answers for instances that are unlinked, or whose SaaS states no
+        // number, so this cannot lower anyone's limit.
+        Integer fromSaas = linkedTeamAllowance();
+        if (fromSaas != null) {
+            log.debug("Linked team allowance: {} users (licence not consulted)", fromSaas);
+            return fromSaas;
+        }
+
         int grandfatheredLimit = settings.getGrandfatheredUserCount();
         if (grandfatheredLimit == 0) {
             // Fallback if not initialized yet - should not happen with validation
@@ -336,6 +351,26 @@ public class UserLicenseSettingsService {
                 licenseMaxUsers,
                 grandfatheredLimit);
         return licenseMaxUsers;
+    }
+
+    /**
+     * Users this instance's linked team is entitled to, or null when SaaS is not the authority
+     * here.
+     *
+     * <p>Null covers three cases that all correctly fall through to the licence: the instance is
+     * not linked, SaaS has never answered, or it answered with no user limit — which is also what
+     * an older SaaS sends, and is indistinguishable from it. Deliberately conservative: capacity
+     * only moves when SaaS states a number.
+     *
+     * <p>When SaaS is merely unreachable, {@link EntitlementCache} keeps serving the freshest
+     * snapshot it has, so a linked instance holds its last known allowance rather than losing it.
+     */
+    private Integer linkedTeamAllowance() {
+        EntitlementCache cache = entitlementCache.getIfAvailable();
+        if (cache == null) {
+            return null;
+        }
+        return cache.current().map(InstanceEntitlement::licensedUsers).orElse(null);
     }
 
     /**

--- a/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
@@ -314,16 +314,6 @@ public class UserLicenseSettingsService {
         validateSettingsIntegrity();
         UserLicenseSettings settings = getOrCreateSettings();
 
-        // A linked instance takes its capacity from SaaS, because that is where the Team plan is
-        // sold and the subscription is the authority. The licence below is the fallback, and it
-        // drains: it only still answers for instances that are unlinked, or whose SaaS states no
-        // number, so this cannot lower anyone's limit.
-        Integer fromSaas = linkedTeamAllowance();
-        if (fromSaas != null) {
-            log.debug("Linked team allowance: {} users (licence not consulted)", fromSaas);
-            return fromSaas;
-        }
-
         int grandfatheredLimit = settings.getGrandfatheredUserCount();
         if (grandfatheredLimit == 0) {
             // Fallback if not initialized yet - should not happen with validation
@@ -331,8 +321,16 @@ public class UserLicenseSettingsService {
             grandfatheredLimit = DEFAULT_USER_LIMIT;
         }
 
-        // No license: use grandfathered limit
+        // A valid licence answers first. Team is moving to being sold on SaaS with no licence at
+        // all, so in the end state only Enterprise holds one, and Enterprise should outrank SaaS:
+        // it is contracted and has to keep working offline. Until then a legacy licence keeps
+        // whatever it granted, and a customer worse off under it can simply remove it.
         if (!hasPaidLicense()) {
+            Integer fromSaas = linkedTeamAllowance();
+            if (fromSaas != null) {
+                log.debug("No licence; linked team allowance: {} users", fromSaas);
+                return fromSaas;
+            }
             log.debug("No license: using grandfathered limit of {}", grandfatheredLimit);
             return grandfatheredLimit;
         }
@@ -357,10 +355,9 @@ public class UserLicenseSettingsService {
      * Users this instance's linked team is entitled to, or null when SaaS is not the authority
      * here.
      *
-     * <p>Null covers three cases that all correctly fall through to the licence: the instance is
-     * not linked, SaaS has never answered, or it answered with no user limit — which is also what
-     * an older SaaS sends, and is indistinguishable from it. Deliberately conservative: capacity
-     * only moves when SaaS states a number.
+     * <p>Only consulted when no licence is installed. Null covers three indistinguishable cases
+     * that all fall through to the grandfathered limit: the instance is not linked, SaaS has never
+     * answered, or it answered with no user limit — which is also what an older SaaS sends.
      *
      * <p>When SaaS is merely unreachable, {@link EntitlementCache} keeps serving the freshest
      * snapshot it has, so a linked instance holds its last known allowance rather than losing it.

--- a/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/InstanceEntitlementInterceptorTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/InstanceEntitlementInterceptorTest.java
@@ -194,7 +194,7 @@ class InstanceEntitlementInterceptorTest {
 
     private static InstanceEntitlement entitled(UnitCalcPolicy policy, LocalDateTime period) {
         return new InstanceEntitlement(
-                true, 0, 0, 100L, EntitlementState.OK, policy, period, period.plusMonths(1));
+                true, 0, 0, 100L, EntitlementState.OK, policy, period, period.plusMonths(1), null);
     }
 
     private static byte[] fivePagePdf() throws Exception {

--- a/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/LocalUsageServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/accountlink/LocalUsageServiceTest.java
@@ -41,7 +41,8 @@ class LocalUsageServiceTest {
                 EntitlementState.OK,
                 null,
                 periodStart,
-                periodStart.plusMonths(1));
+                periodStart.plusMonths(1),
+                null);
     }
 
     @Test

--- a/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
@@ -85,9 +85,10 @@ class UserLicenseSettingsServiceMoreTest {
     }
 
     /**
-     * A linked instance takes its user capacity from SaaS, because that is where the Team plan is
-     * sold. The licence stays as the fallback, so capacity only moves when SaaS states a number --
-     * these pin that it cannot silently lower an existing limit.
+     * A valid licence answers first; SaaS answers when there is none. Team is moving to being sold
+     * with no licence at all, so in the end state only Enterprise holds one and it should outrank
+     * SaaS -- it is contracted and must work offline. These pin that order and the fallbacks
+     * beneath it.
      */
     @Nested
     class LinkedTeamAllowance {
@@ -104,17 +105,33 @@ class UserLicenseSettingsServiceMoreTest {
         }
 
         @Test
-        @DisplayName("SaaS states an allowance, so the licence is not consulted")
-        void saasAllowanceWins() {
+        @DisplayName("no licence: SaaS states the allowance")
+        void saasAnswersWithoutALicence() {
             lockedSettings(7);
             cacheReturns(withAllowance(300));
 
             assertThat(service.calculateMaxAllowedUsers()).isEqualTo(300);
         }
 
+        /**
+         * The precedence decision. A legacy unlimited Server licence keeps what it granted rather
+         * than being silently reduced to the subscription's number; a customer worse off under it
+         * removes the licence.
+         */
         @Test
-        @DisplayName("not linked: the licence still answers")
-        void unlinkedFallsBackToLicence() {
+        @DisplayName("a valid licence outranks the SaaS allowance")
+        void licenceOutranksSaas() {
+            lockedSettings(7);
+            when(licenseKeyChecker.getPremiumLicenseEnabledResult()).thenReturn(License.SERVER);
+            cacheReturns(withAllowance(100));
+
+            // A SERVER licence with licenseMaxUsers = 0 is unlimited; it is not lowered to 100.
+            assertThat(service.calculateMaxAllowedUsers()).isEqualTo(Integer.MAX_VALUE);
+        }
+
+        @Test
+        @DisplayName("not linked: the grandfathered limit answers")
+        void unlinkedFallsBackToGrandfathered() {
             lockedSettings(7);
             when(entitlementCacheProvider.getIfAvailable()).thenReturn(null);
 
@@ -122,8 +139,8 @@ class UserLicenseSettingsServiceMoreTest {
         }
 
         @Test
-        @DisplayName("linked but SaaS has never answered: the licence still answers")
-        void neverFetchedFallsBackToLicence() {
+        @DisplayName("linked but SaaS has never answered: the grandfathered limit answers")
+        void neverFetchedFallsBackToGrandfathered() {
             lockedSettings(7);
             cacheReturns(null);
 
@@ -135,8 +152,8 @@ class UserLicenseSettingsServiceMoreTest {
          * are indistinguishable — so it must fall through rather than cap the instance.
          */
         @Test
-        @DisplayName("SaaS states no limit: the licence still answers")
-        void noLimitFallsBackToLicence() {
+        @DisplayName("SaaS states no limit: the grandfathered limit answers")
+        void noLimitFallsBackToGrandfathered() {
             lockedSettings(7);
             cacheReturns(withAllowance(null));
 

--- a/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
@@ -21,6 +21,9 @@ import org.mockito.quality.Strictness;
 import org.springframework.beans.factory.ObjectProvider;
 
 import stirling.software.common.model.ApplicationProperties;
+import stirling.software.proprietary.accountlink.EntitlementCache;
+import stirling.software.proprietary.accountlink.EntitlementState;
+import stirling.software.proprietary.accountlink.InstanceEntitlement;
 import stirling.software.proprietary.model.UserLicenseSettings;
 import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVerifier.License;
 import stirling.software.proprietary.security.configuration.ee.LicenseKeyChecker;
@@ -40,6 +43,7 @@ class UserLicenseSettingsServiceMoreTest {
     @Mock private UserService userService;
     @Mock private LicenseKeyChecker licenseKeyChecker;
     @Mock private ObjectProvider<LicenseKeyChecker> licenseKeyCheckerProvider;
+    @Mock private ObjectProvider<EntitlementCache> entitlementCacheProvider;
 
     private ApplicationProperties applicationProperties;
     private UserLicenseSettingsService service;
@@ -60,7 +64,8 @@ class UserLicenseSettingsServiceMoreTest {
                         settingsRepository,
                         userService,
                         applicationProperties,
-                        licenseKeyCheckerProvider);
+                        licenseKeyCheckerProvider,
+                        entitlementCacheProvider);
     }
 
     // Saves a freshly initialized + locked settings row with a valid signature.
@@ -77,6 +82,66 @@ class UserLicenseSettingsServiceMoreTest {
         when(userService.getTotalUsersCount()).thenReturn((long) count);
         service.validateSettingsIntegrity();
         return s;
+    }
+
+    /**
+     * A linked instance takes its user capacity from SaaS, because that is where the Team plan is
+     * sold. The licence stays as the fallback, so capacity only moves when SaaS states a number --
+     * these pin that it cannot silently lower an existing limit.
+     */
+    @Nested
+    class LinkedTeamAllowance {
+
+        private void cacheReturns(InstanceEntitlement entitlement) {
+            EntitlementCache cache = org.mockito.Mockito.mock(EntitlementCache.class);
+            when(cache.current()).thenReturn(Optional.ofNullable(entitlement));
+            when(entitlementCacheProvider.getIfAvailable()).thenReturn(cache);
+        }
+
+        private InstanceEntitlement withAllowance(Integer licensedUsers) {
+            return new InstanceEntitlement(
+                    true, 0, 0, null, EntitlementState.OK, null, null, null, licensedUsers);
+        }
+
+        @Test
+        @DisplayName("SaaS states an allowance, so the licence is not consulted")
+        void saasAllowanceWins() {
+            lockedSettings(7);
+            cacheReturns(withAllowance(300));
+
+            assertThat(service.calculateMaxAllowedUsers()).isEqualTo(300);
+        }
+
+        @Test
+        @DisplayName("not linked: the licence still answers")
+        void unlinkedFallsBackToLicence() {
+            lockedSettings(7);
+            when(entitlementCacheProvider.getIfAvailable()).thenReturn(null);
+
+            assertThat(service.calculateMaxAllowedUsers()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("linked but SaaS has never answered: the licence still answers")
+        void neverFetchedFallsBackToLicence() {
+            lockedSettings(7);
+            cacheReturns(null);
+
+            assertThat(service.calculateMaxAllowedUsers()).isEqualTo(7);
+        }
+
+        /**
+         * Null is also what an older SaaS sends and what "no user limit" looks like, and the two
+         * are indistinguishable — so it must fall through rather than cap the instance.
+         */
+        @Test
+        @DisplayName("SaaS states no limit: the licence still answers")
+        void noLimitFallsBackToLicence() {
+            lockedSettings(7);
+            cacheReturns(withAllowance(null));
+
+            assertThat(service.calculateMaxAllowedUsers()).isEqualTo(7);
+        }
     }
 
     @Nested

--- a/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.beans.factory.ObjectProvider;
 
 import stirling.software.common.model.ApplicationProperties;
+import stirling.software.proprietary.accountlink.EntitlementCache;
 import stirling.software.proprietary.model.UserLicenseSettings;
 import stirling.software.proprietary.security.configuration.ee.KeygenLicenseVerifier.License;
 import stirling.software.proprietary.security.configuration.ee.LicenseKeyChecker;
@@ -36,6 +37,7 @@ class UserLicenseSettingsServiceTest {
     @Mock private ApplicationProperties.AutomaticallyGenerated automaticallyGenerated;
     @Mock private LicenseKeyChecker licenseKeyChecker;
     @Mock private ObjectProvider<LicenseKeyChecker> licenseKeyCheckerProvider;
+    @Mock private ObjectProvider<EntitlementCache> entitlementCacheProvider;
 
     private UserLicenseSettingsService service;
     private UserLicenseSettings mockSettings;
@@ -66,7 +68,8 @@ class UserLicenseSettingsServiceTest {
                         settingsRepository,
                         userService,
                         applicationProperties,
-                        licenseKeyCheckerProvider) {
+                        licenseKeyCheckerProvider,
+                        entitlementCacheProvider) {
                     @Override
                     public void validateSettingsIntegrity() {
                         // Override to do nothing in tests - avoid HMAC signature validation

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/InstanceController.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/InstanceController.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.proprietary.billing.UnitCalcPolicy;
+import stirling.software.saas.model.SaasTeamExtensions;
 import stirling.software.saas.payg.billing.TeamBillingContext;
 import stirling.software.saas.payg.billing.TeamBillingService;
 import stirling.software.saas.payg.entitlement.EntitlementService;
@@ -30,6 +31,7 @@ import stirling.software.saas.payg.model.BillingCategory;
 import stirling.software.saas.payg.model.EntitlementState;
 import stirling.software.saas.payg.policy.PricingPolicy;
 import stirling.software.saas.payg.policy.PricingPolicyService;
+import stirling.software.saas.repository.SaasTeamExtensionsRepository;
 
 /**
  * Instance-facing surface (combined billing), authenticated by the <b>device credential</b> — not a
@@ -58,6 +60,7 @@ public class InstanceController {
     private final PricingPolicyService pricingPolicyService;
     private final InstanceUsageIngestService usageIngestService;
     private final LinkedInstanceRepository linkedInstanceRepository;
+    private final SaasTeamExtensionsRepository teamExtensionsRepository;
 
     public InstanceController(
             EntitlementService entitlementService,
@@ -65,12 +68,14 @@ public class InstanceController {
             AccountLinkService accountLinkService,
             PricingPolicyService pricingPolicyService,
             InstanceUsageIngestService usageIngestService,
-            LinkedInstanceRepository linkedInstanceRepository) {
+            LinkedInstanceRepository linkedInstanceRepository,
+            SaasTeamExtensionsRepository teamExtensionsRepository) {
         this.entitlementService = entitlementService;
         this.billingService = billingService;
         this.accountLinkService = accountLinkService;
         this.pricingPolicyService = pricingPolicyService;
         this.usageIngestService = usageIngestService;
+        this.teamExtensionsRepository = teamExtensionsRepository;
         this.linkedInstanceRepository = linkedInstanceRepository;
     }
 
@@ -87,6 +92,11 @@ public class InstanceController {
             long periodSpendUnits,
             Long periodCapUnits,
             String state,
+            // Users the team's Team plan covers, so the instance enforces the capacity the customer
+            // bought rather than reading it from a licence. Null = no user limit, which is both a
+            // team with no Team plan today and the historic unlimited licence; a limit is never
+            // expressed as a sentinel, so no caller can do arithmetic on Integer.MAX_VALUE.
+            Integer licensedUsers,
             // Metering inputs the instance needs to cost + bucket its own usage (Phase 2). The
             // instance computes units locally with this policy and resets its per-period cumulative
             // counters on the [periodStart, periodEnd) boundary.
@@ -210,6 +220,7 @@ public class InstanceController {
                 snap.periodSpendUnits(),
                 snap.periodCapUnits(),
                 coarseState(snap.state()),
+                licensedUsers(teamId),
                 new UnitCalcPolicy(
                         policy.getDocPagesPerUnit(),
                         policy.getDocBytesPerUnit(),
@@ -217,6 +228,22 @@ public class InstanceController {
                         policy.getFileUnitCap()),
                 snap.periodStart(),
                 snap.periodEnd());
+    }
+
+    /**
+     * Users the team's Team plan covers, or null when it has no user limit.
+     *
+     * <p>Read from the seat cap the subscription writes, so the instance and the cloud team enforce
+     * one number. {@code Integer.MAX_VALUE} is the historic "unlimited" sentinel and becomes null
+     * here: the wire contract expresses no-limit as absence, so nothing downstream can accidentally
+     * do arithmetic on it.
+     */
+    private Integer licensedUsers(Long teamId) {
+        return teamExtensionsRepository
+                .findByTeamId(teamId)
+                .map(SaasTeamExtensions::getMaxSeats)
+                .filter(max -> max != null && max > 0 && max < Integer.MAX_VALUE)
+                .orElse(null);
     }
 
     /**

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/InstanceControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/InstanceControllerTest.java
@@ -36,6 +36,7 @@ import stirling.software.saas.payg.model.FeatureGate;
 import stirling.software.saas.payg.model.FeatureSet;
 import stirling.software.saas.payg.policy.PricingPolicy;
 import stirling.software.saas.payg.policy.PricingPolicyService;
+import stirling.software.saas.repository.SaasTeamExtensionsRepository;
 
 /**
  * Pure-Mockito unit tests for {@link InstanceController} — the device-credential entitlement read.
@@ -51,6 +52,7 @@ class InstanceControllerTest {
     @Mock private PricingPolicyService pricingPolicyService;
     @Mock private InstanceUsageIngestService usageIngestService;
     @Mock private LinkedInstanceRepository linkedInstanceRepository;
+    @Mock private SaasTeamExtensionsRepository teamExtensionsRepository;
 
     private InstanceController controller() {
         return new InstanceController(
@@ -59,7 +61,8 @@ class InstanceControllerTest {
                 accountLinkService,
                 pricingPolicyService,
                 usageIngestService,
-                linkedInstanceRepository);
+                linkedInstanceRepository,
+                teamExtensionsRepository);
     }
 
     private static PricingPolicy policy() {


### PR DESCRIPTION
> Pairs with [**SaaS#329**](https://github.com/Stirling-Tools/Stirling-PDF-SaaS/pull/329), which resolves the allowance from the subscription and writes it to the team's seat cap. This is the half that serves and consumes it.

## Current state

Team is sold as one product to both editions, so the **subscription** should be the authority on how many users a team may have — not a licence. A linked instance already trusts SaaS this way for **Processor**: it fetches `/api/v1/instance/entitlement` over the device credential, a local gate enforces the result, and `EntitlementCache` keeps serving the freshest snapshot when SaaS is unreachable.

User capacity was the one thing still read from a licence. That is why the same purchase could entitle a cloud team *and* a self-hosted instance independently.

## Solution

**SaaS serves the allowance** on that same endpoint, sourced from the seat cap the subscription writes, so the instance and the cloud team enforce one number. `Integer.MAX_VALUE` — the historic "unlimited" sentinel — becomes `null` on the wire: no-limit is expressed as *absence*, so nothing downstream can accidentally do arithmetic on a sentinel.

**`calculateMaxAllowedUsers()` consults it.** That method is the single chokepoint for "how many users may this instance have", so **all nine callers redirect without being touched** (`ProprietaryUIDataController`, `InviteLinkController` ×2, `UserController` ×3, `UserService`, and two internal uses).

## Precedence: a valid licence wins

The order is **valid licence → SaaS allowance → grandfathered limit**.

This is not only transitional. In the end state a Team customer has *no* licence, so SaaS answers by default, and only Enterprise still holds one — which *should* outrank SaaS, because it is contracted and has to keep working offline.

Meanwhile a legacy unlimited Server licence keeps what it granted rather than being silently reduced to a subscription number the customer never asked to be capped by. A customer who is worse off under their old licence removes it; that population is small enough to handle by guidance.

**There is no migration event.** The licence path simply drains: as licences lapse it stops being reached and can then be deleted, which satisfies "support existing licences until they all renew" without a flag day.

When SaaS is merely *unreachable*, `EntitlementCache` already serves the last known snapshot — so a linked instance holds its last known allowance rather than losing it. That is the right failure mode for capacity, and it needed no change.

## Not in this PR

- **Cloud enforcement** is still short-circuited for standard teams. Turning it on needs grandfathering — the free allowance is **5**, so it cannot be a silent flip.
- Linking is still opt-in (`stirling.billing.account-link.enabled`). Making it expected for Team/Processor self-hosted is the packaging change that makes this the primary path rather than the fallback.

## Scope

Additive. No schema change. One new nullable field on the entitlement contract, absent-tolerant on both sides.
