### PR TITLE
Hide the search placeholder when the bar slot is too narrow

### DIFF
--- a/frontend/editor/src/core/components/shared/WorkbenchBar.css
+++ b/frontend/editor/src/core/components/shared/WorkbenchBar.css
@@ -98,6 +98,7 @@
   order: 2;
   flex: 1 1 auto;
   min-width: 0;
+  container-type: inline-size;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -120,6 +121,12 @@
 
 [data-mantine-color-scheme="dark"] .workbench-bar-search .super-search input {
   background-color: transparent;
+}
+
+@container (max-width: 9rem) {
+  .workbench-bar-search .super-search input::placeholder {
+    color: transparent;
+  }
 }
 
 /* Crowded: drops to its own full-width row between the top row and the tools. */


### PR DESCRIPTION
In the wrapped phone bar the search slot can be 40 to 90px wide. At 360 and 390 it was already too narrow to show any text, so those sizes look the same before and after; the visible change is at about 430, where the slot showed "Sea". The slot is now a size container and hides the placeholder below 9rem so the pill reads as an icon-only search.
<img width="1600" height="900" alt="7913" src="https://github.com/user-attachments/assets/b2608e5a-5d4f-480a-acb0-276c55357d4e" />
(sorry for bad screenshot its late at night)