### PR TITLE
Keep a thumbnail that has already been generated

### DIFF
--- a/frontend/editor/src/core/hooks/useLazyThumbnail.ts
+++ b/frontend/editor/src/core/hooks/useLazyThumbnail.ts
@@ -91,8 +91,12 @@ export function useLazyThumbnail(
         const file = await indexedDB.loadFile(fileId);
         if (!file || cancelled) return;
         const thumbnail = await generateThumbnailForFile(file);
-        if (cancelled || !thumbnail) return;
-        setThumb(thumbnail);
+        if (!thumbnail) return;
+        // Only the render belongs to the row that asked for it. Caching does not:
+        // rows mount and unmount as the list scrolls, and dropping a thumbnail that
+        // has already been generated means loading the bytes and drawing it again
+        // the next time that row comes round.
+        if (!cancelled) setThumb(thumbnail);
         void indexedDB.updateThumbnail(fileId, thumbnail);
         queueStubThumbUpdate(fileId, thumbnail, (id, url) =>
           updateStirlingFileStub(id, { thumbnailUrl: url }),

--- a/frontend/editor/src/core/hooks/useLazyThumbnail.ts
+++ b/frontend/editor/src/core/hooks/useLazyThumbnail.ts
@@ -92,10 +92,6 @@ export function useLazyThumbnail(
         if (!file || cancelled) return;
         const thumbnail = await generateThumbnailForFile(file);
         if (!thumbnail) return;
-        // Only the render belongs to the row that asked for it. Caching does not:
-        // rows mount and unmount as the list scrolls, and dropping a thumbnail that
-        // has already been generated means loading the bytes and drawing it again
-        // the next time that row comes round.
         if (!cancelled) setThumb(thumbnail);
         void indexedDB.updateThumbnail(fileId, thumbnail);
         queueStubThumbUpdate(fileId, thumbnail, (id, url) =>


### PR DESCRIPTION
The write that caches a thumbnail sat behind the same `cancelled` check as the state update, so a row that scrolled away between generating and storing threw the work away and paid for it again next time it came round.

Cancelling *before* the work is what saves anything — the guards ahead of `loadFile` and `generateThumbnailForFile` still do that. Cancelling after it only loses the result, so now only the `setThumb` render is skipped.