### PR TITLE
Fix profile pictures on the Processor and behind transparent uploads

### DIFF
--- a/frontend/editor/src/core/ui/Avatar.css
+++ b/frontend/editor/src/core/ui/Avatar.css
@@ -60,6 +60,12 @@
   display: block;
 }
 
+/* Ground for a picture, which brings its own. Opaque uploads cover it entirely;
+   a logo with an alpha channel gets the app surface rather than a tone. */
+.sui-avatar--image {
+  background: var(--c-surface);
+}
+
 .sui-avatar--blue {
   background: var(--grad-blue-btn);
 }

--- a/frontend/editor/src/core/ui/Avatar.stories.tsx
+++ b/frontend/editor/src/core/ui/Avatar.stories.tsx
@@ -33,6 +33,26 @@ export const SizeRow: Story = {
   ),
 };
 
+const LOGO_INK = "#111827"; // theme-allow-color a user's uploaded file, which no token reaches
+
+const TRANSPARENT_LOGO =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256">' +
+      `<path d="M128 32 L224 200 H32 Z" fill="${LOGO_INK}"/></svg>`,
+  );
+
+/** An uploaded logo keeps its own transparency: no tone disc behind it. */
+export const WithPicture: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+      <Avatar name="Harper Lee" src={TRANSPARENT_LOGO} size="sm" />
+      <Avatar name="Harper Lee" src={TRANSPARENT_LOGO} size="lg" />
+      <Avatar name="Harper Lee" src={TRANSPARENT_LOGO} size="xl" />
+    </div>
+  ),
+};
+
 export const ToneRow: Story = {
   render: () => (
     <div style={{ display: "flex", gap: 8 }}>

--- a/frontend/editor/src/core/ui/Avatar.tsx
+++ b/frontend/editor/src/core/ui/Avatar.tsx
@@ -56,7 +56,10 @@ export function Avatar({
   const classes = [
     "sui-avatar",
     `sui-avatar--${size}`,
-    `sui-avatar--${tone}`,
+    // The tone is the ground the initials sit on, so it is theirs alone: painted
+    // under a picture it shows through every transparent pixel of an uploaded
+    // logo, which reads as a coloured disc nobody asked for.
+    showImage ? "sui-avatar--image" : `sui-avatar--${tone}`,
     onClick ? "sui-avatar--interactive" : "",
     className ?? "",
   ]

--- a/frontend/editor/src/portal-saas/auth/PortalAuthBoundary.test.tsx
+++ b/frontend/editor/src/portal-saas/auth/PortalAuthBoundary.test.tsx
@@ -25,6 +25,11 @@ vi.mock("@app/auth", () => ({
   AuthProvider: ({ children }: { children: ReactNode }) => children,
 }));
 vi.mock("@app/auth/context", () => ({ useAuth: () => authState }));
+// Passthrough too — the real one builds a Supabase client at import time, which
+// needs env this suite deliberately does not set.
+vi.mock("@app/auth/UseSession", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+}));
 vi.mock("@app/ui", () => ({ Spinner: () => null }));
 vi.mock("@portal/auth/saasSupabase", () => ({ ensureSaasSupabase: vi.fn() }));
 

--- a/frontend/editor/src/portal-saas/auth/PortalAuthBoundary.tsx
+++ b/frontend/editor/src/portal-saas/auth/PortalAuthBoundary.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type ReactNode } from "react";
 import { AuthProvider } from "@app/auth";
 import { useAuth } from "@app/auth/context";
+import { AuthProvider as SaasSessionProvider } from "@app/auth/UseSession";
 import { Spinner } from "@app/ui";
 import { stripBasePath, withBasePath } from "@app/constants/app";
 import { rememberPendingDestination } from "@app/services/pendingDestination";
@@ -79,6 +80,12 @@ function SaasPortalGate({ children }: { children: ReactNode }) {
 /**
  * SaaS override of the portal auth boundary: authenticate against the SaaS Supabase
  * project (inheriting the editor's session) instead of the self-hosted Spring login.
+ *
+ * Two providers, because the Processor mounts outside the editor's AppProviders (it
+ * is a sibling route, not a child). The unified AuthProvider is what gates entry;
+ * the saas session provider is what the saas-layer hooks read - profile picture,
+ * display name, pro status - so without it every one of them sees an unmounted
+ * context and reports nothing. Both read the same persisted session.
  */
 export function PortalAuthBoundary({ children }: { children: ReactNode }) {
   // Configure the shared Supabase client (SaaS project) synchronously here, before
@@ -88,8 +95,10 @@ export function PortalAuthBoundary({ children }: { children: ReactNode }) {
   // signed into the editor is picked up from the persisted session (no second login).
   ensureSaasSupabase();
   return (
-    <AuthProvider mode="supabase">
-      <SaasPortalGate>{children}</SaasPortalGate>
-    </AuthProvider>
+    <SaasSessionProvider>
+      <AuthProvider mode="supabase">
+        <SaasPortalGate>{children}</SaasPortalGate>
+      </AuthProvider>
+    </SaasSessionProvider>
   );
 }

--- a/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
+++ b/frontend/editor/src/saas/components/shared/config/ProfilePictureCropper.tsx
@@ -157,6 +157,9 @@ export const ProfilePictureCropper: React.FC<ProfilePictureCropperProps> = ({
               crop={crop}
               zoom={zoom}
               aspect={1}
+              // Every surface draws the result as a circle, so frame one: a square
+              // guide hands back corners that are then cropped away.
+              cropShape="round"
               onCropChange={onCropChange}
               onZoomChange={onZoomChange}
               onCropComplete={onCropCompleteCallback}


### PR DESCRIPTION
# Description of Changes

- The Processor never showed a profile picture: it mounts as a sibling route of `AppProviders`, so the saas `AuthProvider` — the only thing that fetches the signed bucket URL — was never above it, and every saas-layer hook read an unmounted context. `portal-saas/auth/PortalAuthBoundary` now mounts it alongside the unified provider; both read the same persisted session.
- `Avatar` painted its tone gradient under the `<img>`, so any upload with an alpha channel sat on a blue disc. The tone is now the initials' ground only; a picture gets `--c-surface`.
- The picture cropper framed a square while every surface renders a circle, so the corners you positioned were thrown away — `cropShape="round"` makes the guide match the result.
- Added an `Avatar` story covering a transparent upload.
<img width="607" height="616" alt="image" src="https://github.com/user-attachments/assets/a052cc94-9217-4919-ad01-30082d30c35c" />

---

## Checklist

### General

- [ ] I have read the [Contribution Guidelines](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/CONTRIBUTING.md)
- [x] I have read the [Stirling-PDF Developer Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md) (if applicable)
- [ ] I have read the [How to add new languages to Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md) (if applicable)
- [x] I have performed a self-review of my own code
- [x] Every comment I added says something the code does not ([guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/CODE_COMMENTS.md))
- [x] My changes generate no new warnings

### Documentation

- [ ] I have updated relevant docs on [Stirling-PDF's doc repo](https://github.com/Stirling-Tools/Stirling-Tools.github.io/blob/main/docs/) (if functionality has heavily changed)
- [ ] I have read the section [Add New Translation Tags](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/devGuide/HowToAddNewLanguage.md#add-new-translation-tags) (for new translation tags only)

### Translations (if applicable)

- [ ] I ran [`scripts/counter_translation.py`](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/docs/counter_translation.md)

### UI Changes (if applicable)

- [ ] Screenshots or videos demonstrating the UI changes are attached (e.g., as comments or direct attachments in the PR)

### Testing (if applicable)

- [ ] I have run `task check` to verify linters, typechecks, and tests pass
- [ ] I have tested my changes locally. Refer to the [Testing Guide](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/DeveloperGuide.md#7-testing) for more details.

> `task frontend:check`: typecheck, oxlint, theme-lint and comment-lint all clean. Two tests fail only under full-suite load and pass in isolation — `SuperSearch` and `PolicyDetailPanel`, neither touched here.
