### PR TITLE
Fix all remaining `any` type usages in frontend code

### DIFF
--- a/frontend/editor/src/core/components/shared/config/configSections/ProviderCard.tsx
+++ b/frontend/editor/src/core/components/shared/config/configSections/ProviderCard.tsx
@@ -24,10 +24,10 @@ import {
 interface ProviderCardProps {
   provider: Provider;
   isConfigured: boolean;
-  settings?: Record<string, any>;
-  onSave?: (settings: Record<string, any>) => void;
+  settings?: Record<string, unknown>;
+  onSave?: (settings: Record<string, unknown>) => void;
   onDisconnect?: () => void;
-  onChange?: (settings: Record<string, any>) => void;
+  onChange?: (settings: Record<string, unknown>) => void;
   disabled?: boolean;
   readOnly?: boolean;
 }
@@ -36,7 +36,10 @@ interface ProviderCardProps {
 // renders. An inline `settings = {}` would allocate a new object every render,
 // and the sync effect below lists `settings` as a dependency — so it would
 // re-run and setState on every render, looping until React bails out.
-const NO_SETTINGS: Record<string, any> = {};
+const NO_SETTINGS: Record<string, unknown> = {};
+
+const asString = (value: unknown): string =>
+  typeof value === "string" ? value : "";
 
 export default function ProviderCard({
   provider,
@@ -51,7 +54,7 @@ export default function ProviderCard({
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const [localSettings, setLocalSettings] =
-    useState<Record<string, any>>(settings);
+    useState<Record<string, unknown>>(settings);
 
   // Keep local settings in sync with incoming settings (values loaded from settings.yml)
   // Update whenever parent settings change, whether expanded or not (important for Discard to work)
@@ -64,7 +67,7 @@ export default function ProviderCard({
     if (!isConfigured && !expanded) {
       // First time opening an unconfigured provider - initialize with defaults
       // while preserving any values already present (from settings.yml)
-      const defaultSettings: Record<string, any> = { ...settings };
+      const defaultSettings: Record<string, unknown> = { ...settings };
       provider.fields.forEach((field) => {
         if (field.defaultValue !== undefined) {
           defaultSettings[field.key] =
@@ -76,7 +79,7 @@ export default function ProviderCard({
     setExpanded(!expanded);
   };
 
-  const handleFieldChange = (key: string, value: any) => {
+  const handleFieldChange = (key: string, value: unknown) => {
     if (disabled) return; // Block changes when disabled
     const updated = { ...localSettings, [key]: value };
     setLocalSettings(updated);
@@ -94,7 +97,7 @@ export default function ProviderCard({
   };
 
   const renderField = (field: ProviderField) => {
-    const value = localSettings[field.key] ?? field.defaultValue ?? "";
+    const raw = localSettings[field.key] ?? field.defaultValue;
 
     switch (field.type) {
       case "switch":
@@ -116,7 +119,7 @@ export default function ProviderCard({
               </Text>
             </div>
             <Switch
-              checked={value || false}
+              checked={Boolean(raw)}
               onChange={(e) => handleFieldChange(field.key, e.target.checked)}
               disabled={disabled}
             />
@@ -130,7 +133,7 @@ export default function ProviderCard({
             label={field.label}
             description={field.description}
             placeholder={field.placeholder}
-            value={value}
+            value={asString(raw)}
             onChange={(newValue) => handleFieldChange(field.key, newValue)}
             disabled={disabled}
           />
@@ -143,7 +146,7 @@ export default function ProviderCard({
             label={field.label}
             description={field.description}
             placeholder={field.placeholder}
-            value={value}
+            value={asString(raw)}
             onChange={(e) => handleFieldChange(field.key, e.target.value)}
             disabled={disabled}
           />
@@ -156,7 +159,9 @@ export default function ProviderCard({
             label={field.label}
             description={field.description}
             placeholder={field.placeholder}
-            value={value}
+            value={
+              typeof raw === "number" || typeof raw === "string" ? raw : ""
+            }
             onChange={(num) => handleFieldChange(field.key, num)}
             disabled={disabled}
             allowDecimal={false}
@@ -164,9 +169,7 @@ export default function ProviderCard({
         );
 
       case "tags": {
-        const tagValue = Array.isArray(value)
-          ? value.map((val) => `${val}`)
-          : [];
+        const tagValue = Array.isArray(raw) ? raw.map((val) => `${val}`) : [];
 
         return (
           <TagsInput
@@ -188,7 +191,7 @@ export default function ProviderCard({
             label={field.label}
             description={field.description}
             placeholder={field.placeholder}
-            value={value}
+            value={asString(raw)}
             onChange={(e) => handleFieldChange(field.key, e.target.value)}
             disabled={disabled}
           />

--- a/frontend/editor/src/core/components/tools/automate/AutomationSelection.tsx
+++ b/frontend/editor/src/core/components/tools/automate/AutomationSelection.tsx
@@ -8,6 +8,7 @@ import AutomationImportModal from "@app/components/tools/automate/AutomationImpo
 import { useSuggestedAutomations } from "@app/hooks/tools/automate/useSuggestedAutomations";
 import { AutomationConfig, SuggestedAutomation } from "@app/types/automation";
 import { iconMap } from "@app/components/tools/automate/iconMap";
+import { iconKeyForSuggestedAutomation } from "@app/components/tools/automate/suggestedAutomationIcon";
 import { ToolRegistry } from "@app/data/toolsTaxonomy";
 import {
   downloadAutomationConfig,
@@ -153,7 +154,15 @@ export default function AutomationSelection({
                 description={automation.description}
                 badgeIcon={automation.icon}
                 operations={automation.operations.map((op) => op.operation)}
-                onClick={() => onRun(automation)}
+                // Suggested automations carry a component icon for display; the
+                // run path is typed for saved configs, which store an icon by
+                // name, so convert it to keep the icon if the run is saved.
+                onClick={() =>
+                  onRun({
+                    ...automation,
+                    icon: iconKeyForSuggestedAutomation(automation.id),
+                  })
+                }
                 showMenu={true}
                 onCopy={() => onCopyFromSuggested(automation)}
                 toolRegistry={toolRegistry}

--- a/frontend/editor/src/core/components/tools/automate/suggestedAutomationIcon.ts
+++ b/frontend/editor/src/core/components/tools/automate/suggestedAutomationIcon.ts
@@ -1,0 +1,20 @@
+import { type IconKey } from "@app/components/tools/automate/iconMap";
+
+/**
+ * The saved-config icon key (an {@link iconMap} key) for a built-in suggested
+ * automation, chosen by its id. Suggested automations display a component icon,
+ * but a saved AutomationConfig stores an icon by name.
+ */
+export function iconKeyForSuggestedAutomation(id: string): IconKey {
+  switch (id) {
+    case "secure-pdf-ingestion":
+    case "secure-workflow":
+      return "SecurityIcon";
+    case "email-preparation":
+      return "CompressIcon";
+    case "process-images":
+      return "StarIcon";
+    default:
+      return "SettingsIcon";
+  }
+}

--- a/frontend/editor/src/core/components/viewer/EmbedPdfViewer.tsx
+++ b/frontend/editor/src/core/components/viewer/EmbedPdfViewer.tsx
@@ -1240,9 +1240,9 @@ const EmbedPdfViewerContent = ({
               enableFormFill={shouldEnableFormFill}
               formEditingActive={isFormFillToolActive}
               isManualRedactionMode={isManualRedactMode}
-              signatureApiRef={signatureApiRef as React.RefObject<any>}
-              annotationApiRef={annotationApiRef as React.RefObject<any>}
-              historyApiRef={historyApiRef as React.RefObject<any>}
+              signatureApiRef={signatureApiRef}
+              annotationApiRef={annotationApiRef}
+              historyApiRef={historyApiRef}
               redactionTrackerRef={
                 redactionTrackerRef as React.RefObject<RedactionPendingTrackerAPI>
               }

--- a/frontend/editor/src/core/components/viewer/HistoryAPIBridge.tsx
+++ b/frontend/editor/src/core/components/viewer/HistoryAPIBridge.tsx
@@ -3,7 +3,19 @@ import { useHistoryCapability } from "@embedpdf/plugin-history/react";
 import { useAnnotationCapability } from "@embedpdf/plugin-annotation/react";
 import { useSignature } from "@app/contexts/SignatureContext";
 import { uuidV4, PdfAnnotationSubtype } from "@embedpdf/models";
-import type { HistoryAPI } from "@app/components/viewer/viewerTypes";
+import type { PdfAnnotationObject } from "@embedpdf/models";
+import type {
+  HistoryAPI,
+  AnnotationEvent,
+} from "@app/components/viewer/viewerTypes";
+
+// Signature stamps carry an image data-URL under app-specific fields the
+// installed annotation types don't declare; `object` mirrors the selection
+// wrapper some plugin builds emit on the event.
+type SignatureAnnotation = PdfAnnotationObject & {
+  imageSrc?: string;
+  object?: { pageIndex?: number };
+};
 import {
   ANNOTATION_RECREATION_DELAY_MS,
   ANNOTATION_VERIFICATION_DELAY_MS,
@@ -26,8 +38,9 @@ export const HistoryAPIBridge = forwardRef<HistoryAPI>(
     useEffect(() => {
       if (!annotationApi || !documentReady) return;
 
-      const handleAnnotationEvent = (event: any) => {
-        const annotation = event.annotation;
+      const handleAnnotationEvent = (event: AnnotationEvent) => {
+        if (event.type === "loaded") return;
+        const annotation: SignatureAnnotation = event.annotation;
 
         // Store image data for all STAMP annotations immediately when created or modified
         if (
@@ -69,11 +82,7 @@ export const HistoryAPIBridge = forwardRef<HistoryAPI>(
               annotation.pageIndex ??
               annotation.object?.pageIndex ??
               0;
-            const rect =
-              annotation.rect ||
-              annotation.bounds ||
-              annotation.rectangle ||
-              annotation.position;
+            const rect = annotation.rect;
 
             try {
               annotationApi.deleteAnnotation(pageIndex, annotation.id);

--- a/frontend/editor/src/core/components/viewer/LocalEmbedPDF.tsx
+++ b/frontend/editor/src/core/components/viewer/LocalEmbedPDF.tsx
@@ -122,9 +122,9 @@ interface LocalEmbedPDFProps {
   isManualRedactionMode?: boolean;
   showBakedAnnotations?: boolean;
   onSignatureAdded?: (annotation: PdfAnnotationObject) => void;
-  signatureApiRef?: React.RefObject<SignatureAPI>;
-  annotationApiRef?: React.RefObject<AnnotationAPI>;
-  historyApiRef?: React.RefObject<HistoryAPI>;
+  signatureApiRef?: React.RefObject<SignatureAPI | null>;
+  annotationApiRef?: React.RefObject<AnnotationAPI | null>;
+  historyApiRef?: React.RefObject<HistoryAPI | null>;
   redactionTrackerRef?: React.RefObject<RedactionPendingTrackerAPI>;
   /** File identity passed through to FormFieldOverlay for stale-field guards */
   fileId?: string | null;

--- a/frontend/editor/src/core/components/viewer/RedactionSelectionMenu.stories.tsx
+++ b/frontend/editor/src/core/components/viewer/RedactionSelectionMenu.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { RedactionSelectionMenu } from "@app/components/viewer/RedactionSelectionMenu";
+import {
+  RedactionSelectionMenu,
+  type RedactionSelectionMenuProps,
+} from "@app/components/viewer/RedactionSelectionMenu";
 
 // RedactionSelectionMenu renders only when there's an active document ID
 // (ActiveDocumentContext) and a selected redaction annotation from the live
 // EmbedPDF redaction plugin. Neither exists in Storybook, so the component's
-// own guard clause renders nothing here - that's its real empty state.
+// own guard clause renders nothing here - that's its real empty state, and the
+// args below are never read.
 const meta = {
   title: "Viewer/RedactionSelectionMenu",
   component: RedactionSelectionMenu,
@@ -13,4 +17,6 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {} as RedactionSelectionMenuProps,
+};

--- a/frontend/editor/src/core/components/viewer/RedactionSelectionMenu.tsx
+++ b/frontend/editor/src/core/components/viewer/RedactionSelectionMenu.tsx
@@ -2,7 +2,6 @@ import {
   useRedaction as useEmbedPdfRedaction,
   RedactionSelectionMenuProps,
 } from "@embedpdf/plugin-redaction/react";
-import { PdfAnnotationSubtype } from "@embedpdf/models";
 import { Tooltip, Group } from "@mantine/core";
 import { Button } from "@app/ui/Button";
 import { ActionIcon } from "@app/ui/ActionIcon";
@@ -16,7 +15,7 @@ import { useActiveDocumentId } from "@app/components/viewer/useActiveDocumentId"
 
 export type { RedactionSelectionMenuProps };
 
-export function RedactionSelectionMenu(props: any) {
+export function RedactionSelectionMenu(props: RedactionSelectionMenuProps) {
   const activeDocumentId = useActiveDocumentId();
 
   // Don't render until we have a valid document ID
@@ -35,17 +34,9 @@ function RedactionSelectionMenuInner({
   selected,
   menuWrapperProps,
 }: RedactionSelectionMenuProps & { documentId: string }) {
-  const item =
-    context?.type === "redaction"
-      ? context.item
-      : context?.type === "annotation"
-        ? (context as any).annotation?.object
-        : null;
+  const item = context?.type === "redaction" ? context.item : null;
 
-  const isRedaction =
-    context?.type === "redaction" ||
-    (context?.type === "annotation" &&
-      item?.type === PdfAnnotationSubtype.REDACT);
+  const isRedaction = context?.type === "redaction";
 
   const pageIndex = context?.pageIndex;
   const { t } = useTranslation();

--- a/frontend/editor/src/core/components/viewer/RulerOverlay.tsx
+++ b/frontend/editor/src/core/components/viewer/RulerOverlay.tsx
@@ -418,7 +418,7 @@ export const RulerOverlay = React.forwardRef<
 
   const [zoom, setZoom] = useState<number>(() => {
     try {
-      return ((viewer.getZoomState() as any)?.zoomPercent ?? 140) / 100;
+      return viewer.getZoomState().zoomPercent / 100;
     } catch {
       return 1.4;
     }

--- a/frontend/editor/src/core/components/viewer/SignatureAPIBridge.tsx
+++ b/frontend/editor/src/core/components/viewer/SignatureAPIBridge.tsx
@@ -7,7 +7,11 @@ import {
   useState,
 } from "react";
 import { useAnnotationCapability } from "@embedpdf/plugin-annotation/react";
-import { PdfAnnotationSubtype, uuidV4 } from "@embedpdf/models";
+import {
+  PdfAnnotationSubtype,
+  uuidV4,
+  type PdfAnnotationObject,
+} from "@embedpdf/models";
 import { useSignature } from "@app/contexts/SignatureContext";
 import type {
   SignatureAPI,
@@ -16,6 +20,18 @@ import type {
 import type { SignParameters } from "@app/hooks/tools/sign/useSignParameters";
 import { useViewer } from "@app/contexts/ViewerContext";
 import { useDocumentReady } from "@app/components/viewer/hooks/useDocumentReady";
+
+// The signature tools stash the source image on stamp annotations via custom fields
+type StampAnnotation = PdfAnnotationObject & {
+  imageSrc?: unknown;
+  imageData?: unknown;
+  appearance?: unknown;
+  stampData?: unknown;
+  contents?: unknown;
+  data?: unknown;
+  customData?: unknown;
+  asset?: unknown;
+};
 
 /**
  * Connects the PDF signature (stamp/ink) tools to the shared ViewerContext and SignatureContext.
@@ -319,7 +335,7 @@ export const SignatureAPIBridge = forwardRef<
         const selectedAnnotation = annotationApi.getSelectedAnnotation?.();
 
         if (selectedAnnotation) {
-          const annotation = selectedAnnotation as any;
+          const annotation = selectedAnnotation;
           const pageIndex = annotation.object?.pageIndex || 0;
           const id = annotation.object?.id;
 
@@ -332,22 +348,28 @@ export const SignatureAPIBridge = forwardRef<
             if (pageAnnotationsTask) {
               pageAnnotationsTask
                 .toPromise()
-                .then((pageAnnotations: any) => {
+                .then((pageAnnotations: PdfAnnotationObject[]) => {
                   const currentAnn = pageAnnotations?.find(
-                    (ann: any) => ann.id === id,
+                    (ann: PdfAnnotationObject) => ann.id === id,
                   );
-                  if (currentAnn && currentAnn.imageSrc) {
+                  const imageSrc = (currentAnn as StampAnnotation | undefined)
+                    ?.imageSrc;
+                  if (typeof imageSrc === "string") {
                     // Ensure the image data is stored in our persistent store
-                    storeImageData(id, currentAnn.imageSrc);
+                    storeImageData(id, imageSrc);
                   }
                 })
                 .catch(console.error);
             }
           }
 
-          // Use EmbedPDF's native deletion which should integrate with history
-          if ((annotationApi as any).deleteSelected) {
-            (annotationApi as any).deleteSelected();
+          // Use EmbedPDF's native deletion which should integrate with history.
+          // deleteSelected isn't on the typed capability.
+          const withDeleteSelected = annotationApi as {
+            deleteSelected?: () => void;
+          };
+          if (withDeleteSelected.deleteSelected) {
+            withDeleteSelected.deleteSelected();
           } else {
             // Fallback to direct deletion - less ideal for history
             if (id) {
@@ -469,17 +491,19 @@ export const SignatureAPIBridge = forwardRef<
         if (pageAnnotationsTask) {
           pageAnnotationsTask
             .toPromise()
-            .then((pageAnnotations: any) => {
+            .then((pageAnnotations: PdfAnnotationObject[]) => {
               const annotation = pageAnnotations?.find(
-                (ann: any) => ann.id === annotationId,
+                (ann: PdfAnnotationObject) => ann.id === annotationId,
               );
+              const imageSrc = (annotation as StampAnnotation | undefined)
+                ?.imageSrc;
               if (
                 annotation &&
                 annotation.type === PdfAnnotationSubtype.STAMP &&
-                annotation.imageSrc
+                typeof imageSrc === "string"
               ) {
                 // Store image data before deletion
-                storeImageData(annotationId, annotation.imageSrc);
+                storeImageData(annotationId, imageSrc);
               }
             })
             .catch(console.error);
@@ -494,7 +518,7 @@ export const SignatureAPIBridge = forwardRef<
         annotationApi.setActiveTool(null);
       },
 
-      getPageAnnotations: async (pageIndex: number): Promise<any[]> => {
+      getPageAnnotations: async (pageIndex: number): Promise<unknown[]> => {
         if (!annotationApi || !annotationApi.getPageAnnotations) {
           console.warn("getPageAnnotations not available");
           return [];
@@ -524,13 +548,18 @@ export const SignatureAPIBridge = forwardRef<
         newRect: AnnotationRect,
       ) => {
         if (!annotationApi) return;
-        // v2.7.0: move signature stamp to newRect without regenerating the AP stream,
-        // preserving the original appearance (image data stays intact).
-        (annotationApi as any).moveAnnotation?.(
-          pageIndex,
-          annotationId,
-          newRect,
-        );
+        // v2.7.0 moveAnnotation moves a stamp to a full rect (not just a
+        // Position) without regenerating the AP stream, keeping the image
+        // intact. The installed types still declare the older Position-only
+        // signature, so assert the rect overload the runtime actually accepts.
+        const rectMove = annotationApi as unknown as {
+          moveAnnotation?: (
+            pageIndex: number,
+            annotationId: string,
+            rect: AnnotationRect,
+          ) => void;
+        };
+        rectMove.moveAnnotation?.(pageIndex, annotationId, newRect);
       },
     }),
     [annotationApi, signatureConfig, placementPreviewSize, applyStampDefaults],
@@ -546,7 +575,7 @@ export const SignatureAPIBridge = forwardRef<
         return;
       }
 
-      const annotation: any = event.annotation;
+      const annotation = event.annotation as StampAnnotation;
       const annotationId: string | undefined = annotation?.id;
       if (!annotationId) {
         return;

--- a/frontend/editor/src/core/components/viewer/TextSelectionHandler.tsx
+++ b/frontend/editor/src/core/components/viewer/TextSelectionHandler.tsx
@@ -119,19 +119,6 @@ function findLineBoundaries(
   };
 }
 
-function setSelectionRange(
-  selPlugin: any,
-  documentId: string,
-  pageIndex: number,
-  startIndex: number,
-  endIndex: number,
-): void {
-  selPlugin.clearSelection(documentId);
-  selPlugin.beginSelection(documentId, pageIndex, startIndex);
-  selPlugin.updateSelection(documentId, pageIndex, endIndex);
-  selPlugin.endSelection(documentId);
-}
-
 /**
  * Handles text selection with standard PDF viewer behaviors:
  * - Double-click to select a whole word
@@ -154,7 +141,7 @@ export function TextSelectionHandler({
     if (!selPlugin || !selCapability || !imCapability) return;
 
     const handlers = {
-      onDoubleClick: (pos: Position, _evt: any, modeId: string) => {
+      onDoubleClick: (pos: Position, _evt: unknown, modeId: string) => {
         if (
           Date.now() - tripleClickTimeRef.current <
           TRIPLE_CLICK_TIME_THRESHOLD
@@ -176,7 +163,28 @@ export function TextSelectionHandler({
 
         const localIndex = g - run.charStart;
 
-        const plugin = selPlugin as any;
+        // getCoreDocument and the WASM engine are plugin internals not exposed
+        // on the public capability; reach them structurally.
+        const plugin = selPlugin as unknown as {
+          getCoreDocument: (
+            documentId: string,
+          ) => { document?: unknown } | null | undefined;
+          engine: {
+            getTextSlices: (
+              document: unknown,
+              slices: {
+                pageIndex: number;
+                charIndex: number;
+                charCount: number;
+              }[],
+            ) => {
+              wait: (
+                onOk: (texts: string[]) => void,
+                onErr: () => void,
+              ) => void;
+            };
+          };
+        };
         try {
           const coreDoc = plugin.getCoreDocument(documentId);
           if (!coreDoc?.document) return;
@@ -203,12 +211,18 @@ export function TextSelectionHandler({
                 y: pos.y,
               };
 
-              setSelectionRange(
-                selPlugin,
+              selCapability.setSelection(
+                {
+                  start: {
+                    page: pageIndex,
+                    index: run.charStart + boundaries.start,
+                  },
+                  end: {
+                    page: pageIndex,
+                    index: run.charStart + boundaries.end,
+                  },
+                },
                 documentId,
-                pageIndex,
-                run.charStart + boundaries.start,
-                run.charStart + boundaries.end,
               );
             },
             () => {
@@ -220,7 +234,7 @@ export function TextSelectionHandler({
         }
       },
 
-      onClick: (pos: Position, _evt: any, modeId: string) => {
+      onClick: (pos: Position, _evt: unknown, modeId: string) => {
         const dbl = lastDblClickRef.current;
         if (!dbl) return;
 
@@ -250,12 +264,12 @@ export function TextSelectionHandler({
           tripleClickTimeRef.current = now;
           lastDblClickRef.current = null;
 
-          setSelectionRange(
-            selPlugin,
+          selCapability.setSelection(
+            {
+              start: { page: pageIndex, index: line.start },
+              end: { page: pageIndex, index: line.end },
+            },
             documentId,
-            pageIndex,
-            line.start,
-            line.end,
           );
         }
       },

--- a/frontend/editor/src/core/components/viewer/layerUtils.ts
+++ b/frontend/editor/src/core/components/viewer/layerUtils.ts
@@ -1,8 +1,16 @@
+import type { PDFObject } from "@cantoo/pdf-lib";
+
 export interface LayerInfo {
   id: string;
   name: string;
   visible: boolean;
   children?: LayerInfo[];
+}
+
+// pdfjs types its OCG groups as `any`; these are the fields we read off them.
+interface OcGroup {
+  name?: string;
+  visible?: boolean;
 }
 
 /**
@@ -29,15 +37,14 @@ export async function readPdfLayers(file: Blob): Promise<LayerInfo[]> {
 
     if (!ocConfig) return [];
 
-    // pdfjs v5 uses [Symbol.iterator] and getGroup(id), not getGroups()
-    const groups: Record<string, any> = {};
-    for (const [id, group] of ocConfig as any) {
+    const groups: Record<string, OcGroup> = {};
+    for (const [id, group] of ocConfig) {
       groups[id] = group;
     }
     if (Object.keys(groups).length === 0) return [];
 
     // Use getOrder() for hierarchical display
-    let order: any[] | null = null;
+    let order: unknown[] | null = null;
     try {
       order = ocConfig.getOrder?.() ?? null;
     } catch {
@@ -51,8 +58,8 @@ export async function readPdfLayers(file: Blob): Promise<LayerInfo[]> {
     // Fallback: flat list in enumeration order
     return Object.entries(groups).map(([id, group]) => ({
       id,
-      name: (group as any).name ?? id,
-      visible: (group as any).visible ?? true,
+      name: group.name ?? id,
+      visible: group.visible ?? true,
     }));
   } finally {
     await pdfDoc.destroy();
@@ -63,12 +70,12 @@ export async function readPdfLayers(file: Blob): Promise<LayerInfo[]> {
  * Recursively builds a LayerInfo tree from pdfjs OCG order array.
  * The order array can contain:
  *  - string: an OCG id
- *  - { name: string, order: any[] }: a named group with children
+ *  - { name: string, order: unknown[] }: a named group with children
  *  - array: a nested group
  */
 function buildLayerTree(
-  order: any[],
-  groups: Record<string, any>,
+  order: unknown[],
+  groups: Record<string, OcGroup>,
   visited = new Set<string>(),
 ): LayerInfo[] {
   const result: LayerInfo[] = [];
@@ -82,8 +89,8 @@ function buildLayerTree(
       if (group) {
         result.push({
           id: item,
-          name: (group as any).name ?? item,
-          visible: (group as any).visible ?? true,
+          name: group.name ?? item,
+          visible: group.visible ?? true,
         });
       }
     } else if (Array.isArray(item)) {
@@ -94,7 +101,7 @@ function buildLayerTree(
       // Named group with nested items
       const { name, order: subOrder } = item as {
         name?: string;
-        order?: any[];
+        order?: unknown[];
       };
       const children = subOrder
         ? buildLayerTree(subOrder, groups, visited)
@@ -136,54 +143,53 @@ export async function applyOCGVisibilityToPdf(
   const context = doc.context;
 
   // Access the catalog via the trailer's Root reference
-  const catalogRef = context.trailerInfo.Root;
-  const catalog = context.lookup(
-    catalogRef,
-  ) as unknown as typeof PDFDict.prototype;
+  const catalog = context.lookup(context.trailerInfo.Root);
+  if (!(catalog instanceof PDFDict)) {
+    return doc.save();
+  }
 
   // Get OCProperties dict (may be a direct dict or an indirect reference)
-  const ocPropsRaw = (catalog as any).lookup(PDFName.of("OCProperties"));
+  const ocPropsRaw = catalog.lookup(PDFName.of("OCProperties"));
   if (!ocPropsRaw) {
     return doc.save();
   }
-  const ocProps = (ocPropsRaw instanceof PDFDict
-    ? ocPropsRaw
-    : context.lookup(ocPropsRaw)) as unknown as typeof PDFDict.prototype;
-
-  // Get the /OCGs array
-  const ocgsRaw = (ocProps as any).lookup(PDFName.of("OCGs"));
-  if (!(ocgsRaw instanceof PDFArray)) {
+  const ocProps =
+    ocPropsRaw instanceof PDFDict ? ocPropsRaw : context.lookup(ocPropsRaw);
+  if (!(ocProps instanceof PDFDict)) {
     return doc.save();
   }
-  const ocgsArray = ocgsRaw as unknown as typeof PDFArray.prototype;
+
+  // Get the /OCGs array
+  const ocgsArray = ocProps.lookup(PDFName.of("OCGs"));
+  if (!(ocgsArray instanceof PDFArray)) {
+    return doc.save();
+  }
 
   // Get or create the /D (default config) dict
-  const dRaw = (ocProps as any).lookup(PDFName.of("D"));
+  const dRaw = ocProps.lookup(PDFName.of("D"));
   if (!dRaw) {
     return doc.save();
   }
-  const dDict = (dRaw instanceof PDFDict
-    ? dRaw
-    : context.lookup(dRaw)) as unknown as typeof PDFDict.prototype;
+  const dDict = dRaw instanceof PDFDict ? dRaw : context.lookup(dRaw);
+  if (!(dDict instanceof PDFDict)) {
+    return doc.save();
+  }
 
   // Collect OCG refs for ON vs OFF based on user visibility settings
-  const onRefs: any[] = [];
-  const offRefs: any[] = [];
+  const onRefs: PDFObject[] = [];
+  const offRefs: PDFObject[] = [];
 
-  const size = (ocgsArray as any).size() as number;
+  const size = ocgsArray.size();
   for (let i = 0; i < size; i++) {
-    const ocgRef = (ocgsArray as any).get(i);
-    const ocgDict = context.lookup(
-      ocgRef,
-    ) as unknown as typeof PDFDict.prototype;
-    if (!ocgDict) continue;
+    const ocgRef = ocgsArray.get(i);
+    const ocgDict = context.lookup(ocgRef);
+    if (!(ocgDict instanceof PDFDict)) continue;
 
     // Get the OCG name
-    const nameRaw = (ocgDict as any).lookup(PDFName.of("Name"));
+    const nameRaw = ocgDict.lookup(PDFName.of("Name"));
     let ocgName = "";
     if (nameRaw instanceof PDFString || nameRaw instanceof PDFHexString) {
-      ocgName =
-        (nameRaw as any).decodeText?.() ?? (nameRaw as any).asString?.() ?? "";
+      ocgName = nameRaw.decodeText();
     } else if (nameRaw) {
       ocgName = String(nameRaw);
     }
@@ -200,25 +206,25 @@ export async function applyOCGVisibilityToPdf(
 
   // Set /BaseState to /OFF so all layers start hidden, then /ON lists visible ones.
   // This is unambiguous and avoids conflicts between /BaseState and /ON//OFF.
-  (dDict as any).set(PDFName.of("BaseState"), PDFName.of("OFF"));
+  dDict.set(PDFName.of("BaseState"), PDFName.of("OFF"));
 
   // Set /ON to only the visible layers
   if (onRefs.length > 0) {
-    (dDict as any).set(PDFName.of("ON"), context.obj(onRefs));
+    dDict.set(PDFName.of("ON"), context.obj(onRefs));
   } else {
-    (dDict as any).delete?.(PDFName.of("ON"));
+    dDict.delete(PDFName.of("ON"));
   }
 
   // Set /OFF to only the hidden layers (for viewers that check it)
   if (offRefs.length > 0) {
-    (dDict as any).set(PDFName.of("OFF"), context.obj(offRefs));
+    dDict.set(PDFName.of("OFF"), context.obj(offRefs));
   } else {
-    (dDict as any).delete?.(PDFName.of("OFF"));
+    dDict.delete(PDFName.of("OFF"));
   }
 
-  // Remove /AS (auto-state) array — it can contain usage-based overrides
+  // Remove /AS (auto-state) array - it can contain usage-based overrides
   // (e.g., print vs view) that conflict with our explicit visibility settings.
-  (dDict as any).delete?.(PDFName.of("AS"));
+  dDict.delete(PDFName.of("AS"));
 
   return doc.save();
 }

--- a/frontend/editor/src/core/components/viewer/viewerTypes.ts
+++ b/frontend/editor/src/core/components/viewer/viewerTypes.ts
@@ -45,7 +45,7 @@ export interface SignatureAPI {
   deleteAnnotation: (annotationId: string, pageIndex: number) => void;
   updateDrawSettings: (color: string, size: number) => void;
   deactivateTools: () => void;
-  getPageAnnotations: (pageIndex: number) => Promise<any[]>;
+  getPageAnnotations: (pageIndex: number) => Promise<unknown[]>;
   moveAnnotation?: (
     pageIndex: number,
     annotationId: string,

--- a/frontend/editor/src/core/components/viewer/viewerTypes.ts
+++ b/frontend/editor/src/core/components/viewer/viewerTypes.ts
@@ -160,6 +160,8 @@ export interface AnnotationObject {
   backgroundColor?: string;
   textColor?: string;
   opacity?: number;
+  strokeOpacity?: number;
+  fillOpacity?: number;
   strokeWidth?: number;
   borderWidth?: number;
   lineWidth?: number;

--- a/frontend/editor/src/core/hooks/tools/automate/useSavedAutomations.ts
+++ b/frontend/editor/src/core/hooks/tools/automate/useSavedAutomations.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { AutomationConfig } from "@app/services/automationStorage";
 import { SuggestedAutomation } from "@app/types/automation";
+import { iconKeyForSuggestedAutomation } from "@app/components/tools/automate/suggestedAutomationIcon";
 
 export interface SavedAutomation extends AutomationConfig {}
 
@@ -59,27 +60,11 @@ export function useSavedAutomations() {
         const { automationStorage } =
           await import("@app/services/automationStorage");
 
-        // Map suggested automation icons to MUI icon keys
-        const getIconKey = (_suggestedIcon: { id: string }): string => {
-          // Check the automation ID or name to determine the appropriate icon
-          switch (suggestedAutomation.id) {
-            case "secure-pdf-ingestion":
-            case "secure-workflow":
-              return "SecurityIcon"; // Security icon for security workflows
-            case "email-preparation":
-              return "CompressIcon"; // Compression icon
-            case "process-images":
-              return "StarIcon"; // Star icon for process images
-            default:
-              return "SettingsIcon"; // Default fallback
-          }
-        };
-
         // Convert suggested automation to saved automation format
         const savedAutomation = {
           name: suggestedAutomation.name,
           description: suggestedAutomation.description,
-          icon: getIconKey(suggestedAutomation.icon),
+          icon: iconKeyForSuggestedAutomation(suggestedAutomation.id),
           operations: suggestedAutomation.operations,
         };
 

--- a/frontend/editor/src/core/tools/annotate/useAnnotationSelection.ts
+++ b/frontend/editor/src/core/tools/annotate/useAnnotationSelection.ts
@@ -2,11 +2,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   AnnotationAPI,
   AnnotationToolId,
+  AnnotationSelection,
+  AnnotationObject,
+  AnnotationEvent,
 } from "@app/components/viewer/viewerTypes";
 
 interface UseAnnotationSelectionParams {
   annotationApiRef: React.RefObject<AnnotationAPI | null>;
-  deriveToolFromAnnotation: (annotation: any) => AnnotationToolId | undefined;
+  deriveToolFromAnnotation: (
+    annotation: AnnotationSelection | null | undefined,
+  ) => AnnotationToolId | undefined;
   activeToolRef: React.MutableRefObject<AnnotationToolId>;
   setActiveTool: (toolId: AnnotationToolId) => void;
   setSelectedTextDraft: (text: string) => void;
@@ -43,27 +48,25 @@ const MARKUP_TOOL_IDS = [
 const DRAWING_TOOL_IDS = ["ink", "inkHighlighter"] as const;
 const STAY_ACTIVE_TOOL_IDS = [...MARKUP_TOOL_IDS, ...DRAWING_TOOL_IDS] as const;
 
-const isTextMarkupAnnotation = (annotation: any): boolean => {
+const isTextMarkupAnnotation = (
+  annotation: AnnotationSelection | null | undefined,
+): boolean => {
   const toolId =
     annotation?.customData?.annotationToolId ||
     annotation?.customData?.toolId ||
     annotation?.object?.customData?.annotationToolId ||
     annotation?.object?.customData?.toolId;
-  if (toolId && MARKUP_TOOL_IDS.includes(toolId)) return true;
+  if (toolId && (MARKUP_TOOL_IDS as readonly string[]).includes(toolId))
+    return true;
 
   const type = annotation?.type ?? annotation?.object?.type;
   if (typeof type === "number" && [9, 10, 11, 12].includes(type)) return true;
 
-  const subtype = annotation?.subtype ?? annotation?.object?.subtype;
-  if (typeof subtype === "string") {
-    const lower = subtype.toLowerCase();
-    if (MARKUP_TOOL_IDS.some((t) => lower.includes(t))) return true;
-  }
   return false;
 };
 
 const shouldStayOnPlacementTool = (
-  annotation: any,
+  annotation: AnnotationSelection | null | undefined,
   derivedTool?: string | null | undefined,
 ): boolean => {
   // Text markup tools (highlight, underline, strikeout, squiggly) and drawing tools (ink, inkHighlighter) stay active
@@ -77,7 +80,7 @@ const shouldStayOnPlacementTool = (
     annotation?.object?.customData?.toolId;
 
   // Check if it's a tool that should stay active
-  if (toolId && STAY_ACTIVE_TOOL_IDS.includes(toolId as any)) {
+  if (toolId && (STAY_ACTIVE_TOOL_IDS as readonly string[]).includes(toolId)) {
     return true;
   }
 
@@ -119,26 +122,29 @@ export function useAnnotationSelection({
   setTextAlignment,
   setFreehandHighlighterWidth,
 }: UseAnnotationSelectionParams) {
-  const [selectedAnn, setSelectedAnn] = useState<any | null>(null);
+  const [selectedAnn, setSelectedAnn] = useState<{
+    object: AnnotationObject;
+  } | null>(null);
   const [selectedAnnId, setSelectedAnnId] = useState<string | null>(null);
   const selectedAnnIdRef = useRef<string | null>(null);
 
   const applySelectionFromAnnotation = useCallback(
-    (ann: any | null) => {
+    (ann: AnnotationSelection | null) => {
       const annObject = ann?.object ?? ann ?? null;
       const annId = annObject?.id ?? null;
-      const type = annObject?.type;
+      const type = annObject?.type ?? -1;
       const derivedTool = annObject
         ? deriveToolFromAnnotation(annObject)
         : undefined;
       selectedAnnIdRef.current = annId;
       setSelectedAnnId(annId);
       // Normalize selected annotation to always expose .object for edit panels
-      const normalizedSelection = ann?.object
-        ? ann
-        : annObject
-          ? { object: annObject }
-          : null;
+      const normalizedSelection: { object: AnnotationObject } | null =
+        ann?.object
+          ? { object: ann.object }
+          : annObject
+            ? { object: annObject }
+            : null;
       setSelectedAnn(normalizedSelection);
 
       if (annObject?.contents !== undefined) {
@@ -315,11 +321,11 @@ export function useAnnotationSelection({
   );
 
   useEffect(() => {
-    const api = annotationApiRef.current as any;
+    const api = annotationApiRef.current;
     if (!api) return;
 
     const checkSelection = () => {
-      let ann: any = null;
+      let ann: AnnotationSelection | null = null;
       if (typeof api.getSelectedAnnotation === "function") {
         try {
           ann = api.getSelectedAnnotation();
@@ -349,9 +355,17 @@ export function useAnnotationSelection({
     let interval: ReturnType<typeof setInterval> | null = null;
 
     if (typeof api.onAnnotationEvent === "function") {
-      const handler = (event: any) => {
-        const ann = event?.annotation ?? event?.selectedAnnotation ?? null;
-        const eventType = event?.type;
+      const handler = (event: AnnotationEvent) => {
+        // The handler defends against annotation-event shapes broader than the
+        // installed plugin's typed union (extra event types, a selectedAnnotation
+        // field) across plugin versions; read those structurally.
+        const ev = event as {
+          type?: string;
+          annotation?: AnnotationSelection;
+          selectedAnnotation?: AnnotationSelection;
+        };
+        const ann = ev.annotation ?? ev.selectedAnnotation ?? null;
+        const eventType = ev.type;
         switch (eventType) {
           case "create":
           case "add":
@@ -365,9 +379,7 @@ export function useAnnotationSelection({
             const currentTool = activeToolRef.current;
             const tool =
               deriveToolFromAnnotation(
-                (eventAnn as any)?.object ??
-                  eventAnn ??
-                  api.getSelectedAnnotation?.(),
+                eventAnn?.object ?? eventAnn ?? api.getSelectedAnnotation?.(),
               ) || currentTool;
             const stayOnPlacement = shouldStayOnPlacementTool(eventAnn, tool);
             if (activeToolRef.current !== "select" && !stayOnPlacement) {
@@ -381,7 +393,7 @@ export function useAnnotationSelection({
               applySelectionFromAnnotation(selected ?? eventAnn ?? null);
               const derivedAfter =
                 deriveToolFromAnnotation(
-                  (selected as any)?.object ?? selected ?? eventAnn ?? null,
+                  selected?.object ?? selected ?? eventAnn ?? null,
                 ) || activeToolRef.current;
               const stayOnPlacementAfter = shouldStayOnPlacementTool(
                 selected ?? eventAnn ?? null,

--- a/frontend/editor/src/core/types/automation.ts
+++ b/frontend/editor/src/core/types/automation.ts
@@ -2,9 +2,11 @@
  * Types for automation functionality
  */
 
+import { type ComponentType } from "react";
+
 export interface AutomationOperation {
   operation: string;
-  parameters: Record<string, any>;
+  parameters: Record<string, unknown>;
 }
 
 export interface AutomationConfig {
@@ -22,7 +24,7 @@ export interface AutomationTool {
   operation: string;
   name: string;
   configured: boolean;
-  parameters?: Record<string, any>;
+  parameters?: Record<string, unknown>;
 }
 
 export type AutomationStep =
@@ -65,5 +67,5 @@ export interface SuggestedAutomation {
   operations: AutomationOperation[];
   createdAt: string;
   updatedAt: string;
-  icon: any; // MUI Icon component
+  icon: ComponentType;
 }

--- a/frontend/editor/src/core/types/fileContext.ts
+++ b/frontend/editor/src/core/types/fileContext.ts
@@ -16,11 +16,13 @@ export type ClassificationConfidence = "none" | "low" | "medium" | "high";
 export interface ProcessedFilePage {
   thumbnail?: string;
   pageNumber?: number;
+  originalPageNumber?: number;
   rotation?: number;
   splitBefore?: boolean;
+  splitAfter?: boolean;
   width?: number;
   height?: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ProcessedFileMetadata {
@@ -28,7 +30,8 @@ export interface ProcessedFileMetadata {
   totalPages?: number;
   lastProcessed?: number;
   isEncrypted?: boolean;
-  [key: string]: any;
+  thumbnailUrl?: string;
+  [key: string]: unknown;
 }
 
 /**
@@ -101,12 +104,13 @@ export interface StirlingFile extends File {
 
 // Type guard to check if a File object has an embedded fileId
 export function isStirlingFile(file: File | Blob): file is StirlingFile {
+  const candidate = file as { fileId?: unknown; quickKey?: unknown };
   return (
     file instanceof File &&
     "fileId" in file &&
-    typeof (file as any).fileId === "string" &&
+    typeof candidate.fileId === "string" &&
     "quickKey" in file &&
-    typeof (file as any).quickKey === "string"
+    typeof candidate.quickKey === "string"
   );
 }
 
@@ -129,7 +133,7 @@ export function getFormFillFileId(
   }
 
   // Fallback for Blobs or other objects
-  return `blob-${(file as any).size || 0}`;
+  return `blob-${file.size || 0}`;
 }
 
 // Create a StirlingFile from a regular File object
@@ -181,14 +185,21 @@ export function extractFiles(files: StirlingFile[]): File[] {
 }
 
 // Check if an object is a File or StirlingFile (replaces instanceof File checks)
-export function isFileObject(obj: any): obj is File | StirlingFile {
+export function isFileObject(obj: unknown): obj is File | StirlingFile {
+  const o = obj as {
+    name?: unknown;
+    size?: unknown;
+    type?: unknown;
+    lastModified?: unknown;
+    arrayBuffer?: unknown;
+  };
   return (
-    obj &&
-    typeof obj.name === "string" &&
-    typeof obj.size === "number" &&
-    typeof obj.type === "string" &&
-    typeof obj.lastModified === "number" &&
-    typeof obj.arrayBuffer === "function"
+    !!obj &&
+    typeof o.name === "string" &&
+    typeof o.size === "number" &&
+    typeof o.type === "string" &&
+    typeof o.lastModified === "number" &&
+    typeof o.arrayBuffer === "function"
   );
 }
 

--- a/frontend/editor/src/core/utils/signatureFlattening.ts
+++ b/frontend/editor/src/core/utils/signatureFlattening.ts
@@ -108,8 +108,14 @@ export async function flattenSignatures(
           const pageAnnotations =
             await signatureApiRef.current.getPageAnnotations(pageIndex);
           if (pageAnnotations && pageAnnotations.length > 0) {
-            const sessionAnnotations = pageAnnotations.filter((annotation) =>
-              Boolean(getAnnotationImageData(annotation, getImageData)),
+            const sessionAnnotations = pageAnnotations.filter(
+              (annotation): annotation is SignatureAnnotation =>
+                Boolean(
+                  getAnnotationImageData(
+                    annotation as SignatureAnnotation,
+                    getImageData,
+                  ),
+                ),
             );
 
             if (sessionAnnotations.length > 0) {

--- a/frontend/editor/src/proprietary/components/shared/config/configSections/AdminConnectionsSection.tsx
+++ b/frontend/editor/src/proprietary/components/shared/config/configSections/AdminConnectionsSection.tsx
@@ -934,7 +934,9 @@ export default function AdminConnectionsSection() {
                     key={provider.id}
                     provider={provider}
                     isConfigured={true}
-                    settings={getProviderSettings(provider)}
+                    settings={
+                      getProviderSettings(provider) as Record<string, unknown>
+                    }
                     onChange={(updatedSettings) =>
                       updateProviderSettings(provider, updatedSettings)
                     }
@@ -964,7 +966,9 @@ export default function AdminConnectionsSection() {
                   key={provider.id}
                   provider={provider}
                   isConfigured={false}
-                  settings={getProviderSettings(provider)}
+                  settings={
+                    getProviderSettings(provider) as Record<string, unknown>
+                  }
                   onChange={(updatedSettings) =>
                     updateProviderSettings(provider, updatedSettings)
                   }

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -79,7 +79,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/viewer/SignatureAPIBridge.tsx",
   "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
   "editor/src/core/components/viewer/TextSelectionHandler.tsx",
-  "editor/src/core/components/viewer/RedactionSelectionMenu.tsx",
   "editor/src/core/tools/annotate/useAnnotationSelection.ts",
 ];
 

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -74,7 +74,6 @@ const modernGlobals: OxlintGlobals = {
 
 // Folders not yet conformant to the stricter no-explicit-any rule
 const noExplicitAnyExcludes = [
-  "editor/src/core/components/viewer/layerUtils.ts",
 ];
 
 export default defineConfig({

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -81,7 +81,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/viewer/TextSelectionHandler.tsx",
   "editor/src/core/components/viewer/RedactionSelectionMenu.tsx",
   "editor/src/core/tools/annotate/useAnnotationSelection.ts",
-  "editor/src/core/types/fileContext.ts",
   "editor/src/core/types/automation.ts",
 ];
 

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -72,10 +72,6 @@ const modernGlobals: OxlintGlobals = {
   SuppressedError: "readonly",
 };
 
-// Folders not yet conformant to the stricter no-explicit-any rule
-const noExplicitAnyExcludes = [
-];
-
 export default defineConfig({
   plugins: ["typescript", "import"],
   categories: {
@@ -185,6 +181,7 @@ export default defineConfig({
         allowInterfaces: "with-single-extends",
       },
     ],
+    "typescript/no-explicit-any": "error",
     "typescript/no-extra-non-null-assertion": "error",
     "typescript/no-misused-new": "error",
     "typescript/no-namespace": "error",
@@ -380,15 +377,6 @@ export default defineConfig({
             patterns: [aliasOverRelative, aliasOverSrc],
           },
         ],
-      },
-    },
-    {
-      // Stricter no-explicit-any, enabled everywhere in the editor app EXCEPT
-      // the folders that are not yet conformant (migrated incrementally).
-      files: [APP_SOURCE],
-      excludeFiles: noExplicitAnyExcludes,
-      rules: {
-        "typescript/no-explicit-any": "error",
       },
     },
     {

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -74,7 +74,6 @@ const modernGlobals: OxlintGlobals = {
 
 // Folders not yet conformant to the stricter no-explicit-any rule
 const noExplicitAnyExcludes = [
-  "editor/src/core/components/shared/config/configSections/ProviderCard.tsx",
   "editor/src/core/components/viewer/layerUtils.ts",
 ];
 

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -79,7 +79,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/viewer/SignatureAPIBridge.tsx",
   "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
   "editor/src/core/components/viewer/TextSelectionHandler.tsx",
-  "editor/src/core/components/viewer/RulerOverlay.tsx",
   "editor/src/core/components/viewer/viewerTypes.ts",
   "editor/src/core/components/viewer/EmbedPdfViewer.tsx",
   "editor/src/core/components/viewer/RedactionSelectionMenu.tsx",

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -79,7 +79,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/viewer/SignatureAPIBridge.tsx",
   "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
   "editor/src/core/components/viewer/TextSelectionHandler.tsx",
-  "editor/src/core/components/viewer/viewerTypes.ts",
   "editor/src/core/components/viewer/EmbedPdfViewer.tsx",
   "editor/src/core/components/viewer/RedactionSelectionMenu.tsx",
   "editor/src/core/tools/annotate/useAnnotationSelection.ts",

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -78,7 +78,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/viewer/layerUtils.ts",
   "editor/src/core/components/viewer/SignatureAPIBridge.tsx",
   "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
-  "editor/src/core/components/viewer/TextSelectionHandler.tsx",
   "editor/src/core/tools/annotate/useAnnotationSelection.ts",
 ];
 

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -76,7 +76,6 @@ const modernGlobals: OxlintGlobals = {
 const noExplicitAnyExcludes = [
   "editor/src/core/components/shared/config/configSections/ProviderCard.tsx",
   "editor/src/core/components/viewer/layerUtils.ts",
-  "editor/src/core/components/viewer/SignatureAPIBridge.tsx",
   "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
   "editor/src/core/tools/annotate/useAnnotationSelection.ts",
 ];

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -76,7 +76,6 @@ const modernGlobals: OxlintGlobals = {
 const noExplicitAnyExcludes = [
   "editor/src/core/components/shared/config/configSections/ProviderCard.tsx",
   "editor/src/core/components/viewer/layerUtils.ts",
-  "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
 ];
 
 export default defineConfig({

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -81,7 +81,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/viewer/TextSelectionHandler.tsx",
   "editor/src/core/components/viewer/RedactionSelectionMenu.tsx",
   "editor/src/core/tools/annotate/useAnnotationSelection.ts",
-  "editor/src/core/types/automation.ts",
 ];
 
 export default defineConfig({

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -79,7 +79,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/viewer/SignatureAPIBridge.tsx",
   "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
   "editor/src/core/components/viewer/TextSelectionHandler.tsx",
-  "editor/src/core/components/viewer/EmbedPdfViewer.tsx",
   "editor/src/core/components/viewer/RedactionSelectionMenu.tsx",
   "editor/src/core/tools/annotate/useAnnotationSelection.ts",
   "editor/src/core/types/fileContext.ts",

--- a/frontend/oxlint.config.ts
+++ b/frontend/oxlint.config.ts
@@ -77,7 +77,6 @@ const noExplicitAnyExcludes = [
   "editor/src/core/components/shared/config/configSections/ProviderCard.tsx",
   "editor/src/core/components/viewer/layerUtils.ts",
   "editor/src/core/components/viewer/HistoryAPIBridge.tsx",
-  "editor/src/core/tools/annotate/useAnnotationSelection.ts",
 ];
 
 export default defineConfig({


### PR DESCRIPTION
# Description of Changes
Replaces all remaining uses of the `any` type in our frontend code with either correct types or more type-safe alternatives, and updates the linting config to (finally) ban the `any` type everywhere in the frontend code (unless the linter is explicitly ignored)