### PR TITLE
Fit two Active Files columns at laptop widths

### DIFF
--- a/frontend/editor/src/core/components/fileEditor/FileEditor.tsx
+++ b/frontend/editor/src/core/components/fileEditor/FileEditor.tsx
@@ -382,7 +382,7 @@ const FileEditor = ({
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+                gridTemplateColumns: "repeat(auto-fill, minmax(276px, 1fr))",
                 rowGap: "1.5rem",
                 padding: "1rem",
                 pointerEvents: "auto",


### PR DESCRIPTION
Active Files used a 320px column minimum for 260px cards, so 1025 to 1280 wide workbenches got one column. The minimum is now 276px, giving two columns from about 1180 wide.
<img width="1600" height="1234" alt="7908" src="https://github.com/user-attachments/assets/72f8219e-b3a9-43f2-8d97-c95a8db8e3b5" />

