### PR TITLE
Wrap IndexedDB-restored files before upload so Safari sends their bytes

### DIFF
--- a/frontend/editor/src/core/utils/uploadableFile.test.ts
+++ b/frontend/editor/src/core/utils/uploadableFile.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { uploadableFile } from "@app/utils/uploadableFile";
+
+/** jsdom's Blob has no text(); FileReader is the one byte read it implements. */
+const textOf = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+
+describe("uploadableFile", () => {
+  const source = new File(["%PDF-1.7 body"], "report.pdf", {
+    type: "application/pdf",
+    lastModified: 1_700_000_000_000,
+  });
+
+  it("returns a distinct File object", () => {
+    expect(uploadableFile(source)).not.toBe(source);
+  });
+
+  it("keeps the identity fields the server and the run record read", () => {
+    const wrapped = uploadableFile(source);
+    expect(wrapped.name).toBe(source.name);
+    expect(wrapped.type).toBe(source.type);
+    expect(wrapped.lastModified).toBe(source.lastModified);
+    expect(wrapped.size).toBe(source.size);
+  });
+
+  it("carries the same bytes", async () => {
+    expect(await textOf(uploadableFile(source))).toBe(await textOf(source));
+  });
+});

--- a/frontend/editor/src/core/utils/uploadableFile.ts
+++ b/frontend/editor/src/core/utils/uploadableFile.ts
@@ -1,0 +1,25 @@
+/**
+ * The File to put in a multipart body when the caller's File may have come back
+ * from IndexedDB.
+ *
+ * WebKit stamps a File restored from IndexedDB with a disk path into its own
+ * storage folder, and its form serialiser reads any File with a path from disk.
+ * Since Safari 26.5 the process doing the upload may not read that folder, so
+ * the request goes out with Content-Length 0 and no error, while the same File
+ * reads its bytes fine in JavaScript (https://bugs.webkit.org/show_bug.cgi?id=319985).
+ * The server sees a multipart request with no boundary and rejects it before
+ * any controller runs.
+ *
+ * A File built over another File has no path, so every engine serialises it
+ * through the blob route, which is also the route WebKit takes for a File it
+ * never gave a path. That makes this wrapper correct on every browser today and
+ * after the upstream fix lands, whichever shape that fix takes. It references
+ * the bytes rather than copying them, so it is safe for arbitrarily large files,
+ * and it stays uploadable after the record it came from is rewritten or deleted.
+ */
+export function uploadableFile(file: File): File {
+  return new File([file], file.name, {
+    type: file.type,
+    lastModified: file.lastModified,
+  });
+}

--- a/frontend/editor/src/proprietary/services/policyApi.test.ts
+++ b/frontend/editor/src/proprietary/services/policyApi.test.ts
@@ -18,6 +18,15 @@ function sentForm(): FormData {
   return post.mock.calls.at(-1)?.[1] as FormData;
 }
 
+/** jsdom's Blob has no text(); FileReader is the one byte read it implements. */
+const textOf = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+
 const document = () =>
   new File(["%PDF-1.7"], "quarterly-report.pdf", { type: "application/pdf" });
 
@@ -44,5 +53,16 @@ describe("runStoredPolicy", () => {
     await runStoredPolicy("policy-1", [document()], "editor-file-1");
 
     expect(sentForm().get("fileId")).not.toContain("quarterly-report");
+  });
+
+  it("uploads a fresh File over the caller's bytes, never the caller's File object", async () => {
+    // A File restored from IndexedDB serialises as an empty body in WebKit; a wrapper does not.
+    const source = document();
+    await runStoredPolicy("policy-1", [source], "editor-file-1");
+
+    const sent = sentForm().get("fileInput") as File;
+    expect(sent).not.toBe(source);
+    expect(sent.name).toBe(source.name);
+    expect(await textOf(sent)).toBe(await textOf(source));
   });
 });

--- a/frontend/editor/src/proprietary/services/policyApi.ts
+++ b/frontend/editor/src/proprietary/services/policyApi.ts
@@ -6,6 +6,7 @@
  */
 
 import apiClient from "@app/services/apiClient";
+import { uploadableFile } from "@app/utils/uploadableFile";
 import { getPolicyOutputBaseUrl } from "@app/services/policyOutputBaseUrl";
 import type {
   BackendPolicy,
@@ -37,7 +38,8 @@ export async function runStoredPolicy(
   fileId?: string,
 ): Promise<string> {
   const form = new FormData();
-  for (const file of files) form.append("fileInput", file);
+  // Wrapped: WebKit uploads a File restored from IndexedDB as an empty body.
+  for (const file of files) form.append("fileInput", uploadableFile(file));
   if (fileId) form.append("fileId", fileId);
   // Don't set Content-Type: the HTTP client must generate multipart/form-data
   // WITH its boundary from the FormData body. A manual boundary-less header makes


### PR DESCRIPTION
On Safari and DuckDuckGo 26.5+, a file read back from IndexedDB uploads as an empty body (Content-Length 0). The server rejects the request before any controller runs, so a policy run on that file never starts and no failure is recorded. Chrome is unaffected.

The file comes out of IndexedDB with a disk path attached. WebKit uploads any file with a path by reading it from disk, and since 26.5 the process doing the upload isn't allowed to read that path. It gets nothing back and sends empty bytes instead of an error.

**Fix:** wrap the file in a fresh `File` before putting it in the form. The wrapper has no path, so every browser uploads it through the blob route. No bytes are copied.

This is a patch while we wait for the upstream fix: https://bugs.webkit.org/show_bug.cgi?id=319985. It stays correct after that fix lands, whatever shape it takes, because the wrapper never depends on the path route.

Verified in Safari 26.6.2 with a probe page: the raw IndexedDB file uploads 0 bytes, the wrapped file uploads the full body, including after the stored record is rewritten or deleted and with several uploads in parallel.

Only the policy run path is covered here. The other upload sites share the exposure and are tracked separately.