### PR TITLE
fix(payg): bill the triggering user when an unowned policy runs

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/policy/engine/PolicyEngine.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/policy/engine/PolicyEngine.java
@@ -173,6 +173,10 @@ public class PolicyEngine {
         // than the owner's problem. Three identities, deliberately not interchangeable.
         String triggeringUser = currentActingPrincipal();
         String fileOwner = triggeringUser != null ? triggeringUser : policy.owner();
+        // Unowned policies (the seeded Classification policy) have no owner to bill; fall back to
+        // the triggering user, or the run goes out principal-less and its tool sub-steps bill the
+        // team-less INTERNAL_API_USER, which PAYG refuses with a usage-limit 402.
+        String billingPrincipal = policy.owner() != null ? policy.owner() : triggeringUser;
         // Stored supporting files (certificates, watermark images, ...) load here, before the
         // async hop: worker threads have no principal, so assets bind by the policy's own team.
         PolicyInputs resolved = assetResolver.resolve(policy, inputs);
@@ -183,7 +187,7 @@ public class PolicyEngine {
                 new PipelineDefinition(
                         policy.name(), policy.steps(), outputResolver.resolve(policy));
         return submitForPrincipal(
-                policy.owner(),
+                billingPrincipal,
                 fileOwner,
                 triggeringUser,
                 policy.id(),

--- a/app/proprietary/src/test/java/stirling/software/proprietary/policy/engine/PolicyEngineTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/policy/engine/PolicyEngineTest.java
@@ -532,6 +532,54 @@ class PolicyEngineTest {
     }
 
     @Test
+    void runPolicyBillsTheTriggeringUserWhenThePolicyIsUnowned() throws Exception {
+        // Regression: an unowned policy (the seeded Classification policy) must bill the triggering
+        // user, not a null principal that reverts its tool sub-steps to the team-less
+        // INTERNAL_API_USER and draws a usage-limit 402.
+        when(toolMetadataService.isMultiInput(anyString())).thenReturn(false);
+        when(toolMetadataService.shouldUnpackZipResponse(anyString())).thenReturn(false);
+        int[] counter = {0};
+        when(fileStorage.storeInputStream(any(InputStream.class), anyString()))
+                .thenAnswer(
+                        inv ->
+                                new StoredFile(
+                                        "file-" + ++counter[0],
+                                        ((InputStream) inv.getArgument(0)).readAllBytes().length));
+
+        String[] principalAtDispatch = {"<none>"};
+        when(internalApiClient.post(eq(ROTATE), any()))
+                .thenAnswer(
+                        inv -> {
+                            principalAtDispatch[0] = MDC.get("auditPrincipal");
+                            return ResponseEntity.ok(pdf("rotated", "rotated.pdf"));
+                        });
+
+        Policy unowned =
+                new Policy(
+                        "p1",
+                        "rotate",
+                        null, // unowned, like the seeded Classification policy
+                        true,
+                        List.of(),
+                        List.of(new PipelineStep(ROTATE, Map.of())),
+                        OutputSpec.inline());
+
+        MDC.put("auditPrincipal", "bob"); // the user whose upload triggered the run
+        try {
+            engine.runPolicy(
+                            unowned,
+                            PolicyInputs.of(List.of(pdf("input", "input.pdf"))),
+                            PolicyProgressListener.NOOP)
+                    .completion()
+                    .get(10, TimeUnit.SECONDS);
+        } finally {
+            MDC.remove("auditPrincipal");
+        }
+
+        assertEquals("bob", principalAtDispatch[0]);
+    }
+
+    @Test
     void adHocRunDispatchesToolCallsAsTheSubmittingUser() throws Exception {
         // Ad-hoc runs (no stored policy) bill whoever kicked them off; the principal is captured on
         // the request thread (here simulated via MDC) and re-established on the worker thread.


### PR DESCRIPTION
## Problem

On the pay-as-you-go plan, the "usage limit reached" modal fires when a document classification policy runs, even on a brand-new account that still has its entire free allowance. It reproduces deterministically: upload a PDF that the local classifier is unsure about (so it escalates to the backend AI classify run) and the run comes back `PAYG_LIMIT_REACHED`.

The discriminator that isolates it: on the same account, a user-created **security** policy run succeeds (200), but the **classification** run is refused. So the account is not out of allowance; the classification run is being billed to the wrong identity.

## Root cause

`PolicyEngine.runPolicy` bills `policy.owner()`:

```java
submitForPrincipal(policy.owner(), fileOwner, triggeringUser, ...);
```

The default Classification policy is seeded **unowned** on purpose (`DefaultClassificationPolicySeeder.defaultPolicy` passes `owner = null`, and `repairOwner` clears any legacy placeholder owner to null). So for that policy `billingPrincipal` is `null`.

`runAsPrincipal` only stamps the audit principal onto the async worker thread when it is non-null, so an unowned run leaves the worker with no identity. Each tool sub-step is dispatched via `InternalApiClient`, whose `getApiKeyForUser()` falls back to the `INTERNAL_API_USER` system account when no acting user can be resolved. That account owns no billing team, so `EntitlementGuard` sees a degraded team and refuses the sub-step with `PAYG_LIMIT_REACHED`.

A user-created policy (a security policy, say) has a real owner, so it is billed to that owner and passes. That is exactly why security works and classification does not.

## Fix

Bill the **triggering user** when the policy has no owner, mirroring how output-file ownership already falls back (`fileOwner`):

```java
String billingPrincipal = policy.owner() != null ? policy.owner() : triggeringUser;
```

An unowned policy is enforcing the triggering user's own upload, so their team is the correct payer. With a real acting user on the worker, `InternalApiClient` uses that user's key, the guard sees their (healthy) team, the sub-step runs, and the classification is billed to them. Owned policies are unchanged (still billed to the owner, including trigger-fired runs with no security context). The only case that stays principal-less is a truly unattended run of an unowned policy (no owner and no triggering user), which has nobody to bill.

