### PR TITLE
Place the dismiss-errors button below the workbench bar

### DIFF
--- a/frontend/editor/src/core/components/layout/Workbench.tsx
+++ b/frontend/editor/src/core/components/layout/Workbench.tsx
@@ -302,9 +302,6 @@ export default function Workbench() {
       )}
       {showFloatingSearch && <WorkbenchFloatingSearch />}
 
-      {/* Dismiss All Errors Button */}
-      <DismissAllErrorsButton />
-
       {/* Floating AI chat button + panel */}
       <ChatFAB />
 
@@ -321,6 +318,7 @@ export default function Workbench() {
           ...(currentView === "pageEditor" && { height: 0 }),
         }}
       >
+        <DismissAllErrorsButton />
         <Suspense
           fallback={
             <Center style={{ height: "100%" }}>

--- a/frontend/editor/src/core/components/shared/DismissAllErrorsButton.tsx
+++ b/frontend/editor/src/core/components/shared/DismissAllErrorsButton.tsx
@@ -38,7 +38,7 @@ const DismissAllErrorsButton: React.FC<DismissAllErrorsButtonProps> = ({
         onClick={handleDismissAllErrors}
         style={{
           position: "absolute",
-          top: "calc(48px + 1rem)", // Sit below the 48px-tall WorkbenchBar (top toolbar)
+          top: "0.375rem",
           right: "1rem",
           zIndex: Z_INDEX_TOAST,
           pointerEvents: "auto",


### PR DESCRIPTION
The Dismiss All Errors button assumed a 48px single-row bar and landed on the viewer tool row. It now renders inside the content area just under the bar, 0.375rem from its top edge.