### PR TITLE
Keep the phone notification bell off the floating search

### DIFF
--- a/frontend/editor/src/core/components/shared/WorkbenchFloatingSearch.css
+++ b/frontend/editor/src/core/components/shared/WorkbenchFloatingSearch.css
@@ -29,3 +29,9 @@
   input {
   background-color: transparent;
 }
+
+@media (max-width: 48rem) {
+  .workbench-floating-search {
+    padding-right: 3.75rem;
+  }
+}


### PR DESCRIPTION
On phones the empty-workspace search stretched under the absolutely positioned notification bell. The search row now reserves 3.75rem on the right at 48rem and below.
<img width="1600" height="900" alt="7910" src="https://github.com/user-attachments/assets/4454694f-c194-4af6-b08d-7ad064d0b0e8" />
