### PR TITLE
Leave folders alone when filtering by sharing

### DIFF
--- a/frontend/editor/src/core/components/filesPage/FileManagerView.tsx
+++ b/frontend/editor/src/core/components/filesPage/FileManagerView.tsx
@@ -327,8 +327,10 @@ export default function FileManagerView() {
       // The Cloud tab is the server's view: browser folders and mounts aren't on it.
       if (currentTab === "cloud" && folderKind(f) !== "server") return false;
       // A folder answers to the source filter the way its files would: a server
-      // folder is cloud, a browser folder and a mount are both local.
-      if (originFilter !== "all") {
+      // folder is cloud, a browser folder and a mount are both local. Sharing is a
+      // property of a file, so filtering by it leaves the folders alone rather than
+      // emptying the tree of every one of them.
+      if (originFilter !== "all" && originFilter !== "shared-with-me") {
         const folderOrigin = folderKind(f) === "server" ? "cloud" : "local";
         if (folderOrigin !== originFilter) return false;
       }


### PR DESCRIPTION
`FilesPageOriginFilter` has four values (`all`, `local`, `cloud`, `shared-with-me`) but the folder check only ever resolves a folder to `cloud` or `local`, so picking **Shared with me** failed every folder and emptied the tree.

Sharing is a property of a file, not a folder: a file shared with you arrives with no `folderId` and can't be moved into one. So that filter now leaves folders alone and only narrows the file list. `local` and `cloud` are unaffected.