### PR TITLE
Raise toasts above the mobile bottom bar

### DIFF
--- a/frontend/editor/src/core/components/toast/ToastRenderer.css
+++ b/frontend/editor/src/core/components/toast/ToastRenderer.css
@@ -235,3 +235,11 @@
   color: var(--c-text);
   border-color: var(--c-border);
 }
+
+@media (max-width: 64rem) {
+  .toast-container--bottom-left,
+  .toast-container--bottom-right,
+  .toast-container--bottom-center {
+    bottom: calc(3.75rem + env(safe-area-inset-bottom, 0px));
+  }
+}


### PR DESCRIPTION
Toasts were anchored 16px from the viewport bottom and covered the mobile Tools / Automate / Files / Config bar. At 64rem and below they now sit 3.75rem up plus the safe-area inset, which leaves a few pixels above the bar.
<img width="1600" height="900" alt="7912" src="https://github.com/user-attachments/assets/1df5ccf4-8eac-4117-a546-3ee6932b7f8d" />
