### PR TITLE
Fit the viewer page bar to narrow workbenches

### DIFF
--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.css
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.css
@@ -12,7 +12,20 @@
    itself, so it only plays where the bar actually enters from off-screen —
    mirroring the workbench top bar's 280ms ease, upwards instead of downwards. */
 .pdf-viewer-toolbar-dock {
+  container-type: inline-size;
   animation: pdf-viewer-toolbar-in 280ms ease both;
+}
+
+@container (max-width: 38rem) {
+  .pdf-viewer-toolbar-zoom-slider {
+    display: none;
+  }
+}
+
+@container (max-width: 34rem) {
+  .pdf-viewer-toolbar-wide-only {
+    display: none;
+  }
 }
 
 @keyframes pdf-viewer-toolbar-in {

--- a/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
+++ b/frontend/editor/src/core/components/viewer/PdfViewerToolbar.tsx
@@ -167,6 +167,7 @@ export function PdfViewerToolbar({
         <ActionIcon
           variant="tertiary"
           size={buttonSize}
+          className="pdf-viewer-toolbar-wide-only"
           onClick={handleFirstPage}
           disabled={scrollState.currentPage === 1}
           style={{ minWidth: buttonMinWidth }}
@@ -238,6 +239,7 @@ export function PdfViewerToolbar({
         <ActionIcon
           variant="tertiary"
           size={buttonSize}
+          className="pdf-viewer-toolbar-wide-only"
           onClick={handleLastPage}
           disabled={scrollState.currentPage === scrollState.totalPages}
           style={{ minWidth: buttonMinWidth }}
@@ -262,6 +264,7 @@ export function PdfViewerToolbar({
           <ActionIcon
             variant={isDualPageActive ? "primary" : "secondary"}
             size={buttonSize}
+            className="pdf-viewer-toolbar-wide-only"
             onClick={handleDualPageToggle}
             disabled={scrollState.totalPages <= 1}
             style={{ minWidth: buttonMinWidth }}
@@ -296,6 +299,7 @@ export function PdfViewerToolbar({
           <ActionIcon
             variant={pdfRenderMode !== "normal" ? "primary" : "secondary"}
             size={buttonSize}
+            className="pdf-viewer-toolbar-wide-only"
             onClick={cyclePdfRenderMode}
             style={{ minWidth: buttonMinWidth }}
             aria-label={
@@ -329,6 +333,7 @@ export function PdfViewerToolbar({
             <ZoomOutIcon fontSize="small" />
           </ActionIcon>
           <Slider
+            className="pdf-viewer-toolbar-zoom-slider"
             value={Math.min(Math.max(displayZoomPercent, 20), 500)}
             min={20}
             max={500}


### PR DESCRIPTION
The floating page bar wrapped onto two rows when the workbench was under about 640px. The dock is now a size container: below 38rem the zoom slider hides, below 34rem the first/last page, dual-page and colour-filter buttons hide, so the bar always stays on one row. At 1280 and wider nothing changes.

<img width="1600" height="900" alt="7909" src="https://github.com/user-attachments/assets/95742e05-aa9b-495f-8995-66af8802a035" />
