### PR TITLE
Await the replaced row rather than the action call in the failures list test

### DIFF
--- a/frontend/editor/src/portal/components/failures/FileRunEventList.test.tsx
+++ b/frontend/editor/src/portal/components/failures/FileRunEventList.test.tsx
@@ -347,8 +347,21 @@ describe("FileRunEventList", () => {
 
   it("replaces the acted-on row in place using the server's response", async () => {
     fetchFileRunEvents.mockResolvedValue([event()]);
+    // An acknowledged row comes back offering what is left to do with it, which is
+    // the one thing on screen that tells the replacement from the row it replaced.
     applyFileRunEventAction.mockResolvedValue(
-      event({ status: "ACKNOWLEDGED", statusActor: "me@example.com" }),
+      event({
+        status: "ACKNOWLEDGED",
+        statusActor: "me@example.com",
+        actions: [
+          offer({
+            id: "DISMISS",
+            labelKey: "portal.failures.action.dismiss",
+            defaultLabel: "Dismiss",
+            slot: "OVERFLOW",
+          }),
+        ],
+      }),
     );
 
     render(<FileRunEventList />);
@@ -356,12 +369,11 @@ describe("FileRunEventList", () => {
     fireEvent.click(screen.getByRole("button", { name: "More options" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Acknowledge" }));
 
-    await waitFor(() => {
-      expect(applyFileRunEventAction).toHaveBeenCalledWith(
-        "fre-1",
-        "ACKNOWLEDGE",
-      );
-    });
+    // Wait on the replaced row, not on the call: the call lands synchronously, so
+    // waiting on it leaves the assertions below racing the response into state.
+    expect(await screen.findByRole("button", { name: "Dismiss" })).toBeTruthy();
+    expect(screen.getByText("Password-protected document")).toBeTruthy();
+    expect(applyFileRunEventAction).toHaveBeenCalledWith("fre-1", "ACKNOWLEDGE");
     // Updated from the response rather than by refetching, so the list does not
     // reload and jump under the reviewer.
     expect(fetchFileRunEvents).toHaveBeenCalledTimes(1);

--- a/frontend/editor/src/portal/components/failures/FileRunEventList.test.tsx
+++ b/frontend/editor/src/portal/components/failures/FileRunEventList.test.tsx
@@ -373,7 +373,10 @@ describe("FileRunEventList", () => {
     // waiting on it leaves the assertions below racing the response into state.
     expect(await screen.findByRole("button", { name: "Dismiss" })).toBeTruthy();
     expect(screen.getByText("Password-protected document")).toBeTruthy();
-    expect(applyFileRunEventAction).toHaveBeenCalledWith("fre-1", "ACKNOWLEDGE");
+    expect(applyFileRunEventAction).toHaveBeenCalledWith(
+      "fre-1",
+      "ACKNOWLEDGE",
+    );
     // Updated from the response rather than by refetching, so the list does not
     // reload and jump under the reviewer.
     expect(fetchFileRunEvents).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
The test awaited `applyFileRunEventAction` having been called, which is true synchronously inside the click, so every assertion after it raced the response into state. The response was also identical to the row already on screen, so the replacement could not be observed at all.

The acknowledged row now comes back offering what is left to do with it, and the test awaits that row before asserting. Verified with 8 consecutive clean runs of `src/portal src/proprietary/policies`, two of them under CPU contention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for replacing actions in the file run event list.
  * Added verification that acknowledged events retain the available dismiss action.
  * Confirmed the interface updates before validating the action request, without triggering an unnecessary refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->