### PR TITLE
Add optional trusted timestamp to Sign with Certificate

### DIFF
--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ConfigController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/misc/ConfigController.java
@@ -19,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import stirling.software.SPDF.config.EndpointConfiguration;
 import stirling.software.SPDF.config.EndpointConfiguration.EndpointAvailability;
 import stirling.software.SPDF.config.InitialSetup;
-import stirling.software.SPDF.controller.api.security.TimestampController;
+import stirling.software.SPDF.pdf.signature.TsaUrlResolver;
 import stirling.software.common.annotations.api.ConfigApi;
 import stirling.software.common.configuration.AppConfig;
 import stirling.software.common.configuration.interfaces.ShowAdminInterface;
@@ -373,7 +373,7 @@ public class ConfigController {
                     applicationProperties.getSecurity().getTimestamp();
             configData.put("timestampDefaultTsaUrl", tsConfig.getDefaultTsaUrl());
             configData.put("timestampCustomTsaUrls", tsConfig.getCustomTsaUrls());
-            configData.put("timestampTsaPresets", TimestampController.TSA_PRESETS);
+            configData.put("timestampTsaPresets", TsaUrlResolver.TSA_PRESETS);
 
             // Server certificate settings
             configData.put(

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/CertSignController.java
@@ -76,6 +76,7 @@ import lombok.extern.slf4j.Slf4j;
 import stirling.software.SPDF.config.swagger.StandardPdfResponse;
 import stirling.software.SPDF.model.api.security.SignPDFWithCertRequest;
 import stirling.software.SPDF.pdf.signature.CreateSignatureBase;
+import stirling.software.SPDF.pdf.signature.TsaUrlResolver;
 import stirling.software.SPDF.service.HardwareKeyStoreService;
 import stirling.software.common.annotations.AutoJobPostMapping;
 import stirling.software.common.enumeration.ResourceWeight;
@@ -115,16 +116,19 @@ public class CertSignController {
     private final ServerCertificateServiceInterface serverCertificateService;
     private final TempFileManager tempFileManager;
     private final HardwareKeyStoreService hardwareKeyStoreService;
+    private final TsaUrlResolver tsaUrlResolver;
 
     public CertSignController(
             CustomPDFDocumentFactory pdfDocumentFactory,
             @Autowired(required = false) ServerCertificateServiceInterface serverCertificateService,
             TempFileManager tempFileManager,
-            HardwareKeyStoreService hardwareKeyStoreService) {
+            HardwareKeyStoreService hardwareKeyStoreService,
+            TsaUrlResolver tsaUrlResolver) {
         this.pdfDocumentFactory = pdfDocumentFactory;
         this.serverCertificateService = serverCertificateService;
         this.tempFileManager = tempFileManager;
         this.hardwareKeyStoreService = hardwareKeyStoreService;
+        this.tsaUrlResolver = tsaUrlResolver;
     }
 
     public static void sign(
@@ -292,6 +296,9 @@ public class CertSignController {
         char[] pin = keystorePassword != null ? keystorePassword.toCharArray() : null;
         CreateSignature createSignature =
                 new CreateSignature(ks, pin, request.getAlias(), signingProvider);
+        if (Boolean.TRUE.equals(request.getAddTimestamp())) {
+            createSignature.setTsaUrl(tsaUrlResolver.resolveDefault());
+        }
         TempFile signedOut = tempFileManager.createManagedTempFile(".pdf");
         try (OutputStream os = new FileOutputStream(signedOut.getFile())) {
             sign(

--- a/app/core/src/main/java/stirling/software/SPDF/controller/api/security/TimestampController.java
+++ b/app/core/src/main/java/stirling/software/SPDF/controller/api/security/TimestampController.java
@@ -11,12 +11,6 @@ import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.util.Calendar;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -41,10 +35,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.SPDF.config.swagger.StandardPdfResponse;
 import stirling.software.SPDF.model.api.security.TimestampPdfRequest;
+import stirling.software.SPDF.pdf.signature.TsaUrlResolver;
 import stirling.software.common.annotations.AutoJobPostMapping;
 import stirling.software.common.annotations.api.SecurityApi;
 import stirling.software.common.enumeration.ResourceWeight;
-import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.model.tool.ToolFormat;
 import stirling.software.common.model.tool.ToolIO;
 import stirling.software.common.service.CustomPDFDocumentFactory;
@@ -62,23 +56,11 @@ public class TimestampController {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    /** Built-in TSA presets with labels — single source of truth for backend + frontend. */
-    public static final List<Map<String, String>> TSA_PRESETS =
-            List.of(
-                    Map.of("label", "DigiCert", "url", "http://timestamp.digicert.com"),
-                    Map.of("label", "Sectigo", "url", "http://timestamp.sectigo.com"),
-                    Map.of("label", "SSL.com", "url", "http://ts.ssl.com"),
-                    Map.of("label", "FreeTSA", "url", "https://freetsa.org/tsr"),
-                    Map.of("label", "MeSign", "url", "http://tsa.mesign.com"));
-
-    private static final Set<String> ALLOWED_TSA_PRESET_URLS =
-            TSA_PRESETS.stream().map(p -> p.get("url")).collect(Collectors.toUnmodifiableSet());
-
     private static final int MAX_TSA_RESPONSE_SIZE = 1024 * 1024; // 1 MB
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final CustomPDFDocumentFactory pdfDocumentFactory;
-    private final ApplicationProperties applicationProperties;
+    private final TsaUrlResolver tsaUrlResolver;
     private final TempFileManager tempFileManager;
 
     @AutoJobPostMapping(
@@ -96,42 +78,10 @@ public class TimestampController {
     public ResponseEntity<Resource> timestampPdf(@ModelAttribute TimestampPdfRequest request)
             throws Exception {
         MultipartFile inputFile = request.getFileInput();
-        ApplicationProperties.Security.Timestamp tsConfig =
-                applicationProperties.getSecurity().getTimestamp();
 
-        // Determine effective TSA URL: use request value if provided, otherwise config default
-        String tsaUrl =
-                (request.getTsaUrl() != null && !request.getTsaUrl().isBlank())
-                        ? request.getTsaUrl()
-                        : tsConfig.getDefaultTsaUrl();
-
-        // Build allowed set: built-in presets + admin-configured custom URLs
-        // Filter null/blank entries and validate protocol (TASK-6)
-        Set<String> allowedUrls = new HashSet<>(ALLOWED_TSA_PRESET_URLS);
-        if (tsConfig.getDefaultTsaUrl() != null
-                && !tsConfig.getDefaultTsaUrl().isBlank()
-                && isValidTsaUrlProtocol(tsConfig.getDefaultTsaUrl())) {
-            allowedUrls.add(tsConfig.getDefaultTsaUrl());
-        }
-        List<String> customUrls = tsConfig.getCustomTsaUrls();
-        if (customUrls != null) {
-            customUrls.stream()
-                    .filter(u -> u != null && !u.isBlank() && isValidTsaUrlProtocol(u))
-                    .forEach(allowedUrls::add);
-        }
-
-        // Normalize for case-insensitive comparison (TASK-12)
-        Set<String> normalizedAllowed =
-                allowedUrls.stream()
-                        .map(TimestampController::normalizeTsaUrl)
-                        .collect(Collectors.toSet());
-
-        // Validate TSA URL against allowed set to prevent SSRF
-        if (!normalizedAllowed.contains(normalizeTsaUrl(tsaUrl))) {
-            throw new IllegalArgumentException(
-                    "TSA URL is not in the allowed list. Contact your administrator to add it"
-                            + " via settings.yml (security.timestamp.customTsaUrls).");
-        }
+        // Resolves to the request's URL (if provided) or the admin default, validated
+        // against the allowlist to prevent SSRF.
+        String tsaUrl = tsaUrlResolver.resolve(request.getTsaUrl());
 
         TempFile tempOutputFile = tempFileManager.createManagedTempFile(".pdf");
         try (PDDocument document = pdfDocumentFactory.load(inputFile);
@@ -245,24 +195,6 @@ public class TimestampController {
             if (connection != null) {
                 connection.disconnect();
             }
-        }
-    }
-
-    private static boolean isValidTsaUrlProtocol(String url) {
-        String lower = url.toLowerCase(Locale.ROOT);
-        return lower.startsWith("http://") || lower.startsWith("https://");
-    }
-
-    private static String normalizeTsaUrl(String url) {
-        try {
-            URI uri = URI.create(url.trim());
-            String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
-            String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
-            int port = uri.getPort();
-            String path = uri.getPath() == null ? "" : uri.getPath();
-            return scheme + "://" + host + (port == -1 ? "" : ":" + port) + path;
-        } catch (Exception e) {
-            return url.toLowerCase(Locale.ROOT);
         }
     }
 

--- a/app/core/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
+++ b/app/core/src/main/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequest.java
@@ -93,4 +93,12 @@ public class SignPDFWithCertRequest extends PDFFile {
             defaultValue = "true",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean showLogo;
+
+    @Schema(
+            description =
+                    "Whether to embed an RFC 3161 trusted timestamp alongside the signature,"
+                            + " recording when the signature was applied. Uses the"
+                            + " admin-configured default TSA server.",
+            defaultValue = "true")
+    private Boolean addTimestamp = true;
 }

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TSAClient.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TSAClient.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -53,6 +54,9 @@ public class TSAClient {
             new DefaultDigestAlgorithmIdentifierFinder();
     // SecureRandom.getInstanceStrong() would be better, but sometimes blocks on Linux
     private static final Random RANDOM = new SecureRandom();
+    private static final int CONNECT_TIMEOUT_MILLIS = 30_000;
+    private static final int READ_TIMEOUT_MILLIS = 30_000;
+    private static final int MAX_RESPONSE_SIZE = 1024 * 1024;
     private final URL url;
     private final String username;
     private final String password;
@@ -128,6 +132,13 @@ public class TSAClient {
 
         // todo: support proxy servers
         URLConnection connection = url.openConnection();
+        connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+        connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+        if (connection instanceof HttpURLConnection httpConnection) {
+            // The TSA URL is validated against an allowlist before reaching this client;
+            // without this, a redirect could be used to bypass that allowlist (SSRF-by-redirect).
+            httpConnection.setInstanceFollowRedirects(false);
+        }
         connection.setDoOutput(true);
         connection.setDoInput(true);
         connection.setRequestProperty("Content-Type", "application/timestamp-query");
@@ -161,7 +172,15 @@ public class TSAClient {
 
         byte[] response;
         try (InputStream input = connection.getInputStream()) {
-            response = input.readAllBytes();
+            response = input.readNBytes(MAX_RESPONSE_SIZE);
+            if (input.read() != -1) {
+                throw new IOException(
+                        "Response from "
+                                + url
+                                + " exceeds maximum allowed size of "
+                                + MAX_RESPONSE_SIZE
+                                + " bytes");
+            }
         } catch (IOException ex) {
             LOG.error("Exception when reading from {}", this.url, ex);
             throw ex;

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
@@ -54,18 +54,27 @@ public class TsaUrlResolver {
 
         String tsaUrl =
                 (requestedUrl != null && !requestedUrl.isBlank())
-                        ? requestedUrl
+                        ? requestedUrl.trim()
                         : tsConfig.getDefaultTsaUrl();
 
+        if (tsaUrl == null || tsaUrl.isBlank()) {
+            throw new IllegalArgumentException(
+                    "No default TSA URL is configured (security.timestamp.defaultTsaUrl)."
+                            + " Contact your administrator to configure one.");
+        }
+
+        if (!isValidTsaUrlProtocol(tsaUrl)) {
+            throw new IllegalArgumentException("TSA URL must start with http:// or https://");
+        }
+
         Set<String> normalizedAllowed =
-                allowedUrls(tsConfig).stream()
-                        .map(TsaUrlResolver::normalize)
-                        .collect(Collectors.toSet());
+                allowedUrls(tsConfig).stream().map(TsaUrlResolver::normalize).collect(Collectors.toSet());
 
         if (!normalizedAllowed.contains(normalize(tsaUrl))) {
             throw new IllegalArgumentException(
                     "TSA URL is not in the allowed list. Contact your administrator to add it"
-                            + " via settings.yml (security.timestamp.customTsaUrls).");
+                            + " via settings.yml (security.timestamp.defaultTsaUrl or security.timestamp.customTsaUrls)."
+                            );
         }
 
         return tsaUrl;

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
@@ -1,0 +1,116 @@
+package stirling.software.SPDF.pdf.signature;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import stirling.software.common.model.ApplicationProperties;
+
+/**
+ * Resolves and validates RFC 3161 Time Stamp Authority (TSA) URLs against an allowlist, shared by
+ * every feature that can embed a TSA timestamp (standalone timestamping, certificate signing).
+ *
+ * <p>A TSA URL is never trusted as-is: {@link stirling.software.SPDF.pdf.signature.TSAClient} opens
+ * a raw HTTP connection to whatever URL it is given, so accepting an arbitrary URL here would let a
+ * caller turn the server into an SSRF proxy. Only the built-in presets and the admin-configured
+ * URLs in {@code security.timestamp} are ever allowed.
+ */
+@Component
+@RequiredArgsConstructor
+public class TsaUrlResolver {
+
+    /** Built-in TSA presets with labels — single source of truth for backend + frontend. */
+    public static final List<Map<String, String>> TSA_PRESETS =
+            List.of(
+                    Map.of("label", "DigiCert", "url", "http://timestamp.digicert.com"),
+                    Map.of("label", "Sectigo", "url", "http://timestamp.sectigo.com"),
+                    Map.of("label", "SSL.com", "url", "http://ts.ssl.com"),
+                    Map.of("label", "FreeTSA", "url", "https://freetsa.org/tsr"),
+                    Map.of("label", "MeSign", "url", "http://tsa.mesign.com"));
+
+    private static final Set<String> ALLOWED_TSA_PRESET_URLS =
+            TSA_PRESETS.stream().map(p -> p.get("url")).collect(Collectors.toUnmodifiableSet());
+
+    private final ApplicationProperties applicationProperties;
+
+    /**
+     * Resolves the effective TSA URL for a request and validates it against the allowlist.
+     *
+     * @param requestedUrl the URL the caller asked for, or null/blank to use the admin default
+     * @return the validated URL to use
+     * @throws IllegalArgumentException if the resolved URL is not in the allowlist
+     */
+    public String resolve(String requestedUrl) {
+        ApplicationProperties.Security.Timestamp tsConfig =
+                applicationProperties.getSecurity().getTimestamp();
+
+        String tsaUrl =
+                (requestedUrl != null && !requestedUrl.isBlank())
+                        ? requestedUrl
+                        : tsConfig.getDefaultTsaUrl();
+
+        Set<String> normalizedAllowed =
+                allowedUrls(tsConfig).stream()
+                        .map(TsaUrlResolver::normalize)
+                        .collect(Collectors.toSet());
+
+        if (!normalizedAllowed.contains(normalize(tsaUrl))) {
+            throw new IllegalArgumentException(
+                    "TSA URL is not in the allowed list. Contact your administrator to add it"
+                            + " via settings.yml (security.timestamp.customTsaUrls).");
+        }
+
+        return tsaUrl;
+    }
+
+    /** Resolves the admin-configured default TSA URL, validated against the allowlist. */
+    public String resolveDefault() {
+        return resolve(null);
+    }
+
+    private static Set<String> allowedUrls(ApplicationProperties.Security.Timestamp tsConfig) {
+        Set<String> allowedUrls = new HashSet<>(ALLOWED_TSA_PRESET_URLS);
+
+        String defaultTsaUrl = tsConfig.getDefaultTsaUrl();
+        if (defaultTsaUrl != null
+                && !defaultTsaUrl.isBlank()
+                && isValidTsaUrlProtocol(defaultTsaUrl)) {
+            allowedUrls.add(defaultTsaUrl);
+        }
+
+        List<String> customUrls = tsConfig.getCustomTsaUrls();
+        if (customUrls != null) {
+            customUrls.stream()
+                    .filter(u -> u != null && !u.isBlank() && isValidTsaUrlProtocol(u))
+                    .forEach(allowedUrls::add);
+        }
+
+        return allowedUrls;
+    }
+
+    private static boolean isValidTsaUrlProtocol(String url) {
+        String lower = url.toLowerCase(Locale.ROOT);
+        return lower.startsWith("http://") || lower.startsWith("https://");
+    }
+
+    private static String normalize(String url) {
+        try {
+            URI uri = URI.create(url.trim());
+            String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+            String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
+            int port = uri.getPort();
+            String path = uri.getPath() == null ? "" : uri.getPath();
+            return scheme + "://" + host + (port == -1 ? "" : ":" + port) + path;
+        } catch (Exception e) {
+            return url.toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
@@ -110,7 +110,7 @@ public class TsaUrlResolver {
             String path = uri.getPath() == null ? "" : uri.getPath();
             return scheme + "://" + host + (port == -1 ? "" : ":" + port) + path;
         } catch (Exception e) {
-            return url.toLowerCase(Locale.ROOT);
+            return url == null ? "" : url.toLowerCase(Locale.ROOT);
         }
     }
 }

--- a/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
+++ b/app/core/src/main/java/stirling/software/SPDF/pdf/signature/TsaUrlResolver.java
@@ -68,13 +68,14 @@ public class TsaUrlResolver {
         }
 
         Set<String> normalizedAllowed =
-                allowedUrls(tsConfig).stream().map(TsaUrlResolver::normalize).collect(Collectors.toSet());
+                allowedUrls(tsConfig).stream()
+                        .map(TsaUrlResolver::normalize)
+                        .collect(Collectors.toSet());
 
         if (!normalizedAllowed.contains(normalize(tsaUrl))) {
             throw new IllegalArgumentException(
                     "TSA URL is not in the allowed list. Contact your administrator to add it"
-                            + " via settings.yml (security.timestamp.defaultTsaUrl or security.timestamp.customTsaUrls)."
-                            );
+                            + " via settings.yml (security.timestamp.defaultTsaUrl or security.timestamp.customTsaUrls).");
         }
 
         return tsaUrl;

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/security/CertSignControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/security/CertSignControllerTest.java
@@ -33,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 import jakarta.servlet.http.HttpServletRequest;
 
 import stirling.software.SPDF.model.api.security.SignPDFWithCertRequest;
+import stirling.software.SPDF.pdf.signature.TsaUrlResolver;
 import stirling.software.SPDF.service.HardwareKeyStoreService;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.TempFile;
@@ -56,6 +57,7 @@ class CertSignControllerTest {
     @Mock private TempFileManager tempFileManager;
     @Mock private HardwareKeyStoreService hardwareKeyStoreService;
     @Mock private HttpServletRequest httpRequest;
+    @Mock private TsaUrlResolver tsaUrlResolver;
 
     @InjectMocks private CertSignController certSignController;
 
@@ -173,6 +175,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         ResponseEntity<Resource> response =
                 certSignController.signPDFWithCert(request, httpRequest);
@@ -200,6 +203,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         ResponseEntity<Resource> response =
                 certSignController.signPDFWithCert(request, httpRequest);
@@ -224,6 +228,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         IllegalArgumentException exception =
                 assertThrows(
@@ -253,6 +258,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         ResponseEntity<Resource> response =
                 certSignController.signPDFWithCert(request, httpRequest);
@@ -285,6 +291,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         ResponseEntity<Resource> response =
                 certSignController.signPDFWithCert(request, httpRequest);
@@ -317,6 +324,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         ResponseEntity<Resource> response =
                 certSignController.signPDFWithCert(request, httpRequest);
@@ -349,6 +357,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         ResponseEntity<Resource> response =
                 certSignController.signPDFWithCert(request, httpRequest);
@@ -381,6 +390,7 @@ class CertSignControllerTest {
         request.setName("tester");
         request.setPageNumber(1);
         request.setShowLogo(false);
+        request.setAddTimestamp(false);
 
         ResponseEntity<Resource> response =
                 certSignController.signPDFWithCert(request, httpRequest);

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/security/CertSignControllerTimestampTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/security/CertSignControllerTimestampTest.java
@@ -1,0 +1,189 @@
+package stirling.software.SPDF.controller.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import stirling.software.SPDF.model.api.security.SignPDFWithCertRequest;
+import stirling.software.SPDF.pdf.signature.TsaUrlResolver;
+import stirling.software.SPDF.service.HardwareKeyStoreService;
+import stirling.software.common.service.CustomPDFDocumentFactory;
+import stirling.software.common.util.TempFile;
+import stirling.software.common.util.TempFileManager;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Verifies that {@code addTimestamp} on {@link SignPDFWithCertRequest} is actually wired end to
+ * end: resolved through {@link TsaUrlResolver}, set on the {@code CreateSignature} instance, and
+ * used by {@link stirling.software.SPDF.pdf.signature.CreateSignatureBase#sign} to contact a real
+ * TSA server while the PDF is being signed.
+ *
+ * <p>A loopback {@link MockWebServer} stands in for the TSA. {@link CertSignController}'s own
+ * {@code sign} helper swallows exceptions from the underlying signing call (it only logs them), so
+ * a garbage TSA response never surfaces as a thrown exception here - the only reliable signal that
+ * the timestamp path actually ran is whether the mock server received the HTTP request at all.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CertSignControllerTimestampTest {
+
+    @Mock private CustomPDFDocumentFactory pdfDocumentFactory;
+    @Mock private TempFileManager tempFileManager;
+    @Mock private HardwareKeyStoreService hardwareKeyStoreService;
+    @Mock private HttpServletRequest httpRequest;
+    @Mock private TsaUrlResolver tsaUrlResolver;
+
+    private CertSignController certSignController;
+    private MockWebServer server;
+    private byte[] pdfBytes;
+    private byte[] pfxBytes;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        certSignController =
+                new CertSignController(
+                        pdfDocumentFactory,
+                        null,
+                        tempFileManager,
+                        hardwareKeyStoreService,
+                        tsaUrlResolver);
+
+        lenient()
+                .when(tempFileManager.createManagedTempFile(anyString()))
+                .thenAnswer(
+                        inv -> {
+                            File f =
+                                    Files.createTempFile("test", inv.<String>getArgument(0))
+                                            .toFile();
+                            TempFile tf = mock(TempFile.class);
+                            lenient().when(tf.getFile()).thenReturn(f);
+                            lenient().when(tf.getPath()).thenReturn(f.toPath());
+                            return tf;
+                        });
+
+        lenient()
+                .when(pdfDocumentFactory.load(any(MultipartFile.class)))
+                .thenAnswer(invocation -> Loader.loadPDF(pdfBytes));
+
+        try (PDDocument doc = new PDDocument()) {
+            doc.addPage(new PDPage());
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            doc.save(baos);
+            pdfBytes = baos.toByteArray();
+        }
+
+        ClassPathResource pfxResource = new ClassPathResource("certs/test-cert.pfx");
+        try (InputStream is = pfxResource.getInputStream();
+                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            is.transferTo(baos);
+            pfxBytes = baos.toByteArray();
+        }
+
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    private SignPDFWithCertRequest baseRequest(boolean addTimestamp) {
+        MockMultipartFile pdfFile =
+                new MockMultipartFile(
+                        "fileInput", "test.pdf", MediaType.APPLICATION_PDF_VALUE, pdfBytes);
+        MockMultipartFile pfxFile =
+                new MockMultipartFile("p12File", "test-cert.pfx", "application/x-pkcs12", pfxBytes);
+
+        SignPDFWithCertRequest request = new SignPDFWithCertRequest();
+        request.setFileInput(pdfFile);
+        request.setCertType("PFX");
+        request.setP12File(pfxFile);
+        request.setPassword("password");
+        request.setShowSignature(false);
+        request.setReason("test");
+        request.setLocation("test");
+        request.setName("tester");
+        request.setPageNumber(1);
+        request.setShowLogo(false);
+        request.setAddTimestamp(addTimestamp);
+        return request;
+    }
+
+    @Test
+    @DisplayName(
+            "addTimestamp=true resolves the default TSA URL and POSTs a timestamp query while signing")
+    void addTimestampTrueContactsTsaServer() throws Exception {
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .addHeader("Content-Type", "application/timestamp-reply")
+                        .setBody("not-a-real-token"));
+
+        String tsaUrl = server.url("/tsr").toString();
+        when(tsaUrlResolver.resolveDefault()).thenReturn(tsaUrl);
+
+        SignPDFWithCertRequest request = baseRequest(true);
+
+        certSignController.signPDFWithCert(request, httpRequest);
+
+        verify(tsaUrlResolver).resolveDefault();
+
+        RecordedRequest recorded = server.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(
+                recorded,
+                "certificate signing with addTimestamp=true should have contacted the TSA server");
+        assertEquals("POST", recorded.getMethod());
+        assertEquals("/tsr", recorded.getPath());
+        assertEquals("application/timestamp-query", recorded.getHeader("Content-Type"));
+    }
+
+    @Test
+    @DisplayName("addTimestamp=false never resolves a TSA URL or contacts a TSA server")
+    void addTimestampFalseSkipsTsa() throws Exception {
+        SignPDFWithCertRequest request = baseRequest(false);
+
+        certSignController.signPDFWithCert(request, httpRequest);
+
+        verify(tsaUrlResolver, org.mockito.Mockito.never()).resolveDefault();
+        assertEquals(
+                0,
+                server.getRequestCount(),
+                "no HTTP call should be made to the TSA server when addTimestamp is false");
+    }
+}

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/security/TimestampControllerMoreTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/security/TimestampControllerMoreTest.java
@@ -31,6 +31,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
 import stirling.software.SPDF.model.api.security.TimestampPdfRequest;
+import stirling.software.SPDF.pdf.signature.TsaUrlResolver;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.service.CustomPDFDocumentFactory;
 import stirling.software.common.util.TempFile;
@@ -90,7 +91,10 @@ class TimestampControllerMoreTest {
                         });
 
         controller =
-                new TimestampController(pdfDocumentFactory, applicationProperties, tempFileManager);
+                new TimestampController(
+                        pdfDocumentFactory,
+                        new TsaUrlResolver(applicationProperties),
+                        tempFileManager);
 
         server = new MockWebServer();
         server.start();

--- a/app/core/src/test/java/stirling/software/SPDF/controller/api/security/TimestampControllerTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/controller/api/security/TimestampControllerTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -24,8 +23,10 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
 import stirling.software.SPDF.model.api.security.TimestampPdfRequest;
+import stirling.software.SPDF.pdf.signature.TsaUrlResolver;
 import stirling.software.common.model.ApplicationProperties;
 import stirling.software.common.service.CustomPDFDocumentFactory;
+import stirling.software.common.util.TempFileManager;
 
 @DisplayName("TimestampController security tests")
 @ExtendWith(MockitoExtension.class)
@@ -34,8 +35,9 @@ class TimestampControllerTest {
 
     @Mock private CustomPDFDocumentFactory pdfDocumentFactory;
     @Mock private ApplicationProperties applicationProperties;
+    @Mock private TempFileManager tempFileManager;
 
-    @InjectMocks private TimestampController controller;
+    private TimestampController controller;
 
     private ApplicationProperties.Security security;
     private ApplicationProperties.Security.Timestamp tsConfig;
@@ -48,6 +50,10 @@ class TimestampControllerTest {
         security.setTimestamp(tsConfig);
 
         when(applicationProperties.getSecurity()).thenReturn(security);
+
+        // TsaUrlResolver is not mocked - the allowlist logic under test lives there now.
+        TsaUrlResolver tsaUrlResolver = new TsaUrlResolver(applicationProperties);
+        controller = new TimestampController(pdfDocumentFactory, tsaUrlResolver, tempFileManager);
 
         mockPdfFile =
                 new MockMultipartFile(

--- a/app/core/src/test/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequestBindingTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequestBindingTest.java
@@ -39,7 +39,7 @@ class SignPDFWithCertRequestBindingTest {
         binder.bind(request);
 
         assertTrue(
-                target.getAddTimestamp(),
+                Boolean.TRUE.equals(target.getAddTimestamp()),
                 "addTimestamp should stay at its default (true) when the request omits it,"
                         + " so existing frontend callers get a timestamp with zero UI changes");
     }

--- a/app/core/src/test/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequestBindingTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/model/api/security/SignPDFWithCertRequestBindingTest.java
@@ -1,0 +1,46 @@
+package stirling.software.SPDF.model.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.web.bind.ServletRequestDataBinder;
+
+/**
+ * Verifies the exact concern behind making {@code addTimestamp} default to {@code true}: today's
+ * frontend does not know this field exists and will never send it in the multipart form. Spring's
+ * data binder must leave the field's default value ({@code true}) untouched when it is absent from
+ * the request, the same way {@code @ModelAttribute SignPDFWithCertRequest} binds it in {@link
+ * stirling.software.SPDF.controller.api.security.CertSignController#signPDFWithCert}.
+ *
+ * <p>If this ever regressed to {@code null}/{@code false}, every existing "Sign with Certificate"
+ * caller would silently stop getting a timestamp with no code or UI change on their side - exactly
+ * the kind of default-value gotcha that assuming "the field initializer will just work" glosses
+ * over.
+ */
+class SignPDFWithCertRequestBindingTest {
+
+    @Test
+    @DisplayName(
+            "addTimestamp stays true after binding a multipart request that never sends the field"
+                    + " (today's unmodified frontend request)")
+    void addTimestampDefaultsToTrueWhenFieldIsAbsentFromTheRequest() throws Exception {
+        MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+        // Simulate today's frontend request: only the fields it actually knows about.
+        request.setParameter("certType", "PFX");
+        request.setParameter("password", "password");
+        request.setParameter("showSignature", "false");
+        request.setParameter("showLogo", "false");
+        // Deliberately no "addTimestamp" parameter.
+
+        SignPDFWithCertRequest target = new SignPDFWithCertRequest();
+        ServletRequestDataBinder binder = new ServletRequestDataBinder(target);
+        binder.bind(request);
+
+        assertTrue(
+                target.getAddTimestamp(),
+                "addTimestamp should stay at its default (true) when the request omits it,"
+                        + " so existing frontend callers get a timestamp with zero UI changes");
+    }
+}

--- a/app/core/src/test/java/stirling/software/SPDF/pdf/signature/TSAClientTest.java
+++ b/app/core/src/test/java/stirling/software/SPDF/pdf/signature/TSAClientTest.java
@@ -41,10 +41,14 @@ import org.bouncycastle.tsp.TimeStampRequest;
 import org.bouncycastle.tsp.TimeStampResponse;
 import org.bouncycastle.tsp.TimeStampResponseGenerator;
 import org.bouncycastle.tsp.TimeStampTokenGenerator;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Exercises the vendored PDFBox {@link TSAClient}. The TSA HTTP boundary is replaced with a mocked
@@ -278,6 +282,76 @@ class TSAClientTest {
                                             new ByteArrayInputStream("data".getBytes())))
                     .isInstanceOf(IOException.class)
                     .hasMessageContaining("no route");
+        }
+    }
+
+    /**
+     * These exercise a real loopback {@link MockWebServer} instead of a mocked {@link
+     * URLConnection}, because the properties under test - whether a redirect is actually followed,
+     * whether an oversized response is actually read in full - are exactly the behavior a mock
+     * would otherwise have to fake.
+     */
+    @Nested
+    @DisplayName("Security hardening")
+    class SecurityHardening {
+
+        private MockWebServer server;
+
+        @AfterEach
+        void tearDown() throws IOException {
+            if (server != null) {
+                server.shutdown();
+            }
+        }
+
+        @Test
+        @DisplayName("does not follow a redirect from the TSA server (SSRF-by-redirect)")
+        void doesNotFollowRedirect() throws Exception {
+            server = new MockWebServer();
+            server.start();
+            server.enqueue(
+                    new MockResponse()
+                            .setResponseCode(302)
+                            .addHeader("Location", server.url("/should-not-be-hit").toString()));
+
+            TSAClient client =
+                    new TSAClient(
+                            server.url("/tsr").url(),
+                            null,
+                            null,
+                            MessageDigest.getInstance("SHA-256"));
+
+            // A 302 body is not a valid TSA response, so this must fail either way; what matters
+            // is how many requests the server actually received.
+            assertThatThrownBy(
+                    () -> client.getTimeStampToken(new ByteArrayInputStream("hello".getBytes())));
+
+            assertThat(server.getRequestCount())
+                    .as("client must not have followed the redirect to a second URL")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("rejects a response larger than the maximum allowed size")
+        void rejectsOversizedResponse() throws Exception {
+            server = new MockWebServer();
+            server.start();
+            byte[] oversized = new byte[2 * 1024 * 1024]; // 2 MB, over the 1 MB cap
+            server.enqueue(new MockResponse().setBody(new okio.Buffer().write(oversized)));
+
+            TSAClient client =
+                    new TSAClient(
+                            server.url("/tsr").url(),
+                            null,
+                            null,
+                            MessageDigest.getInstance("SHA-256"));
+
+            assertThatThrownBy(
+                            () ->
+                                    client.getTimeStampToken(
+                                            new ByteArrayInputStream("hello".getBytes())))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("exceeds maximum allowed size");
         }
     }
 

--- a/frontend/editor/src/core/components/tools/certSign/CertSignAutomationSettings.tsx
+++ b/frontend/editor/src/core/components/tools/certSign/CertSignAutomationSettings.tsx
@@ -13,6 +13,7 @@ import CertificateFormatSettings from "@app/components/tools/certSign/Certificat
 import CertificateFilesSettings from "@app/components/tools/certSign/CertificateFilesSettings";
 import HardwareCertificateSettings from "@app/components/tools/certSign/HardwareCertificateSettings";
 import SignatureAppearanceSettings from "@app/components/tools/certSign/SignatureAppearanceSettings";
+import TimestampToggleSettings from "@app/components/tools/certSign/TimestampToggleSettings";
 
 interface CertSignAutomationSettingsProps {
   parameters: CertSignParameters;
@@ -66,6 +67,13 @@ const CertSignAutomationSettings = ({
 
       {/* Signature Appearance Settings */}
       <SignatureAppearanceSettings
+        parameters={parameters}
+        onParameterChange={onParameterChange}
+        disabled={disabled}
+      />
+
+      {/* Trusted Timestamp */}
+      <TimestampToggleSettings
         parameters={parameters}
         onParameterChange={onParameterChange}
         disabled={disabled}

--- a/frontend/editor/src/core/components/tools/certSign/HardwareCertificateSettings.stories.tsx
+++ b/frontend/editor/src/core/components/tools/certSign/HardwareCertificateSettings.stories.tsx
@@ -13,6 +13,7 @@ const baseParameters: CertSignParameters = {
   name: "",
   pageNumber: 1,
   showLogo: true,
+  addTimestamp: true,
 };
 
 const meta = {

--- a/frontend/editor/src/core/components/tools/certSign/TimestampToggleSettings.test.tsx
+++ b/frontend/editor/src/core/components/tools/certSign/TimestampToggleSettings.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import TimestampToggleSettings from "@app/components/tools/certSign/TimestampToggleSettings";
+import { CertSignParameters } from "@app/hooks/tools/certSign/useCertSignParameters";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <MantineProvider>{children}</MantineProvider>
+);
+
+const baseParameters: CertSignParameters = {
+  signMode: "MANUAL",
+  certType: "PFX",
+  password: "",
+  showSignature: false,
+  reason: "",
+  location: "",
+  name: "",
+  pageNumber: 1,
+  showLogo: true,
+  addTimestamp: true,
+};
+
+describe("TimestampToggleSettings", () => {
+  const mockOnParameterChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders a single checkbox, checked when addTimestamp is true (the default)", () => {
+    render(
+      <TestWrapper>
+        <TimestampToggleSettings
+          parameters={baseParameters}
+          onParameterChange={mockOnParameterChange}
+        />
+      </TestWrapper>,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+  });
+
+  test("renders unchecked when addTimestamp is false", () => {
+    render(
+      <TestWrapper>
+        <TimestampToggleSettings
+          parameters={{ ...baseParameters, addTimestamp: false }}
+          onParameterChange={mockOnParameterChange}
+        />
+      </TestWrapper>,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+  });
+
+  test("clicking the checkbox reports the toggled value to onParameterChange", () => {
+    render(
+      <TestWrapper>
+        <TimestampToggleSettings
+          parameters={baseParameters}
+          onParameterChange={mockOnParameterChange}
+        />
+      </TestWrapper>,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    checkbox.click();
+
+    expect(mockOnParameterChange).toHaveBeenCalledWith("addTimestamp", false);
+  });
+
+  test("is disabled when the disabled prop is set", () => {
+    render(
+      <TestWrapper>
+        <TimestampToggleSettings
+          parameters={baseParameters}
+          onParameterChange={mockOnParameterChange}
+          disabled
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+});

--- a/frontend/editor/src/core/components/tools/certSign/TimestampToggleSettings.tsx
+++ b/frontend/editor/src/core/components/tools/certSign/TimestampToggleSettings.tsx
@@ -1,0 +1,44 @@
+import { Stack, Checkbox, Text } from "@mantine/core";
+import { useTranslation } from "react-i18next";
+import { CertSignParameters } from "@app/hooks/tools/certSign/useCertSignParameters";
+
+interface TimestampToggleSettingsProps {
+  parameters: CertSignParameters;
+  onParameterChange: <K extends keyof CertSignParameters>(
+    key: K,
+    value: CertSignParameters[K],
+  ) => void;
+  disabled?: boolean;
+}
+
+const TimestampToggleSettings = ({
+  parameters,
+  onParameterChange,
+  disabled = false,
+}: TimestampToggleSettingsProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Stack gap="xs">
+      <Checkbox
+        label={t(
+          "certSign.timestamp.label",
+          "Add a trusted timestamp (recommended)",
+        )}
+        checked={parameters.addTimestamp}
+        onChange={(event) =>
+          onParameterChange("addTimestamp", event.currentTarget.checked)
+        }
+        disabled={disabled}
+      />
+      <Text size="xs" c="dimmed">
+        {t(
+          "certSign.timestamp.note",
+          "Records when the signature was applied, using a trusted timestamp server. Turn this off if this environment has no network access to reach one.",
+        )}
+      </Text>
+    </Stack>
+  );
+};
+
+export default TimestampToggleSettings;

--- a/frontend/editor/src/core/hooks/tools/certSign/useCertSignOperation.ts
+++ b/frontend/editor/src/core/hooks/tools/certSign/useCertSignOperation.ts
@@ -28,12 +28,16 @@ export const certSignToApiParams = (
 ): CertSignApiParams => {
   // AUTO mode signs with the server certificate; no keystore/password is sent.
   if (parameters.signMode === "AUTO") {
-    return withSignatureAppearance({ certType: "SERVER" }, parameters);
+    return withSignatureAppearance(
+      { certType: "SERVER", addTimestamp: parameters.addTimestamp },
+      parameters,
+    );
   }
 
   const apiParams: CertSignApiParams = {
     certType: parameters.certType as CertSignApiParams["certType"],
     password: parameters.password,
+    addTimestamp: parameters.addTimestamp,
   };
 
   // Non-file identifiers depend on the chosen certificate type.
@@ -102,6 +106,7 @@ export const certSignFromApiParams = (
   const result: Partial<CertSignParameters> = {
     signMode: apiParams.certType === "SERVER" ? "AUTO" : "MANUAL",
     showSignature: apiParams.showSignature ?? defaultParameters.showSignature,
+    addTimestamp: apiParams.addTimestamp ?? defaultParameters.addTimestamp,
   };
 
   if (apiParams.certType !== "SERVER") {

--- a/frontend/editor/src/core/hooks/tools/certSign/useCertSignParameters.ts
+++ b/frontend/editor/src/core/hooks/tools/certSign/useCertSignParameters.ts
@@ -30,6 +30,9 @@ export interface CertSignParameters extends BaseParameters {
   name: string;
   pageNumber: number;
   showLogo: boolean;
+
+  // Whether to embed an RFC 3161 trusted timestamp alongside the signature.
+  addTimestamp: boolean;
 }
 
 export const defaultParameters: CertSignParameters = {
@@ -42,6 +45,7 @@ export const defaultParameters: CertSignParameters = {
   name: "",
   pageNumber: 1,
   showLogo: true,
+  addTimestamp: true,
 };
 
 export type CertSignParametersHook = BaseParametersHook<CertSignParameters>;

--- a/frontend/editor/src/core/tools/CertSign.tsx
+++ b/frontend/editor/src/core/tools/CertSign.tsx
@@ -7,6 +7,7 @@ import CertificateFormatSettings from "@app/components/tools/certSign/Certificat
 import CertificateFilesSettings from "@app/components/tools/certSign/CertificateFilesSettings";
 import HardwareCertificateSettings from "@app/components/tools/certSign/HardwareCertificateSettings";
 import SignatureAppearanceSettings from "@app/components/tools/certSign/SignatureAppearanceSettings";
+import TimestampToggleSettings from "@app/components/tools/certSign/TimestampToggleSettings";
 import { useCertSignParameters } from "@app/hooks/tools/certSign/useCertSignParameters";
 import { useCertSignOperation } from "@app/hooks/tools/certSign/useCertSignOperation";
 import { useCertificateTypeTips } from "@app/components/tooltips/useCertificateTypeTips";
@@ -163,6 +164,21 @@ const CertSign = (props: BaseToolProps) => {
         tooltip: appearanceTips,
         content: (
           <SignatureAppearanceSettings
+            parameters={base.params.parameters}
+            onParameterChange={base.params.updateParameter}
+            disabled={base.endpointLoading}
+          />
+        ),
+      },
+      {
+        title: t("certSign.timestamp.stepTitle", "Trusted Timestamp"),
+        isCollapsed: base.settingsCollapsed || !areCertFilesConfigured(),
+        onCollapsedClick:
+          base.settingsCollapsed || !areCertFilesConfigured()
+            ? base.handleSettingsReset
+            : undefined,
+        content: (
+          <TimestampToggleSettings
             parameters={base.params.parameters}
             onParameterChange={base.params.updateParameter}
             disabled={base.endpointLoading}

--- a/frontend/editor/src/core/types/toolApiTypes.ts
+++ b/frontend/editor/src/core/types/toolApiTypes.ts
@@ -1358,6 +1358,10 @@ export type SecurityGetInfoOnPdfRequest = Record<string, never>;
 export type SecurityRemoveCertSignRequest = Record<string, never>;
 export interface SignPDFWithCertRequest {
   /**
+   * Whether to embed an RFC 3161 trusted timestamp alongside the signature, recording when the signature was applied. Uses the admin-configured default TSA server.
+   */
+  addTimestamp?: boolean;
+  /**
    * The alias of the certificate to sign with. Required for WINDOWS_STORE and recommended for PKCS11 tokens holding multiple certificates.
    */
   alias?: string;


### PR DESCRIPTION
Closes #7919

Extracts the TSA URL allowlist/SSRF validation from TimestampController into a shared TsaUrlResolver, and wires it into cert-sign so a signature can optionally embed an RFC 3161 timestamp using the admin-configured default TSA server.

- Backend: SignPDFWithCertRequest.addTimestamp (default true), resolved and validated via TsaUrlResolver before being set on CreateSignature
- Frontend: a single "Add a trusted timestamp (recommended)" checkbox, defaulted to checked, per maintainer feedback against exposing TSA URL selection to signature users
- Tests: TsaUrlResolver's allowlist behavior (via TimestampControllerTest, unchanged), a real mock-TSA-server proof that addTimestamp actually contacts the TSA (CertSignControllerTimestampTest), and a binding test confirming existing callers get addTimestamp=true with no changes on their side (SignPDFWithCertRequestBindingTest)

# Description of Changes

**What changed**: `CertSignController`'s "Sign with Certificate" endpoint can now embed an RFC 3161 trusted timestamp in the signature, reusing the TSA allowlist/SSRF-validation logic already built for the standalone Timestamp PDF tool (now extracted into a shared `TsaUrlResolver`). Defaults to on, no TSA server selection exposed in the UI (see discussion on the issue).

**Why**: closes the two-step workflow described in the issue - timestamping no longer requires a separate tool call, and it's on by default so less experienced users get it without knowing it exists.

**Challenges**: the signing engine (`CreateSignatureBase`) already had `setTsaUrl()` wired for exactly this, but nothing validated the URL before using it - `ValidationTimeStamp`/`TSAClient` will happily open an HTTP connection to whatever URL they're given. Reused rather than duplicated the existing allowlist instead of adding a second, unvalidated path.

Closes #7919

---

## Checklist

### General

- [x] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [x] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [x] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

**Note on scope**: the issue didn't ask for a refactor, but duplicating the
SSRF-sensitive allowlist logic into CertSignController felt riskier than
extracting it once into TsaUrlResolver (DRY) - both features now share the
same validated allowlist instead of two copies that could drift apart. Happy
to inline it back into CertSignController instead if you'd prefer a smaller,
more contained diff.

