### PR TITLE
Give the search dropdown a visible edge in dark mode

### DIFF
--- a/frontend/editor/src/core/components/shared/superSearch/SuperSearch.css
+++ b/frontend/editor/src/core/components/shared/superSearch/SuperSearch.css
@@ -271,3 +271,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+[data-mantine-color-scheme="dark"] .super-search-dropdown {
+  border-color: var(--c-border-strong);
+}


### PR DESCRIPTION
The search results dropdown used the subtle border token, which in dark mode is 5% white and invisible against the workbench. It now uses the strong border token in dark.