### PR TITLE
Support root and non-root Docker runtime modes

### DIFF
--- a/.taskfiles/docker.yml
+++ b/.taskfiles/docker.yml
@@ -5,6 +5,16 @@ vars:
   EMBEDDED_DIR: docker/embedded
 
 tasks:
+  check:
+    desc: "Check Docker runtime user modes"
+    vars:
+      IMAGE: '{{.IMAGE | default "stirling-pdf"}}'
+      PYTHON: '{{.PYTHON | default "python3"}}'
+    cmds:
+      - for script in scripts/init.sh scripts/init-without-ocr.sh scripts/runtime-user.sh; do bash -n "$script" || exit; done
+      - '{{.PYTHON}} testing/docker/test_runtime_user_startup.py --image "{{.IMAGE}}"'
+      - '{{.PYTHON}} testing/docker/test_runtime_users.py --image "{{.IMAGE}}" {{.CLI_ARGS}}'
+
   build:
     desc: "Build standard Docker image"
     cmds:

--- a/docker/README-runtime-users.md
+++ b/docker/README-runtime-users.md
@@ -1,0 +1,118 @@
+# Container runtime users
+
+The embedded, backend, fat, and ultra-lite images support these launch modes:
+
+| Configuration | Entrypoint | Java and converters |
+| --- | --- | --- |
+| Default | root | UID/GID 1000:1000 |
+| `PUID=1002 PGID=1003` | root | UID/GID 1002:1003 |
+| `PUID=0 PGID=0` | root | root |
+| `--user 1000:1000` | UID/GID 1000:1000 | UID/GID 1000:1000 |
+| `--user 12345:12346` with prepared writable mounts | UID/GID 12345:12346 | UID/GID 12345:12346 |
+
+There is no separate root opt-in flag. When the entrypoint starts as root,
+`PUID` and `PGID` select the application identity. When it starts as non-root,
+Docker's effective UID, primary GID, and supplementary groups are authoritative;
+the image's default `PUID`/`PGID` values are ignored. The UID need not have an
+entry in `/etc/passwd`.
+
+## Choose a mode
+
+Normal startup prepares data ownership as root and launches the application as
+1000:1000:
+
+```sh
+docker run --rm -p 8080:8080 stirling-pdf
+```
+
+Select another application identity, or select root explicitly:
+
+```sh
+docker run --rm -e PUID=1002 -e PGID=1003 -p 8080:8080 stirling-pdf
+docker run --rm -e PUID=0 -e PGID=0 -p 8080:8080 stirling-pdf
+```
+
+Start the entire container as the default non-root identity:
+
+```sh
+docker run --rm --user 1000:1000 --cap-drop=ALL \
+  --security-opt=no-new-privileges:true -p 8080:8080 stirling-pdf
+```
+
+`--user 0:0` alone still uses the default `PUID`/`PGID` to launch the application.
+Set `PUID=0 PGID=0` to select root for the application too.
+
+## Writable storage
+
+The image prepares its built-in data directories for UID/GID 1000:1000. For a
+different direct `--user`, or a read-only container filesystem, provide writable
+mounts for:
+
+- `/home/stirlingpdfuser` (or the directory selected by `HOME`)
+- `/configs`, `/logs`, `/customFiles`, `/pipeline`, and `/storage`
+- `/tmp`
+- `/opt/stirling-engine/data` when using the fat image
+
+Prepare the mounted directories with the selected UID/GID before starting a
+non-root container. It cannot change ownership on your behalf. Existing files,
+including a persisted database, must also be accessible to that identity.
+Startup reports the exact unwritable directory and exits if preparation is
+incomplete; it does not make the directory world-writable.
+
+For named volumes, mount them with `volume-nocopy` after preparing ownership.
+Otherwise Docker can copy the image directory's ownership back into an empty
+volume. For example, to prepare a configs volume for UID/GID 12345:12346:
+
+```sh
+docker volume create stirling-configs
+docker run --rm --user 0:0 --entrypoint sh \
+  --mount type=volume,source=stirling-configs,target=/configs,volume-nocopy \
+  stirling-pdf -c 'chown -R 12345:12346 /configs'
+```
+
+Use the same mount option on the application container, and prepare the other
+data volumes similarly. Read-only data mounts are not suitable for these paths.
+
+If `/tmp` is a tmpfs, include `exec`: PDFium and other native libraries are
+extracted and loaded from Java's temporary directory. For example:
+
+```sh
+--tmpfs /tmp:rw,exec,uid=12345,gid=12346,mode=1777
+```
+
+Combining prepared data mounts, that tmpfs, `--user 12345:12346`, and
+`--read-only` runs the application with a read-only image filesystem. The
+image's code and scripts do not need writable mounts.
+
+## Startup and optional features
+
+Root startup needs `CHOWN`, `DAC_OVERRIDE`, and `FOWNER` to prepare mounted
+storage, `SETUID`/`SETGID` to launch a different identity, and `KILL` for graceful
+shutdown across that identity boundary. The supplied Compose files include
+these capabilities. A container started directly as non-root can drop them all.
+
+Invalid UID/GID values, failed remapping, and a missing `setpriv` executable are
+startup errors when the requested identity cannot be applied. There is no
+automatic fallback to a different application UID. Explicit root mode does
+not need `setpriv` when its UID/GID already match the entrypoint.
+
+Custom OCR languages mounted at `/usr/share/tessdata` are combined with bundled
+languages through a temporary symlink directory. No writes to the system
+tessdata directory are needed. An explicit `TESSDATA_PREFIX` takes precedence.
+
+System package or font installation still needs an image build or a prepared
+mount; selecting a non-root user does not grant permission to modify `/usr`.
+
+## Run the integration checks
+
+Build the desired image, install the test dependencies, and run:
+
+```sh
+python -m pip install -r testing/docker/requirements.txt
+python testing/docker/test_runtime_users.py --image stirling-pdf
+```
+
+Use `--lite` for the ultra-lite image, and supply mode names to run a subset,
+such as `direct1000 root`. `--output /path/to/results` preserves response files,
+container logs, process identities, and the JSON result summary. Test containers
+and volumes are removed after each case.

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,9 @@
 
 This directory contains the organized Docker configurations for the split frontend/backend architecture.
 
+See [Container runtime users](README-runtime-users.md) for root, non-root, and
+read-only container configuration.
+
 ## Using Taskfile (Recommended)
 
 All Docker commands can be run from the project root using [Task](https://taskfile.dev/):

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -86,6 +86,11 @@ COPY app/core/src/main/resources/static/fonts/*.ttf /usr/share/fonts/truetype/
 
 # Permissions and configuration
 RUN set -eux; \
+    groupmod -o -g 1000 stirlingpdfgroup; \
+    usermod -o -u 1000 stirlingpdfuser; \
+    mkdir -p /logs /configs /customFiles /pipeline /storage /tmp/stirling-pdf /tmp/.X11-unix; \
+    chown -R stirlingpdfuser:stirlingpdfgroup /home/stirlingpdfuser /logs /configs /customFiles /pipeline /storage /tmp/stirling-pdf; \
+    chmod 1777 /tmp/.X11-unix; \
     chmod +x /scripts/*; \
     ln -s /logs /app/logs; \
     ln -s /configs /app/configs; \

--- a/docker/embedded/Dockerfile
+++ b/docker/embedded/Dockerfile
@@ -116,6 +116,11 @@ COPY app/core/src/main/resources/static/fonts/*.ttf /usr/share/fonts/truetype/
 
 # Permissions and configuration
 RUN set -eux; \
+    groupmod -o -g 1000 stirlingpdfgroup; \
+    usermod -o -u 1000 stirlingpdfuser; \
+    mkdir -p /logs /configs /customFiles /pipeline /storage /tmp/stirling-pdf /tmp/.X11-unix; \
+    chown -R stirlingpdfuser:stirlingpdfgroup /home/stirlingpdfuser /logs /configs /customFiles /pipeline /storage /tmp/stirling-pdf; \
+    chmod 1777 /tmp/.X11-unix; \
     chmod +x /scripts/*; \
     ln -s /logs /app/logs; \
     ln -s /configs /app/configs; \

--- a/docker/embedded/Dockerfile.fat
+++ b/docker/embedded/Dockerfile.fat
@@ -131,6 +131,11 @@ COPY app/core/src/main/resources/static/fonts/*.ttf /usr/share/fonts/truetype/
 
 # Permissions and configuration
 RUN set -eux; \
+    groupmod -o -g 1000 stirlingpdfgroup; \
+    usermod -o -u 1000 stirlingpdfuser; \
+    mkdir -p /logs /configs /customFiles /pipeline /storage /tmp/stirling-pdf /tmp/.X11-unix; \
+    chown -R stirlingpdfuser:stirlingpdfgroup /home/stirlingpdfuser /logs /configs /customFiles /pipeline /storage /tmp/stirling-pdf; \
+    chmod 1777 /tmp/.X11-unix; \
     chmod +x /scripts/*; \
     ln -s /logs /app/logs; \
     ln -s /configs /app/configs; \

--- a/docker/embedded/Dockerfile.ultra-lite
+++ b/docker/embedded/Dockerfile.ultra-lite
@@ -123,6 +123,7 @@ RUN mkdir -p $HOME /configs /logs /customFiles /pipeline/watchedFolders /pipelin
 
 # Copy scripts and built artifacts after OS package layer to maximize cache reuse.
 COPY scripts/init-without-ocr.sh /scripts/init-without-ocr.sh
+COPY scripts/runtime-user.sh /scripts/runtime-user.sh
 COPY scripts/installFonts.sh /scripts/installFonts.sh
 COPY scripts/stirling-diagnostics.sh /scripts/stirling-diagnostics.sh
 

--- a/scripts/init-without-ocr.sh
+++ b/scripts/init-without-ocr.sh
@@ -87,14 +87,29 @@ cleanup() {
     fi
   fi
 
-  # Kill any remaining children (watchdog, Xvfb, etc.)
+  # Xvfb removes its display lock during shutdown; let it finish before PID 1 exits.
+  if [ -n "${XVFB_PID:-}" ]; then
+    kill -TERM "$XVFB_PID" 2>/dev/null || true
+    wait "$XVFB_PID" 2>/dev/null || true
+  fi
+
+  # Kill any remaining children (watchdog, etc.)
   pkill -P $$ 2>/dev/null || true
 
+  if [ -n "${STIRLING_TESSDATA_TEMP:-}" ]; then
+    rm -f -- "$STIRLING_TESSDATA_TEMP"/*
+    rmdir -- "$STIRLING_TESSDATA_TEMP"
+  fi
   log "Cleanup complete."
 }
 
 trap 'SHUTDOWN_REQUESTED=1; cleanup' SIGTERM
 trap cleanup EXIT
+
+UMASK_VAL="${UMASK:-022}"
+umask "$UMASK_VAL" 2>/dev/null || umask 022
+
+source "$(dirname "${BASH_SOURCE[0]}")/runtime-user.sh"
 
 print_versions
 
@@ -122,7 +137,6 @@ tcp_port_check() {
   if [ -n "${BASH_VERSION:-}" ] && command_exists bash; then
     run_with_timeout "$timeout_secs" bash -c "exec 3<>/dev/tcp/${host}/${port}" 2>/dev/null
     local result=$?
-    exec 3>&- 2>/dev/null || true
     return $result
   fi
 
@@ -180,52 +194,6 @@ check_unoserver_ready() {
 UNOSERVER_PIDS=()
 UNOSERVER_PORTS=()
 UNOSERVER_UNO_PORTS=()
-
-CURRENT_USER="$(id -un)"
-CURRENT_UID="$(id -u)"
-
-# setpriv when root must drop, none when the current user already is the target, root when the
-# drop is impossible. Decided once by resolve_privilege_mode() ahead of the first caller: a
-# per-call decision would announce a failed drop from whichever caller ran first, and callers
-# such as the write probe below discard stderr.
-PRIVILEGE_MODE=""
-
-run_as_runtime_user() {
-  if [ "$PRIVILEGE_MODE" = setpriv ]; then
-    # Set HOME/USER/LOGNAME to match gosu behavior (setpriv does not touch env vars)
-    env HOME="$(getent passwd "$RUNTIME_USER" | cut -d: -f6)" \
-        USER="$RUNTIME_USER" \
-        LOGNAME="$RUNTIME_USER" \
-      setpriv --reuid="$RUNTIME_USER" --regid="$(id -gn "$RUNTIME_USER")" --init-groups -- "$@"
-  else
-    "$@"
-  fi
-}
-
-resolve_privilege_mode() {
-  if [ "$RUID" -eq 0 ]; then
-    PRIVILEGE_MODE=none
-    log "Running the application and converters as ${RUNTIME_USER} (uid 0)."
-    return
-  fi
-  if [ "$CURRENT_USER" = "$RUNTIME_USER" ]; then
-    PRIVILEGE_MODE=none
-    log "Running as ${RUNTIME_USER} (uid ${CURRENT_UID}); no privilege drop needed."
-    return
-  fi
-  if [ "$CURRENT_UID" -ne 0 ]; then
-    PRIVILEGE_MODE=none
-    log "Running as ${CURRENT_USER} (uid ${CURRENT_UID}) rather than ${RUNTIME_USER}; commands run as the current user."
-    return
-  fi
-  if command_exists setpriv; then
-    PRIVILEGE_MODE=setpriv
-    log "Dropping privileges to ${RUNTIME_USER} (uid ${RUID}) for the application, the AI engine and every LibreOffice process."
-    return
-  fi
-  PRIVILEGE_MODE=root
-  log "WARNING: setpriv is not available; running the application and converters as ${CURRENT_USER}."
-}
 
 run_as_runtime_user_with_timeout() {
   local secs=$1; shift
@@ -307,7 +275,7 @@ start_unoserver_instance() {
   local profile_dir="${LIBREOFFICE_PROFILE}/instance_${port}"
   run_as_runtime_user mkdir -p "$profile_dir"
   # --user-installation is a plain path; unoserver 3.6 crashes if pre-wrapped as file://.
-  run_as_runtime_user env ${OFFICE_LD_PRELOAD:+LD_PRELOAD="$OFFICE_LD_PRELOAD"} "$UNOSERVER_BIN" \
+  "${RUNTIME_COMMAND[@]}" env ${OFFICE_LD_PRELOAD:+LD_PRELOAD="$OFFICE_LD_PRELOAD"} "$UNOSERVER_BIN" \
     --interface 127.0.0.1 \
     --port "$port" \
     --uno-port "$uno_port" \
@@ -854,35 +822,6 @@ esac
 log "running with JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}"
 log "Running Stirling PDF with DISABLE_ADDITIONAL_FEATURES=${DISABLE_ADDITIONAL_FEATURES:-} and VERSION_TAG=${VERSION_TAG:-<unset>}"
 
-# ---------- UMASK ----------
-# Set default permissions mask.
-UMASK_VAL="${UMASK:-022}"
-umask "$UMASK_VAL" 2>/dev/null || umask 022
-
-# ---------- XDG_RUNTIME_DIR ----------
-# Create the runtime directory, respecting UID/GID settings.
-RUNTIME_USER="stirlingpdfuser"
-if id -u "$RUNTIME_USER" >/dev/null 2>&1; then
-  RUID="$(id -u "$RUNTIME_USER")"
-  RGID="$(id -g "$RUNTIME_USER")"
-  RGRP="$(id -gn "$RUNTIME_USER")"
-else
-  RUID="$(id -u)"
-  RGID="$(id -g)"
-  RGRP="$(id -gn)"
-  RUNTIME_USER="$(id -un)"
-fi
-CURRENT_USER="$(id -un)"
-CURRENT_UID="$(id -u)"
-
-export XDG_RUNTIME_DIR="/tmp/xdg-${RUID}"
-mkdir -p "${XDG_RUNTIME_DIR}" || true
-if [ "$(id -u)" -eq 0 ]; then
-  chown "${RUNTIME_USER}:${RGRP}" "${XDG_RUNTIME_DIR}" 2>/dev/null || true
-fi
-chmod 700 "${XDG_RUNTIME_DIR}" 2>/dev/null || true
-log "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}"
-
 # ---------- Optional ----------
 # Disable advanced HTML operations if required.
 if [[ "${INSTALL_BOOK_AND_ADVANCED_HTML_OPS:-false}" == "true" && "${FAT_DOCKER:-true}" != "true" ]]; then
@@ -894,66 +833,6 @@ if [[ "${FAT_DOCKER:-true}" != "true" && -x /scripts/download-security-jar.sh ]]
   /scripts/download-security-jar.sh || true
 fi
 
-# ---------- UID/GID remap ----------
-# Remap user/group IDs to match container runtime settings.
-if [ "$(id -u)" -eq 0 ]; then
-  if id -u stirlingpdfuser >/dev/null 2>&1; then
-    if [ -n "${PUID:-}" ] && [ "$PUID" != "$(id -u stirlingpdfuser)" ]; then
-      usermod -o -u "$PUID" stirlingpdfuser || true
-      chown stirlingpdfuser:stirlingpdfgroup "${XDG_RUNTIME_DIR}" 2>/dev/null || true
-    fi
-  fi
-  if getent group stirlingpdfgroup >/dev/null 2>&1; then
-    if [ -n "${PGID:-}" ] && [ "$PGID" != "$(getent group stirlingpdfgroup | cut -d: -f3)" ]; then
-      groupmod -o -g "$PGID" stirlingpdfgroup || true
-    fi
-  fi
-  RUID="$(id -u "$RUNTIME_USER")"
-  RGID="$(id -g "$RUNTIME_USER")"
-  RGRP="$(id -gn "$RUNTIME_USER")"
-fi
-
-resolve_privilege_mode
-
-# ---------- Permissions ----------
-# Ensure required directories exist and set correct permissions.
-log "Setting permissions..."
-mkdir -p /tmp/stirling-pdf /tmp/stirling-pdf/heap_dumps /logs /configs /configs/heap_dumps /configs/cache /customFiles /pipeline /storage || true
-# State the runtime writes, and nothing it executes. /scripts and the application jars stay
-# root-owned in the image and are absent here, so a compromised converter running at the runtime
-# uid cannot rewrite the code root executes on the next restart.
-CHOWN_PATHS=("$HOME" "/logs" "/configs" "/customFiles" "/pipeline" "/storage" "/tmp/stirling-pdf")
-# Chowned here rather than at build time so it follows PUID/PGID remapping.
-if [ -d "${STIRLING_ENGINE_HOME:-/opt/stirling-engine}" ]; then
-  mkdir -p "${STIRLING_ENGINE_HOME:-/opt/stirling-engine}/data" || true
-  CHOWN_PATHS+=("${STIRLING_ENGINE_HOME:-/opt/stirling-engine}/data")
-fi
-CHOWN_OK=true
-for p in "${CHOWN_PATHS[@]}"; do
-  if [ -e "$p" ]; then
-    chown -R "stirlingpdfuser:stirlingpdfgroup" "$p" 2>/dev/null || CHOWN_OK=false
-    # u+rwX, never a fixed mode: it gives the owner traversal on directories and read/write on
-    # files without touching the group and other bits, so the 0600 the app writes on
-    # credential-encryption.key and file-encryption.key survives every restart.
-    chmod -R u+rwX "$p" 2>/dev/null || true
-  fi
-done
-
-# Verify write access to critical directories; repair if chown failed on bind mounts
-CRITICAL_DIRS=("/configs" "/logs" "/customFiles" "/pipeline" "/storage")
-for dir in "${CRITICAL_DIRS[@]}"; do
-  if [ -d "$dir" ]; then
-    # Test write access as the runtime user
-    if ! run_as_runtime_user test -w "$dir" 2>/dev/null; then
-      log "WARNING: ${RUNTIME_USER} cannot write to $dir - attempting to fix directory permissions"
-      # Directories only: opening up existing files here would strip the owner-only mode off any
-      # key already sitting in the mount.
-      find "$dir" -type d -exec chmod o+rwx {} + 2>/dev/null \
-        || log "ERROR: Could not grant ${RUNTIME_USER} write access to $dir. Check your volume mount permissions (e.g. set PUID/PGID or fix host directory ownership)."
-    fi
-  fi
-done
-
 # ---------- Xvfb ----------
 # Start a virtual framebuffer for GUI-based LibreOffice interactions.
 if command_exists Xvfb; then
@@ -961,7 +840,8 @@ if command_exists Xvfb; then
   # X refuses to create its socket directory once euid is not 0, so it has to exist beforehand.
   mkdir -p /tmp/.X11-unix 2>/dev/null || true
   chmod 1777 /tmp/.X11-unix 2>/dev/null || true
-  run_as_runtime_user Xvfb :99 -screen 0 1024x768x24 -nolisten tcp +extension GLX +render -noreset > /dev/null 2>&1 &
+  "${RUNTIME_COMMAND[@]}" Xvfb :99 -screen 0 1024x768x24 -nolisten tcp +extension GLX +render -noreset > /dev/null 2>&1 &
+  XVFB_PID=$!
   export DISPLAY=:99
   # Brief pause so Xvfb accepts connections before unoserver tries to attach
   sleep 1
@@ -1044,28 +924,12 @@ elif [ -x "$STIRLING_ENGINE_HOME/.venv/bin/python" ]; then
     --app-dir "$STIRLING_ENGINE_HOME/src"
   )
   # init.sh exports PYTHONPATH for unoserver's 3.12 venv; inheriting it breaks the 3.13 engine.
-  if [ "$PRIVILEGE_MODE" = setpriv ]; then
-    env -u PYTHONPATH \
-        HOME="$(getent passwd "$RUNTIME_USER" | cut -d: -f6)" \
-        USER="$RUNTIME_USER" \
-        LOGNAME="$RUNTIME_USER" \
-      setpriv --reuid="$RUNTIME_USER" --regid="$(id -gn "$RUNTIME_USER")" --init-groups -- "${ENGINE_CMD[@]}" &
-  else
-    env -u PYTHONPATH "${ENGINE_CMD[@]}" &
-  fi
+  "${RUNTIME_COMMAND[@]}" env -u PYTHONPATH "${ENGINE_CMD[@]}" &
   ENGINE_PID=$!
   log "AI engine started (PID $ENGINE_PID)"
 fi
 
-if [ "$PRIVILEGE_MODE" = setpriv ]; then
-  # Set HOME/USER/LOGNAME to match gosu behavior (setpriv does not touch env vars)
-  env HOME="$(getent passwd "$RUNTIME_USER" | cut -d: -f6)" \
-      USER="$RUNTIME_USER" \
-      LOGNAME="$RUNTIME_USER" \
-    setpriv --reuid="$RUNTIME_USER" --regid="$(id -gn "$RUNTIME_USER")" --init-groups -- "${JAVA_CMD[@]}" &
-else
-  "${JAVA_CMD[@]}" &
-fi
+"${RUNTIME_COMMAND[@]}" "${JAVA_CMD[@]}" &
 
 JAVA_PID=$!
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -66,38 +66,27 @@ if [ ${#PYTHON_PATH_ENTRIES[@]} -gt 0 ]; then
   export PYTHONPATH
 fi
 
-# # === tessdata ===
-# # Prepare Tesseract OCR data directory.
-# In Debian, tesseract looks in /usr/share/tesseract-ocr/5/tessdata
-# For backwards compatibility, copy any user-mounted files from /usr/share/tessdata
 TESSDATA_SYSTEM="/usr/share/tesseract-ocr/5/tessdata"
 TESSDATA_MOUNT="/usr/share/tessdata"
 
-log_warn() {
-  echo "[init][warn] $*" >&2
-}
-
-# Ensure system tessdata directory exists
-mkdir -p "$TESSDATA_SYSTEM" 2>/dev/null || true
-
-# For backwards compatibility: if user mounted custom languages to /usr/share/tessdata,
-# copy them to the system location where Tesseract actually looks
-if [ -d "$TESSDATA_MOUNT" ] && [ "$(ls -A "$TESSDATA_MOUNT" 2>/dev/null)" ]; then
-  log_warn "Found user-mounted tessdata in $TESSDATA_MOUNT, copying to system location $TESSDATA_SYSTEM"
-  cp -rn "$TESSDATA_MOUNT"/* "$TESSDATA_SYSTEM"/ 2>/dev/null || true
+# An explicit prefix is authoritative. The legacy mount overlays the bundled languages
+# through readable symlinks, so it also works with a non-root or read-only container.
+if [ -z "${TESSDATA_PREFIX:-}" ]; then
+  export TESSDATA_PREFIX="$TESSDATA_SYSTEM"
+  if [ -d "$TESSDATA_MOUNT" ] && [ "$(ls -A "$TESSDATA_MOUNT")" ]; then
+    STIRLING_TESSDATA_TEMP=$(mktemp -d /tmp/stirling-tessdata.XXXXXX)
+    chmod 755 "$STIRLING_TESSDATA_TEMP"
+    for dir in "$TESSDATA_SYSTEM" "$TESSDATA_MOUNT"; do
+      for entry in "$dir"/*; do
+        [ -e "$entry" ] || continue
+        ln -sfn "$entry" "$STIRLING_TESSDATA_TEMP/$(basename "$entry")"
+      done
+    done
+    export STIRLING_TESSDATA_TEMP
+    export TESSDATA_PREFIX="$STIRLING_TESSDATA_TEMP"
+  fi
 fi
-
-# Set TESSDATA_PREFIX to system location
-export TESSDATA_PREFIX="$TESSDATA_SYSTEM"
-log_warn "Using TESSDATA_PREFIX=$TESSDATA_PREFIX"
-
-# === Temp dir ===
-# Ensure the temporary directory exists and has proper permissions.
-mkdir -p /tmp/stirling-pdf
-chown -R stirlingpdfuser:stirlingpdfgroup /tmp/stirling-pdf || true
-# u+rwX rather than a fixed mode: uploads and temp files stay owner-only instead of being
-# republished world-readable on every start.
-chmod -R u+rwX /tmp/stirling-pdf || true
+printf '[init] Using TESSDATA_PREFIX=%s\n' "$TESSDATA_PREFIX" >&2
 
 # === Start application ===
 # Run the main init script that handles the full startup logic.

--- a/scripts/runtime-user.sh
+++ b/scripts/runtime-user.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Sourced by the entrypoint. Docker --user owns the identity when already non-root;
+# otherwise PUID/PGID select the identity used for application child processes.
+runtime_error() {
+  log "ERROR: $*"
+  exit 1
+}
+
+validate_runtime_id() {
+  local name=$1 value=$2
+  [[ "$value" =~ ^(0|[1-9][0-9]{0,9})$ ]] && [ "$value" -le 4294967294 ] \
+    || runtime_error "$name must be an integer between 0 and 4294967294; received '$value'."
+}
+
+CURRENT_UID=$(id -u)
+CURRENT_GID=$(id -g)
+PRIVILEGE_MODE=none
+
+if [ "$CURRENT_UID" -ne 0 ]; then
+  RUID=$CURRENT_UID
+  RGID=$CURRENT_GID
+  if [ "${PUID:-$RUID}" != "$RUID" ] || [ "${PGID:-$RGID}" != "$RGID" ]; then
+    log "Docker --user selects ${RUID}:${RGID}; PUID/PGID are ignored when the entrypoint is non-root."
+  fi
+else
+  RUID=${PUID:-$(id -u stirlingpdfuser 2>/dev/null || printf 1000)}
+  RGID=${PGID:-$(id -g stirlingpdfuser 2>/dev/null || printf 1000)}
+  validate_runtime_id PUID "$RUID"
+  validate_runtime_id PGID "$RGID"
+  if [ "$RUID" -ne 0 ]; then
+    command_exists setpriv || runtime_error "Cannot launch requested UID ${RUID}: setpriv is missing. Install util-linux or start the container with --user ${RUID}:${RGID}."
+    id stirlingpdfuser >/dev/null 2>&1 || runtime_error "The image has no stirlingpdfuser account."
+    if [ "$(id -g stirlingpdfuser)" != "$RGID" ]; then
+      groupmod -o -g "$RGID" stirlingpdfgroup || runtime_error "Could not apply PGID=${RGID}."
+    fi
+    if [ "$(id -u stirlingpdfuser)" != "$RUID" ]; then
+      usermod -o -u "$RUID" stirlingpdfuser || runtime_error "Could not apply PUID=${RUID}."
+    fi
+  fi
+  if [ "$RUID" -ne "$CURRENT_UID" ] || [ "$RGID" -ne "$CURRENT_GID" ]; then
+    command_exists setpriv || runtime_error "Cannot select ${RUID}:${RGID}: setpriv is missing."
+    PRIVILEGE_MODE=setpriv
+  fi
+fi
+
+if [ "$(id -u stirlingpdfuser 2>/dev/null || true)" = "$RUID" ]; then
+  RUNTIME_USER=stirlingpdfuser
+else
+  RUNTIME_USER=$(id -un 2>/dev/null || printf '%s' "$RUID")
+fi
+export HOME=${HOME:-/home/stirlingpdfuser}
+RUNTIME_COMMAND=(env "HOME=$HOME" "USER=$RUNTIME_USER" "LOGNAME=$RUNTIME_USER")
+if [ "$PRIVILEGE_MODE" = setpriv ]; then
+  RUNTIME_COMMAND+=(setpriv --reuid="$RUID" --regid="$RGID" --clear-groups --)
+fi
+
+run_as_runtime_user() {
+  "${RUNTIME_COMMAND[@]}" "$@"
+}
+
+log "Application runtime: ${RUID}:${RGID}; entrypoint: ${CURRENT_UID}:${CURRENT_GID}."
+run_as_runtime_user true || runtime_error "Could not launch a process as ${RUID}:${RGID}. Check the container's SETUID/SETGID capabilities."
+
+RUNTIME_DIRS=("$HOME" /logs /configs /customFiles /pipeline /storage /tmp/stirling-pdf)
+if [ -d "${STIRLING_ENGINE_HOME:-/opt/stirling-engine}" ]; then
+  RUNTIME_DIRS+=("${STIRLING_ENGINE_HOME:-/opt/stirling-engine}/data")
+fi
+for dir in "${RUNTIME_DIRS[@]}"; do
+  mkdir -p "$dir" 2>/dev/null || runtime_error "Cannot create $dir. Mount a directory writable by ${RUID}:${RGID}."
+  if [ "$CURRENT_UID" -eq 0 ]; then
+    chown -R "${RUID}:${RGID}" "$dir" \
+      || runtime_error "Cannot set ownership of $dir to ${RUID}:${RGID}. Prepare the mount ownership and use --user ${RUID}:${RGID}."
+    chmod -R u+rwX "$dir" || runtime_error "Cannot set owner access on $dir."
+  fi
+  run_as_runtime_user test -w "$dir" \
+    || runtime_error "$dir is not writable by ${RUID}:${RGID}. Set its ownership or mount a writable directory."
+done
+run_as_runtime_user mkdir -p /configs/cache /configs/heap_dumps /tmp/stirling-pdf/heap_dumps /pipeline/watchedFolders /pipeline/finishedFolders
+
+export XDG_RUNTIME_DIR="/tmp/xdg-${RUID}"
+mkdir -p "$XDG_RUNTIME_DIR" || runtime_error "Cannot create $XDG_RUNTIME_DIR."
+if [ "$CURRENT_UID" -eq 0 ]; then
+  chown "${RUID}:${RGID}" "$XDG_RUNTIME_DIR"
+fi
+run_as_runtime_user chmod 700 "$XDG_RUNTIME_DIR" \
+  || runtime_error "$XDG_RUNTIME_DIR must be owned by ${RUID}:${RGID}."

--- a/testing/docker/requirements.txt
+++ b/testing/docker/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.32,<3
+pypdf>=6,<7

--- a/testing/docker/test_runtime_user_startup.py
+++ b/testing/docker/test_runtime_user_startup.py
@@ -1,0 +1,69 @@
+import argparse
+import json
+import pathlib
+import subprocess
+
+parser = argparse.ArgumentParser(
+    description="Check runtime-user configuration and startup failures."
+)
+parser.add_argument("--image", required=True)
+parser.add_argument("--output")
+options = parser.parse_args()
+image = options.image
+setup = 'log() { echo "$*"; }; command_exists() { command -v "$1" >/dev/null 2>&1; }; '
+cases = [
+    ("bad-uid", ["-e", "PUID=oops"], "", "PUID must be an integer", 1),
+    ("negative-uid", ["-e", "PUID=-1"], "", "PUID must be an integer", 1),
+    ("too-large-gid", ["-e", "PGID=4294967295"], "", "PGID must be an integer", 1),
+    (
+        "missing-setpriv",
+        [],
+        "mv /usr/bin/setpriv /usr/bin/setpriv.hidden; ",
+        "setpriv is missing",
+        1,
+    ),
+    (
+        "root-without-setpriv",
+        ["-e", "PUID=0", "-e", "PGID=0"],
+        "mv /usr/bin/setpriv /usr/bin/setpriv.hidden; ",
+        "uid=0(root)",
+        0,
+    ),
+    ("no-switch-capabilities", ["--cap-drop=ALL"], "", "Could not launch a process", 1),
+    ("unprepared-numeric-user", ["--user", "12345:12346"], "", "not writable", 1),
+    (
+        "root-group-nonroot-user",
+        ["-e", "PUID=1000", "-e", "PGID=0"],
+        "",
+        "gid=0(root)",
+        0,
+    ),
+]
+results = []
+for name, args, prefix, expected, rc in cases:
+    p = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            *args,
+            "--entrypoint",
+            "bash",
+            image,
+            "-c",
+            prefix + setup + "source /scripts/runtime-user.sh; run_as_runtime_user id",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    result = {
+        "name": name,
+        "pass": p.returncode == rc and expected in p.stdout + p.stderr,
+        "exit": p.returncode,
+        "output": p.stdout + p.stderr,
+    }
+    results.append(result)
+    print(json.dumps(result), flush=True)
+if options.output:
+    pathlib.Path(options.output).write_text(json.dumps(results, indent=2))
+raise SystemExit(int(any(not r["pass"] for r in results)))

--- a/testing/docker/test_runtime_users.py
+++ b/testing/docker/test_runtime_users.py
@@ -1,0 +1,459 @@
+import argparse
+import concurrent.futures
+import io
+import json
+import mimetypes
+import os
+import pathlib
+import subprocess
+import tempfile
+import time
+import zipfile
+
+import requests
+from pypdf import PdfReader
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+FIX = REPO / "testing/cucumber/exampleFiles"
+IMAGE = ""
+OUT = pathlib.Path()
+PREFIX = f"runtime-users-{os.getpid()}"
+LITE = False
+RESULTS = []
+
+
+def docker(*args, check=True):
+    p = subprocess.run(["docker", *map(str, args)], text=True, capture_output=True)
+    if check and p.returncode:
+        raise RuntimeError(p.stderr.strip() or p.stdout.strip())
+    return p
+
+
+def pdf_check(data):
+    assert data.startswith(b"%PDF"), data[:150]
+    r = PdfReader(io.BytesIO(data))
+    assert len(r.pages) > 0
+    return r
+
+
+def run_case(mode, args, uid, gid, prepared=False, read_only=False):
+    name = PREFIX + "-" + mode
+    directory = OUT / mode
+    directory.mkdir(exist_ok=True)
+    record = {
+        "mode": mode,
+        "image": IMAGE,
+        "expected_identity": f"{uid}:{gid}",
+        "tests": [],
+    }
+    RESULTS.append(record)
+    mounts = []
+    volumes = []
+    try:
+        if prepared:
+            for idx, path in enumerate(
+                [
+                    "/home/stirlingpdfuser",
+                    "/configs",
+                    "/logs",
+                    "/customFiles",
+                    "/pipeline",
+                    "/storage",
+                ]
+            ):
+                v = f"{name}-{idx}"
+                docker("volume", "create", v)
+                volumes.append(v)
+                mounts += [
+                    "--mount",
+                    f"type=volume,source={v},target={path},volume-nocopy",
+                ]
+            docker(
+                "run",
+                "--rm",
+                *mounts,
+                "--entrypoint",
+                "sh",
+                IMAGE,
+                "-c",
+                (
+                    f"chown -R {uid}:{gid} /home/stirlingpdfuser /configs /logs "
+                    "/customFiles /pipeline /storage"
+                ),
+            )
+            mounts += ["--tmpfs", f"/tmp:rw,exec,uid={uid},gid={gid},mode=1777"]
+        if read_only:
+            mounts += ["--read-only"]
+        docker(
+            "run",
+            "-d",
+            "--name",
+            name,
+            "--label",
+            "codex-test=pr7680-runtime",
+            "--memory",
+            "2g",
+            "-p",
+            "127.0.0.1::8080",
+            *args,
+            *mounts,
+            "-e",
+            "SECURITY_ENABLELOGIN=false",
+            "-e",
+            "SECURITY_CSRFDISABLED=true",
+            "-e",
+            "SYSTEM_ENABLEANALYTICS=false",
+            IMAGE,
+        )
+        port = json.loads(docker("inspect", name).stdout)[0]["NetworkSettings"][
+            "Ports"
+        ]["8080/tcp"][0]["HostPort"]
+        base = "http://127.0.0.1:" + port
+
+        def ready():
+            nonlocal base
+            current = json.loads(docker("inspect", name).stdout)[0]["NetworkSettings"][
+                "Ports"
+            ]["8080/tcp"][0]["HostPort"]
+            base = "http://127.0.0.1:" + current
+            deadline = time.monotonic() + 150
+            while time.monotonic() < deadline:
+                state = json.loads(docker("inspect", name).stdout)[0]["State"]
+                if not state["Running"]:
+                    raise RuntimeError("startup exit " + str(state["ExitCode"]))
+                try:
+                    response = requests.get(base + "/api/v1/info/status", timeout=3)
+                    if response.status_code == 200 and "UP" in response.text:
+                        return
+                except requests.RequestException:
+                    pass
+                time.sleep(2)
+            raise RuntimeError("startup timed out")
+
+        ready()
+        front = requests.get(base + "/", timeout=15)
+        config = requests.get(base + "/api/v1/config/app-config", timeout=15)
+        assert front.status_code == 200 and "<html" in front.text.lower()
+        assert config.status_code == 200 and isinstance(config.json(), dict)
+        record["tests"].append({"name": "frontend and app configuration", "pass": True})
+        ps = docker("exec", name, "ps", "-eo", "pid,ppid,uid,gid,comm").stdout
+        (directory / "processes.txt").write_text(ps)
+        engines = [
+            line.split()
+            for line in ps.splitlines()[1:]
+            if line.split()[-1] in ["java", "soffice.bin", "Xvfb"]
+        ]
+        assert ({"java"} if LITE else {"java", "Xvfb", "soffice.bin"}) <= {
+            p[-1] for p in engines
+        }, ps
+        assert all(p[2:4] == [str(uid), str(gid)] for p in engines), engines
+        record["tests"].append(
+            {
+                "name": "startup and runtime process identities",
+                "pass": True,
+                "processes": engines,
+            }
+        )
+
+        def call(title, path, file=None, data=None, files=None, kind="pdf"):
+            start = time.monotonic()
+            try:
+                uploads = files or [
+                    (
+                        "fileInput",
+                        (
+                            file.name,
+                            file.read_bytes(),
+                            mimetypes.guess_type(file.name)[0]
+                            or "application/octet-stream",
+                        ),
+                    )
+                ]
+                response = requests.post(
+                    base + path, files=uploads, data=data or {}, timeout=120
+                )
+                (directory / (title + ".bin")).write_bytes(response.content)
+                assert response.status_code == 200, (
+                    response.status_code,
+                    response.text[:250],
+                )
+                if kind == "pdf":
+                    pdf_check(response.content)
+                elif kind == "zip":
+                    assert zipfile.is_zipfile(io.BytesIO(response.content))
+                record["tests"].append(
+                    {
+                        "name": title,
+                        "pass": True,
+                        "seconds": round(time.monotonic() - start, 2),
+                        "bytes": len(response.content),
+                    }
+                )
+                return response.content
+            except Exception as e:
+                record["tests"].append({"name": title, "pass": False, "error": str(e)})
+            finally:
+                print(mode, title, record["tests"][-1]["pass"], flush=True)
+
+        pdf = REPO / "testing/test_pdf_1.pdf"
+        for ext in [] if LITE else ["docx", "pptx", "odt", "odp", "rtf"]:
+            call("office-" + ext, "/api/v1/convert/file/pdf", FIX / ("example." + ext))
+        if not LITE:
+            call(
+                "flat-odf",
+                "/api/v1/convert/file/pdf",
+                FIX / "security_flat_inline.fodt",
+            )
+        if not LITE:
+            call("html", "/api/v1/convert/html/pdf", FIX / "example.html")
+        if not LITE:
+            call("markdown", "/api/v1/convert/markdown/pdf", FIX / "example.md")
+        call("rotate", "/api/v1/general/rotate-pdf", pdf, {"angle": "90"})
+        call(
+            "merge",
+            "/api/v1/general/merge-pdfs",
+            files=[
+                ("fileInput", ("one.pdf", pdf.read_bytes())),
+                ("fileInput", ("two.pdf", pdf.read_bytes())),
+            ],
+        )
+        call(
+            "compress",
+            "/api/v1/misc/compress-pdf",
+            FIX / "ghost3.pdf",
+            {"optimizeLevel": "4"},
+        )
+        if not LITE:
+            call(
+                "ocr",
+                "/api/v1/misc/ocr-pdf",
+                pdf,
+                {
+                    "languages": "eng",
+                    "ocrType": "force-ocr",
+                    "ocrRenderType": "hocr",
+                    "sidecar": "false",
+                    "deskew": "false",
+                    "clean": "false",
+                    "cleanFinal": "false",
+                },
+            )
+        if not LITE:
+            call(
+                "pdfa",
+                "/api/v1/convert/pdf/pdfa",
+                FIX / "pdfa2.pdf",
+                {"outputFormat": "pdfa"},
+            )
+        if not LITE:
+            call(
+                "epub",
+                "/api/v1/convert/pdf/epub",
+                pdf,
+                {"outputFormat": "EPUB", "detectChapters": "false"},
+                kind="zip",
+            )
+        call("images", "/api/v1/convert/pdf/cbz", pdf, {"dpi": "72"}, kind="zip")
+
+        def convert_one(i):
+            r = requests.post(
+                base + "/api/v1/convert/file/pdf",
+                files={
+                    "fileInput": ("example.docx", (FIX / "example.docx").read_bytes())
+                },
+                timeout=120,
+            )
+            assert r.status_code == 200, r.text[:200]
+            pdf_check(r.content)
+
+        if not LITE:
+            try:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+                    list(pool.map(convert_one, range(3)))
+                record["tests"].append(
+                    {"name": "three concurrent office conversions", "pass": True}
+                )
+            except Exception as e:
+                record["tests"].append(
+                    {
+                        "name": "three concurrent office conversions",
+                        "pass": False,
+                        "error": str(e),
+                    }
+                )
+        try:
+            docker(
+                "exec",
+                "--user",
+                f"{uid}:{gid}",
+                name,
+                "sh",
+                "-c",
+                (
+                    "umask 077; printf persistence-ok "
+                    "> /configs/runtime-test-sentinel; "
+                    "test -s /configs/settings.yml"
+                ),
+            )
+            before = docker(
+                "exec", name, "stat", "-c", "%u:%g %a", "/configs/runtime-test-sentinel"
+            ).stdout.strip()
+            start = time.monotonic()
+            docker("stop", "-t", "35", name)
+            elapsed = time.monotonic() - start
+            state = json.loads(docker("inspect", name).stdout)[0]["State"]
+            assert state["ExitCode"] == 0, state
+            logs = docker("logs", name).stdout + docker("logs", name).stderr
+            assert "Job queue shutdown complete" in logs, logs[-1000:]
+            record["tests"].append(
+                {
+                    "name": "graceful stop",
+                    "pass": True,
+                    "exit": state["ExitCode"],
+                    "seconds": round(elapsed, 2),
+                }
+            )
+            docker("start", name)
+            ready()
+            after = docker(
+                "exec", name, "stat", "-c", "%u:%g %a", "/configs/runtime-test-sentinel"
+            ).stdout.strip()
+            assert before == after and after == f"{uid}:{gid} 600", (before, after)
+            assert (
+                docker("exec", name, "cat", "/configs/runtime-test-sentinel").stdout
+                == "persistence-ok"
+            )
+            record["tests"].append(
+                {"name": "restart and 0600 file persistence", "pass": True}
+            )
+            call(
+                "rotate-after-restart",
+                "/api/v1/general/rotate-pdf",
+                pdf,
+                {"angle": "90"},
+            )
+            if not LITE:
+                call(
+                    "office-after-restart",
+                    "/api/v1/convert/file/pdf",
+                    FIX / "example.docx",
+                )
+            restart_ps = docker("exec", name, "ps", "-eo", "uid,gid,comm").stdout
+            if not LITE:
+                assert "Xvfb" in restart_ps, restart_ps
+            record["tests"].append({"name": "processes after restart", "pass": True})
+        except Exception as e:
+            record["tests"].append(
+                {"name": "lifecycle", "pass": False, "error": str(e)}
+            )
+    except Exception as e:
+        record["error"] = str(e)
+        print(mode, "ERROR", e, flush=True)
+    finally:
+        logs = docker("logs", name, check=False)
+        (directory / "container.log").write_text(logs.stdout + logs.stderr)
+        docker("rm", "-f", name, check=False)
+        for v in volumes:
+            docker("volume", "rm", v, check=False)
+        (OUT / "results.json").write_text(json.dumps(RESULTS, indent=2))
+        print(
+            mode,
+            "COMPLETE",
+            sum(t["pass"] for t in record["tests"]),
+            "/",
+            len(record["tests"]),
+            record.get("error", ""),
+            flush=True,
+        )
+
+
+MODES = {
+    "default": ([], 1000, 1000, False, False),
+    "root": (["-e", "PUID=0", "-e", "PGID=0"], 0, 0, False, False),
+    "mapped": (
+        [
+            "-e",
+            "PUID=1002",
+            "-e",
+            "PGID=1003",
+            "--cap-drop=ALL",
+            "--cap-add=CHOWN",
+            "--cap-add=DAC_OVERRIDE",
+            "--cap-add=FOWNER",
+            "--cap-add=KILL",
+            "--cap-add=SETGID",
+            "--cap-add=SETUID",
+            "--security-opt=no-new-privileges:true",
+        ],
+        1002,
+        1003,
+        False,
+        False,
+    ),
+    "direct1000": (
+        [
+            "--user",
+            "1000:1000",
+            "--cap-drop=ALL",
+            "--security-opt=no-new-privileges:true",
+        ],
+        1000,
+        1000,
+        False,
+        False,
+    ),
+    "direct12345": (
+        [
+            "--user",
+            "12345:12346",
+            "--cap-drop=ALL",
+            "--security-opt=no-new-privileges:true",
+        ],
+        12345,
+        12346,
+        True,
+        False,
+    ),
+    "readonly": (
+        [
+            "--user",
+            "12345:12346",
+            "--cap-drop=ALL",
+            "--security-opt=no-new-privileges:true",
+        ],
+        12345,
+        12346,
+        True,
+        True,
+    ),
+}
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Test Docker runtime identities, conversions and lifecycle."
+    )
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--output", default=None)
+    parser.add_argument(
+        "--lite", action="store_true", help="Only test tools included in ultra-lite"
+    )
+    parser.add_argument("modes", nargs="*", help="Modes: " + ", ".join(MODES))
+    opts = parser.parse_args()
+    if any(mode not in MODES for mode in opts.modes):
+        parser.error("Unknown mode; choose from " + ", ".join(MODES))
+    IMAGE = opts.image
+    LITE = opts.lite
+    OUT = pathlib.Path(
+        opts.output or tempfile.mkdtemp(prefix="stirling-runtime-tests-")
+    )
+    OUT.mkdir(parents=True, exist_ok=True)
+    for mode in opts.modes or MODES:
+        run_case(mode, *MODES[mode])
+    print("Results:", OUT / "results.json")
+    raise SystemExit(
+        int(
+            any(
+                r.get("error") or any(not t["pass"] for t in r["tests"])
+                for r in RESULTS
+            )
+        )
+    )


### PR DESCRIPTION
Support explicit root and non-root Docker runtime modes across the embedded, backend, fat and ultra-lite images. Centralize identity selection and writable-directory preparation so startup can honour PUID/PGID or a directly supplied Docker --user identity.

### Runtime selection

- Default: prepare storage as root, then run Java, LibreOffice, Xvfb and the fat image's AI engine as 1000:1000.
- `PUID=1002 PGID=1003`: select a different application UID/GID.
- `PUID=0 PGID=0`: run the application as root.
- `--user UID:GID`: run the whole container under that identity, including numeric UIDs without a passwd entry. An already non-root identity takes precedence over PUID/PGID.

### Scope

- Move shared runtime setup into `scripts/runtime-user.sh`; reject invalid or unavailable identities with actionable errors.
- Prepare image data ownership for direct non-root startup. Support arbitrary UIDs and read-only image filesystems when writable mounts are prepared appropriately.
- Preserve supplementary groups for direct non-root launches and existing file modes across restart.
- Load custom OCR languages through a temporary overlay and respect an explicit TESSDATA_PREFIX.
- Keep application processes as direct children for signalling and exit-code handling; wait for Xvfb display-lock cleanup during shutdown.
- Preserve startup diagnostics and apply UMASK before creating runtime directories.
- Add runtime-user documentation and repeatable `task docker:check` startup/integration tests.

### Base branch and integration

This PR still targets `security/office-conversion-ssrf-hardening`, the branch of the closed #7680. Its displayed diff is only the incremental runtime-user work against that branch; it is not the full change relative to main.

#7680 was split into #8076, #8077 and #8078. After those land, rebase the incremental runtime-user changes onto main, retarget this PR, reconcile overlapping Docker/startup changes, and rerun validation. The line counts below will change if the base or diff changes.

### Validation recorded in this PR

The existing validation report records Linux ARM64 testing through Docker Desktop:

- Standard image: all six modes, 23 checks each, including office formats, HTML/Markdown, OCR, PDF/A, compression, merge/rotate, EPUB/CBZ, concurrency and restart persistence.
- Backend: root, direct non-root and read-only modes, 23 checks each.
- Ultra-lite: root, direct non-root and read-only modes, 10 checks each.
- Fat: four boots each as root and non-root, checking engine health, identities, office conversion and graceful shutdown.
- Startup errors, login/database persistence, authenticated background jobs, custom OCR data, supplementary groups, restrictive umask and JVM crash exit codes.

Arbitrary direct UIDs require appropriately owned writable mounts. x86-64 and AI inference were not exercised in that reported run. This description update does not represent a new test run.

The test dependencies now require requests >=2.33.0 and pypdf >=6.16.1, excluding the versions flagged by the security check while retaining the existing major-version caps. Both minimum versions were installed together; pip check and the runtime suite's PDF validation helper passed.

Tests/dependencies and documentation account for 651 of 802 added lines (81%). Runtime-source changes add 125 lines and remove 184 as setup logic is consolidated.

The refreshed Aikido check still reports one medium issue. Its GitHub check supplies no finding details and the linked report requires an authenticated Aikido session; this remains unresolved pending the current report.

### Diff size

Snapshot: `a7af3db` against `security/office-conversion-ssrf-hardening`, 13 changed files.

| Category | Added | Removed | Total changed |
| --- | ---: | ---: | ---: |
| Production source and runtime scripts | 125 | 184 | 309 |
| Build, CI and deployment configuration | 26 | 0 | 26 |
| Tests, fixtures and test dependencies | 530 | 0 | 530 |
| Documentation | 121 | 0 | 121 |
| **Total** | **802** | **184** | **986** |

These are GitHub diff-line counts grouped by file purpose, including comments and blank lines; they are not executable-statement counts or whole-file sizes. “Total changed” is additions plus removals, not net growth. Counts are a snapshot and need refreshing after code or base changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable root and non-root Docker runtime configurations with configurable user and group IDs.
  - Improved container setup for application data, temporary files, logs, mounted storage, and runtime permissions.
  - Enhanced OCR data handling while preserving custom Tesseract configuration.

- **Documentation**
  - Added guidance for container user modes, permissions, writable mounts, capabilities, and read-only configurations.

- **Tests**
  - Added Docker-based startup and runtime validation for identity, permissions, conversions, persistence, restarts, and failure scenarios.
  - Added a task for running Docker runtime checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->