### PR TITLE
Give saas_team_extensions.max_seats one meaning

### DIFF
--- a/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
@@ -338,10 +338,9 @@ public class UserLicenseSettingsService {
         if (!hasPaidLicense()) {
             Integer fromSaas = linkedTeamAllowance();
             if (fromSaas != null) {
-                // Floored at the grandfathered limit, so linking an account can only ever raise
-                // the ceiling. Otherwise a solo cloud account -- whose team the instance binds to
-                // before any invitation is accepted -- would hand back its own seat count and
-                // refuse every user creation from then on.
+                // Floored at the grandfathered limit, so linking can only raise the ceiling.
+                // Otherwise a solo cloud account, whose team the instance binds to before any
+                // invitation is accepted, hands back its own seat count and refuses every user.
                 int allowed = Math.max(grandfatheredLimit, fromSaas);
                 log.debug(
                         "No licence; linked team allowance {} against grandfathered {}: {} users",

--- a/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
+++ b/app/proprietary/src/main/java/stirling/software/proprietary/service/UserLicenseSettingsService.java
@@ -45,7 +45,14 @@ import stirling.software.proprietary.security.service.UserService;
 @RequiredArgsConstructor
 public class UserLicenseSettingsService {
 
-    private static final int DEFAULT_USER_LIMIT = 5;
+    /**
+     * Users an installation gets before it has to buy capacity. The one free-allowance number in
+     * Java: the saas seat reader floors on it, and {@code
+     * pricing_policy.server_free_user_allowance} is seeded to match so the two editions quote the
+     * same figure.
+     */
+    public static final int DEFAULT_USER_LIMIT = 5;
+
     private static final String SIGNATURE_SEPARATOR = ":";
     private static final String DEFAULT_INTEGRITY_SECRET = "stirling-pdf-user-license-guard";
 
@@ -302,12 +309,14 @@ public class UserLicenseSettingsService {
      *
      * <ul>
      *   <li>Grandfathered limit = max(5, existing user count at V1→V2 migration)
-     *   <li>No license: Uses grandfathered limit only
+     *   <li>No license, not linked: Uses grandfathered limit only
+     *   <li>No license, linked: max(grandfathered limit, the linked team's allowance)
      *   <li>SERVER license (maxUsers=0): Unlimited users (Integer.MAX_VALUE)
      *   <li>ENTERPRISE license (maxUsers>0): License seats only (NO grandfathering added)
      * </ul>
      *
-     * <p>IMPORTANT: Paid licenses REPLACE the limit, they don't add to grandfathering.
+     * <p>IMPORTANT: Paid licenses REPLACE the limit, they don't add to grandfathering. A linked
+     * team's allowance does not: linking is monotonic, so it can only raise the ceiling.
      *
      * @return Maximum number of users allowed (Integer.MAX_VALUE for unlimited)
      */
@@ -329,8 +338,17 @@ public class UserLicenseSettingsService {
         if (!hasPaidLicense()) {
             Integer fromSaas = linkedTeamAllowance();
             if (fromSaas != null) {
-                log.debug("No licence; linked team allowance: {} users", fromSaas);
-                return fromSaas;
+                // Floored at the grandfathered limit, so linking an account can only ever raise
+                // the ceiling. Otherwise a solo cloud account -- whose team the instance binds to
+                // before any invitation is accepted -- would hand back its own seat count and
+                // refuse every user creation from then on.
+                int allowed = Math.max(grandfatheredLimit, fromSaas);
+                log.debug(
+                        "No licence; linked team allowance {} against grandfathered {}: {} users",
+                        fromSaas,
+                        grandfatheredLimit,
+                        allowed);
+                return allowed;
             }
             log.debug("No license: using grandfathered limit of {}", grandfatheredLimit);
             return grandfatheredLimit;

--- a/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
@@ -161,9 +161,8 @@ class UserLicenseSettingsServiceMoreTest {
         }
 
         /**
-         * The bug this closes: users.team_id points at the personal team until an invitation is
-         * accepted, so a solo cloud account used to publish a ceiling of its own team size and the
-         * instance then refused every user creation.
+         * users.team_id points at the personal team until an invitation is accepted, so a solo
+         * cloud account's own team size must not become the instance's ceiling.
          */
         @Test
         @DisplayName("a SaaS allowance below the grandfathered limit does not lower it")

--- a/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
+++ b/app/proprietary/src/test/java/stirling/software/proprietary/service/UserLicenseSettingsServiceMoreTest.java
@@ -159,6 +159,43 @@ class UserLicenseSettingsServiceMoreTest {
 
             assertThat(service.calculateMaxAllowedUsers()).isEqualTo(7);
         }
+
+        /**
+         * The bug this closes: users.team_id points at the personal team until an invitation is
+         * accepted, so a solo cloud account used to publish a ceiling of its own team size and the
+         * instance then refused every user creation.
+         */
+        @Test
+        @DisplayName("a SaaS allowance below the grandfathered limit does not lower it")
+        void lowerAllowanceDoesNotShrinkTheInstance() {
+            lockedSettings(7);
+            cacheReturns(withAllowance(1));
+
+            assertThat(service.calculateMaxAllowedUsers()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("a SaaS allowance above the grandfathered limit raises it")
+        void higherAllowanceRaisesTheCeiling() {
+            lockedSettings(7);
+            cacheReturns(withAllowance(100));
+
+            assertThat(service.calculateMaxAllowedUsers()).isEqualTo(100);
+        }
+
+        /**
+         * The grandfathered count is re-floored at the default on every read, so the floor holds
+         * even for an instance that never had more than the free allowance.
+         */
+        @Test
+        @DisplayName("a SaaS allowance below the default never drops the instance under it")
+        void neverBelowTheDefault() {
+            lockedSettings(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+            cacheReturns(withAllowance(1));
+
+            assertThat(service.calculateMaxAllowedUsers())
+                    .isEqualTo(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+        }
     }
 
     @Nested

--- a/app/saas/src/main/java/stirling/software/saas/accountlink/InstanceController.java
+++ b/app/saas/src/main/java/stirling/software/saas/accountlink/InstanceController.java
@@ -231,18 +231,13 @@ public class InstanceController {
     }
 
     /**
-     * Users the team's Team plan covers, or null when it has no user limit.
-     *
-     * <p>Read from the seat cap the subscription writes, so the instance and the cloud team enforce
-     * one number. {@code Integer.MAX_VALUE} is the historic "unlimited" sentinel and becomes null
-     * here: the wire contract expresses no-limit as absence, so nothing downstream can accidentally
-     * do arithmetic on it.
+     * Users the team's Team plan covers, or null when it has no user limit. Read from the seat cap
+     * the subscription writes, so the instance and the cloud team enforce one number.
      */
     private Integer licensedUsers(Long teamId) {
         return teamExtensionsRepository
                 .findByTeamId(teamId)
-                .map(SaasTeamExtensions::getMaxSeats)
-                .filter(max -> max != null && max > 0 && max < Integer.MAX_VALUE)
+                .map(SaasTeamExtensions::licensedUsers)
                 .orElse(null);
     }
 

--- a/app/saas/src/main/java/stirling/software/saas/model/SaasTeamExtensions.java
+++ b/app/saas/src/main/java/stirling/software/saas/model/SaasTeamExtensions.java
@@ -130,14 +130,14 @@ public class SaasTeamExtensions implements Serializable {
      * one place that judgement is made, so the wallet, the linked-instance entitlement and the
      * Users page cannot disagree about what the column is saying.
      *
-     * <p>Null covers everything that is not an allowance. Team sells in blocks of 100 and every
-     * team gets {@link UserLicenseSettingsService#DEFAULT_USER_LIMIT} users free, so a value at or
-     * below that was never purchased and could restrict nothing if it were. {@link
-     * Integer#MAX_VALUE} is the historic unlimited sentinel; returning it would let a caller do
-     * arithmetic on it, and no-limit is expressed as absence.
+     * <p>Team sells in blocks of 100 and every team gets {@link
+     * UserLicenseSettingsService#DEFAULT_USER_LIMIT} users free, so a value at or below that was
+     * never purchased and could restrict nothing if it were. {@link Integer#MAX_VALUE} is the
+     * historic unlimited sentinel; returning it would let a caller do arithmetic on it, and
+     * no-limit is expressed as absence.
      *
      * <p>Enforcement does not go through here: {@link #hasAvailableSeats()} still compares the raw
-     * column, which is deliberate while cloud capacity is unenforced for standard teams.
+     * column while cloud capacity is unenforced for standard teams.
      */
     public Integer licensedUsers() {
         if (maxSeats == null

--- a/app/saas/src/main/java/stirling/software/saas/model/SaasTeamExtensions.java
+++ b/app/saas/src/main/java/stirling/software/saas/model/SaasTeamExtensions.java
@@ -72,11 +72,7 @@ public class SaasTeamExtensions implements Serializable {
     @Column(name = "seats_used", nullable = false)
     private Integer seatsUsed = 0;
 
-    /**
-     * Users this team is allowed. Rows are created lazily for teams that have bought nothing, so
-     * the default is the free allowance rather than a placeholder: read it through {@link
-     * #licensedUsers()}, which is what tells a purchased allowance from that floor.
-     */
+    /** Defaults to the free allowance, rows being created before anything is bought. */
     @Column(name = "max_seats", nullable = false)
     private Integer maxSeats = UserLicenseSettingsService.DEFAULT_USER_LIMIT;
 

--- a/app/saas/src/main/java/stirling/software/saas/model/SaasTeamExtensions.java
+++ b/app/saas/src/main/java/stirling/software/saas/model/SaasTeamExtensions.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 
 /**
  * Saas-only sidecar that holds the seat / billing / personal-team metadata for a {@link Team}.
@@ -66,13 +67,18 @@ public class SaasTeamExtensions implements Serializable {
     private Boolean isPersonal = Boolean.FALSE;
 
     @Column(name = "seat_count", nullable = false)
-    private Integer seatCount = 1;
+    private Integer seatCount = UserLicenseSettingsService.DEFAULT_USER_LIMIT;
 
     @Column(name = "seats_used", nullable = false)
     private Integer seatsUsed = 0;
 
+    /**
+     * Users this team is allowed. Rows are created lazily for teams that have bought nothing, so
+     * the default is the free allowance rather than a placeholder: read it through {@link
+     * #licensedUsers()}, which is what tells a purchased allowance from that floor.
+     */
     @Column(name = "max_seats", nullable = false)
-    private Integer maxSeats = 1;
+    private Integer maxSeats = UserLicenseSettingsService.DEFAULT_USER_LIMIT;
 
     @Column(name = "created_by_user_id")
     private Long createdByUserId;
@@ -100,8 +106,8 @@ public class SaasTeamExtensions implements Serializable {
     }
 
     /**
-     * Whether this team has unused seats. Personal teams enforce a 1-seat limit; standard teams are
-     * unlimited.
+     * Whether this team has unused seats. Personal teams are bound by {@code max_seats}; standard
+     * teams are unlimited, because cloud capacity is not enforced yet.
      */
     public boolean hasAvailableSeats() {
         if (isPersonal()) {
@@ -111,10 +117,34 @@ public class SaasTeamExtensions implements Serializable {
     }
 
     /**
-     * Whether this team accepts new invitations. Personal teams (1 seat, owned by one user) never
-     * do; standard teams always do.
+     * Whether this team accepts new invitations. Personal teams (a single user's own team) never
+     * do; standard teams always do. The first invitation converts the team rather than being
+     * refused — see {@code SaasTeamService.inviteUserToTeam}.
      */
     public boolean canInviteMembers() {
         return !isPersonal();
+    }
+
+    /**
+     * Users this team is allowed, or null when {@code max_seats} holds no purchased allowance. The
+     * one place that judgement is made, so the wallet, the linked-instance entitlement and the
+     * Users page cannot disagree about what the column is saying.
+     *
+     * <p>Null covers everything that is not an allowance. Team sells in blocks of 100 and every
+     * team gets {@link UserLicenseSettingsService#DEFAULT_USER_LIMIT} users free, so a value at or
+     * below that was never purchased and could restrict nothing if it were. {@link
+     * Integer#MAX_VALUE} is the historic unlimited sentinel; returning it would let a caller do
+     * arithmetic on it, and no-limit is expressed as absence.
+     *
+     * <p>Enforcement does not go through here: {@link #hasAvailableSeats()} still compares the raw
+     * column, which is deliberate while cloud capacity is unenforced for standard teams.
+     */
+    public Integer licensedUsers() {
+        if (maxSeats == null
+                || maxSeats <= UserLicenseSettingsService.DEFAULT_USER_LIMIT
+                || maxSeats >= Integer.MAX_VALUE) {
+            return null;
+        }
+        return maxSeats;
     }
 }

--- a/app/saas/src/main/java/stirling/software/saas/payg/api/PaygWalletController.java
+++ b/app/saas/src/main/java/stirling/software/saas/payg/api/PaygWalletController.java
@@ -255,20 +255,15 @@ public class PaygWalletController {
     }
 
     /**
-     * The team's user-capacity holding.
-     *
-     * <p>The cap is written from the Team subscription, so a team holds Team exactly when it
-     * carries a real one. Integer.MAX_VALUE is the sentinel a team carries before it ever holds a
-     * Team plan, and it reports as no holding and no limit rather than as a number, so nothing
-     * downstream does arithmetic on it.
+     * The team's user-capacity holding. The cap is written from the Team subscription, so a team
+     * holds Team exactly when {@link SaasTeamExtensions#licensedUsers()} states one.
      */
     private WalletSnapshotResponse.TeamHolding teamHolding(Long teamId) {
         int usersInUse = Math.toIntExact(memberRepo.countByTeamId(teamId));
         Integer licensed =
                 teamExtensionsRepository
                         .findByTeamId(teamId)
-                        .map(SaasTeamExtensions::getMaxSeats)
-                        .filter(max -> max != null && max > 0 && max < Integer.MAX_VALUE)
+                        .map(SaasTeamExtensions::licensedUsers)
                         .orElse(null);
         return new WalletSnapshotResponse.TeamHolding(licensed != null, licensed, usersInUse);
     }

--- a/app/saas/src/main/java/stirling/software/saas/service/SaasTeamExtensionService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/SaasTeamExtensionService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 import stirling.software.saas.model.SaasTeamExtensions;
 import stirling.software.saas.repository.SaasTeamExtensionsRepository;
 
@@ -58,8 +59,16 @@ public class SaasTeamExtensionService {
                 .orElse(0);
     }
 
+    /**
+     * Users the team is allowed, raw. A team with no row has bought nothing, so it reads as the
+     * free allowance -- the same value a lazily-created row carries. Callers deciding whether a
+     * team holds a purchased allowance want {@link SaasTeamExtensions#licensedUsers()} instead.
+     */
     public int getMaxSeats(Team team) {
-        return repository.findByTeamId(team.getId()).map(SaasTeamExtensions::getMaxSeats).orElse(1);
+        return repository
+                .findByTeamId(team.getId())
+                .map(SaasTeamExtensions::getMaxSeats)
+                .orElse(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
     }
 
     public Long getCreatedByUserId(Team team) {

--- a/app/saas/src/main/java/stirling/software/saas/service/SaasTeamExtensionService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/SaasTeamExtensionService.java
@@ -60,9 +60,8 @@ public class SaasTeamExtensionService {
     }
 
     /**
-     * Users the team is allowed, raw. A team with no row has bought nothing, so it reads as the
-     * free allowance -- the same value a lazily-created row carries. Callers deciding whether a
-     * team holds a purchased allowance want {@link SaasTeamExtensions#licensedUsers()} instead.
+     * The raw column; a missing row reads as the free allowance. Callers asking whether a team
+     * bought anything want {@link SaasTeamExtensions#licensedUsers()}.
      */
     public int getMaxSeats(Team team) {
         return repository

--- a/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
@@ -250,14 +250,11 @@ public class SaasTeamService {
                     team.getName(),
                     inviter.getUsername());
             saasTeamExtensionService.setPersonal(team, false);
-            // The free allowance, not the unlimited sentinel. Converting does not buy capacity, so
-            // the column keeps stating what the team is allowed; a Team subscription overwrites it
-            // with the real number. Invitations past the allowance still go through, because
-            // capacity is short-circuited for standard teams -- enforcement is a separate change.
-            saasTeamExtensionService.setSeats(
-                    team,
-                    UserLicenseSettingsService.DEFAULT_USER_LIMIT,
-                    UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+            // Still the unlimited sentinel, which is what a standard team is until it buys: nothing
+            // enforces capacity for one. Writing the free allowance here instead would state a
+            // ceiling nothing honours, and SaasTeamController's availableSeats would go negative as
+            // the team grew past it. The sentinel goes when enforcement arrives.
+            saasTeamExtensionService.setSeats(team, Integer.MAX_VALUE, Integer.MAX_VALUE);
         }
 
         // Validate: team can invite (not personal, has available seats)

--- a/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
@@ -21,6 +21,7 @@ import stirling.software.proprietary.security.database.repository.UserRepository
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.repository.TeamMembershipRepository;
 import stirling.software.proprietary.security.repository.TeamRepository;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 import stirling.software.saas.accountlink.LinkedInstanceRepository;
 import stirling.software.saas.billing.repository.BillingSubscriptionRepository;
 import stirling.software.saas.config.SupabaseConfigurationProperties;
@@ -126,7 +127,13 @@ public class SaasTeamService {
         Team savedTeam = teamRepository.save(team);
 
         saasTeamExtensionService.setPersonal(savedTeam, true);
-        saasTeamExtensionService.setSeats(savedTeam, 1, 1);
+        // The free allowance, not 1. max_seats means "users this team is allowed", and a signup
+        // gets the same free users as any other installation; a linked instance reads this number
+        // as its own ceiling, so a 1 here would refuse every user it tried to create.
+        saasTeamExtensionService.setSeats(
+                savedTeam,
+                UserLicenseSettingsService.DEFAULT_USER_LIMIT,
+                UserLicenseSettingsService.DEFAULT_USER_LIMIT);
         saasTeamExtensionService.setCreatedByUserId(savedTeam, user.getId());
         saasTeamExtensionsRepository.incrementSeatsUsed(savedTeam.getId());
 
@@ -243,8 +250,14 @@ public class SaasTeamService {
                     team.getName(),
                     inviter.getUsername());
             saasTeamExtensionService.setPersonal(team, false);
-            // Unlimited seats once converted to standard
-            saasTeamExtensionService.setSeats(team, Integer.MAX_VALUE, Integer.MAX_VALUE);
+            // The free allowance, not the unlimited sentinel. Converting does not buy capacity, so
+            // the column keeps stating what the team is allowed; a Team subscription overwrites it
+            // with the real number. Invitations past the allowance still go through, because
+            // capacity is short-circuited for standard teams -- enforcement is a separate change.
+            saasTeamExtensionService.setSeats(
+                    team,
+                    UserLicenseSettingsService.DEFAULT_USER_LIMIT,
+                    UserLicenseSettingsService.DEFAULT_USER_LIMIT);
         }
 
         // Validate: team can invite (not personal, has available seats)

--- a/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
+++ b/app/saas/src/main/java/stirling/software/saas/service/SaasTeamService.java
@@ -127,9 +127,8 @@ public class SaasTeamService {
         Team savedTeam = teamRepository.save(team);
 
         saasTeamExtensionService.setPersonal(savedTeam, true);
-        // The free allowance, not 1. max_seats means "users this team is allowed", and a signup
-        // gets the same free users as any other installation; a linked instance reads this number
-        // as its own ceiling, so a 1 here would refuse every user it tried to create.
+        // The free allowance, not 1: a linked instance reads this number as its own ceiling, so
+        // a 1 here would refuse every user it tried to create.
         saasTeamExtensionService.setSeats(
                 savedTeam,
                 UserLicenseSettingsService.DEFAULT_USER_LIMIT,

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/InstanceControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/InstanceControllerTest.java
@@ -24,7 +24,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import stirling.software.proprietary.billing.UnitCalcPolicy;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 import stirling.software.saas.accountlink.InstanceController.EntitlementResponse;
+import stirling.software.saas.model.SaasTeamExtensions;
 import stirling.software.saas.payg.billing.TeamBillingContext;
 import stirling.software.saas.payg.billing.TeamBillingService;
 import stirling.software.saas.payg.entitlement.EntitlementService;
@@ -113,6 +115,30 @@ class InstanceControllerTest {
         assertThat(body.freeRemainingUnits()).isEqualTo(500L);
         assertThat(body.periodCapUnits()).isNull();
         assertThat(body.state()).isEqualTo("OK");
+    }
+
+    /**
+     * The bug this closes: users.team_id points at the personal team until an invitation is
+     * accepted, so a solo account's team published a ceiling of 1 and the instance refused every
+     * user creation from then on. Only a purchased allowance reaches the wire.
+     */
+    @Test
+    void entitlement_reportsOnlyAPurchasedAllowance() {
+        Authentication token = new LinkedInstanceAuthenticationToken(4L, 9L);
+        when(billingService.forTeam(9L)).thenReturn(freeBilling(500L));
+        when(entitlementService.getSnapshot(9L))
+                .thenReturn(snapshot(EntitlementState.FULL, 0L, null));
+        when(pricingPolicyService.getEffectivePolicy(9L)).thenReturn(policy());
+
+        SaasTeamExtensions free = new SaasTeamExtensions();
+        free.setMaxSeats(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+        when(teamExtensionsRepository.findByTeamId(9L)).thenReturn(Optional.of(free));
+        assertThat(controller().entitlement(token).getBody().licensedUsers()).isNull();
+
+        SaasTeamExtensions purchased = new SaasTeamExtensions();
+        purchased.setMaxSeats(300);
+        when(teamExtensionsRepository.findByTeamId(9L)).thenReturn(Optional.of(purchased));
+        assertThat(controller().entitlement(token).getBody().licensedUsers()).isEqualTo(300);
     }
 
     @Test

--- a/app/saas/src/test/java/stirling/software/saas/accountlink/InstanceControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/accountlink/InstanceControllerTest.java
@@ -117,11 +117,7 @@ class InstanceControllerTest {
         assertThat(body.state()).isEqualTo("OK");
     }
 
-    /**
-     * The bug this closes: users.team_id points at the personal team until an invitation is
-     * accepted, so a solo account's team published a ceiling of 1 and the instance refused every
-     * user creation from then on. Only a purchased allowance reaches the wire.
-     */
+    /** Only a purchased allowance reaches the wire: a solo account's team is not a ceiling. */
     @Test
     void entitlement_reportsOnlyAPurchasedAllowance() {
         Authentication token = new LinkedInstanceAuthenticationToken(4L, 9L);

--- a/app/saas/src/test/java/stirling/software/saas/model/SaasTeamExtensionsTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/model/SaasTeamExtensionsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 
 /** Constructor, defaults, accessor, and seat/personal-team branch tests for SaasTeamExtensions. */
 class SaasTeamExtensionsTest {
@@ -19,9 +20,12 @@ class SaasTeamExtensionsTest {
         SaasTeamExtensions ext = new SaasTeamExtensions();
         assertThat(ext.getTeamType()).isEqualTo(SaasTeamExtensions.TEAM_TYPE_STANDARD);
         assertThat(ext.getIsPersonal()).isFalse();
-        assertThat(ext.getSeatCount()).isEqualTo(1);
         assertThat(ext.getSeatsUsed()).isZero();
-        assertThat(ext.getMaxSeats()).isEqualTo(1);
+        // A lazily-created row has bought nothing, so it holds the free allowance rather than a
+        // placeholder -- which licensedUsers() then reports as no allowance.
+        assertThat(ext.getSeatCount()).isEqualTo(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+        assertThat(ext.getMaxSeats()).isEqualTo(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+        assertThat(ext.licensedUsers()).isNull();
         assertThat(ext.isPersonal()).isFalse();
     }
 
@@ -132,6 +136,60 @@ class SaasTeamExtensionsTest {
             SaasTeamExtensions personal = new SaasTeamExtensions();
             personal.setIsPersonal(Boolean.TRUE);
             assertThat(personal.canInviteMembers()).isFalse();
+        }
+    }
+
+    /**
+     * The boundaries that decide whether {@code max_seats} is reporting a purchased allowance. Four
+     * things have written that column, so these pin which values are allowances and which are not.
+     */
+    @Nested
+    @DisplayName("licensedUsers")
+    class LicensedUsers {
+
+        private SaasTeamExtensions withMaxSeats(Integer maxSeats) {
+            SaasTeamExtensions ext = new SaasTeamExtensions();
+            ext.setMaxSeats(maxSeats);
+            return ext;
+        }
+
+        @Test
+        @DisplayName("null column states no allowance")
+        void nullIsNoAllowance() {
+            assertThat(withMaxSeats(null).licensedUsers()).isNull();
+        }
+
+        @Test
+        @DisplayName("the personal-team 1 states no allowance")
+        void personalTeamSentinel() {
+            assertThat(withMaxSeats(1).licensedUsers()).isNull();
+        }
+
+        @Test
+        @DisplayName("exactly the free allowance states no allowance")
+        void freeAllowanceIsNotPurchased() {
+            assertThat(withMaxSeats(UserLicenseSettingsService.DEFAULT_USER_LIMIT).licensedUsers())
+                    .isNull();
+        }
+
+        @Test
+        @DisplayName("one above the free allowance is a real allowance")
+        void justAboveTheFloorCounts() {
+            int justAbove = UserLicenseSettingsService.DEFAULT_USER_LIMIT + 1;
+            assertThat(withMaxSeats(justAbove).licensedUsers()).isEqualTo(justAbove);
+        }
+
+        @Test
+        @DisplayName("a purchased block reports its size")
+        void purchasedBlock() {
+            assertThat(withMaxSeats(300).licensedUsers()).isEqualTo(300);
+        }
+
+        /** Returning it would let a caller add to it; no-limit is expressed as absence. */
+        @Test
+        @DisplayName("the unlimited sentinel states no allowance")
+        void unlimitedSentinel() {
+            assertThat(withMaxSeats(Integer.MAX_VALUE).licensedUsers()).isNull();
         }
     }
 }

--- a/app/saas/src/test/java/stirling/software/saas/model/SaasTeamExtensionsTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/model/SaasTeamExtensionsTest.java
@@ -21,8 +21,7 @@ class SaasTeamExtensionsTest {
         assertThat(ext.getTeamType()).isEqualTo(SaasTeamExtensions.TEAM_TYPE_STANDARD);
         assertThat(ext.getIsPersonal()).isFalse();
         assertThat(ext.getSeatsUsed()).isZero();
-        // A lazily-created row has bought nothing, so it holds the free allowance rather than a
-        // placeholder -- which licensedUsers() then reports as no allowance.
+        // A lazily-created row has bought nothing, so licensedUsers() reports no allowance.
         assertThat(ext.getSeatCount()).isEqualTo(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
         assertThat(ext.getMaxSeats()).isEqualTo(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
         assertThat(ext.licensedUsers()).isNull();
@@ -139,10 +138,7 @@ class SaasTeamExtensionsTest {
         }
     }
 
-    /**
-     * The boundaries that decide whether {@code max_seats} is reporting a purchased allowance. Four
-     * things have written that column, so these pin which values are allowances and which are not.
-     */
+    /** Which values of {@code max_seats} are a purchased allowance, and which are not. */
     @Nested
     @DisplayName("licensedUsers")
     class LicensedUsers {

--- a/app/saas/src/test/java/stirling/software/saas/payg/api/PaygWalletControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/payg/api/PaygWalletControllerTest.java
@@ -35,6 +35,7 @@ import stirling.software.proprietary.model.TeamMembership;
 import stirling.software.proprietary.security.database.repository.UserRepository;
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.repository.TeamMembershipRepository;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 import stirling.software.saas.model.SaasTeamExtensions;
 import stirling.software.saas.payg.api.PaygWalletController.UpdateCapRequest;
 import stirling.software.saas.payg.api.WalletSnapshotResponse.MemberRow;
@@ -201,6 +202,35 @@ class PaygWalletControllerTest {
         assertThat(body.team().usersInUse()).isEqualTo(40);
         // Team and Processor stay independent: a Team plan says nothing about the meter.
         assertThat(body.processor().active()).isFalse();
+    }
+
+    /**
+     * Every team's row now holds a real number, so the free allowance is what an unpurchased row
+     * carries. It is not a Team holding, and reporting it as the meter's denominator would show a
+     * ceiling nobody bought.
+     */
+    @Test
+    void getWallet_freeAllowanceRow_holdsNoTeam() {
+        User user = userWithId(63L, UUID.randomUUID());
+        Team team = teamWithId(63L);
+        when(userRepository.findBySupabaseId(any())).thenReturn(Optional.of(user));
+        user.setTeam(team);
+        when(memberRepo.findByTeamIdAndUserId(team.getId(), 63L))
+                .thenReturn(Optional.of(membership(team, user, TeamRole.MEMBER)));
+        when(memberRepo.countByTeamId(63L)).thenReturn(2L);
+        SaasTeamExtensions ext = new SaasTeamExtensions();
+        ext.setMaxSeats(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+        when(teamExtensionsRepository.findByTeamId(63L)).thenReturn(Optional.of(ext));
+        when(billingService.forTeam(63L)).thenReturn(freeBilling(500L));
+        when(entitlementService.getSnapshot(63L)).thenReturn(snapshot(0L, 500L));
+        stubEmptyLedgerReads(63L);
+
+        WalletSnapshotResponse body = controller.getWallet(jwtAuth(user.getSupabaseId())).getBody();
+
+        assertThat(body).isNotNull();
+        assertThat(body.team().held()).isFalse();
+        assertThat(body.team().licensedUsers()).isNull();
+        assertThat(body.team().usersInUse()).isEqualTo(2);
     }
 
     /**

--- a/app/saas/src/test/java/stirling/software/saas/payg/api/PaygWalletControllerTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/payg/api/PaygWalletControllerTest.java
@@ -205,9 +205,8 @@ class PaygWalletControllerTest {
     }
 
     /**
-     * Every team's row now holds a real number, so the free allowance is what an unpurchased row
-     * carries. It is not a Team holding, and reporting it as the meter's denominator would show a
-     * ceiling nobody bought.
+     * An unpurchased row carries the free allowance, which is not a Team holding: reporting it as
+     * the meter's denominator would show a ceiling nobody bought.
      */
     @Test
     void getWallet_freeAllowanceRow_holdsNoTeam() {

--- a/app/saas/src/test/java/stirling/software/saas/service/SaasTeamExtensionServiceTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/service/SaasTeamExtensionServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import stirling.software.proprietary.model.Team;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 import stirling.software.saas.model.SaasTeamExtensions;
 import stirling.software.saas.repository.SaasTeamExtensionsRepository;
 
@@ -28,10 +29,10 @@ import stirling.software.saas.repository.SaasTeamExtensionsRepository;
  * Unit tests for {@link SaasTeamExtensionService}.
  *
  * <p>The service is a thin read/write facade over {@link SaasTeamExtensionsRepository}. Reads
- * return safe defaults when no row exists (non-personal, STANDARD type, seatsUsed=0, maxSeats=1,
- * createdBy=null, hasAvailableSeats=true, canInviteMembers=true); writes create the row lazily via
- * {@code getOrCreate}. Pure delegation + Optional mapping, so everything is mocked at the
- * repository boundary.
+ * return safe defaults when no row exists (non-personal, STANDARD type, seatsUsed=0, maxSeats=the
+ * free allowance, createdBy=null, hasAvailableSeats=true, canInviteMembers=true); writes create the
+ * row lazily via {@code getOrCreate}. Pure delegation + Optional mapping, so everything is mocked
+ * at the repository boundary.
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -98,7 +99,8 @@ class SaasTeamExtensionServiceTest {
             assertThat(saved.getTeamType()).isEqualTo(SaasTeamExtensions.TEAM_TYPE_STANDARD);
             assertThat(saved.isPersonal()).isFalse();
             assertThat(saved.getSeatsUsed()).isZero();
-            assertThat(saved.getMaxSeats()).isEqualTo(1);
+            assertThat(saved.getMaxSeats())
+                    .isEqualTo(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
             assertThat(result).isSameAs(saved);
         }
     }
@@ -212,12 +214,13 @@ class SaasTeamExtensionServiceTest {
     class GetMaxSeats {
 
         @Test
-        @DisplayName("no row defaults to 1 (not 0)")
-        void noRow_one() {
+        @DisplayName("no row defaults to the free allowance")
+        void noRow_freeAllowance() {
             Team team = team();
             when(repository.findByTeamId(TEAM_ID)).thenReturn(Optional.empty());
 
-            assertThat(service.getMaxSeats(team)).isEqualTo(1);
+            assertThat(service.getMaxSeats(team))
+                    .isEqualTo(UserLicenseSettingsService.DEFAULT_USER_LIMIT);
         }
 
         @Test

--- a/app/saas/src/test/java/stirling/software/saas/service/SaasTeamServiceTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/service/SaasTeamServiceTest.java
@@ -311,14 +311,10 @@ class SaasTeamServiceTest {
             service.inviteUserToTeam(teamId, "b@x.com", inviter);
 
             verify(saasTeamExtensionService).setPersonal(t, false);
-            // Converting buys no capacity, so the column keeps stating the free allowance rather
-            // than the unlimited sentinel. Invitations past it still go through: capacity is
-            // short-circuited for standard teams.
-            verify(saasTeamExtensionService)
-                    .setSeats(
-                            t,
-                            UserLicenseSettingsService.DEFAULT_USER_LIMIT,
-                            UserLicenseSettingsService.DEFAULT_USER_LIMIT);
+            // Still the sentinel. A standard team has no user limit until it buys one, and nothing
+            // enforces capacity for one, so stating the free allowance here would announce a
+            // ceiling nothing honours.
+            verify(saasTeamExtensionService).setSeats(t, Integer.MAX_VALUE, Integer.MAX_VALUE);
         }
 
         @Test

--- a/app/saas/src/test/java/stirling/software/saas/service/SaasTeamServiceTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/service/SaasTeamServiceTest.java
@@ -171,8 +171,7 @@ class SaasTeamServiceTest {
 
             assertThat(result).isSameAs(saved);
             verify(saasTeamExtensionService).setPersonal(saved, true);
-            // The free allowance, not 1: a linked instance reads this number as its own user
-            // ceiling, and a 1 there refused every user it tried to create.
+            // The free allowance, not 1: a linked instance reads this as its own ceiling.
             verify(saasTeamExtensionService)
                     .setSeats(
                             saved,

--- a/app/saas/src/test/java/stirling/software/saas/service/SaasTeamServiceTest.java
+++ b/app/saas/src/test/java/stirling/software/saas/service/SaasTeamServiceTest.java
@@ -36,6 +36,7 @@ import stirling.software.proprietary.security.model.Authority;
 import stirling.software.proprietary.security.model.User;
 import stirling.software.proprietary.security.repository.TeamMembershipRepository;
 import stirling.software.proprietary.security.repository.TeamRepository;
+import stirling.software.proprietary.service.UserLicenseSettingsService;
 import stirling.software.saas.accountlink.LinkedInstanceRepository;
 import stirling.software.saas.billing.repository.BillingSubscriptionRepository;
 import stirling.software.saas.config.SupabaseConfigurationProperties;
@@ -170,7 +171,13 @@ class SaasTeamServiceTest {
 
             assertThat(result).isSameAs(saved);
             verify(saasTeamExtensionService).setPersonal(saved, true);
-            verify(saasTeamExtensionService).setSeats(saved, 1, 1);
+            // The free allowance, not 1: a linked instance reads this number as its own user
+            // ceiling, and a 1 there refused every user it tried to create.
+            verify(saasTeamExtensionService)
+                    .setSeats(
+                            saved,
+                            UserLicenseSettingsService.DEFAULT_USER_LIMIT,
+                            UserLicenseSettingsService.DEFAULT_USER_LIMIT);
             verify(saasTeamExtensionService).setCreatedByUserId(saved, 1L);
             verify(saasTeamExtensionsRepository).incrementSeatsUsed(50L);
 
@@ -285,7 +292,7 @@ class SaasTeamServiceTest {
         }
 
         @Test
-        @DisplayName("converts a personal team to standard (unlimited seats) on first invitation")
+        @DisplayName("converts a personal team to standard on first invitation")
         void personalTeam_convertedToStandard() {
             Team t = team(teamId, "My Team");
             User inviter = user(1L, "a@x.com", "alice");
@@ -304,7 +311,14 @@ class SaasTeamServiceTest {
             service.inviteUserToTeam(teamId, "b@x.com", inviter);
 
             verify(saasTeamExtensionService).setPersonal(t, false);
-            verify(saasTeamExtensionService).setSeats(t, Integer.MAX_VALUE, Integer.MAX_VALUE);
+            // Converting buys no capacity, so the column keeps stating the free allowance rather
+            // than the unlimited sentinel. Invitations past it still go through: capacity is
+            // short-circuited for standard teams.
+            verify(saasTeamExtensionService)
+                    .setSeats(
+                            t,
+                            UserLicenseSettingsService.DEFAULT_USER_LIMIT,
+                            UserLicenseSettingsService.DEFAULT_USER_LIMIT);
         }
 
         @Test

--- a/frontend/editor/src/saas/portal/usersBackend.ts
+++ b/frontend/editor/src/saas/portal/usersBackend.ts
@@ -64,9 +64,8 @@ const FREE_USER_ALLOWANCE = 5;
 
 /**
  * Users the team is allowed, or null when `maxSeats` holds no purchased allowance. Must agree with
- * `SaasTeamExtensions.licensedUsers()`, which the wallet and the linked-instance entitlement both
- * answer through: a team on the free allowance has no limit to show, and the unlimited sentinel is
- * never a number.
+ * `SaasTeamExtensions.licensedUsers()`: a team on the free allowance has no limit to show, and the
+ * unlimited sentinel is never a number.
  */
 function normalizeSeatLimit(max: number | undefined): number | null {
   if (!max || max <= FREE_USER_ALLOWANCE || max >= 2147483647) return null;

--- a/frontend/editor/src/saas/portal/usersBackend.ts
+++ b/frontend/editor/src/saas/portal/usersBackend.ts
@@ -59,9 +59,17 @@ interface InvitationDTO {
 /** No last-activity signal on the team endpoints, so the column reads a dash. */
 const NO_ACTIVITY = "-";
 
-/** 0 / huge sentinel seat values mean "no limit". */
+/** Mirrors `UserLicenseSettingsService.DEFAULT_USER_LIMIT`; keep the two in step. */
+const FREE_USER_ALLOWANCE = 5;
+
+/**
+ * Users the team is allowed, or null when `maxSeats` holds no purchased allowance. Must agree with
+ * `SaasTeamExtensions.licensedUsers()`, which the wallet and the linked-instance entitlement both
+ * answer through: a team on the free allowance has no limit to show, and the unlimited sentinel is
+ * never a number.
+ */
 function normalizeSeatLimit(max: number | undefined): number | null {
-  if (!max || max <= 0 || max >= 100000) return null;
+  if (!max || max <= FREE_USER_ALLOWANCE || max >= 2147483647) return null;
   return max;
 }
 


### PR DESCRIPTION
## Current state

`saas_team_extensions.max_seats` is written by four different things and means something different in each case:

| Value | Written by | Meaning |
|---|---|---|
| `1` | `createPersonalTeam` at signup | personal team, no members allowed |
| `Integer.MAX_VALUE` | first invitation, and subscription lapse | no cap enforced |
| a head count | legacy `plan:pro` via `updateTeamSeats` | seats bought |
| `servers x 100` | `syncTeamUserAllowance` | a purchased allowance |

Five readers each guess at which one they are looking at. Three used `max > 0 && max < Integer.MAX_VALUE`, one used `max >= 100000`, one defaulted a missing row to `1`.

## Problem

`users.team_id` points at the personal team until an invitation is *accepted*, so a solo cloud account binds its self-hosted instance to a team whose `max_seats` is `1`. That `1` passes every one of those filters:

It self-heals only if that person later invites someone to their *cloud* team. It is latent rather than live, because `stirling.billing.account-link.enabled` defaults off today, but it blocks turning that flag on.

## Solution

One reader, one floor, and one direction of travel.

- `SaasTeamExtensions.licensedUsers()` is now the only interpretation of the column: `null` for a null value, for anything at or below the free allowance, and for the sentinel. A Team plan sells in blocks of 100 and every team gets `DEFAULT_USER_LIMIT` free, so a smaller value was never a purchased allowance and could not restrict anything if it were. All five readers go through it, including the frontend's `normalizeSeatLimit()`.
- `calculateMaxAllowedUsers()` takes `Math.max(grandfatheredLimit, fromSaas)`. Since `grandfatheredLimit` is already `max(DEFAULT_USER_LIMIT, userCountAtFirstBoot)` and is re-floored on every read, this one change gives both "never below the free allowance" and "linking never reduces what the instance already had".
- `createPersonalTeam` stamps the free allowance instead of `1`.
- The SaaS migration rewrites only values at or below the free allowance. Teams above it keep the sentinel, which is the honest value while cloud enforcement is still short-circuited: they have no user limit yet.
- `pricing_policy.server_free_user_allowance` gets its first consumer. It was seeded at 5 and read by `getPlanPackaging()` but nothing used it, so the free allowance existed as two independent constants.

**Not in scope.** Cloud enforcement is untouched: `hasAvailableSeats()` still returns true for standard teams and the atomic claim still skips them. Flipping that needs the trial-expiry call first. Choosing how to represent a grandfathered floor belongs with the same change, which is why the snapshot is not here.

## Stories, and how each is proved

| Story | Test |
|---|---|
| A self-hosted admin who links a solo cloud account can still create users | `InstanceControllerTest` asserts the wire reports no allowance rather than `1`; `SaasTeamServiceTest` asserts the free allowance is stamped at signup |
| Linking never reduces the allowance the instance already had | `UserLicenseSettingsServiceMoreTest`, three cases: SaaS below the grandfathered limit, above it, and absent |
| A team that bought nothing is not reported as holding a Team plan | `PaygWalletControllerTest`; and `SaasTeamServiceTest` asserts conversion keeps the sentinel rather than writing a ceiling |
| The column is read one way everywhere | `SaasTeamExtensionsTest$LicensedUsers`, six boundary cases: null, 1, exactly the free allowance, free + 1, 300, `MAX_VALUE` |
| The free allowance comes from policy, not a second constant | `teamUserAllowance_test.ts` sets a policy allowance of 8 and asserts the lapse path writes 8 |
| A self-hosted customer's licence is honoured until it renews | No code needed. `calculateMaxAllowedUsers()` guards the whole SaaS branch behind `if (!hasPaidLicense())`, so a licensed install never consults the SaaS allowance. Covered by the existing `LinkedTeamAllowance` tests |

## Notes for review

- The SaaS half is Stirling-Tools/Stirling-PDF-SaaS#330, against `v3` (the migration plus the `teamUserAllowance.ts` change). This PR is incomplete without it.
- Personal teams now carry a 5-seat ceiling instead of 1. Every increment path was traced: no reachable path admits a user that `1` refused, because `inviteUserToTeam` converts a personal team to standard before the seat check.
- `SaasTeamController` has two `availableSeats` sites computing `maxSeats - seatsUsed`. They are unchanged here and still do arithmetic on the sentinel. Worth a follow-up, along with `updateTeamSeats`'s `maxSeats == 1` to personal flip, whose threshold is now a product question.
- The migration has not been run against a database.
