### PR TITLE
Cap the tool panel width on tablets

### DIFF
--- a/frontend/editor/src/core/components/tools/RightSidebar.tsx
+++ b/frontend/editor/src/core/components/tools/RightSidebar.tsx
@@ -214,6 +214,8 @@ export default function RightSidebar() {
             transition: "opacity 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94)",
             height: "100%",
             width: isMobile ? "100%" : expandedWidth,
+            maxWidth: isMobile ? "44rem" : undefined,
+            marginInline: isMobile ? "auto" : undefined,
             flexShrink: 0,
             display: "flex",
             flexDirection: "column",


### PR DESCRIPTION
Tool forms stretched across the full 768 to 1024px tablet width. The mobile tool panel is now capped at 44rem and centred.
<img width="1600" height="958" alt="7915" src="https://github.com/user-attachments/assets/0489673f-a9e5-4185-b0e7-02295de9fb61" />
I think this is opinionated? thoughts?