### PR TITLE
Add a comment-review skill for the judgment half of the comment standard

### DIFF
--- a/.claude/skills/comment-review/SKILL.md
+++ b/.claude/skills/comment-review/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: comment-review
+description: >-
+  Review and improve the code comments a PR or branch adds, against the standard in
+  devGuide/CODE_COMMENTS.md: cut the ones that restate the code, tighten the verbose
+  ones, reframe what-comments into the why or the constraint, and add the contract
+  docs the change left missing. Runs comment-lint for the mechanical rules first,
+  then judges what a linter cannot: padding around one real fact, facts already
+  stated by a type or a name, comments that will go stale on the next unrelated
+  change, and new public surfaces left undocumented. Applies comment-only edits and
+  reports every verdict in chat. Use when asked to review, clean up, trim, thin out
+  or improve the comments on a PR or branch, to strip AI-looking narration before
+  requesting review, or when comment-lint findings need judgment rather than a
+  mechanical fix. Pass --report-only to change nothing.
+argument-hint: "[pr-number|branch|base-ref] [--report-only]"
+allowed-tools: Bash, Read, Grep, Glob, Edit
+---
+
+# Comment review
+
+Make the comments this branch adds fewer and worth more. Every comment kept is a line
+someone has to maintain and eventually reconcile with the code, so it has to pay for
+itself. A pass that only deletes is half the job: the same read should find the
+contract, hazard and unit the change introduced and left unsaid.
+
+`$ARGUMENTS` may name a PR number, a branch, or a base ref; default is this branch
+against where it forked from the main line. `--report-only` reports without editing.
+
+## The standard
+
+`AGENTS.md` section "Comments" is the short form; `devGuide/CODE_COMMENTS.md` is the
+authority, with the reasoning and the worked examples. **Read
+`devGuide/CODE_COMMENTS.md` before judging anything.** Do not work from memory of what
+a good comment is: the repo has already decided, and the four jobs (contract, why,
+hazard, map) are the whole permitted set.
+
+## Hard rules
+
+1. **Comment-only diff.** Never rename, extract, reorder or restructure code in this
+   pass. Where the right fix is a code change, report it as a suggestion.
+2. **Scope is what the branch adds or edits.** Comments the branch never touched are
+   the standing backlog (`task pre-commit:comment-lint:all`), not this review.
+3. **Never delete information you cannot re-derive from the code in front of you.** If
+   verifying the comment sent you into another file, a spec, or the git log, it is
+   carrying information. Keep it; tighten at most.
+4. **Never invent a rationale.** If the why is not determinable from the code, cut the
+   comment or flag it for the author. A fabricated why gets trusted, which is worse
+   than silence.
+5. **No suppressions.** Do not add `comment-lint-allow` to make a finding go away. If a
+   rule is genuinely wrong, say which and why in the report.
+6. **Report in chat.** Never post to the PR, never reply to threads, never resolve
+   anything, unless the user asks in this session.
+7. **No ratio targets.** Volume is not the metric. A dense header on a genuinely
+   complex file can be exactly right, and the repo's highest comment-ratio commits are
+   its best-documented work. Judge one comment at a time.
+
+## Process
+
+### 1. Scope the change
+
+Read the PR's own base branch rather than assuming main, because a stacked PR whose
+base is another PR would otherwise be reviewed together with its parent:
+
+```bash
+gh pr view <n> --json baseRefName,headRefName,title
+```
+
+Then get the head onto disk. `gh pr checkout <n>` normally, but it fails when
+another worktree already holds that branch, and a review needs no branch of its own:
+
+```bash
+git fetch -f origin <headRefName>:refs/review/pr<n>-head <baseRefName>:refs/review/pr<n>-base
+git checkout --detach refs/review/pr<n>-head
+BASE=$(git merge-base HEAD refs/review/pr<n>-base)
+```
+
+A stale remote ref can fail the fetch entirely ("incorrect old value provided"). Fetch
+the two branches by name as above rather than fetching everything, and confirm the
+head commit is the PR's before reading anything.
+
+With no PR number, review this branch against where it forked from the main line:
+`BASE=$(git merge-base HEAD origin/main)`.
+
+### 2. Mechanical pass
+
+```bash
+node scripts/lint/comment-lint.mjs --since "$BASE"
+```
+
+If it warns that oxlint is missing, run `task frontend:install` first or the TS and TSX
+half is silently unchecked. Each finding names a rule in
+`scripts/lint/comment-rules.mjs`; the fix is the rewrite the rule implies. The rules
+are deliberately narrow, they do not judge trailing comments at all, and each one
+excludes readings that had an innocent form. So a clean run says nothing about
+verbosity: it is the floor, not the review.
+
+### 3. Inventory every comment the branch adds
+
+```bash
+node .claude/skills/comment-review/added-comments.mjs "$BASE"
+```
+
+This is the checklist, and it over-reports slightly by design. Every entry on it gets
+a verdict. Do not rewrite it as an inline awk or perl one-liner: `$0` and `$1` in the
+script body are rewritten by argument interpolation before the shell sees them, which
+silently produces an empty inventory and a review that judged nothing.
+
+Also read what the branch **removed**:
+
+```bash
+git diff "$BASE"...HEAD | grep -E "^-\s*(//|/\*|\*|#)" | head -40
+```
+
+A rewritten comment shows up as one line added and one removed, and the removed half
+is where a fact goes missing. A branch that has already had a tightening pass is the
+likeliest place to find one.
+
+### 4. Read the code, not the diff
+
+Open each file at the comment. A diff hunk is not enough to judge one: you need the
+code it introduces, the signature it claims to document, and whether the fact it states
+is already carried by a type, a name, a constant, an enum's own cases, or a doc block
+two lines up. Two copies of one fact drift apart, which is the maintenance cost with
+none of the value.
+
+### 5. Judge
+
+Five tests, cheapest first:
+
+- **Delete it.** Is any information lost? If not, it stays deleted.
+- **Altitude.** Does it sit at a different level of detail than the code below, either
+  lower (a precise fact the code implies but does not say) or higher (intent a reader
+  would otherwise assemble from ten lines)? Same altitude is the definition of
+  redundant.
+- **Name.** Could a better identifier, an extracted function or a named constant carry
+  it instead? Then the comment is the wrong fix.
+- **Staleness.** Will this need editing the next time the code changes for an unrelated
+  reason? A comment that tracks the code rather than constrains it will drift and then
+  mislead.
+- **Duplication.** Is this fact stated somewhere else already? Delete the copy.
+
+Give every inventoried comment exactly one verdict:
+
+- **Cut.** Restates the code, banners a section, narrates steps or history, is
+  commented-out code, duplicates a fact, or pads one real fact with three sentences
+  that only set each other up.
+- **Tighten.** The fact is real and the prose is long. Keep the fact, drop the words.
+  One fact per comment; no sentence whose only job is to introduce the next one.
+- **Reframe.** It says what the code does. State the why, the hazard or the contract
+  instead, subject to rule 4.
+- **Add.** The change introduced something a caller outside the file can reach, or an
+  invariant, unit, ordering requirement, lifetime, thread-safety or error semantic, and
+  left it undocumented. Also the map comment a genuinely complex new file needs.
+- **Keep.** Earns its place. Count these; do not list them one by one.
+
+**Do not cut:**
+
+- Hazards: "must stay in sync with X", "order matters because Y", "do not remove, it
+  prevents Z".
+- Units, ranges, encodings, magic-byte decodes, currency and timezone assumptions.
+  These are mostly trailing comments, which the linter leaves alone because on this
+  codebase most of them are right.
+- The alternative that was rejected, and the reason.
+- Spec, RFC and CVE references, and TODOs that carry an issue.
+- Security and failure semantics: fail-closed ordering, what is deliberately not
+  defended, ownership and lifetime.
+- Anything whose truth you had to leave the file to verify.
+
+### 6. Apply
+
+Skip this step entirely under `--report-only`.
+
+Edit comments only. Match the file's convention: Javadoc summary fragments rather than
+"This method returns", JSDoc on the `@app/*` seams and layer boundaries with no
+`@param` restating a typed signature, Python docstrings where the type does not carry
+the contract. Plain ASCII prose, no em dashes, no repeated bold lead-ins.
+
+Then run the formatter for each language touched, because rewrapping a doc block
+changes line wrapping and the format gate will fail otherwise:
+
+- Java: `task backend:format`
+- TS and TSX: `task frontend:format`
+- Python: `task engine:fix`
+
+Re-run `node scripts/lint/comment-lint.mjs --since "$BASE"` and confirm it is clean. Do
+not commit unless asked. The diff is comment-only, so `git diff` is the entire review
+surface.
+
+### 7. Report
+
+Terse, in chat:
+
+- One counts line: `N in scope: X cut, Y tightened, Z reframed, A added, K kept`.
+- Per file, one line per changed comment: a clickable `path:line`, the verdict, and the
+  reason in a few words. No before/after quoting unless it is genuinely unclear.
+- **Needs your call**, listing what you deliberately did not do: comments whose truth
+  you could not verify, rationale you would have had to invent, and the code changes a
+  comment was papering over (extract this, rename that, split the file).
+- Any linter finding you believe is wrong, naming the rule.
+
+## Principles
+
+- Fewer comments, more information in each.
+- The reader is a new contributor with this file open, not someone who read the PR.
+- Deleting a good comment costs more than keeping a mediocre one. Uncertainty means
+  keep it and flag it.
+- The additions matter as much as the cuts. A branch that leaves a new public surface
+  undocumented is not improved by trimming its narration.

--- a/.claude/skills/comment-review/added-comments.mjs
+++ b/.claude/skills/comment-review/added-comments.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+// Every comment line a range adds, as `file:line text`, for the review checklist.
+//
+//   node .claude/skills/comment-review/added-comments.mjs <base-ref> [head-ref]
+//
+// Line-based on purpose: it over-reports (a `//` inside a string, a `*` opening a
+// wrapped expression) rather than miss one, and the reviewer opens the file anyway.
+// A shell one-liner cannot do this job: `$0` and `$1` in an awk or perl script are
+// rewritten by skill argument interpolation before the shell ever sees them.
+
+import { execFileSync } from "node:child_process";
+
+const [base, head = "HEAD"] = process.argv.slice(2);
+if (!base) {
+  process.stderr.write("usage: added-comments.mjs <base-ref> [head-ref]\n");
+  process.exit(2);
+}
+
+const diff = execFileSync("git", ["diff", "-U0", "--no-color", `${base}...${head}`], {
+  encoding: "utf8",
+  maxBuffer: 1 << 28,
+});
+
+const OPENS_COMMENT = /^\+\s*(\/\/|\/\*|\*|#|"""|'''|\{\/\*)/;
+
+let file = null;
+let line = 0;
+let count = 0;
+
+for (const raw of diff.split("\n")) {
+  if (raw.startsWith("+++ ")) {
+    file = raw.slice(4).replace(/^b\//, "").trim();
+    continue;
+  }
+  // The new-file start of the hunk. Single-line hunks omit the count, so read the
+  // number rather than splitting on the comma that may not be there.
+  const hunk = /^@@ .*?\+(\d+)/.exec(raw);
+  if (hunk) {
+    line = Number(hunk[1]);
+    continue;
+  }
+  if (!raw.startsWith("+")) continue;
+  if (OPENS_COMMENT.test(raw)) {
+    process.stdout.write(`${file}:${line} ${raw.slice(1).trim()}\n`);
+    count += 1;
+  }
+  line += 1;
+}
+
+process.stderr.write(`${count} added comment lines\n`);

--- a/devGuide/CODE_COMMENTS.md
+++ b/devGuide/CODE_COMMENTS.md
@@ -230,3 +230,12 @@ whoever touches a file first.
 To turn the editor hook off, put `{ "env": { "COMMENT_LINT_HOOK": "0" } }` in
 `.claude/settings.local.json`. The commit-time gate still applies, so you lose the
 early warning rather than the check.
+
+## The review pass
+
+The linter only reaches the mechanical half. The `/comment-review` skill
+(`.claude/skills/comment-review/`) is the pass for the rest: the comment that is
+accurate and three times longer than the fact it carries, the fact already stated by
+the type above it, and the public surface a change left undocumented. It scopes to
+what the branch adds, edits comments only, and reports its verdicts rather than
+posting them anywhere.


### PR DESCRIPTION
# Description of Changes

**Current state.** `devGuide/CODE_COMMENTS.md` holds the comment standard, and `task comment-lint` enforces the mechanical part of it on the lines a change adds: banners, step narration, history, commented-out code, doc tags that restate a signature, unowned TODOs. Those rules are deliberately narrow, and they do not judge trailing comments at all.

**Problem.** The comments that get through the linter are the expensive ones. A comment can be accurate, pass every rule, and still be three times longer than the fact it carries, or restate something the type above it already says. Two copies of one fact then drift, and the reader maintains both. The opposite failure has no gate either: a change adds a public surface, an invariant or a unit and documents none of them. Both are judgment calls, which is why they were left out of the linter instead of being written as more rules.

**Solution.** A project skill, `/comment-review`, for that judgment pass:

- Scopes to what a branch or PR adds and edits, so the standing full-tree backlog stays out of whoever touches a file first.
- Runs `comment-lint` first, then inventories every comment line the branch adds and gives each one a verdict: cut, tighten, reframe, add, or keep. The `add` verdict is what stops it being a deletion machine.
- Reads what the branch **removed** as well. A rewritten comment is one line added and one removed, and the removed half is where a fact goes missing.
- Edits comments only. Where the real fix is a code change (extract this, rename that, split the file), it reports the suggestion rather than making it.
- Protects the load-bearing comments explicitly: hazards, units and encodings, the rejected alternative, spec and CVE references, failure semantics, and anything whose truth needed a second file to verify. Uncertainty means keep and flag, never delete.
- Reports verdicts in chat. It posts nothing to the PR.

`added-comments.mjs` is the inventory. It is a script rather than an inline awk one-liner because `$0` and `$1` in a shell script body are rewritten by skill argument interpolation before the shell sees them, which silently yields an empty inventory and a review that judged nothing while looking like it worked.

No runtime code changes: this is agent tooling plus a pointer from the standard to it.

## How to test

The inventory on its own, against any base:

```bash
node .claude/skills/comment-review/added-comments.mjs origin/main
```

In Claude Code, `/comment-review <pr-number>`, or `--report-only` to have it change nothing.

The first run was against #7886, whose head commit was already a comment-tightening pass. `comment-lint` reported clean on both engines; the judgment pass found 9 of 21 comments worth changing, the headline one being a rationale for a nullable parameter that the tightening commit had dropped. Those fixes are on that PR.

Verified here: `task comment-lint` clean on the added `.mjs` (it is held to the same rules as the app), and the inventory checked against real hunks including single-line ones, where a naive parse reports line 0.

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.
