### PR TITLE
Fit the page editor control bar on small phones

### DIFF
--- a/frontend/editor/src/core/components/pageEditor/PageEditorControls.tsx
+++ b/frontend/editor/src/core/components/pageEditor/PageEditorControls.tsx
@@ -8,6 +8,7 @@ import RotateRightIcon from "@mui/icons-material/RotateRight";
 import DeleteIcon from "@mui/icons-material/Delete";
 import InsertPageBreakIcon from "@mui/icons-material/InsertPageBreak";
 import { useTranslation } from "react-i18next";
+import { useMediaQuery } from "@mantine/hooks";
 
 interface PageEditorControlsProps {
   // Close/Reset functions
@@ -54,6 +55,8 @@ const PageEditorControls = ({
   splitPositions,
 }: PageEditorControlsProps) => {
   const { t } = useTranslation();
+  const isNarrow = useMediaQuery("(max-width: 30rem)") ?? false;
+  const controlSize = isNarrow ? "md" : "lg";
   // Calculate split tooltip text using smart toggle logic
   const getSplitTooltip = () => {
     if (!splitPositions || !displayDocument || selectedPageIds.length === 0) {
@@ -115,7 +118,7 @@ const PageEditorControls = ({
         style={{
           display: "flex",
           alignItems: "center",
-          gap: 12,
+          gap: isNarrow ? 6 : 12,
           borderTopLeftRadius: 16,
           borderTopRightRadius: 16,
           borderBottomLeftRadius: 0,
@@ -125,19 +128,18 @@ const PageEditorControls = ({
           border: "1px solid var(--c-border)",
           borderRadius: "16px 16px 0 0",
           pointerEvents: "auto",
-          minWidth: 360,
+          minWidth: isNarrow ? 0 : 360,
           maxWidth: 700,
           flexWrap: "wrap",
           justifyContent: "center",
-          padding: "1rem",
-          paddingBottom: "1rem",
+          padding: isNarrow ? "0.75rem 0.5rem" : "1rem",
         }}
       >
         {/* Undo/Redo */}
         <Tooltip label={t("pageEditor.toolbar.undo", "Undo")}>
           <ActionIcon
             variant="tertiary"
-            size="lg"
+            size={controlSize}
             onClick={onUndo}
             disabled={!canUndo}
             aria-label={t("pageEditor.toolbar.undo", "Undo")}
@@ -148,7 +150,7 @@ const PageEditorControls = ({
         <Tooltip label={t("pageEditor.toolbar.redo", "Redo")}>
           <ActionIcon
             variant="tertiary"
-            size="lg"
+            size={controlSize}
             onClick={onRedo}
             disabled={!canRedo}
             aria-label={t("pageEditor.toolbar.redo", "Redo")}
@@ -162,7 +164,7 @@ const PageEditorControls = ({
             width: 1,
             height: 28,
             backgroundColor: "var(--mantine-color-gray-3)",
-            margin: "0 8px",
+            margin: isNarrow ? "0 4px" : "0 8px",
           }}
         />
 
@@ -172,7 +174,7 @@ const PageEditorControls = ({
         >
           <ActionIcon
             variant="tertiary"
-            size="lg"
+            size={controlSize}
             onClick={() => onRotate("left")}
             disabled={selectedPageIds.length === 0}
             aria-label={t(
@@ -188,7 +190,7 @@ const PageEditorControls = ({
         >
           <ActionIcon
             variant="tertiary"
-            size="lg"
+            size={controlSize}
             onClick={() => onRotate("right")}
             disabled={selectedPageIds.length === 0}
             aria-label={t(
@@ -202,7 +204,7 @@ const PageEditorControls = ({
         <Tooltip label={t("pageEditor.toolbar.delete", "Delete Selected")}>
           <ActionIcon
             variant="tertiary"
-            size="lg"
+            size={controlSize}
             onClick={onDelete}
             disabled={selectedPageIds.length === 0}
             aria-label={t("pageEditor.toolbar.delete", "Delete Selected")}
@@ -213,7 +215,7 @@ const PageEditorControls = ({
         <Tooltip label={getSplitTooltip()}>
           <ActionIcon
             variant="tertiary"
-            size="lg"
+            size={controlSize}
             onClick={onSplit}
             disabled={selectedPageIds.length === 0}
             aria-label={getSplitTooltip()}
@@ -224,7 +226,7 @@ const PageEditorControls = ({
         <Tooltip label={getPageBreakTooltip()}>
           <ActionIcon
             variant="tertiary"
-            size="lg"
+            size={controlSize}
             onClick={onPageBreak}
             disabled={selectedPageIds.length === 0}
             aria-label={getPageBreakTooltip()}


### PR DESCRIPTION
The page editor's floating control bar wrapped to two rows on 360 to 390px phones. Below 30rem it uses medium controls, a 6px gap and tighter padding so all seven controls fit on one row.
<img width="3000" height="2400" alt="image" src="https://github.com/user-attachments/assets/f6b5e352-9caa-4387-8418-4e336989ced4" />