### PR TITLE
Give the linked-instance CORS wildcard only to unknown origins

### DIFF
--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.Customizer;
@@ -399,22 +400,36 @@ public class SupabaseSecurityConfig {
                         "X-Stirling-Skipped-Field-Edits-Total"));
         cfg.setAllowCredentials(true);
         cfg.setMaxAge(3600L);
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        // Registered ahead of "/**": the source returns the first pattern that matches, not the
-        // most specific one.
-        if (accountLinkEnabled) {
-            CorsConfiguration linked = linkedInstanceCors();
-            for (String path : LINKED_INSTANCE_PATHS) {
-                source.registerCorsConfiguration(path, linked);
-            }
+        UrlBasedCorsConfigurationSource allowListed = new UrlBasedCorsConfigurationSource();
+        allowListed.registerCorsConfiguration("/**", cfg);
+        if (!accountLinkEnabled) {
+            return allowListed;
         }
-        source.registerCorsConfiguration("/**", cfg);
-        return source;
+
+        UrlBasedCorsConfigurationSource linked = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration linkedCfg = linkedInstanceCors();
+        for (String path : LINKED_INSTANCE_PATHS) {
+            linked.registerCorsConfiguration(path, linkedCfg);
+        }
+        // Split by origin, not by path: first-party calls these same paths too, from the editor's
+        // axios client, which sends cookies and X-Browser-Id. Handing an allow-listed origin the
+        // credential-free wildcard breaks it, so only an origin the allow-list would have rejected
+        // falls through to the linked-instance config.
+        return request -> {
+            CorsConfiguration known = allowListed.getCorsConfiguration(request);
+            String origin = request.getHeader(HttpHeaders.ORIGIN);
+            if (known != null && origin != null && known.checkOrigin(origin) != null) {
+                return known;
+            }
+            CorsConfiguration fallback = linked.getCorsConfiguration(request);
+            return fallback != null ? fallback : known;
+        };
     }
 
     /**
      * Any-origin CORS for the reads a linked self-hosted instance makes from its own browser, whose
-     * origin cannot be known in advance.
+     * origin cannot be known in advance. Only origins the allow-list rejects ever reach this;
+     * anything already allow-listed keeps the credentialed config.
      *
      * <p>Safe only because it carries no credentials: this chain is bearer-token only and nothing
      * in the SaaS module reads a cookie, so the browser attaches no ambient authority and a hostile

--- a/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
+++ b/app/saas/src/main/java/stirling/software/saas/security/SupabaseSecurityConfig.java
@@ -411,14 +411,14 @@ public class SupabaseSecurityConfig {
         for (String path : LINKED_INSTANCE_PATHS) {
             linked.registerCorsConfiguration(path, linkedCfg);
         }
-        // Split by origin, not by path: first-party calls these same paths too, from the editor's
-        // axios client, which sends cookies and X-Browser-Id. Handing an allow-listed origin the
-        // credential-free wildcard breaks it, so only an origin the allow-list would have rejected
-        // falls through to the linked-instance config.
+        // Split by origin, not by path: our own frontends call these same paths and need the
+        // allow-list policy, which is wider on headers, methods and credentials. Only an origin it
+        // would have rejected falls through to the linked-instance config.
         return request -> {
-            CorsConfiguration known = allowListed.getCorsConfiguration(request);
             String origin = request.getHeader(HttpHeaders.ORIGIN);
-            if (known != null && origin != null && known.checkOrigin(origin) != null) {
+            // "/**" is registered above unconditionally, so this always resolves.
+            CorsConfiguration known = allowListed.getCorsConfiguration(request);
+            if (origin == null || known.checkOrigin(origin) != null) {
                 return known;
             }
             CorsConfiguration fallback = linked.getCorsConfiguration(request);

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -29,7 +29,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.proprietary.security.service.TeamService;
@@ -181,9 +180,14 @@ class SupabaseSecurityConfigMoreTest {
     @DisplayName("corsConfigurationSource")
     class Cors {
 
+        /**
+         * Through the interface: the bean's concrete type depends on whether account linking is on,
+         * so a downcast here breaks the moment a test in this class turns it on. A path outside
+         * LINKED_INSTANCE_PATHS always resolves to the "/**" config either way.
+         */
         private CorsConfiguration cors(CorsConfigurationSource source) {
-            UrlBasedCorsConfigurationSource ub = (UrlBasedCorsConfigurationSource) source;
-            return ub.getCorsConfigurations().get("/**");
+            return source.getCorsConfiguration(
+                    new MockHttpServletRequest("GET", "/api/v1/config/ui"));
         }
 
         @Test
@@ -460,8 +464,8 @@ class SupabaseSecurityConfigMoreTest {
         void firstPartyKeepsCredentials(String path) {
             CorsConfiguration cfg = resolve(source(true), path, FIRST_PARTY);
 
-            // The editor's axios client sends cookies and X-Browser-Id here. Handing it the
-            // credential-free wildcard is what broke `task staging:saas`.
+            // Our own frontends send X-Browser-Id here, which the linked-instance policy does
+            // not allow; handing them that policy breaks the preflight.
             assertThat(cfg.getAllowCredentials()).isTrue();
             assertThat(cfg.checkOrigin(FIRST_PARTY)).isEqualTo(FIRST_PARTY);
             assertThat(cfg.getAllowedHeaders()).contains("X-Browser-Id");
@@ -469,10 +473,11 @@ class SupabaseSecurityConfigMoreTest {
 
         @ParameterizedTest
         @ValueSource(ints = {5173, 5174, 3000, 4321, 61234})
-        @DisplayName("outside production a local dev server keeps credentials on any port")
+        @DisplayName("with no operator origin list, a dev server keeps credentials on any port")
         void anyLoopbackPortKeepsCredentials(int port) {
-            // The dev frontend is cross-origin to the backend whichever port it lands on, so the
-            // split has to key off "loopback in a non-production profile", never a fixed port.
+            // Holds only while system.corsAllowedOrigins is empty, since an operator list replaces
+            // LOOPBACK_ANY_PORT rather than adding to it. The dev frontend is cross-origin to the
+            // backend whichever port it lands on, so nothing here may key off a fixed port.
             String origin = "http://localhost:" + port;
 
             CorsConfiguration cfg = resolve(devProfileSource(), "/api/v1/payg/wallet", origin);
@@ -491,9 +496,9 @@ class SupabaseSecurityConfigMoreTest {
                 })
         @DisplayName("the desktop app's webview origins keep credentials too")
         void desktopKeepsCredentials(String origin) {
-            // cloud/ compiles into the desktop build, so the Tauri webview reaches
-            // /api/v1/payg/wallet through the same credentialed axios client. These origins are
-            // added to the allow-list unconditionally, so they must take the allow-list branch.
+            // The desktop app reaches this backend from a webview origin over browser fetch -
+            // ChatContext streams from it with credentials: "include" - which is why these origins
+            // are allow-listed unconditionally. They must keep taking the allow-list branch.
             CorsConfiguration cfg = resolve(source(true), "/api/v1/payg/wallet", origin);
 
             assertThat(cfg.getAllowCredentials()).isTrue();
@@ -516,6 +521,19 @@ class SupabaseSecurityConfigMoreTest {
             assertThat(cfg.checkHttpMethod(HttpMethod.GET)).isNotNull();
             assertThat(cfg.checkHttpMethod(HttpMethod.POST)).isNotNull();
             assertThat(cfg.checkHttpMethod(HttpMethod.PATCH)).isNotNull();
+        }
+
+        @Test
+        @DisplayName("a request carrying no Origin gets the allow-list, not the wildcard")
+        void noOriginHeaderKeepsAllowList() {
+            // A live branch: the source is consulted before anything decides whether this is even
+            // a CORS request, so a same-origin call arrives with no Origin to match.
+            CorsConfiguration cfg =
+                    source(true)
+                            .getCorsConfiguration(
+                                    new MockHttpServletRequest("GET", "/api/v1/payg/wallet"));
+
+            assertThat(cfg.getAllowCredentials()).isTrue();
         }
 
         @Test

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -474,6 +474,23 @@ class SupabaseSecurityConfigMoreTest {
             assertThat(cfg.getAllowedHeaders()).contains("X-Browser-Id");
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {SELF_HOSTED, FIRST_PARTY, "tauri://localhost"})
+        @DisplayName("the portal's own request is satisfied whichever branch an origin takes")
+        void portalRequestWorksOnEitherBranch(String origin) {
+            // A self-hosted instance can sit on an allow-listed origin (localhost:5173 ships in
+            // the defaults), so it takes the credentialed branch rather than the wildcard. That is
+            // fine only if both branches accept what apiClient.saas actually sends.
+            CorsConfiguration cfg = resolve(source(true), "/api/v1/payg/wallet", origin);
+
+            assertThat(cfg.checkOrigin(origin)).isNotNull();
+            assertThat(cfg.checkHeaders(List.of("authorization", "content-type", "accept")))
+                    .isNotNull();
+            assertThat(cfg.checkHttpMethod(HttpMethod.GET)).isNotNull();
+            assertThat(cfg.checkHttpMethod(HttpMethod.POST)).isNotNull();
+            assertThat(cfg.checkHttpMethod(HttpMethod.PATCH)).isNotNull();
+        }
+
         @Test
         @DisplayName("no wildcard at all when account linking is off")
         void flagOffKeepsAllowList() {

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -455,6 +455,25 @@ class SupabaseSecurityConfigMoreTest {
             assertThat(cfg.getAllowedHeaders()).contains("X-Browser-Id");
         }
 
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "tauri://localhost",
+                    "http://tauri.localhost",
+                    "https://tauri.localhost"
+                })
+        @DisplayName("the desktop app's webview origins keep credentials too")
+        void desktopKeepsCredentials(String origin) {
+            // cloud/ compiles into the desktop build, so the Tauri webview reaches
+            // /api/v1/payg/wallet through the same credentialed axios client. These origins are
+            // added to the allow-list unconditionally, so they must take the allow-list branch.
+            CorsConfiguration cfg = resolve(source(true), "/api/v1/payg/wallet", origin);
+
+            assertThat(cfg.getAllowCredentials()).isTrue();
+            assertThat(cfg.checkOrigin(origin)).isEqualTo(origin);
+            assertThat(cfg.getAllowedHeaders()).contains("X-Browser-Id");
+        }
+
         @Test
         @DisplayName("no wildcard at all when account linking is off")
         void flagOffKeepsAllowList() {

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -371,8 +371,20 @@ class SupabaseSecurityConfigMoreTest {
             return cfg.corsConfigurationSource();
         }
 
-        /** An allow-listed origin: the SaaS frontend in dev, which is cross-origin to :8080. */
-        private static final String FIRST_PARTY = "http://localhost:5173";
+        /**
+         * An allow-listed origin, deliberately not a localhost one: which port anybody runs the dev
+         * server on is their business, and pinning one here would assert the wrong thing.
+         */
+        private static final String FIRST_PARTY = "https://app.stirling.com";
+
+        /** Outside production the allow-list covers loopback on any port, so exercise that too. */
+        private CorsConfigurationSource devProfileSource() {
+            MockEnvironment dev = new MockEnvironment();
+            dev.setActiveProfiles("saas", "staging");
+            SupabaseSecurityConfig cfg = config(new ApplicationProperties(), dev);
+            ReflectionTestUtils.setField(cfg, "accountLinkEnabled", true);
+            return cfg.corsConfigurationSource();
+        }
 
         private CorsConfiguration resolve(
                 CorsConfigurationSource source, String path, String origin) {
@@ -456,6 +468,21 @@ class SupabaseSecurityConfigMoreTest {
         }
 
         @ParameterizedTest
+        @ValueSource(ints = {5173, 5174, 3000, 4321, 61234})
+        @DisplayName("outside production a local dev server keeps credentials on any port")
+        void anyLoopbackPortKeepsCredentials(int port) {
+            // The dev frontend is cross-origin to the backend whichever port it lands on, so the
+            // split has to key off "loopback in a non-production profile", never a fixed port.
+            String origin = "http://localhost:" + port;
+
+            CorsConfiguration cfg = resolve(devProfileSource(), "/api/v1/payg/wallet", origin);
+
+            assertThat(cfg.getAllowCredentials()).isTrue();
+            assertThat(cfg.checkOrigin(origin)).isEqualTo(origin);
+            assertThat(cfg.getAllowedHeaders()).contains("X-Browser-Id");
+        }
+
+        @ParameterizedTest
         @ValueSource(
                 strings = {
                     "tauri://localhost",
@@ -478,9 +505,9 @@ class SupabaseSecurityConfigMoreTest {
         @ValueSource(strings = {SELF_HOSTED, FIRST_PARTY, "tauri://localhost"})
         @DisplayName("the portal's own request is satisfied whichever branch an origin takes")
         void portalRequestWorksOnEitherBranch(String origin) {
-            // A self-hosted instance can sit on an allow-listed origin (localhost:5173 ships in
-            // the defaults), so it takes the credentialed branch rather than the wildcard. That is
-            // fine only if both branches accept what apiClient.saas actually sends.
+            // A self-hosted instance can sit on an allow-listed origin, so it takes the
+            // credentialed branch rather than the wildcard. That is fine only if both branches
+            // accept what apiClient.saas actually sends.
             CorsConfiguration cfg = resolve(source(true), "/api/v1/payg/wallet", origin);
 
             assertThat(cfg.checkOrigin(origin)).isNotNull();

--- a/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/security/SupabaseSecurityConfigMoreTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -370,8 +371,14 @@ class SupabaseSecurityConfigMoreTest {
             return cfg.corsConfigurationSource();
         }
 
-        private CorsConfiguration resolve(CorsConfigurationSource source, String path) {
-            return source.getCorsConfiguration(new MockHttpServletRequest("GET", path));
+        /** An allow-listed origin: the SaaS frontend in dev, which is cross-origin to :8080. */
+        private static final String FIRST_PARTY = "http://localhost:5173";
+
+        private CorsConfiguration resolve(
+                CorsConfigurationSource source, String path, String origin) {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+            request.addHeader(HttpHeaders.ORIGIN, origin);
+            return source.getCorsConfiguration(request);
         }
 
         @ParameterizedTest
@@ -389,7 +396,7 @@ class SupabaseSecurityConfigMoreTest {
                 })
         @DisplayName("every apiClient.saas path is readable from any origin")
         void portalReadsAllowAnyOrigin(String path) {
-            CorsConfiguration cfg = resolve(source(true), path);
+            CorsConfiguration cfg = resolve(source(true), path, SELF_HOSTED);
 
             assertThat(cfg.checkOrigin(SELF_HOSTED)).isEqualTo("*");
             // The wildcard is only defensible without credentials. These must never both be set:
@@ -400,7 +407,7 @@ class SupabaseSecurityConfigMoreTest {
         @Test
         @DisplayName("PATCH is allowed; the cap endpoint needs it")
         void patchAllowed() {
-            CorsConfiguration cfg = resolve(source(true), "/api/v1/payg/cap");
+            CorsConfiguration cfg = resolve(source(true), "/api/v1/payg/cap", SELF_HOSTED);
 
             assertThat(cfg.checkHttpMethod(HttpMethod.PATCH)).isNotNull();
         }
@@ -423,16 +430,35 @@ class SupabaseSecurityConfigMoreTest {
                 })
         @DisplayName("every other path keeps the credentialed allow-list")
         void otherPathsUnchanged(String path) {
-            CorsConfiguration cfg = resolve(source(true), path);
+            CorsConfiguration cfg = resolve(source(true), path, SELF_HOSTED);
 
             assertThat(cfg.getAllowCredentials()).isTrue();
             assertThat(cfg.checkOrigin(SELF_HOSTED)).isNull();
         }
 
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "/api/v1/payg/wallet",
+                    "/api/v1/payg/cap",
+                    "/api/v1/procurement/quote",
+                    "/api/v1/account-link/instances"
+                })
+        @DisplayName("an allow-listed origin keeps credentials on the very same paths")
+        void firstPartyKeepsCredentials(String path) {
+            CorsConfiguration cfg = resolve(source(true), path, FIRST_PARTY);
+
+            // The editor's axios client sends cookies and X-Browser-Id here. Handing it the
+            // credential-free wildcard is what broke `task staging:saas`.
+            assertThat(cfg.getAllowCredentials()).isTrue();
+            assertThat(cfg.checkOrigin(FIRST_PARTY)).isEqualTo(FIRST_PARTY);
+            assertThat(cfg.getAllowedHeaders()).contains("X-Browser-Id");
+        }
+
         @Test
         @DisplayName("no wildcard at all when account linking is off")
         void flagOffKeepsAllowList() {
-            CorsConfiguration cfg = resolve(source(false), "/api/v1/payg/wallet");
+            CorsConfiguration cfg = resolve(source(false), "/api/v1/payg/wallet", SELF_HOSTED);
 
             assertThat(cfg.getAllowCredentials()).isTrue();
             assertThat(cfg.checkOrigin(SELF_HOSTED)).isNull();


### PR DESCRIPTION
## Current state

`SupabaseSecurityConfig` picks a CORS policy by **path**. There are two, registered in order:

1. `/api/v1/payg/**`, `/api/v1/procurement/**`, `/api/v1/legal/**`, `/api/v1/account-link/instances/**` → any origin, no credentials, and a deliberately small header and method set. Added so a linked self-hosted instance, whose origin cannot be known in advance, can read its billing data.
2. `/**` → the allow-list (`app.stirling.com`, the Tauri webview origins, loopback outside production), with credentials and a wider header set.

`UrlBasedCorsConfigurationSource` returns the *first* pattern that matches, so anything on those four path groups gets policy 1 — whoever the caller is.

## Problem

Our own frontends call those paths too, and policy 1 is too narrow for them.

The Plan page reads the wallet through the editor's axios client. On the saas build that resolves to [`saas/services/apiClient.ts`](frontend/editor/src/saas/services/apiClient.ts#L87), which sends **`X-Browser-Id`** on every request. Policy 1 does not list that header, so the preflight fails and the wallet call never runs.

It only bites where a first-party frontend is **cross-origin** to the backend, which today means local dev: `--mode saas` points the app at the backend by absolute URL while Vite serves the UI on another port, so `task staging:saas` and `task linked:staging` fail on the wallet call. Production web serves `VITE_API_BASE_URL=/`, so those calls are same-origin and CORS never applies.

## Solution

Choose the policy by **origin** rather than by path, because both kinds of caller legitimately use the same paths.

The bean resolves the allow-list first. If the request's `Origin` is one the allow-list accepts, it gets policy 2, unchanged. Only an origin the allow-list would have rejected — a customer's own deployment, which is the whole point of policy 1 — falls through to the wildcard. A request with no `Origin` at all is not a CORS request and gets the allow-list.

| Origin | `/api/v1/payg/wallet` |
| --- | --- |
| `app.stirling.com`, a dev server on loopback, the Tauri origins | allow-list, credentials kept |
| a linked self-hosted instance | any origin, no credentials |
| an unknown origin on any other path | rejected |

With `stirling.billing.account-link.enabled` off, the bean returns the plain allow-list source and none of this applies.

**Why not just add `X-Browser-Id` to policy 1?** It would fix today's failure, and nothing currently on those paths needs the rest of policy 2 — there is no PUT or DELETE on any of them, the browser never sends `X-API-KEY`, and the exposed headers are read only by the form-fill tool. But it leaves first-party traffic permanently on a policy shaped for unknown origins, and that is an invisible trap: this backend already receives credentialed browser requests from a first-party origin (the desktop app streams from `/api/v1/ai/**` with `credentials: "include"`, which is why the Tauri origins are allow-listed at all). Whoever next adds a streaming or credentialed endpoint under one of these four prefixes would get a confusing preflight failure with nothing pointing here. Keying on origin makes that class of failure impossible rather than merely absent.

**Why the wildcard branch stays safe:** it carries no credentials. The chain is bearer-token only (`STATELESS`, no form login), nothing in `app/saas` reads a cookie, and `apiClient.saas` never sets `credentials` on `fetch`. Authorisation is untouched — callers still present a JWT and are still resolved to a team by the existing gates. This decides only which origins may read a response.

**A self-hosted instance may itself sit on an allow-listed origin** (loopback is allow-listed outside production), so it takes the credentialed branch. That is fine: for what `apiClient.saas` actually sends — `Accept`, `Authorization`, `Content-Type` over GET/POST/PATCH, no cookies — the allow-list policy is a superset of the wildcard one, and an echoed `Access-Control-Allow-Origin` serves a credential-free request as well as `*` does.

## How to test

```bash
ENABLE_SAAS=true ./gradlew :saas:test --tests "*SupabaseSecurityConfigMoreTest*"
```

34 cases in `LinkedInstanceCors`, covering both branches and the boundary between them:

| Test | Asserts |
| --- | --- |
| `portalReadsAllowAnyOrigin` | every `apiClient.saas` path is readable from an unknown origin, and never with credentials |
| `patchAllowed` | PATCH is permitted; the spend-cap endpoint needs it |
| `firstPartyKeepsCredentials` | an allow-listed origin keeps credentials and `X-Browser-Id` |
| `anyLoopbackPortKeepsCredentials` | with no operator origin list, that holds on any port rather than a hard-coded one |
| `desktopKeepsCredentials` | the three Tauri webview origins behave like any allow-listed origin |
| `portalRequestWorksOnEitherBranch` | the portal's own request succeeds whichever branch it lands on |
| `noOriginHeaderKeepsAllowList` | a request with no `Origin` resolves to the allow-list |
| `otherPathsUnchanged` | `/api/v1/instance/**`, the connect handshake and the non-portal `ui-data` paths keep the allow-list |
| `flagOffKeepsAllowList` | no wildcard exists at all when account linking is disabled |

13 of those fail on `main` and pass here.

Full suite: 1329 tests, 0 failures.

Manually: `task staging:saas`, open Plan and Usage, and the wallet loads with no CORS error in the console.
