### PR TITLE
Keep the file list Modified column on one line

### DIFF
--- a/frontend/editor/src/core/components/filesPage/FilesPage.css
+++ b/frontend/editor/src/core/components/filesPage/FilesPage.css
@@ -348,7 +348,9 @@
 
 .files-page-list-row {
   display: grid;
-  grid-template-columns: 2.25rem minmax(0, 3fr) 1fr 1fr 1fr 2.5rem;
+  grid-template-columns:
+    2.25rem minmax(0, 3fr) minmax(3.5rem, 1fr) minmax(4.5rem, 1fr)
+    minmax(max-content, 1.5fr) 2.5rem;
   gap: 0.5rem;
   align-items: center;
   /* Same offscreen skip as .files-page-card. */
@@ -1491,7 +1493,10 @@
     grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
     gap: 0.5rem;
   }
-  /* List view at tiny widths becomes cramped - drop the size + type + modified
+}
+
+@media (max-width: 560px) {
+  /* List view at narrow widths becomes cramped - drop the size + type + modified
      columns and let name + actions take the room. */
   .files-page-list-row {
     grid-template-columns: 1.75rem minmax(0, 1fr) 2rem;


### PR DESCRIPTION
The list view's Modified column was a plain 1fr track and wrapped date and time onto two lines from 768 to 1366 wide; it now sizes to its content while Name absorbs the difference. The narrow-width column drop moves from 420px to 560px so 430 to 560 phones show only the name.
<img width="1808" height="900" alt="7905" src="https://github.com/user-attachments/assets/8b1d81d6-45ca-408c-bb7e-83c78f47e278" />
