### PR TITLE
Wrap file library filters instead of truncating them

### DIFF
--- a/frontend/editor/src/core/components/filesPage/FilesPage.css
+++ b/frontend/editor/src/core/components/filesPage/FilesPage.css
@@ -200,12 +200,20 @@
   margin-left: auto;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 0.5rem;
   /* Allow this container to shrink below its intrinsic content width so
      the bulk-action group + filter selects + view toggle can compete for
      space without bursting out of the toolbar (which previously bled
      under the right-hand details panel at wider viewports). */
   min-width: 0;
+}
+
+.files-page-toolbar-actions > .mantine-Select-root,
+.files-page-toolbar-actions > .mantine-MultiSelect-root,
+.files-page-toolbar-actions > .mantine-TextInput-root {
+  flex-shrink: 0;
 }
 
 /* Bulk-action buttons (Add to workspace, Quick view, Move to, Remove)


### PR DESCRIPTION
At 1025 to 1180 the source filter shrank to "All source" or "A". The toolbar action group now wraps its filter controls onto a second line instead of shrinking them.
<img width="1600" height="900" alt="7907" src="https://github.com/user-attachments/assets/745ffd5f-32fd-45be-9e1c-35f1d84b9c0d" />
