### PR TITLE
fix(onboarding): don't trip the usage-limit modal during the guided tour

### DIFF
--- a/frontend/editor/src/core/hooks/useTourActive.test.tsx
+++ b/frontend/editor/src/core/hooks/useTourActive.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTourActive } from "@app/hooks/useTourActive";
+import {
+  TOUR_STATE_EVENT,
+  dispatchTourState,
+} from "@app/constants/events";
+
+describe("useTourActive", () => {
+  test("starts inactive", () => {
+    const { result } = renderHook(() => useTourActive());
+    expect(result.current).toBe(false);
+  });
+
+  test("flips true while a tour is open and back to false when it closes", () => {
+    const { result } = renderHook(() => useTourActive());
+
+    act(() => dispatchTourState(true));
+    expect(result.current).toBe(true);
+
+    act(() => dispatchTourState(false));
+    expect(result.current).toBe(false);
+  });
+
+  test("treats a payload-less tour-state event as inactive", () => {
+    const { result } = renderHook(() => useTourActive());
+
+    act(() => dispatchTourState(true));
+    expect(result.current).toBe(true);
+
+    // Defensive: an event with no detail must not read as "tour open".
+    act(() => window.dispatchEvent(new Event(TOUR_STATE_EVENT)));
+    expect(result.current).toBe(false);
+  });
+
+  test("stops listening after unmount", () => {
+    const { result, unmount } = renderHook(() => useTourActive());
+    unmount();
+
+    act(() => dispatchTourState(true));
+    // No throw and no stale update: the listener was removed on unmount.
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/editor/src/core/hooks/useTourActive.ts
+++ b/frontend/editor/src/core/hooks/useTourActive.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { TOUR_STATE_EVENT, type TourStatePayload } from "@app/constants/events";
+
+/**
+ * Whether a guided product tour is currently running.
+ *
+ * <p>Tracks {@link TOUR_STATE_EVENT}, which the onboarding tour runners dispatch on open/close.
+ * Starts {@code false} and flips with each event, so a consumer mounted before the tour opens sees
+ * the transition.
+ *
+ * <p>Used to suppress background side effects that must not fire during a scripted demo: notably
+ * the document-classification and policy auto-run pipelines, whose backend steps are billable and
+ * entitlement-gated. The tour loads a canned sample file purely to demonstrate a tool; running it
+ * through those pipelines would consume the account's usage and can trip the usage-limit gate,
+ * which is why a brand-new account can see the "limit reached" modal mid-tour.
+ */
+export function useTourActive(): boolean {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const onTourState = (event: Event) => {
+      const detail = (event as CustomEvent<TourStatePayload>).detail;
+      setActive(Boolean(detail?.isOpen));
+    };
+    window.addEventListener(TOUR_STATE_EVENT, onTourState);
+    return () => window.removeEventListener(TOUR_STATE_EVENT, onTourState);
+  }, []);
+
+  return active;
+}

--- a/frontend/editor/src/proprietary/components/policies/PolicyAutoRunController.tsx
+++ b/frontend/editor/src/proprietary/components/policies/PolicyAutoRunController.tsx
@@ -1,3 +1,4 @@
+import { useTourActive } from "@app/hooks/useTourActive";
 import { usePolicyAutoRun } from "@app/components/policies/usePolicyAutoRun";
 import { usePolicyLocalPasses } from "@app/components/policies/usePolicyLocalPasses";
 
@@ -5,11 +6,19 @@ import { usePolicyLocalPasses } from "@app/components/policies/usePolicyLocalPas
  * Headless controller that drives policy auto-run (enforce every enabled policy
  * on every uploaded file). Mounted once wherever the editor is open so runs fire
  * regardless of whether the policy panel is visible. Renders nothing.
+ *
+ * <p>Paused while a guided tour is running: the tour loads a throwaway sample file
+ * purely to demonstrate a tool, and running it through the policy pipelines would
+ * meter a billable classification and dispatch an entitlement-gated server run
+ * that, on the pay-as-you-go plan, can surface the usage-limit modal in the
+ * middle of onboarding (even on a brand-new account). A demo must have no billing
+ * side effects. See {@link useTourActive}.
  */
 export function PolicyAutoRunController() {
+  const tourActive = useTourActive();
   // Server-dispatched, file-producing policies and their chain.
-  usePolicyAutoRun();
+  usePolicyAutoRun({ paused: tourActive });
   // Policies with a browser-side fast path (e.g. classification's heuristic), run generically.
-  usePolicyLocalPasses();
+  usePolicyLocalPasses({ paused: tourActive });
   return null;
 }

--- a/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyAutoRun.ts
@@ -129,7 +129,9 @@ function isTerminal(status: PolicyRunStatus): boolean {
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-export function usePolicyAutoRun(): void {
+export function usePolicyAutoRun({
+  paused = false,
+}: { paused?: boolean } = {}): void {
   const { fileStubs } = useAllFiles();
   const { addFiles, updateStirlingFileStub } = useFileManagement();
   const { consumeFiles } = useFileContext();
@@ -237,6 +239,9 @@ export function usePolicyAutoRun(): void {
   // Fire only the FIRST upload policy per file; the chaining effect below runs the rest
   // on each previous output, so policies apply cumulatively in order.
   useEffect(() => {
+    // Paused during a guided tour: its throwaway sample must not auto-dispatch a billable,
+    // entitlement-gated server run (see PolicyAutoRunController / useTourActive).
+    if (paused) return;
     const firstPolicyKey = orderedUploadPolicyKeys[0];
     if (!firstPolicyKey) return;
     const backendId = policies[firstPolicyKey]?.backendId;
@@ -264,7 +269,7 @@ export function usePolicyAutoRun(): void {
         })
         .finally(() => dispatching.current.delete(key));
     }
-  }, [fileStubs, policies, orderedUploadPolicyKeys, unlocksVersion]);
+  }, [paused, fileStubs, policies, orderedUploadPolicyKeys, unlocksVersion]);
 
   // Once a run's output lands, fire the next upload policy on it - success only, once per
   // run. isDispatched guards re-dispatch across reloads.

--- a/frontend/editor/src/proprietary/components/policies/usePolicyLocalPasses.ts
+++ b/frontend/editor/src/proprietary/components/policies/usePolicyLocalPasses.ts
@@ -32,7 +32,9 @@ interface ActivePass {
   requiresAiEngine: boolean;
 }
 
-export function usePolicyLocalPasses(): void {
+export function usePolicyLocalPasses({
+  paused = false,
+}: { paused?: boolean } = {}): void {
   const { fileStubs } = useAllFiles();
   const { updateStirlingFileStub } = useFileManagement();
   const { bumpRevision } = useIndexedDB();
@@ -71,7 +73,9 @@ export function usePolicyLocalPasses(): void {
   }, [policies]);
 
   useEffect(() => {
-    if (configLoading || passes.length === 0) return;
+    // Paused during a guided tour: its throwaway sample must not be classified/metered or have a
+    // server run escalated against the account (see PolicyAutoRunController / useTourActive).
+    if (paused || configLoading || passes.length === 0) return;
     const claimKey = (policyKey: string, s: StirlingFileStub) =>
       `${policyKey}:${s.id as string}:${s.lastModified ?? 0}`;
     // Collect one idle batch of pending (pass, file) work across all passes.
@@ -133,6 +137,7 @@ export function usePolicyLocalPasses(): void {
       cancelIdle();
     };
   }, [
+    paused,
     fileStubs,
     passes,
     aiEnabled,


### PR DESCRIPTION
## Problem

On the pay-as-you-go (SaaS) plan, the guided product tour can pop the "usage limit reached" / "Woah, N PDFs Processed" modal in the middle of onboarding, on a brand-new account that still has its full free allowance. It reproduces consistently: start the tour, and the modal appears.

## Why it happens

The tour loads a throwaway sample (`samples/Sample.pdf`) into the workbench purely to demonstrate a tool. Loading any file kicks off the policy pipelines that run on upload:

1. `usePolicyLocalPasses` runs the classification local pass on the sample. That pass posts a metered (billable) classification run, and because the canned sample gets a low-confidence local verdict, it escalates to a backend classification run.
2. The escalated run is a billable, entitlement-gated server operation. When it is refused with a usage-limit response, `usePolicyAutoRun` broadcasts the usage-limit signal and the `UsageLimitModalHost` opens the modal.

So a demo that only meant to show the Crop tool ends up metering usage and can trip the usage-limit gate. A guided demo should have no billing side effects.

## What this PR does

Pause the policy pipelines while a guided tour is running:

- Adds `useTourActive`, a small hook that tracks the existing `TOUR_STATE_EVENT` (the same signal the tour already uses to hide the cookie-consent banner).
- `PolicyAutoRunController` reads it and passes `paused` into `usePolicyAutoRun` and `usePolicyLocalPasses`.
- Each hook's dispatch effect early-returns while paused, so the tour's sample is never classified, metered, or escalated to a server run.

The tour clears and deletes its sample when it finishes (`restoreWorkbenchState`), so there is nothing left to process once the tour ends; the pause does not defer work onto real files. Both hooks keep their existing no-argument behaviour (default `paused: false`), so nothing changes outside a tour.

## How to test

1. SaaS build, brand-new account.
2. Start the tools tour and let it load the sample.
3. Expected: no usage-limit modal, and no classification meter / policy run fired for the sample (check the network tab: no `POST /api/v1/policies/classify/meter` and no `POST /api/v1/policies/.../run` during the tour).
4. After the tour, upload a real file: classification and policy auto-run behave normally.

## Scope and follow-up (not in this PR)

This fixes the onboarding trigger. It is deliberately scoped and does not touch the PAYG entitlement path.

There is a separate, deeper issue worth its own investigation: the escalated classification run comes back usage-limited even when the account's own team is healthy (a plain server-tool policy run on the same account succeeds). That points at an internal automation sub-step being entitlement-checked against the wrong identity (the loopback's API-key principal / `INTERNAL_API_USER`) rather than the run owner, which `PolicyEngine` itself warns about. Confirming it needs one runtime data point (the resolved principal + team on the failing `classify-and-label` loopback vs. the security run). That fix belongs in the entitlement layer and should not be guessed at blind, so it is intentionally left out here.
