### PR TITLE
Stop file library card metadata wrapping mid-value

### DIFF
--- a/frontend/editor/src/core/components/filesPage/FilesPage.css
+++ b/frontend/editor/src/core/components/filesPage/FilesPage.css
@@ -505,29 +505,24 @@
   letter-spacing: -0.005em;
 }
 
+/* Values wrap as whole units onto their own lines rather than breaking
+   mid-value ("239.26 / KB") around a stranded separator. */
 .files-page-card-meta {
   font-size: 0.76rem;
   color: var(--c-text-subtle);
   display: flex;
-  align-items: center;
-  gap: 0.4rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: 0.4rem;
+  row-gap: 0.05rem;
 }
 
-/* Narrow cards: let the values wrap as whole units onto their own lines rather
-   than breaking mid-value ("239.26 / KB") around a stranded separator. */
-@media (max-width: 64rem) {
-  .files-page-card-meta {
-    flex-wrap: wrap;
-    align-items: baseline;
-    column-gap: 0.4rem;
-    row-gap: 0.05rem;
-  }
-  .files-page-card-meta > span {
-    white-space: nowrap;
-  }
-  .files-page-card-meta-sep {
-    display: none;
-  }
+.files-page-card-meta > span {
+  white-space: nowrap;
+}
+
+.files-page-card-meta-sep {
+  display: none;
 }
 
 /* Parent-folder breadcrumb shown on cards/rows during recursive search so


### PR DESCRIPTION
Card metadata (size and date) wrapped mid-value on desktop because the whole-unit wrapping rule only applied at 1024px and below. The rule now applies at every width: values stay on one line each and wrap as units.
<img width="1864" height="900" alt="7904" src="https://github.com/user-attachments/assets/f992308e-74d1-4747-8953-ea14321bd223" />
